### PR TITLE
feat: integrate portfolio risk guards across runners

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -13,10 +13,12 @@ from ..adapters.binance_ws import BinanceWSAdapter
 from ..execution.paper import PaperAdapter
 from ..strategies.breakout_atr import BreakoutATR
 from ..risk.manager import RiskManager
+from ..risk.daily_guard import DailyGuard, GuardLimits
+from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 
 # Persistencia opcional (Timescale). No es obligatorio para correr.
 try:
-    from ..storage.timescale import get_engine, insert_trade
+    from ..storage.timescale import get_engine, insert_trade, insert_risk_event
     _CAN_PG = True
 except Exception:
     _CAN_PG = False
@@ -79,7 +81,18 @@ class BarAggregator:
             "volume": [b.v for b in bars],
         })
 
-async def run_live_binance(symbol: str = "BTC/USDT", fee_bps: float = 1.5, persist_pg: bool = False):
+async def run_live_binance(
+    symbol: str = "BTC/USDT",
+    fee_bps: float = 1.5,
+    persist_pg: bool = False,
+    total_cap_usdt: float = 1000.0,
+    per_symbol_cap_usdt: float = 500.0,
+    soft_cap_pct: float = 0.10,
+    soft_cap_grace_sec: int = 30,
+    daily_max_loss_usdt: float = 100.0,
+    daily_max_drawdown_pct: float = 0.05,
+    max_consecutive_losses: int = 3,
+):
     """
     Pipeline en vivo:
       WS Binance -> agregador 1m -> BreakoutATR -> Risk -> PaperAdapter
@@ -88,6 +101,19 @@ async def run_live_binance(symbol: str = "BTC/USDT", fee_bps: float = 1.5, persi
     broker = PaperAdapter(fee_bps=fee_bps)
     risk = RiskManager(max_pos=1.0)
     strat = BreakoutATR()
+    guard = PortfolioGuard(GuardConfig(
+        total_cap_usdt=total_cap_usdt,
+        per_symbol_cap_usdt=per_symbol_cap_usdt,
+        venue="binance",
+        soft_cap_pct=soft_cap_pct,
+        soft_cap_grace_sec=soft_cap_grace_sec,
+    ))
+    dguard = DailyGuard(GuardLimits(
+        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_drawdown_pct=daily_max_drawdown_pct,
+        max_consecutive_losses=max_consecutive_losses,
+        halt_action="close_all",
+    ), venue="binance")
 
     pg_engine = get_engine() if (persist_pg and _CAN_PG) else None
     if persist_pg and not _CAN_PG:
@@ -101,6 +127,18 @@ async def run_live_binance(symbol: str = "BTC/USDT", fee_bps: float = 1.5, persi
         px: float = float(t["price"])
         qty: float = float(t["qty"] or 0.0)
         broker.update_last_price(symbol, px)
+        guard.mark_price(symbol, px)
+        dguard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: px}))
+        halted, reason = dguard.check_halt()
+        if halted:
+            log.error("[HALT] motivo=%s", reason)
+            if pg_engine is not None:
+                try:
+                    insert_risk_event(pg_engine, venue="binance", symbol=symbol,
+                                      kind=f"HALT_{reason}", message=f"HALT: {reason}", details={})
+                except Exception:
+                    log.exception("Persist failure: risk_event HALT")
+            continue
 
         # Persistencia opcional: guardar trade crudo
         if pg_engine is not None:
@@ -132,12 +170,27 @@ async def run_live_binance(symbol: str = "BTC/USDT", fee_bps: float = 1.5, persi
         delta = risk.size(signal.side, signal.strength)
         if abs(delta) > 1e-9:
             side = "buy" if delta > 0 else "sell"
-            import asyncio as _a
+            action, reason, metrics = guard.soft_cap_decision(symbol, side, abs(delta), closed.c)
+            if action == "block":
+                log.warning("[PG] Bloqueado %s: %s", symbol, reason)
+                if pg_engine is not None:
+                    try:
+                        insert_risk_event(pg_engine, venue="binance", symbol=symbol,
+                                          kind="VIOLATION", message=reason, details=metrics)
+                    except Exception:
+                        log.exception("Persist failure: risk_event VIOLATION")
+                continue
+            elif action == "soft_allow" and pg_engine is not None:
+                try:
+                    insert_risk_event(pg_engine, venue="binance", symbol=symbol,
+                                      kind="INFO", message=reason, details=metrics)
+                except Exception:
+                    log.exception("Persist failure: risk_event INFO")
             resp = await broker.place_order(symbol, side, "market", abs(delta))
             fills += 1
             log.info("FILL live %s", resp)
-            # Actualizar RiskManager con el fill ejecutado
             risk.add_fill(side, abs(delta))
+            guard.update_position_on_order(symbol, side, abs(delta))
 
         # Persistir barra 1m si quieres (opcional; requiere tabla market.bars creada)
         # Puedes descomentar y ampliar con INSERT a bars.

--- a/src/tradingbot/live/runner_futures_testnet.py
+++ b/src/tradingbot/live/runner_futures_testnet.py
@@ -15,6 +15,15 @@ from ..strategies.breakout_atr import BreakoutATR
 from ..risk.manager import RiskManager
 from ..execution.order_types import Order
 from ..execution.paper import PaperAdapter  # para equity mark si no quieres consultar mark price
+from ..risk.daily_guard import DailyGuard, GuardLimits
+from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
+
+# Persistencia opcional
+try:
+    from ..storage.timescale import get_engine, insert_risk_event
+    _CAN_PG = True
+except Exception:
+    _CAN_PG = False
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +36,14 @@ async def run_live_binance_futures_testnet(
     leverage: int = 5,
     trade_qty: float = 0.001,  # tamaño de orden por señal
     dry_run: bool = True,      # True = no envía a testnet; usa PaperAdapter
+    persist_pg: bool = False,
+    total_cap_usdt: float = 1000.0,
+    per_symbol_cap_usdt: float = 500.0,
+    soft_cap_pct: float = 0.10,
+    soft_cap_grace_sec: int = 30,
+    daily_max_loss_usdt: float = 100.0,
+    daily_max_drawdown_pct: float = 0.05,
+    max_consecutive_losses: int = 3,
 ):
     """
     WS Binance (precio) -> agregación 1m -> estrategia -> Risk -> (Paper o Futures Testnet)
