### PR TITLE
Add QuestDB backend with storage tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,5 +56,19 @@ services:
     depends_on:
       - prometheus
 
+  questdb:
+    image: questdb/questdb:latest
+    ports:
+      - "9000:9000"   # REST API
+      - "8812:8812"   # PostgreSQL wire protocol
+    volumes:
+      - questdb-data:/root/.questdb
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/health" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   tsdb-data:
+  questdb-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,8 @@ asyncpg>=0.29
 # Monitoring
 prometheus-client>=0.20
 
+# Testing
+pytest-asyncio>=0.23
+
 # Backtesting helpers
 vectorbtpro==0.0.0; python_version == "0"  # placeholder si se usa luego

--- a/src/tradingbot/config.py
+++ b/src/tradingbot/config.py
@@ -12,6 +12,16 @@ class Settings(BaseSettings):
     pg_password: str = "postgres"
     pg_db: str = "trading"
 
+    # Storage backend: "timescale" or "questdb"
+    db_backend: str = Field(default="timescale")
+
+    # QuestDB connection parameters (PostgreSQL wire protocol)
+    questdb_host: str = "localhost"
+    questdb_port: int = 8812
+    questdb_user: str = "admin"
+    questdb_password: str = "quest"
+    questdb_db: str = "qdb"
+
     # Exchanges Spot (por si los usas luego)
     binance_api_key: str | None = None
     binance_api_secret: str | None = None

