### PR TITLE
Add execution algos and order options

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -9,7 +9,16 @@ class ExchangeAdapter(ABC):
         """Yield dicts with ts, price, qty, side."""
 
     @abstractmethod
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float, price: float | None = None) -> dict:
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+    ) -> dict:
         """Return provider response (paper/live)."""
 
     @abstractmethod

--- a/src/tradingbot/execution/algos.py
+++ b/src/tradingbot/execution/algos.py
@@ -1,0 +1,121 @@
+"""Execution algorithms that split large orders into smaller slices.
+
+These are simplified implementations intended for testing and examples.
+Each algorithm uses an :class:`ExecutionRouter` to route the generated
+sub-orders to the underlying adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator, Iterable, List
+
+from .order_types import Order
+from .router import ExecutionRouter
+
+
+@dataclass
+class TWAP:
+    """Time Weighted Average Price execution.
+
+    Parameters
+    ----------
+    router: ExecutionRouter
+        Router used to actually send sub-orders.
+    slices: int
+        Number of slices in which to split the parent order.
+    delay: float, optional
+        Delay in seconds between slices. Default ``0``.
+    """
+
+    router: ExecutionRouter
+    slices: int
+    delay: float = 0.0
+
+    async def execute(self, order: Order) -> List[dict]:
+        qty_per = order.qty / self.slices
+        results: List[dict] = []
+        for _ in range(self.slices):
+            child = Order(
+                symbol=order.symbol,
+                side=order.side,
+                type_=order.type_,
+                qty=qty_per,
+                price=order.price,
+                post_only=order.post_only,
+                time_in_force=order.time_in_force,
+            )
+            res = await self.router.execute(child)
+            results.append(res)
+            if self.delay:
+                await asyncio.sleep(self.delay)
+        return results
+
+
+@dataclass
+class VWAP:
+    """Volume Weighted Average Price execution.
+
+    The order is split according to the provided volume profile.
+    """
+
+    router: ExecutionRouter
+    volumes: Iterable[float]
+    delay: float = 0.0
+
+    async def execute(self, order: Order) -> List[dict]:
+        vols = list(self.volumes)
+        total = sum(vols)
+        results: List[dict] = []
+        for v in vols:
+            qty = order.qty * (v / total) if total else 0.0
+            child = Order(
+                symbol=order.symbol,
+                side=order.side,
+                type_=order.type_,
+                qty=qty,
+                price=order.price,
+                post_only=order.post_only,
+                time_in_force=order.time_in_force,
+            )
+            res = await self.router.execute(child)
+            results.append(res)
+            if self.delay:
+                await asyncio.sleep(self.delay)
+        return results
+
+
+@dataclass
+class POV:
+    """Percentage of Volume execution.
+
+    Consumes a percentage of the observed market volume.
+    """
+
+    router: ExecutionRouter
+    participation_rate: float  # 0 < rate <= 1
+
+    async def execute(self, order: Order, trades: AsyncIterator[dict]) -> List[dict]:
+        executed = 0.0
+        results: List[dict] = []
+        async for trade in trades:
+            remaining = order.qty - executed
+            if remaining <= 0:
+                break
+            slice_qty = min(trade.get("qty", 0.0) * self.participation_rate, remaining)
+            if slice_qty <= 0:
+                continue
+            child = Order(
+                symbol=order.symbol,
+                side=order.side,
+                type_=order.type_,
+                qty=slice_qty,
+                price=order.price,
+                post_only=order.post_only,
+                time_in_force=order.time_in_force,
+            )
+            res = await self.router.execute(child)
+            results.append(res)
+            executed += slice_qty
+        return results

--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -7,3 +7,5 @@ class Order:
     type_: str   # market/limit
     qty: float
     price: float | None = None
+    post_only: bool = False
+    time_in_force: str | None = None

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -87,7 +87,16 @@ class PaperAdapter(ExchangeAdapter):
             "ts": (ts.isoformat() if ts else None),
         }
 
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float, price: float | None = None) -> dict:
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+    ) -> dict:
         order_id = self._next_order_id()
         last = self.state.last_px.get(symbol)
         if last is None:

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -15,5 +15,7 @@ class ExecutionRouter:
             side=order.side,
             type_=order.type_,
             qty=order.qty,
-            price=order.price
+            price=order.price,
+            post_only=order.post_only,
+            time_in_force=order.time_in_force
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,16 @@ class DummyAdapter(ExchangeAdapter):
         for trade in self._trades:
             yield trade
 
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float, price: float | None = None):
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+    ):
         return {"status": "placed", "symbol": symbol, "side": side, "qty": qty, "price": price}
 
     async def cancel_order(self, order_id: str):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,9 @@
 import pytest
 
+from tradingbot.execution.order_types import Order
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.algos import TWAP, VWAP, POV
+
 
 @pytest.mark.asyncio
 async def test_paper_adapter_execution(paper_adapter, mock_order):
@@ -11,3 +15,41 @@ async def test_paper_adapter_execution(paper_adapter, mock_order):
 
     cancel = await paper_adapter.cancel_order(res["order_id"])
     assert cancel["status"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_twap_splits_orders(paper_adapter):
+    paper_adapter.update_last_price("BTCUSDT", 100.0)
+    router = ExecutionRouter(paper_adapter)
+    order = Order(symbol="BTCUSDT", side="buy", type_="market", qty=4.0)
+    algo = TWAP(router, slices=4)
+    res = await algo.execute(order)
+    assert len(res) == 4
+    assert paper_adapter.state.pos["BTCUSDT"].qty == pytest.approx(4.0)
+
+
+@pytest.mark.asyncio
+async def test_vwap_distribution(paper_adapter):
+    paper_adapter.update_last_price("BTCUSDT", 100.0)
+    router = ExecutionRouter(paper_adapter)
+    order = Order(symbol="BTCUSDT", side="buy", type_="market", qty=6.0)
+    algo = VWAP(router, volumes=[1, 2, 3])
+    res = await algo.execute(order)
+    assert len(res) == 3
+    assert paper_adapter.state.pos["BTCUSDT"].qty == pytest.approx(6.0)
+
+
+@pytest.mark.asyncio
+async def test_pov_participates(paper_adapter):
+    paper_adapter.update_last_price("BTCUSDT", 100.0)
+    router = ExecutionRouter(paper_adapter)
+    order = Order(symbol="BTCUSDT", side="buy", type_="market", qty=5.0)
+
+    async def trades():
+        for q in [4.0, 4.0, 4.0]:
+            yield {"ts": 0, "price": 100.0, "qty": q, "side": "buy"}
+
+    algo = POV(router, participation_rate=0.5)
+    res = await algo.execute(order, trades())
+    assert paper_adapter.state.pos["BTCUSDT"].qty == pytest.approx(5.0)
+    assert len(res) >= 2


### PR DESCRIPTION
## Summary
- add TWAP, VWAP and POV execution algorithms
- support post-only and time-in-force on orders and Binance adapters
- demo execution algos via new CLI command and test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb30f354832d90a523e4106fb8b5