### PR TITLE
Add cross exchange arbitrage strategy with persistence

### DIFF
--- a/sql/schema_timescale.sql
+++ b/sql/schema_timescale.sql
@@ -70,6 +70,19 @@ CREATE TABLE IF NOT EXISTS market.tri_signals (
 );
 CREATE INDEX IF NOT EXISTS idx_tri_signals_ts ON market.tri_signals(ts);
 
+-- Cross exchange arbitrage opportunities
+CREATE TABLE IF NOT EXISTS market.cross_signals (
+  id bigserial PRIMARY KEY,
+  ts timestamptz NOT NULL DEFAULT now(),
+  symbol text NOT NULL,
+  spot_exchange text NOT NULL,
+  perp_exchange text NOT NULL,
+  spot_px numeric NOT NULL,
+  perp_px numeric NOT NULL,
+  edge numeric NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cross_signals_ts ON market.cross_signals(ts);
+
 -- Portfolio exposure snapshots (por símbolo)
 CREATE TABLE IF NOT EXISTS market.portfolio_snapshots (
   ts timestamptz NOT NULL DEFAULT now(),

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -48,6 +48,17 @@ def insert_tri_signal(engine, *, exchange: str, base: str, mid: str, quote: str,
             VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional_quote, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
         '''), dict(exchange=exchange, base=base, mid=mid, quote=quote, direction=direction, edge=edge, notional_quote=notional_quote, taker_fee_bps=taker_fee_bps, buffer_bps=buffer_bps, bq=bq, mq=mq, mb=mb))
 
+
+def insert_cross_signal(engine, *, symbol: str, spot_exchange: str, perp_exchange: str,
+                        spot_px: float, perp_px: float, edge: float):
+    """Persist cross-exchange arbitrage opportunities."""
+    with engine.begin() as conn:
+        conn.execute(text('''
+            INSERT INTO market.cross_signals (symbol, spot_exchange, perp_exchange, spot_px, perp_px, edge)
+            VALUES (:symbol, :spot_exchange, :perp_exchange, :spot_px, :perp_px, :edge)
+        '''), dict(symbol=symbol, spot_exchange=spot_exchange, perp_exchange=perp_exchange,
+                   spot_px=spot_px, perp_px=perp_px, edge=edge))
+
 # --- Lecturas simples para API ---
 
 def select_recent_tri_signals(engine, limit: int = 100) -> list[dict[str, Any]]:

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from ..adapters.base import ExchangeAdapter
+
+try:
+    from ..storage.timescale import get_engine, insert_cross_signal, insert_fill
+    _CAN_PG = True
+except Exception:  # pragma: no cover - Timescale optional
+    _CAN_PG = False
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CrossArbConfig:
+    """Configuration for cross exchange spot/perp arbitrage."""
+
+    symbol: str
+    spot: ExchangeAdapter
+    perp: ExchangeAdapter
+    threshold: float = 0.001  # premium threshold as decimal (0.001 = 0.1%)
+    notional: float = 100.0  # quote currency notional per leg
+    persist_pg: bool = False
+
+
+async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
+    """Run a simple spot/perp cross exchange arbitrage loop.
+
+    The function listens to trade streams from both adapters. When the
+    difference between perp and spot price exceeds ``cfg.threshold`` it sends
+    offsetting market orders on each venue and persists the opportunity and
+    resulting fills into TimescaleDB (if available).
+    """
+
+    last: Dict[str, Optional[float]] = {"spot": None, "perp": None}
+    balances: Dict[str, float] = {cfg.spot.name: 0.0, cfg.perp.name: 0.0}
+    trade_lock = asyncio.Lock()
+
+    engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None
+    if cfg.persist_pg and not _CAN_PG:
+        log.warning("Persistencia habilitada pero Timescale no disponible.")
+
+    async def maybe_trade() -> None:
+        if last["spot"] is None or last["perp"] is None:
+            return
+        # compute premium: perp vs spot
+        edge = (last["perp"] - last["spot"]) / last["spot"]
+        if abs(edge) < cfg.threshold:
+            return
+        async with trade_lock:
+            # recompute inside lock to avoid race
+            edge = (last["perp"] - last["spot"]) / last["spot"]
+            if abs(edge) < cfg.threshold:
+                return
+
+            qty = cfg.notional / last["spot"]
+            ts = datetime.now(timezone.utc)
+
+            # persist opportunity
+            if engine is not None:
+                try:
+                    insert_cross_signal(
+                        engine,
+                        symbol=cfg.symbol,
+                        spot_exchange=cfg.spot.name,
+                        perp_exchange=cfg.perp.name,
+                        spot_px=last["spot"],
+                        perp_px=last["perp"],
+                        edge=edge,
+                    )
+                except Exception as e:  # pragma: no cover - logging only
+                    log.debug("No se pudo insertar cross_signal: %s", e)
+
+            # determine sides
+            if edge > 0:
+                spot_side, perp_side = "buy", "sell"
+            else:
+                spot_side, perp_side = "sell", "buy"
+
+            # execute offsetting orders
+            resp_spot, resp_perp = await asyncio.gather(
+                cfg.spot.place_order(cfg.symbol, spot_side, "market", qty),
+                cfg.perp.place_order(cfg.symbol, perp_side, "market", qty),
+            )
+
+            balances[cfg.spot.name] += qty if spot_side == "buy" else -qty
+            balances[cfg.perp.name] += qty if perp_side == "buy" else -qty
+
+            if engine is not None:
+                try:
+                    insert_fill(
+                        engine,
+                        ts=ts,
+                        venue=cfg.spot.name,
+                        strategy="cross_arbitrage",
+                        symbol=cfg.symbol,
+                        side=spot_side,
+                        type_="market",
+                        qty=qty,
+                        price=resp_spot.get("price"),
+                        fee_usdt=None,
+                        raw=resp_spot,
+                    )
+                    insert_fill(
+                        engine,
+                        ts=ts,
+                        venue=cfg.perp.name,
+                        strategy="cross_arbitrage",
+                        symbol=cfg.symbol,
+                        side=perp_side,
+                        type_="market",
+                        qty=qty,
+                        price=resp_perp.get("price"),
+                        fee_usdt=None,
+                        raw=resp_perp,
+                    )
+                except Exception as e:  # pragma: no cover - logging only
+                    log.debug("No se pudo insertar fills: %s", e)
+
+            log.info(
+                "CROSS ARB edge=%.4f%% spot=%.2f perp=%.2f qty=%.6f pos_spot=%.6f pos_perp=%.6f",
+                edge * 100,
+                last["spot"],
+                last["perp"],
+                qty,
+                balances[cfg.spot.name],
+                balances[cfg.perp.name],
+            )
+
+    async def listen_spot():
+        async for t in cfg.spot.stream_trades(cfg.symbol):
+            px = t.get("price")
+            if px is not None:
+                last["spot"] = float(px)
+                await maybe_trade()
+
+    async def listen_perp():
+        async for t in cfg.perp.stream_trades(cfg.symbol):
+            px = t.get("price")
+            if px is not None:
+                last["perp"] = float(px)
+                await maybe_trade()
+
+    await asyncio.gather(listen_spot(), listen_perp())


### PR DESCRIPTION
## Summary
- add `cross_exchange_arbitrage` strategy to trade spot/perp price differences and persist signals/fills
- support TimescaleDB storage for cross-arbitrage opportunities via `insert_cross_signal`
- extend DB schema with `market.cross_signals` table

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc0f76d80832d86510307b931ed12