### PR TITLE
Add trade metrics and Sentry reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,4 @@ PG_DB=trading
 # Runtime
 ENV=dev
 LOG_LEVEL=INFO
+SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ insert_orderbook(
     bid_px=[...], bid_qty=[...], ask_px=[...], ask_qty=[...],
 )
 ```
+
+## Monitoreo y alertas
+
+Este proyecto expone métricas Prometheus para latencia de APIs, errores de websockets, fills de órdenes, slippage y eventos de riesgo. Los dashboards de ejemplo para Grafana se encuentran en `monitoring/grafana`.
+
+Para reportar excepciones a Sentry, define `SENTRY_DSN` en tu archivo `.env`. La configuración de logging inicializará Sentry automáticamente cuando este valor esté presente.

--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -27,9 +27,45 @@
       ],
       "datasource": "Prometheus",
       "id": 2
+    },
+    {
+      "type": "graph",
+      "title": "Order fills",
+      "targets": [
+        {
+          "expr": "increase(order_fills_total[5m])",
+          "legendFormat": "{{symbol}} {{side}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 3
+    },
+    {
+      "type": "graph",
+      "title": "Slippage (bps 95th)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(order_slippage_bps_bucket[5m])) by (le))",
+          "legendFormat": "95th percentile"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 4
+    },
+    {
+      "type": "graph",
+      "title": "Risk events",
+      "targets": [
+        {
+          "expr": "increase(risk_events_total[5m])",
+          "legendFormat": "{{event_type}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 5
     }
   ],
   "schemaVersion": 16,
   "title": "TradeBot Metrics",
-  "version": 1
+  "version": 2
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ asyncpg>=0.29
 
 # Monitoring
 prometheus-client>=0.20
+sentry-sdk>=1.40
 
 # Backtesting helpers
 vectorbtpro==0.0.0; python_version == "0"  # placeholder si se usa luego

--- a/src/tradingbot/config.py
+++ b/src/tradingbot/config.py
@@ -4,6 +4,7 @@ from pydantic import Field
 class Settings(BaseSettings):
     env: str = Field(default="dev")
     log_level: str = Field(default="INFO")
+    sentry_dsn: str | None = None
 
     # DB
     pg_host: str = "localhost"

--- a/src/tradingbot/logging_conf.py
+++ b/src/tradingbot/logging_conf.py
@@ -1,6 +1,11 @@
 import logging, sys
 from .config import settings
 
+try:
+    import sentry_sdk
+except Exception:  # pragma: no cover - sentry optional
+    sentry_sdk = None
+
 def setup_logging():
     level = getattr(logging, settings.log_level.upper(), logging.INFO)
     logging.basicConfig(
@@ -8,3 +13,6 @@ def setup_logging():
         format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )
+
+    if settings.sentry_dsn and sentry_sdk is not None:
+        sentry_sdk.init(dsn=settings.sentry_dsn, environment=settings.env)

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -20,3 +20,24 @@ WS_FAILURES = Counter(
     "Total websocket connection failures",
     ["adapter"],
 )
+
+# Order fills by symbol and side
+FILL_COUNT = Counter(
+    "order_fills",
+    "Total order fills",
+    ["symbol", "side"],
+)
+
+# Slippage observed in order execution (basis points)
+SLIPPAGE = Histogram(
+    "order_slippage_bps",
+    "Distribution of order execution slippage in basis points",
+    ["symbol", "side"],
+)
+
+# Risk management events triggered
+RISK_EVENTS = Counter(
+    "risk_events",
+    "Total risk management events",
+    ["event_type"],
+)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,20 @@
+from tradingbot.utils.metrics import FILL_COUNT, SLIPPAGE, RISK_EVENTS
+
+
+def test_fill_slippage_risk_metrics():
+    FILL_COUNT.labels(symbol="BTCUSDT", side="buy").inc()
+    samples = list(FILL_COUNT.collect())[0].samples
+    fill_sample = [s for s in samples if s.name == "order_fills_total" and s.labels["symbol"] == "BTCUSDT" and s.labels["side"] == "buy"][0]
+    assert fill_sample.value == 1.0
+
+    SLIPPAGE.labels(symbol="BTCUSDT", side="buy").observe(0.5)
+    samples = list(SLIPPAGE.collect())[0].samples
+    count_sample = [s for s in samples if s.name == "order_slippage_bps_count" and s.labels["symbol"] == "BTCUSDT" and s.labels["side"] == "buy"][0]
+    sum_sample = [s for s in samples if s.name == "order_slippage_bps_sum" and s.labels["symbol"] == "BTCUSDT" and s.labels["side"] == "buy"][0]
+    assert count_sample.value == 1.0
+    assert sum_sample.value == 0.5
+
+    RISK_EVENTS.labels(event_type="limit_breach").inc()
+    samples = list(RISK_EVENTS.collect())[0].samples
+    risk_sample = [s for s in samples if s.name == "risk_events_total" and s.labels["event_type"] == "limit_breach"][0]
+    assert risk_sample.value == 1.0


### PR DESCRIPTION
## Summary
- track fills, slippage and risk events with Prometheus metrics
- initialize Sentry if `SENTRY_DSN` is configured
- expand Grafana dashboard and document monitoring setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcb282e20832d9b9a00a9b1e60f80