### PR TITLE
Add order flow imbalance strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ cp .env.example .env
 # 4) Probar backtest de ejemplo (simulado, CSV)
 python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
 
+# Ejemplo usando la estrategia de flujo de órdenes
+python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv --strategy order_flow
+# Los parámetros ``window``, ``upper`` y ``lower`` pueden ajustarse programáticamente.
+
 # 5) Iniciar API de control/monitoreo
 uvicorn tradingbot.apps.api.main:app --reload --port 8080
 ```

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -19,8 +19,15 @@ from ..live.runner_futures_testnet_multi import run_live_binance_futures_testnet
 app = typer.Typer(add_completion=False)
 
 @app.command()
-def backtest(data: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"):
-    """Backtest vectorizado simple desde CSV (columnas: timestamp, open, high, low, close, volume)"""
+def backtest(
+    data: str,
+    symbol: str = "BTC/USDT",
+    strategy: str = typer.Option(
+        "breakout_atr",
+        help="Estrategia a usar: breakout_atr, momentum, mean_reversion u order_flow",
+    ),
+):
+    """Backtest vectorizado simple desde CSV (columnas: timestamp, open, high, low, close, volume)."""
     setup_logging()
     res = run_backtest_csv(data, symbol=symbol, strategy=strategy)
     typer.echo(res)
@@ -29,7 +36,10 @@ def backtest(data: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"
 def run_csv_paper(
     data: str,
     symbol: str = "BTC/USDT",
-    strategy: str = "breakout_atr",
+    strategy: str = typer.Option(
+        "breakout_atr",
+        help="Estrategia a usar: breakout_atr, momentum, mean_reversion u order_flow",
+    ),
     sleep_ms: int = 50,
     max_bars: int = 0,
 ):

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -1,12 +1,14 @@
 from .breakout_atr import BreakoutATR
 from .momentum import Momentum
 from .mean_reversion import MeanReversion
+from .order_flow import OrderFlow
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
     BreakoutATR.name: BreakoutATR,
     Momentum.name: Momentum,
     MeanReversion.name: MeanReversion,
+    OrderFlow.name: OrderFlow,
 }
 
-__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "STRATEGIES"]
+__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "OrderFlow", "STRATEGIES"]

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from .base import Strategy, Signal
+from ..data.features import order_flow_imbalance
+
+
+class OrderFlow(Strategy):
+    """Estrategia basada en el flujo de órdenes (Order Flow Imbalance).
+
+    Agrega el OFI en una ventana configurable y genera señales cuando la
+    suma supera umbrales superiores o inferiores.
+    """
+
+    name = "order_flow"
+
+    def __init__(self, window: int = 5, upper: float = 0.0, lower: float = 0.0):
+        self.window = window
+        self.upper = upper
+        self.lower = lower
+
+    def on_bar(self, bar: dict) -> Signal | None:
+        """Procesa una nueva barra y devuelve una señal basada en OFI."""
+        df: pd.DataFrame = bar["window"]
+        if not {"bid_qty", "ask_qty"}.issubset(df.columns):
+            return None
+        if len(df) <= self.window:
+            return None
+
+        ofi = order_flow_imbalance(df[["bid_qty", "ask_qty"]])
+        agg = ofi.rolling(self.window).sum().iloc[-1]
+
+        if agg > self.upper:
+            return Signal("buy", 1.0)
+        if agg < self.lower:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,4 +1,7 @@
+import pandas as pd
+
 from tradingbot.strategies.breakout_atr import BreakoutATR
+from tradingbot.strategies.order_flow import OrderFlow
 
 
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
@@ -9,3 +12,28 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
 
     sig_sell = strat.on_bar({"window": breakout_df_sell})
     assert sig_sell.side == "sell"
+
+
+def test_order_flow_signals():
+    df_buy = pd.DataFrame({
+        "bid_qty": [10, 11, 12, 13],
+        "ask_qty": [10, 10, 10, 10],
+    })
+    df_sell = pd.DataFrame({
+        "bid_qty": [10, 10, 10, 10],
+        "ask_qty": [10, 11, 12, 13],
+    })
+    df_flat = pd.DataFrame({
+        "bid_qty": [10, 10, 10, 10],
+        "ask_qty": [10, 10, 10, 10],
+    })
+    strat = OrderFlow(window=2, upper=1, lower=-1)
+
+    sig_buy = strat.on_bar({"window": df_buy})
+    assert sig_buy.side == "buy"
+
+    sig_sell = strat.on_bar({"window": df_sell})
+    assert sig_sell.side == "sell"
+
+    sig_flat = strat.on_bar({"window": df_flat})
+    assert sig_flat.side == "flat"


### PR DESCRIPTION
## Summary
- implement order flow strategy computing order flow imbalance with configurable window and thresholds
- register strategy and document usage via CLI and README
- add tests covering buy, sell, and flat signals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcb268ccc832dacd9f516369ff730