### PR TITLE
Add funding and orderbook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,32 @@ uvicorn tradingbot.apps.api.main:app --reload --port 8080
 ```
 
 > **Nota**: este repo es un esqueleto funcional. Los adaptadores WS/REST y ejecución están stubs listos para ser implementados paso a paso.
+
+## Esquema de datos y carga
+
+El archivo `sql/schema_timescale.sql` crea el esquema `market` con tablas básicas para el almacenamiento de mercado:
+
+- `trades`: ejecuciones individuales
+- `orderbook`: snapshots del libro de órdenes (`bid_px`, `bid_qty`, `ask_px`, `ask_qty`)
+- `bars`: agregados OHLCV
+- `funding`: tasas de funding de perps
+
+Para cargar la estructura en una instancia de TimescaleDB:
+
+```bash
+psql -h localhost -U postgres -f sql/schema_timescale.sql
+```
+
+Luego puedes insertar datos desde Python utilizando los helpers:
+
+```python
+from tradingbot.storage.timescale import get_engine, insert_funding, insert_orderbook
+
+engine = get_engine()
+insert_funding(engine, ts=..., exchange="binance", symbol="BTCUSDT", rate=0.0001, interval_sec=3600)
+insert_orderbook(
+    engine,
+    ts=..., exchange="binance", symbol="BTCUSDT",
+    bid_px=[...], bid_qty=[...], ask_px=[...], ask_qty=[...],
+)
+```

--- a/sql/schema_timescale.sql
+++ b/sql/schema_timescale.sql
@@ -14,6 +14,18 @@ CREATE TABLE IF NOT EXISTS market.trades (
 );
 SELECT create_hypertable('market.trades', by_range('ts'), if_not_exists => TRUE);
 
+-- Orderbook snapshots
+CREATE TABLE IF NOT EXISTS market.orderbook (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  bid_px numeric[] NOT NULL,
+  bid_qty numeric[] NOT NULL,
+  ask_px numeric[] NOT NULL,
+  ask_qty numeric[] NOT NULL
+);
+SELECT create_hypertable('market.orderbook', by_range('ts'), if_not_exists => TRUE);
+
 -- Bars
 CREATE TABLE IF NOT EXISTS market.bars (
   ts timestamptz NOT NULL,

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -34,6 +34,23 @@ def insert_bar_1m(engine, exchange: str, symbol: str, ts, o: float, h: float,
             dict(ts=ts, exchange=exchange, symbol=symbol, o=o, h=h, l=low, c=c, v=v),
         )
 
+def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, interval_sec: int):
+    with engine.begin() as conn:
+        conn.execute(text('''
+            INSERT INTO market.funding (ts, exchange, symbol, rate, interval_sec)
+            VALUES (:ts, :exchange, :symbol, :rate, :interval_sec)
+        '''), dict(ts=ts, exchange=exchange, symbol=symbol, rate=rate, interval_sec=interval_sec))
+
+def insert_orderbook(engine, *, ts, exchange: str, symbol: str,
+                     bid_px: list[float], bid_qty: list[float],
+                     ask_px: list[float], ask_qty: list[float]):
+    with engine.begin() as conn:
+        conn.execute(text('''
+            INSERT INTO market.orderbook (ts, exchange, symbol, bid_px, bid_qty, ask_px, ask_qty)
+            VALUES (:ts, :exchange, :symbol, :bid_px, :bid_qty, :ask_px, :ask_qty)
+        '''), dict(ts=ts, exchange=exchange, symbol=symbol,
+                   bid_px=bid_px, bid_qty=bid_qty, ask_px=ask_px, ask_qty=ask_qty))
+
 def insert_order(engine, *, strategy: str, exchange: str, symbol: str, side: str, type_: str, qty: float, px: float | None, status: str, ext_order_id: str | None = None, notes: dict | None = None):
     with engine.begin() as conn:
         conn.execute(text('''


### PR DESCRIPTION
## Summary
- define `funding` and `orderbook` tables in Timescale schema
- add `insert_funding` and `insert_orderbook` helpers
- document data schema and loading instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc1026410832da2ccc8c565ba27e0