### PR TITLE
Add momentum and mean reversion strategies

### DIFF
--- a/src/tradingbot/backtest/event_engine.py
+++ b/src/tradingbot/backtest/event_engine.py
@@ -1,18 +1,21 @@
 import logging
 from pathlib import Path
 import pandas as pd
-from ..strategies.breakout_atr import BreakoutATR
+from ..strategies import STRATEGIES
 from ..risk.manager import RiskManager
 
 log = logging.getLogger(__name__)
 
-def run_backtest_csv(csv_path: str, symbol: str = "BTC/USDT"):
+def run_backtest_csv(csv_path: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"):
     path = Path(csv_path)
     df = pd.read_csv(path)
     # Expected columns: timestamp, open, high, low, close, volume
     equity = 0.0
     pos = 0.0
-    strat = BreakoutATR()
+    strat_cls = STRATEGIES.get(strategy)
+    if strat_cls is None:
+        raise ValueError(f"unknown strategy: {strategy}")
+    strat = strat_cls()
     risk = RiskManager(max_pos=1.0)
 
     window = 120  # bars for features

--- a/src/tradingbot/data/features.py
+++ b/src/tradingbot/data/features.py
@@ -14,6 +14,23 @@ def keltner_channels(df: pd.DataFrame, ema_n: int = 20, atr_n: int = 14, mult: f
     return upper, lower
 
 
+def rsi(df: pd.DataFrame, n: int = 14) -> pd.Series:
+    """Relative Strength Index of the ``close`` column.
+
+    Uses an exponential moving average formulation which closely follows
+    the original indicator.  Values are bounded between 0 and 100.
+    """
+
+    delta = df["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.ewm(span=n, adjust=False).mean()
+    avg_loss = loss.ewm(span=n, adjust=False).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi.fillna(100)
+
+
 def order_flow_imbalance(df: pd.DataFrame) -> pd.Series:
     """Compute Order Flow Imbalance (OFI) using top of book changes.
 

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -1,1 +1,12 @@
+from .breakout_atr import BreakoutATR
+from .momentum import Momentum
+from .mean_reversion import MeanReversion
 
+# Registry of available strategies, useful for CLI/backtests
+STRATEGIES = {
+    BreakoutATR.name: BreakoutATR,
+    Momentum.name: Momentum,
+    MeanReversion.name: MeanReversion,
+}
+
+__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "STRATEGIES"]

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from .base import Strategy, Signal
+from ..data.features import rsi, order_flow_imbalance
+
+class MeanReversion(Strategy):
+    name = "mean_reversion"
+
+    def __init__(self, rsi_n: int = 14, upper: float = 70.0, lower: float = 30.0):
+        self.rsi_n = rsi_n
+        self.upper = upper
+        self.lower = lower
+
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.rsi_n + 1:
+            return None
+        rsi_series = rsi(df, self.rsi_n)
+        last_rsi = rsi_series.iloc[-1]
+        ofi_val = 0.0
+        if {"bid_qty", "ask_qty"}.issubset(df.columns):
+            ofi_val = order_flow_imbalance(df[["bid_qty", "ask_qty"]]).iloc[-1]
+        if last_rsi > self.upper and ofi_val <= 0:
+            return Signal("sell", 1.0)
+        if last_rsi < self.lower and ofi_val >= 0:
+            return Signal("buy", 1.0)
+        return Signal("flat", 0.0)

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from .base import Strategy, Signal
+from ..data.features import rsi, order_flow_imbalance
+
+class Momentum(Strategy):
+    name = "momentum"
+
+    def __init__(self, rsi_n: int = 14, rsi_threshold: float = 60.0):
+        self.rsi_n = rsi_n
+        self.threshold = rsi_threshold
+
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.rsi_n + 1:
+            return None
+        rsi_series = rsi(df, self.rsi_n)
+        last_rsi = rsi_series.iloc[-1]
+        ofi_val = 0.0
+        if {"bid_qty", "ask_qty"}.issubset(df.columns):
+            ofi_val = order_flow_imbalance(df[["bid_qty", "ask_qty"]]).iloc[-1]
+        if last_rsi > self.threshold and ofi_val >= 0:
+            return Signal("buy", 1.0)
+        if last_rsi < 100 - self.threshold and ofi_val <= 0:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from tradingbot.data.features import order_flow_imbalance, depth_imbalance
+from tradingbot.data.features import order_flow_imbalance, depth_imbalance, rsi
 
 def test_order_flow_imbalance():
     df = pd.DataFrame({
@@ -22,3 +22,11 @@ def test_depth_imbalance():
         (4-7)/(4+7),
     ]
     assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
+
+
+def test_rsi_range():
+    df = pd.DataFrame({"close": list(range(1, 30))})
+    values = rsi(df, 14)
+    # RSI is bounded between 0 and 100 and increases for a strong uptrend
+    assert values.iloc[-1] > 70
+    assert values.dropna().between(0, 100).all()


### PR DESCRIPTION
## Summary
- implement RSI indicator and expose it in features
- add Momentum and MeanReversion strategies leveraging RSI and order flow imbalance
- register strategies with CLI and backtester for easy selection
- cover RSI with unit tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc0e86768832d8c75deb97a726014