@@ -36,6 +53,21 @@ async def run_live_binance_futures_testnet(
     strat = BreakoutATR()
     risk = RiskManager(max_pos=1.0)
     state = LiveState()
+    guard = PortfolioGuard(GuardConfig(
+        total_cap_usdt=total_cap_usdt,
+        per_symbol_cap_usdt=per_symbol_cap_usdt,
+        venue="binance_futures_testnet",
+        soft_cap_pct=soft_cap_pct,
+        soft_cap_grace_sec=soft_cap_grace_sec
+    ))
+    dguard = DailyGuard(GuardLimits(
+        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_drawdown_pct=daily_max_drawdown_pct,
+        max_consecutive_losses=max_consecutive_losses,
+        halt_action="close_all"
+    ), venue="binance_futures_testnet")
+
+    engine = get_engine() if (persist_pg and _CAN_PG) else None
 
     # Broker
     if dry_run:
@@ -55,6 +87,18 @@ async def run_live_binance_futures_testnet(
 
         # actualiza last local (para equity en PaperAdapter)
         broker.update_last_price(symbol, px)
+        guard.mark_price(symbol, px)
+        dguard.on_mark(datetime.now(timezone.utc), equity_now=0.0)
+        halted, reason = dguard.check_halt()
+        if halted:
+            log.error("[HALT FUTURES] motivo=%s", reason)
+            if engine is not None:
+                try:
+                    insert_risk_event(engine, venue="binance_futures_testnet", symbol=symbol,
+                                      kind=f"HALT_{reason}", message=f"FUTURES halt: {reason}", details={})
+                except Exception:
+                    log.exception("FUTURES persist failure: risk_event HALT")
+            continue
 
         closed = agg.on_trade(ts, px, qty)
         if closed is None:
@@ -75,6 +119,23 @@ async def run_live_binance_futures_testnet(
 
         side = "buy" if delta > 0 else "sell"
 
+        action, reason, metrics = guard.soft_cap_decision(symbol, side, abs(trade_qty), closed.c)
+        if action == "block":
+            log.warning("[PG] Bloqueado %s: %s", symbol, reason)
+            if engine is not None:
+                try:
+                    insert_risk_event(engine, venue="binance_futures_testnet", symbol=symbol,
+                                      kind="VIOLATION", message=reason, details=metrics)
+                except Exception:
+                    log.exception("FUTURES persist failure: risk_event VIOLATION")
+            continue
+        elif action == "soft_allow" and engine is not None:
+            try:
+                insert_risk_event(engine, venue="binance_futures_testnet", symbol=symbol,
+                                  kind="INFO", message=reason, details=metrics)
+            except Exception:
+                log.exception("FUTURES persist failure: risk_event INFO")
+
         # --- NEW: cap por balance futures (USDT libre y leverage) ---
         from ..execution.balance import fetch_futures_usdt_free, cap_qty_by_balance_futures
         try:
@@ -94,6 +155,7 @@ async def run_live_binance_futures_testnet(
             log.info("LIVE FILL (dry_run=%s) %s", dry_run, resp)
             # Actualizar RiskManager con el fill ejecutado
             risk.add_fill(side, capped_qty)
+            guard.update_position_on_order(symbol, side, float(capped_qty))
         except Exception as e:
             log.error("Error enviando orden: %s", e)
 


### PR DESCRIPTION
## Summary
- add return tracking and correlation matrix to `PortfolioGuard`
- wire `DailyGuard` and `PortfolioGuard` into live runners with TimescaleDB event logging

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc0f1b184832d8de14bdff3529777