### PR TITLE
Add order book streaming and persistence

### DIFF
--- a/src/tradingbot/data/ingest.py
+++ b/src/tradingbot/data/ingest.py
@@ -1,11 +1,43 @@
 import logging, asyncio
 from ..bus import EventBus
-from ..types import Tick
+from ..types import Tick, OrderBook
+from ..storage.timescale import insert_orderbook
 
 log = logging.getLogger(__name__)
 
 async def run_trades_stream(adapter, symbol: str, bus: EventBus):
     async for d in adapter.stream_trades(symbol):
         # Normalizar (placeholder)
-        tick = Tick(ts=d.get("ts"), exchange=adapter.name, symbol=symbol, price=d.get("price") or 0.0, qty=d.get("qty") or 0.0, side=d.get("side"))
+        tick = Tick(
+            ts=d.get("ts"),
+            exchange=adapter.name,
+            symbol=symbol,
+            price=d.get("price") or 0.0,
+            qty=d.get("qty") or 0.0,
+            side=d.get("side"),
+        )
         await bus.publish("trades", tick)
+
+
+async def run_orderbook_stream(adapter, symbol: str, depth: int, bus: EventBus, engine):
+    async for d in adapter.stream_orderbook(symbol, depth):
+        ob = OrderBook(
+            ts=d.get("ts"),
+            exchange=adapter.name,
+            symbol=symbol,
+            bid_px=d.get("bid_px") or [],
+            bid_qty=d.get("bid_qty") or [],
+            ask_px=d.get("ask_px") or [],
+            ask_qty=d.get("ask_qty") or [],
+        )
+        await bus.publish("orderbook", ob)
+        insert_orderbook(
+            engine,
+            ts=ob.ts,
+            exchange=ob.exchange,
+            symbol=ob.symbol,
+            bid_px=ob.bid_px,
+            bid_qty=ob.bid_qty,
+            ask_px=ob.ask_px,
+            ask_qty=ob.ask_qty,
+        )

--- a/src/tradingbot/types.py
+++ b/src/tradingbot/types.py
@@ -21,3 +21,14 @@ class Bar:
     l: float
     c: float
     v: float
+
+
+@dataclass
+class OrderBook:
+    ts: datetime
+    exchange: str
+    symbol: str
+    bid_px: list[float]
+    bid_qty: list[float]
+    ask_px: list[float]
+    ask_qty: list[float]

--- a/tests/test_data_ingest.py
+++ b/tests/test_data_ingest.py
@@ -1,0 +1,62 @@
+import pytest
+from datetime import datetime, timezone
+
+from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.bus import EventBus
+from tradingbot.data.ingest import run_orderbook_stream
+from tradingbot.storage import timescale
+from tradingbot.types import OrderBook
+
+
+class DummyOBAdapter(ExchangeAdapter):
+    name = "dummy"
+
+    def __init__(self, snapshots):
+        self._snapshots = snapshots
+
+    async def stream_trades(self, symbol: str):
+        if False:
+            yield {}
+
+    async def stream_orderbook(self, symbol: str, depth: int):
+        for snap in self._snapshots:
+            yield snap
+
+    async def place_order(self, *args, **kwargs):
+        return {}
+
+    async def cancel_order(self, order_id: str):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_run_orderbook_stream_persists(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    snapshot = {
+        "ts": ts,
+        "bid_px": [100.0, 99.5],
+        "bid_qty": [1.0, 2.0],
+        "ask_px": [100.5, 101.0],
+        "ask_qty": [1.5, 2.5],
+    }
+    adapter = DummyOBAdapter([snapshot])
+    bus = EventBus()
+    published = []
+    bus.subscribe("orderbook", lambda ob: published.append(ob))
+
+    inserted = []
+
+    def fake_insert(engine, **data):
+        inserted.append(data)
+
+    monkeypatch.setattr("tradingbot.data.ingest.insert_orderbook", fake_insert)
+
+    await run_orderbook_stream(adapter, "BTC/USDT", depth=5, bus=bus, engine="engine")
+
+    assert len(published) == 1
+    ob = published[0]
+    assert isinstance(ob, OrderBook)
+    assert ob.bid_px == [100.0, 99.5]
+    assert len(inserted) == 1
+    assert inserted[0]["symbol"] == "BTC/USDT"
+    assert inserted[0]["bid_px"] == [100.0, 99.5]


### PR DESCRIPTION
## Summary
- add `stream_orderbook` to Binance futures and spot websocket adapters
- introduce `OrderBook` dataclass and ingestion workflow that stores snapshots in Timescale
- test order book ingestion and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb394b54832d8957af581d98abf9