### PR TITLE
Add risk kill switch with stop-loss and drawdown checks

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -169,6 +169,10 @@ async def run_live_binance(
 
         delta = risk.size(signal.side, signal.strength)
         if abs(delta) > 1e-9:
+            # Verifica límites de riesgo antes de enviar cualquier orden
+            if not risk.check_limits(closed.c):
+                log.warning("RiskManager disabled; kill switch activated")
+                continue
             side = "buy" if delta > 0 else "sell"
             action, reason, metrics = guard.soft_cap_decision(symbol, side, abs(delta), closed.c)
             if action == "block":

--- a/src/tradingbot/live/runner_futures_testnet.py
+++ b/src/tradingbot/live/runner_futures_testnet.py
@@ -119,6 +119,10 @@ async def run_live_binance_futures_testnet(
 
         side = "buy" if delta > 0 else "sell"
 
+        if not risk.check_limits(closed.c):
+            log.warning("RiskManager disabled; kill switch activated")
+            continue
+
         action, reason, metrics = guard.soft_cap_decision(symbol, side, abs(trade_qty), closed.c)
         if action == "block":
             log.warning("[PG] Bloqueado %s: %s", symbol, reason)

--- a/src/tradingbot/live/runner_futures_testnet_multi.py
+++ b/src/tradingbot/live/runner_futures_testnet_multi.py
@@ -352,6 +352,10 @@ async def run_live_binance_futures_testnet_multi(
 
         side = "buy" if delta > 0 else "sell"
 
+        if not risks[sym].check_limits(closed.c):
+            log.warning("[%s] RiskManager disabled; kill switch activated", sym)
+            continue
+
         # ----- SOFT CAPS -----
         action, reason, metrics = guard.soft_cap_decision(sym, side, abs(trade_qty), closed.c)
         if action == "block":

--- a/src/tradingbot/live/runner_spot_testnet.py
+++ b/src/tradingbot/live/runner_spot_testnet.py
@@ -121,6 +121,10 @@ async def run_live_binance_spot_testnet(
 
         side = "buy" if delta > 0 else "sell"
 
+        if not risk.check_limits(closed.c):
+            log.warning("RiskManager disabled; kill switch activated")
+            continue
+
         # --- Portfolio guard ---
         action, reason, metrics = guard.soft_cap_decision(symbol, side, abs(trade_qty), closed.c)
         if action == "block":

--- a/src/tradingbot/live/runner_spot_testnet_multi.py
+++ b/src/tradingbot/live/runner_spot_testnet_multi.py
@@ -330,6 +330,10 @@ async def run_live_binance_spot_testnet_multi(
 
         side = "buy" if delta > 0 else "sell"
 
+        if not risks[sym].check_limits(closed.c):
+            log.warning("[%s] RiskManager disabled; kill switch activated", sym)
+            continue
+
         # ----- SOFT CAPS -----
         action, reason, metrics = guard.soft_cap_decision(sym, side, abs(trade_qty), closed.c)
         if action == "block":

--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -1,22 +1,55 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class Position:
     qty: float = 0.0
 
+
 class RiskManager:
-    def __init__(self, max_pos: float = 1.0):
+    """Gestor de riesgo mínimo.
+
+    Añade límites de pérdida y drawdown y un *kill switch* mediante ``enabled``.
+    ``check_limits`` debe invocarse con el precio de mercado actual antes de
+    enviar cualquier orden.  Si los límites se violan, ``enabled`` se vuelve
+    ``False`` y no se deben continuar enviando órdenes.
+    """
+
+    def __init__(
+        self,
+        max_pos: float = 1.0,
+        stop_loss_pct: float = 0.0,
+        max_drawdown_pct: float = 0.0,
+    ):
         self.max_pos = max_pos
+        self.stop_loss_pct = abs(stop_loss_pct)
+        self.max_drawdown_pct = abs(max_drawdown_pct)
+        self.enabled = True
         self.pos = Position()
+        # Variables internas para cálculo de SL/DD
+        self._entry_price: float | None = None
+        self._peak_price: float | None = None  # máximo a favor (long) / mínimo a favor (short)
+        self._trough_price: float | None = None
+
+    def _reset_price_trackers(self) -> None:
+        self._entry_price = None
+        self._peak_price = None
+        self._trough_price = None
 
     def set_position(self, qty: float) -> None:
         """Sincroniza la posición mantenida por el RiskManager con el qty real."""
         self.pos.qty = float(qty)
+        if abs(self.pos.qty) < 1e-12:
+            self._reset_price_trackers()
 
     def add_fill(self, side: str, qty: float) -> None:
         """Actualiza posición interna tras un fill."""
         signed = float(qty) if side == "buy" else -float(qty)
+        prev = self.pos.qty
         self.pos.qty += signed
+        # Si se cerró o se invirtió la posición, reinicia trackers de precio
+        if prev == 0 or prev * self.pos.qty <= 0:
+            self._reset_price_trackers()
 
     def size(self, signal_side: str, strength: float = 1.0) -> float:
         """
@@ -25,3 +58,54 @@ class RiskManager:
         """
         target = self.max_pos * (1 if signal_side == "buy" else -1 if signal_side == "sell" else 0)
         return target - self.pos.qty
+
+    def check_limits(self, price: float) -> bool:
+        """Verifica stop loss y drawdown.
+
+        Actualiza precios de referencia y retorna ``True`` si aún se pueden
+        operar órdenes.  Si un límite se viola, ``enabled`` pasa a ``False`` y
+        la función devuelve ``False``.
+        """
+
+        if not self.enabled:
+            return False
+
+        qty = self.pos.qty
+        if abs(qty) < 1e-12:
+            # Sin posición -> resetea referencias
+            self._reset_price_trackers()
+            return True
+
+        px = float(price)
+        if self._entry_price is None:
+            # Primer precio tras abrir posición
+            self._entry_price = px
+            self._peak_price = px
+            self._trough_price = px
+            return True
+
+        if qty > 0:  # posición larga
+            if px > (self._peak_price or px):
+                self._peak_price = px
+            if px < (self._trough_price or px):
+                self._trough_price = px
+            loss_pct = (self._entry_price - px) / self._entry_price if self.stop_loss_pct > 0 else 0.0
+            drawdown = (
+                (self._peak_price - px) / self._peak_price if self.max_drawdown_pct > 0 and self._peak_price else 0.0
+            )
+        else:  # posición corta
+            if px < (self._trough_price or px):
+                self._trough_price = px
+            if px > (self._peak_price or px):
+                self._peak_price = px
+            loss_pct = (px - self._entry_price) / self._entry_price if self.stop_loss_pct > 0 else 0.0
+            drawdown = (
+                (px - self._trough_price) / self._trough_price if self.max_drawdown_pct > 0 and self._trough_price else 0.0
+            )
+
+        if self.stop_loss_pct > 0 and loss_pct >= self.stop_loss_pct:
+            self.enabled = False
+        if self.max_drawdown_pct > 0 and drawdown >= self.max_drawdown_pct:
+            self.enabled = False
+
+        return self.enabled

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -4,3 +4,26 @@ def test_risk_manager_position(risk_manager):
     risk_manager.add_fill("buy", 2)
     assert risk_manager.pos.qty == 3
     assert risk_manager.size("buy") == 2
+
+
+def test_stop_loss_triggers_disable():
+    from tradingbot.risk.manager import RiskManager
+
+    rm = RiskManager(max_pos=1, stop_loss_pct=0.05)
+    rm.set_position(1)
+    assert rm.check_limits(100)
+    # caída del 6% -> excede stop_loss_pct
+    assert not rm.check_limits(94)
+    assert rm.enabled is False
+
+
+def test_drawdown_triggers_disable():
+    from tradingbot.risk.manager import RiskManager
+
+    rm = RiskManager(max_pos=1, max_drawdown_pct=0.05)
+    rm.set_position(1)
+    assert rm.check_limits(100)
+    assert rm.check_limits(110)  # peak
+    # retroceso >5% desde el pico
+    assert not rm.check_limits(104)
+    assert rm.enabled is False


### PR DESCRIPTION
## Summary
- extend RiskManager with stop-loss and max drawdown limits plus an `enabled` kill switch
- add `check_limits` calls across live runners to block orders when risk limits trip
- add tests verifying stop loss and drawdown deactivate trading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb33b200832dbbbe8d14351c9306