--- a/src/tradingbot/storage/__init__.py
+++ b/src/tradingbot/storage/__init__.py
@@ -1,1 +1,17 @@
+"""Simple wrapper to select the storage backend at runtime.
+
+The application can persist market data either in TimescaleDB or QuestDB.  The
+choice is controlled by ``settings.db_backend``.  This module exposes a uniform
+API so callers can simply import ``tradingbot.storage`` and obtain the
+appropriate helpers.
+"""
+
+from ..config import settings
+
+if settings.db_backend.lower() == "questdb":
+    from .quest import get_engine, insert_trade, insert_orderbook  # noqa: F401
+else:  # default to timescale
+    from .timescale import get_engine, insert_trade, insert_orderbook  # noqa: F401
+
+__all__ = ["get_engine", "insert_trade", "insert_orderbook"]
 

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -1,1 +1,121 @@
-# QuestDB integration placeholder
+"""Storage helpers for QuestDB.
+
+This module mirrors a small subset of the TimescaleDB storage helpers so that
+the rest of the application can switch between backends with minimal changes.
+QuestDB speaks the PostgreSQL wire protocol, therefore we reuse SQLAlchemy with
+the ``psycopg2`` driver to perform inserts.
+
+The implementation here intentionally keeps the SQL very small and avoids
+QuestDB specific extensions so that the functions are also easy to unit test
+using an in-memory SQLite database.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+
+from sqlalchemy import create_engine, text
+
+from ..config import settings
+
+log = logging.getLogger(__name__)
+
+
+def qs_url() -> str:
+    """Build the SQLAlchemy URL for QuestDB.
+
+    QuestDB exposes the PostgreSQL wire protocol on port 8812.  Credentials are
+    optional in a default installation but are included here for completeness
+    and to mirror the structure used for TimescaleDB.
+    """
+
+    return (
+        f"postgresql+psycopg2://{settings.questdb_user}:{settings.questdb_password}"
+        f"@{settings.questdb_host}:{settings.questdb_port}/{settings.questdb_db}"
+    )
+
+
+def get_engine():
+    """Return a SQLAlchemy engine connected to QuestDB."""
+
+    return create_engine(qs_url(), pool_pre_ping=True)
+
+
+def insert_trade(engine, t):
+    """Insert a trade tick into QuestDB.
+
+    Parameters
+    ----------
+    engine: SQLAlchemy engine obtained via :func:`get_engine` or any compatible
+        engine (e.g. an in-memory SQLite engine for tests).
+    t: object
+        Trade-like object with ``exchange``, ``symbol``, ``price`` (``px``),
+        ``qty`` and ``side`` attributes.  A timestamp field is optional; if not
+        provided the current UTC time is used.
+    """
+
+    ts = getattr(t, "ts", None) or datetime.utcnow()
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO trades (ts, exchange, symbol, px, qty, side, trade_id)
+                VALUES (:ts, :exchange, :symbol, :px, :qty, :side, :trade_id)
+                """
+            ),
+            dict(
+                ts=ts,
+                exchange=t.exchange,
+                symbol=t.symbol,
+                px=t.price,
+                qty=t.qty,
+                side=t.side,
+                trade_id=getattr(t, "trade_id", None),
+            ),
+        )
+
+
+def insert_orderbook(
+    engine,
+    *,
+    ts,
+    exchange: str,
+    symbol: str,
+    bid_px: list[float],
+    bid_qty: list[float],
+    ask_px: list[float],
+    ask_qty: list[float],
+):
+    """Persist an orderbook snapshot into QuestDB.
+
+    Lists are serialized to JSON before insertion so that the function works
+    across different database engines (QuestDB stores them as ``STRING`` when
+    inserted via the PostgreSQL interface).
+    """
+
+    payload = dict(
+        ts=ts,
+        exchange=exchange,
+        symbol=symbol,
+        bid_px=json.dumps(bid_px),
+        bid_qty=json.dumps(bid_qty),
+        ask_px=json.dumps(ask_px),
+        ask_qty=json.dumps(ask_qty),
+    )
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO orderbook (ts, exchange, symbol, bid_px, bid_qty, ask_px, ask_qty)
+                VALUES (:ts, :exchange, :symbol, :bid_px, :bid_qty, :ask_px, :ask_qty)
+                """
+            ),
+            payload,
+        )
+
+
+__all__ = ["get_engine", "insert_trade", "insert_orderbook"]
+

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import importlib
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine, text
+
+from tradingbot.config import settings
+
+
+def _setup_engine():
+    """Create an in-memory SQLite engine with minimal tables."""
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE trades (
+                    ts TEXT,
+                    exchange TEXT,
+                    symbol TEXT,
+                    px REAL,
+                    qty REAL,
+                    side TEXT,
+                    trade_id TEXT
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE orderbook (
+                    ts TEXT,
+                    exchange TEXT,
+                    symbol TEXT,
+                    bid_px TEXT,
+                    bid_qty TEXT,
+                    ask_px TEXT,
+                    ask_qty TEXT
+                )
+                """
+            )
+        )
+    return engine
+
+
+def _reload_storage_backend(backend: str):
+    settings.db_backend = backend
+    import tradingbot.storage as storage
+
+    return importlib.reload(storage)
+
+
+def test_insert_and_read_trade():
+    storage = _reload_storage_backend("questdb")
+    engine = _setup_engine()
+
+    t = SimpleNamespace(exchange="binance", symbol="BTCUSDT", price=100.0, qty=1.0, side="buy")
+    storage.insert_trade(engine, t)
+
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT exchange, symbol, px, qty, side FROM trades")
+        ).fetchone()
+
+    assert row == ("binance", "BTCUSDT", 100.0, 1.0, "buy")
+
+
+def test_insert_and_read_orderbook():
+    storage = _reload_storage_backend("questdb")
+    engine = _setup_engine()
+
+    storage.insert_orderbook(
+        engine,
+        ts="2024-01-01T00:00:00",
+        exchange="binance",
+        symbol="BTCUSDT",
+        bid_px=[100.0, 99.5],
+        bid_qty=[1.0, 0.5],
+        ask_px=[100.5, 101.0],
+        ask_qty=[0.8, 1.2],
+    )
+
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT bid_px, bid_qty, ask_px, ask_qty FROM orderbook")
+        ).fetchone()
+
+    assert json.loads(row[0]) == [100.0, 99.5]
+    assert json.loads(row[1]) == [1.0, 0.5]
+    assert json.loads(row[2]) == [100.5, 101.0]
+    assert json.loads(row[3]) == [0.8, 1.2]
+


### PR DESCRIPTION
## Summary
- support QuestDB storage with engine and insert helpers
- add runtime flag to choose TimescaleDB or QuestDB
- include QuestDB service in docker-compose
- test QuestDB storage writes and reads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb2a3470832db5b4ebd8938f3964