### PR TITLE
Add adapter, strategy, execution and risk tests with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+      - name: Run tests
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+import sys
+import pathlib
+import pytest
+
+# Ensure the src package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.execution.paper import PaperAdapter
+
+
+class DummyAdapter(ExchangeAdapter):
+    def __init__(self, trades):
+        self._trades = trades
+
+    async def stream_trades(self, symbol: str):
+        for trade in self._trades:
+            yield trade
+
+    async def place_order(self, symbol: str, side: str, type_: str, qty: float, price: float | None = None):
+        return {"status": "placed", "symbol": symbol, "side": side, "qty": qty, "price": price}
+
+    async def cancel_order(self, order_id: str):
+        return {"status": "canceled", "order_id": order_id}
+
+
+@pytest.fixture
+def mock_trades():
+    return [
+        {"ts": 1, "price": 100.0, "qty": 1.0, "side": "buy"},
+        {"ts": 2, "price": 101.0, "qty": 2.0, "side": "sell"},
+    ]
+
+
+@pytest.fixture
+def mock_order():
+    return {"symbol": "BTCUSDT", "side": "buy", "type_": "market", "qty": 1.0}
+
+
+@pytest.fixture
+def mock_adapter(mock_trades):
+    return DummyAdapter(mock_trades)
+
+
+@pytest.fixture
+def paper_adapter():
+    return PaperAdapter()
+
+
+@pytest.fixture
+def breakout_df_buy():
+    import pandas as pd
+    data = {
+        "open": [1, 2, 3, 4],
+        "high": [2, 3, 4, 5],
+        "low": [0.5, 1.5, 2.5, 3.5],
+        "close": [1.5, 2.5, 3.5, 8.0],
+        "volume": [1, 1, 1, 1],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def breakout_df_sell():
+    import pandas as pd
+    data = {
+        "open": [1, 2, 3, 4],
+        "high": [2, 3, 4, 5],
+        "low": [0.5, 1.5, 2.5, 3.5],
+        "close": [1.5, 2.5, 3.5, -2.0],
+        "volume": [1, 1, 1, 1],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def risk_manager():
+    from tradingbot.risk.manager import RiskManager
+
+    return RiskManager(max_pos=5)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+async def collect_trades(adapter):
+    trades = []
+    async for t in adapter.stream_trades("BTCUSDT"):
+        trades.append(t)
+    return trades
+
+
+@pytest.mark.asyncio
+async def test_mock_adapter_stream_and_orders(mock_adapter, mock_trades, mock_order):
+    collected = await collect_trades(mock_adapter)
+    assert collected == mock_trades
+
+    order_res = await mock_adapter.place_order(**mock_order)
+    assert order_res["status"] == "placed"
+    assert order_res["symbol"] == mock_order["symbol"]
+
+    cancel = await mock_adapter.cancel_order("1")
+    assert cancel["status"] == "canceled"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_paper_adapter_execution(paper_adapter, mock_order):
+    paper_adapter.update_last_price(mock_order["symbol"], 100.0)
+
+    res = await paper_adapter.place_order(**mock_order)
+    assert res["status"] == "filled"
+    assert paper_adapter.state.pos[mock_order["symbol"]].qty == mock_order["qty"]
+
+    cancel = await paper_adapter.cancel_order(res["order_id"])
+    assert cancel["status"] == "canceled"

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,6 @@
+
+def test_risk_manager_position(risk_manager):
+    risk_manager.set_position(1)
+    risk_manager.add_fill("buy", 2)
+    assert risk_manager.pos.qty == 3
+    assert risk_manager.size("buy") == 2

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,11 @@
+from tradingbot.strategies.breakout_atr import BreakoutATR
+
+
+def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
+    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0)
+
+    sig_buy = strat.on_bar({"window": breakout_df_buy})
+    assert sig_buy.side == "buy"
+
+    sig_sell = strat.on_bar({"window": breakout_df_sell})
+    assert sig_sell.side == "sell"


### PR DESCRIPTION
## Summary
- add fixtures and tests for adapters, execution, strategies and risk
- configure GitHub Actions to run pytest

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc0fed4f4832dbfaf9935f39b2f99