### PR TITLE
Add funding polling and cash-and-carry strategy

### DIFF
--- a/src/tradingbot/data/funding.py
+++ b/src/tradingbot/data/funding.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ..bus import EventBus
+
+try:  # optional persistence
+    from ..storage.timescale import get_engine, insert_funding
+    _CAN_PG = True
+except Exception:  # pragma: no cover - optional dependency
+    _CAN_PG = False
+
+log = logging.getLogger(__name__)
+
+async def poll_funding(adapter, symbol: str, bus: EventBus, interval: int = 60, persist_pg: bool = False) -> None:
+    """Poll periodic funding rates and publish them on the event bus.
+
+    The ``adapter`` is expected to expose an asynchronous ``fetch_funding``
+    method returning a mapping with at least ``rate`` and ``interval_sec``
+    fields.  Each retrieved funding is published to the ``"funding"`` topic of
+    the provided :class:`EventBus` and optionally persisted into TimescaleDB
+    using :func:`insert_funding`.
+    """
+    engine = get_engine() if (persist_pg and _CAN_PG) else None
+    while True:
+        try:
+            info: Any = await adapter.fetch_funding(symbol)
+            rate = float(info.get("rate") or info.get("fundingRate") or 0.0)
+            interval_sec = int(info.get("interval_sec") or info.get("interval", 0))
+            ts = info.get("ts") or datetime.now(timezone.utc)
+            event = {
+                "ts": ts,
+                "exchange": getattr(adapter, "name", "unknown"),
+                "symbol": symbol,
+                "rate": rate,
+                "interval_sec": interval_sec,
+            }
+            await bus.publish("funding", event)
+            if engine is not None:
+                try:
+                    insert_funding(engine, ts=ts, exchange=event["exchange"], symbol=symbol, rate=rate, interval_sec=interval_sec)
+                except Exception as e:  # pragma: no cover - logging only
+                    log.debug("No se pudo insertar funding: %s", e)
+        except asyncio.CancelledError:  # allow task cancellation
+            raise
+        except Exception as e:  # pragma: no cover - logging only
+            log.warning("poll_funding error: %s", e)
+        await asyncio.sleep(interval)

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -1,12 +1,14 @@
 from .breakout_atr import BreakoutATR
 from .momentum import Momentum
 from .mean_reversion import MeanReversion
+from .cash_and_carry import CashAndCarry
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
     BreakoutATR.name: BreakoutATR,
     Momentum.name: Momentum,
     MeanReversion.name: MeanReversion,
+    CashAndCarry.name: CashAndCarry,
 }
 
-__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "STRATEGIES"]
+__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "CashAndCarry", "STRATEGIES"]

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import Strategy, Signal
+
+try:  # optional persistence
+    from ..storage.timescale import get_engine, insert_cross_signal
+    _CAN_PG = True
+except Exception:  # pragma: no cover - optional
+    _CAN_PG = False
+
+log = logging.getLogger(__name__)
+
+@dataclass
+class CashCarryConfig:
+    symbol: str
+    spot_exchange: str = "spot"
+    perp_exchange: str = "perp"
+    threshold: float = 0.0  # minimum basis to act
+    persist_pg: bool = False
+
+class CashAndCarry(Strategy):
+    """Simple cash-and-carry strategy using spot vs perpetual futures funding.
+
+    The strategy looks at the price basis between spot and perpetual markets
+    together with the current funding rate.  When funding is positive and the
+    perp trades at a premium greater than ``threshold`` the strategy issues a
+    ``long`` signal (long spot/short perp).  When funding is negative and the
+    perp trades at a discount beyond the threshold a ``short`` signal is
+    produced (short spot/long perp).
+    """
+
+    name = "cash_and_carry"
+
+    def __init__(self, cfg: CashCarryConfig):
+        self.cfg = cfg
+        self.engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None
+
+    def on_bar(self, bar: dict) -> Optional[Signal]:
+        spot = bar.get("spot")
+        perp = bar.get("perp")
+        funding = bar.get("funding")
+        if spot is None or perp is None or funding is None:
+            return None
+        basis = (perp - spot) / spot
+        if funding > 0 and basis > self.cfg.threshold:
+            self._persist_signal(basis, spot, perp)
+            return Signal("long", basis)
+        if funding < 0 and basis < -self.cfg.threshold:
+            self._persist_signal(basis, spot, perp)
+            return Signal("short", -basis)
+        return Signal("flat", 0.0)
+
+    def _persist_signal(self, basis: float, spot_px: float, perp_px: float) -> None:
+        if self.engine is None:
+            return
+        try:
+            insert_cross_signal(
+                self.engine,
+                symbol=self.cfg.symbol,
+                spot_exchange=self.cfg.spot_exchange,
+                perp_exchange=self.cfg.perp_exchange,
+                spot_px=spot_px,
+                perp_px=perp_px,
+                edge=basis,
+            )
+        except Exception as e:  # pragma: no cover - logging only
+            log.debug("No se pudo insertar cash&carry signal: %s", e)

--- a/tests/test_cash_and_carry.py
+++ b/tests/test_cash_and_carry.py
@@ -1,0 +1,42 @@
+import asyncio
+import pytest
+
+from tradingbot.bus import EventBus
+from tradingbot.data.funding import poll_funding
+from tradingbot.strategies.cash_and_carry import CashAndCarry, CashCarryConfig
+
+
+class DummyAdapter:
+    name = "dummy"
+
+    def __init__(self):
+        self.count = 0
+
+    async def fetch_funding(self, symbol: str):
+        self.count += 1
+        return {"rate": 0.001 if self.count == 1 else -0.001, "interval_sec": 3600}
+
+
+@pytest.mark.asyncio
+async def test_poll_funding_publishes_events():
+    adapter = DummyAdapter()
+    bus = EventBus()
+    received = []
+    bus.subscribe("funding", lambda e: received.append(e))
+    task = asyncio.create_task(poll_funding(adapter, "BTCUSDT", bus, interval=0.01))
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert received and received[0]["rate"] == 0.001
+
+
+def test_cash_and_carry_strategy():
+    cfg = CashCarryConfig(symbol="BTCUSDT", threshold=0.0001)
+    strat = CashAndCarry(cfg)
+    sig_long = strat.on_bar({"spot": 100.0, "perp": 101.0, "funding": 0.001})
+    assert sig_long and sig_long.side == "long"
+    sig_short = strat.on_bar({"spot": 100.0, "perp": 99.0, "funding": -0.001})
+    assert sig_short and sig_short.side == "short"
+    sig_flat = strat.on_bar({"spot": 100.0, "perp": 100.0, "funding": 0.0001})
+    assert sig_flat and sig_flat.side == "flat"


### PR DESCRIPTION
## Summary
- add funding polling utility that publishes funding events and persists rates
- implement cash-and-carry strategy using spot/perp prices and funding
- cover new funding and strategy logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb3689d8832daa4b16b1689b9e42