### PR TITLE
Add microstructure imbalance features

### DIFF
--- a/src/tradingbot/data/features.py
+++ b/src/tradingbot/data/features.py
@@ -12,3 +12,55 @@ def keltner_channels(df: pd.DataFrame, ema_n: int = 20, atr_n: int = 14, mult: f
     upper = ema + mult * _atr
     lower = ema - mult * _atr
     return upper, lower
+
+
+def order_flow_imbalance(df: pd.DataFrame) -> pd.Series:
+    """Compute Order Flow Imbalance (OFI) using top of book changes.
+
+    The implementation follows a simplified formulation where OFI is the
+    difference between changes in bid and ask queue sizes.  Positive values
+    indicate buying pressure while negative values indicate selling pressure.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with columns ``bid_qty`` and ``ask_qty`` representing the
+        top of book quantities.
+
+    Returns
+    -------
+    pd.Series
+        Series of OFI values aligned with ``df``'s index.
+    """
+
+    bid_delta = df['bid_qty'].diff().fillna(0)
+    ask_delta = df['ask_qty'].diff().fillna(0)
+    return bid_delta - ask_delta
+
+
+def depth_imbalance(df: pd.DataFrame) -> pd.Series:
+    """Depth imbalance between bid and ask queues.
+
+    Defined as ``(bid_qty - ask_qty) / (bid_qty + ask_qty)``.  Values are
+    bounded between -1 and 1 where positive numbers indicate a larger bid
+    queue (buy side) and negative numbers indicate a larger ask queue (sell
+    side).
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame with columns ``bid_qty`` and ``ask_qty``.
+
+    Returns
+    -------
+    pd.Series
+        Depth imbalance series.
+    """
+
+    bid_qty = df['bid_qty']
+    ask_qty = df['ask_qty']
+    denom = bid_qty + ask_qty
+    # Avoid division by zero
+    denom = denom.replace(0, np.nan)
+    return (bid_qty - ask_qty) / denom
+

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from tradingbot.data.features import order_flow_imbalance, depth_imbalance
+
+def test_order_flow_imbalance():
+    df = pd.DataFrame({
+        'bid_qty': [5, 7, 3, 4],
+        'ask_qty': [8, 6, 5, 7],
+    })
+    ofi = order_flow_imbalance(df)
+    assert list(ofi) == [0, 4, -3, -1]
+
+def test_depth_imbalance():
+    df = pd.DataFrame({
+        'bid_qty': [5, 7, 3, 4],
+        'ask_qty': [8, 6, 5, 7],
+    })
+    di = depth_imbalance(df)
+    expected = [
+        (5-8)/(5+8),
+        (7-6)/(7+6),
+        (3-5)/(3+5),
+        (4-7)/(4+7),
+    ]
+    assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))


### PR DESCRIPTION
## Summary
- add order flow imbalance and depth imbalance indicators
- test microstructure features with synthetic order book data

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fbbb8bf5c832d902736c864b98af2