### PR TITLE
Add Bybit and OKX adapters with websocket streams

### DIFF
--- a/src/tradingbot/adapters/__init__.py
+++ b/src/tradingbot/adapters/__init__.py
@@ -1,1 +1,19 @@
+"""Adapters de exchanges disponibles."""
 
+from .base import ExchangeAdapter
+from .binance_spot import BinanceSpotAdapter
+from .binance_futures import BinanceFuturesAdapter
+from .bybit_spot import BybitSpotAdapter
+from .bybit_futures import BybitFuturesAdapter
+from .okx_spot import OKXSpotAdapter
+from .okx_futures import OKXFuturesAdapter
+
+__all__ = [
+    "ExchangeAdapter",
+    "BinanceSpotAdapter",
+    "BinanceFuturesAdapter",
+    "BybitSpotAdapter",
+    "BybitFuturesAdapter",
+    "OKXSpotAdapter",
+    "OKXFuturesAdapter",
+]

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -1,0 +1,85 @@
+# src/tradingbot/adapters/bybit_futures.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import websockets
+
+try:
+    import ccxt
+except Exception:  # pragma: no cover - ccxt optional during tests
+    ccxt = None
+
+from .base import ExchangeAdapter
+
+log = logging.getLogger(__name__)
+
+
+class BybitFuturesAdapter(ExchangeAdapter):
+    """Adapter para futuros/perpetuos USDT de Bybit."""
+
+    name = "bybit_futures"
+
+    def __init__(self):
+        if ccxt is None:
+            raise RuntimeError("ccxt no está instalado")
+        self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "swap"}})
+
+    async def _to_thread(self, fn, *args, **kwargs):
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://stream.bybit.com/v5/public/linear"
+        sub = {"op": "subscribe", "args": [f"publicTrade.{symbol}"]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for t in msg.get("data", []) or []:
+                            price = float(t.get("p"))
+                            qty = float(t.get("v", 0))
+                            side = t.get("S", "").lower()
+                            ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+            except Exception as e:  # pragma: no cover - network paths
+                log.warning("Bybit futures trade WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://stream.bybit.com/v5/public/linear"
+        sub = {"op": "subscribe", "args": [f"orderbook.1.{symbol}"]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        data = msg.get("data") or {}
+                        if not data:
+                            continue
+                        bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
+                        asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
+                        ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
+                        yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+            except Exception as e:  # pragma: no cover - network paths
+                log.warning("Bybit futures book WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
+                          price: float | None = None) -> dict:
+        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+
+    async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
+        return await self._to_thread(self.rest.cancel_order, order_id, symbol)

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -1,0 +1,86 @@
+# src/tradingbot/adapters/bybit_spot.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import websockets
+
+try:
+    import ccxt
+except Exception:  # pragma: no cover - ccxt optional during tests
+    ccxt = None
+
+from .base import ExchangeAdapter
+
+log = logging.getLogger(__name__)
+
+
+class BybitSpotAdapter(ExchangeAdapter):
+    """Adapter para Spot de Bybit usando WS público y REST via CCXT."""
+
+    name = "bybit_spot"
+
+    def __init__(self):
+        if ccxt is None:
+            raise RuntimeError("ccxt no está instalado")
+        # enableRateLimit respeta límites de la API
+        self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+
+    async def _to_thread(self, fn, *args, **kwargs):
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://stream.bybit.com/v5/public/spot"
+        sub = {"op": "subscribe", "args": [f"publicTrade.{symbol}"]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for t in msg.get("data", []) or []:
+                            price = float(t.get("p"))
+                            qty = float(t.get("v", 0))
+                            side = t.get("S", "").lower()
+                            ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+            except Exception as e:  # pragma: no cover - network paths
+                log.warning("Bybit spot trade WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://stream.bybit.com/v5/public/spot"
+        sub = {"op": "subscribe", "args": [f"orderbook.1.{symbol}"]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        data = msg.get("data") or {}
+                        if not data:
+                            continue
+                        bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
+                        asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
+                        ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
+                        yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+            except Exception as e:  # pragma: no cover - network paths
+                log.warning("Bybit spot book WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
+                          price: float | None = None) -> dict:
+        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+
+    async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
+        return await self._to_thread(self.rest.cancel_order, order_id, symbol)

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -1,0 +1,84 @@
+# src/tradingbot/adapters/okx_futures.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import websockets
+
+try:
+    import ccxt
+except Exception:  # pragma: no cover
+    ccxt = None
+
+from .base import ExchangeAdapter
+
+log = logging.getLogger(__name__)
+
+
+class OKXFuturesAdapter(ExchangeAdapter):
+    """Adapter para futuros/swap perpetuos de OKX."""
+
+    name = "okx_futures"
+
+    def __init__(self):
+        if ccxt is None:
+            raise RuntimeError("ccxt no está instalado")
+        # "swap" cubre contratos perpetuos
+        self.rest = ccxt.okx({"enableRateLimit": True, "options": {"defaultType": "swap"}})
+
+    async def _to_thread(self, fn, *args, **kwargs):
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://ws.okx.com:8443/ws/v5/public"
+        sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": symbol}]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for t in msg.get("data", []) or []:
+                            price = float(t.get("px"))
+                            qty = float(t.get("sz", 0))
+                            side = t.get("side", "")
+                            ts = datetime.fromtimestamp(int(t.get("ts", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+            except Exception as e:  # pragma: no cover
+                log.warning("OKX futures trade WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://ws.okx.com:8443/ws/v5/public"
+        sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": symbol}]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for d in msg.get("data", []) or []:
+                            bids = [[float(p), float(q)] for p, q, *_ in d.get("bids", [])]
+                            asks = [[float(p), float(q)] for p, q, *_ in d.get("asks", [])]
+                            ts = datetime.fromtimestamp(int(d.get("ts", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+            except Exception as e:  # pragma: no cover
+                log.warning("OKX futures book WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
+                          price: float | None = None) -> dict:
+        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+
+    async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
+        return await self._to_thread(self.rest.cancel_order, order_id, symbol)

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -1,0 +1,83 @@
+# src/tradingbot/adapters/okx_spot.py
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+import websockets
+
+try:
+    import ccxt
+except Exception:  # pragma: no cover
+    ccxt = None
+
+from .base import ExchangeAdapter
+
+log = logging.getLogger(__name__)
+
+
+class OKXSpotAdapter(ExchangeAdapter):
+    """Adapter para Spot de OKX usando websockets y CCXT."""
+
+    name = "okx_spot"
+
+    def __init__(self):
+        if ccxt is None:
+            raise RuntimeError("ccxt no está instalado")
+        self.rest = ccxt.okx({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+
+    async def _to_thread(self, fn, *args, **kwargs):
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://ws.okx.com:8443/ws/v5/public"
+        sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": symbol}]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for t in msg.get("data", []) or []:
+                            price = float(t.get("px"))
+                            qty = float(t.get("sz", 0))
+                            side = t.get("side", "")
+                            ts = datetime.fromtimestamp(int(t.get("ts", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+            except Exception as e:  # pragma: no cover
+                log.warning("OKX spot trade WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+        url = "wss://ws.okx.com:8443/ws/v5/public"
+        sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": symbol}]}
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    await ws.send(json.dumps(sub))
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        for d in msg.get("data", []) or []:
+                            bids = [[float(p), float(q)] for p, q, *_ in d.get("bids", [])]
+                            asks = [[float(p), float(q)] for p, q, *_ in d.get("asks", [])]
+                            ts = datetime.fromtimestamp(int(d.get("ts", 0)) / 1000, tz=timezone.utc)
+                            yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+            except Exception as e:  # pragma: no cover
+                log.warning("OKX spot book WS error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
+                          price: float | None = None) -> dict:
+        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+
+    async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
+        return await self._to_thread(self.rest.cancel_order, order_id, symbol)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,4 +1,11 @@
 import pytest
+from tradingbot.adapters import (
+    BybitSpotAdapter,
+    BybitFuturesAdapter,
+    OKXSpotAdapter,
+    OKXFuturesAdapter,
+)
+from tradingbot.adapters.base import ExchangeAdapter
 
 
 async def collect_trades(adapter):
@@ -19,3 +26,13 @@ async def test_mock_adapter_stream_and_orders(mock_adapter, mock_trades, mock_or
 
     cancel = await mock_adapter.cancel_order("1")
     assert cancel["status"] == "canceled"
+
+
+def test_registered_adapters_are_subclasses():
+    for cls in (
+        BybitSpotAdapter,
+        BybitFuturesAdapter,
+        OKXSpotAdapter,
+        OKXFuturesAdapter,
+    ):
+        assert issubclass(cls, ExchangeAdapter)


### PR DESCRIPTION
## Summary
- add Bybit spot/futures adapters with websocket trade/orderbook feeds and CCXT REST order support
- add OKX spot/futures adapters with websocket feeds and CCXT REST order methods
- expose all adapters through `tradingbot.adapters` and test registration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcb3cbd38832d999c07a6087bfe3d