### PR TITLE
Add order flow imbalance strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,30 @@ cp .env.example .env
 # 4) Probar backtest de ejemplo (simulado, CSV)
 python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
 
+# 4b) Estrategia Order Flow (CSV con `bid_qty` y `ask_qty`)
+python -m tradingbot.cli backtest --data /path/to/orderbook.csv --strategy order_flow
+
 # 5) Iniciar API de control/monitoreo
 uvicorn tradingbot.apps.api.main:app --reload --port 8080
 ```
 
 > **Nota**: este repo es un esqueleto funcional. Los adaptadores WS/REST y ejecución están stubs listos para ser implementados paso a paso.
+
+## Estrategias
+
+### Order Flow
+
+Estrategia basada en el indicador *Order Flow Imbalance* (OFI). Calcula el
+promedio del OFI en una ventana configurable y genera señales de compra o venta
+cuando supera los umbrales definidos (`buy_threshold`, `sell_threshold`).
+
+Ejemplo de uso con el CLI:
+
+```bash
+python -m tradingbot.cli backtest --data /path/to/orderbook.csv --strategy order_flow
+```
+
+El CSV debe contener las columnas `bid_qty` y `ask_qty`.
 
 ## Esquema de datos y carga
 

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -22,7 +22,14 @@ from ..live.runner_futures_testnet_multi import run_live_binance_futures_testnet
 app = typer.Typer(add_completion=False)
 
 @app.command()
-def backtest(data: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"):
+def backtest(
+    data: str,
+    symbol: str = "BTC/USDT",
+    strategy: str = typer.Option(
+        "breakout_atr",
+        help="Estrategia a usar, e.g. breakout_atr, momentum, order_flow",
+    ),
+):
     """Backtest vectorizado simple desde CSV (columnas: timestamp, open, high, low, close, volume)"""
     setup_logging()
     res = run_backtest_csv(data, symbol=symbol, strategy=strategy)
@@ -32,7 +39,10 @@ def backtest(data: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"
 def run_csv_paper(
     data: str,
     symbol: str = "BTC/USDT",
-    strategy: str = "breakout_atr",
+    strategy: str = typer.Option(
+        "breakout_atr",
+        help="Estrategia, e.g. breakout_atr, order_flow",
+    ),
     sleep_ms: int = 50,
     max_bars: int = 0,
 ):

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -2,6 +2,7 @@ from .breakout_atr import BreakoutATR
 from .momentum import Momentum
 from .mean_reversion import MeanReversion
 from .cash_and_carry import CashAndCarry
+from .order_flow import OrderFlow
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
@@ -9,6 +10,7 @@ STRATEGIES = {
     Momentum.name: Momentum,
     MeanReversion.name: MeanReversion,
     CashAndCarry.name: CashAndCarry,
+    OrderFlow.name: OrderFlow,
 }
 
-__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "CashAndCarry", "STRATEGIES"]
+__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "CashAndCarry", "OrderFlow", "STRATEGIES"]

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from .base import Strategy, Signal
+from ..data.features import order_flow_imbalance
+
+
+class OrderFlow(Strategy):
+    """Order Flow Imbalance strategy.
+
+    Calculates the mean Order Flow Imbalance (OFI) over a rolling window and
+    issues buy/sell signals when the mean exceeds the configured thresholds.
+    """
+
+    name = "order_flow"
+
+    def __init__(self, window: int = 3, buy_threshold: float = 1.0, sell_threshold: float = 1.0):
+        self.window = window
+        self.buy_threshold = buy_threshold
+        self.sell_threshold = sell_threshold
+
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        needed = {"bid_qty", "ask_qty"}
+        if not needed.issubset(df.columns) or len(df) < self.window:
+            return None
+        ofi_series = order_flow_imbalance(df[list(needed)])
+        ofi_mean = ofi_series.iloc[-self.window:].mean()
+        if ofi_mean > self.buy_threshold:
+            return Signal("buy", 1.0)
+        if ofi_mean < -self.sell_threshold:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,4 +1,6 @@
+import pandas as pd
 from tradingbot.strategies.breakout_atr import BreakoutATR
+from tradingbot.strategies.order_flow import OrderFlow
 
 
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
@@ -8,4 +10,20 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     assert sig_buy.side == "buy"
 
     sig_sell = strat.on_bar({"window": breakout_df_sell})
+    assert sig_sell.side == "sell"
+
+
+def test_order_flow_signals():
+    df_buy = pd.DataFrame({
+        "bid_qty": [1, 2, 3, 5],
+        "ask_qty": [5, 4, 3, 2],
+    })
+    df_sell = pd.DataFrame({
+        "bid_qty": [5, 4, 3, 2],
+        "ask_qty": [1, 2, 3, 5],
+    })
+    strat = OrderFlow(window=3, buy_threshold=1.0, sell_threshold=1.0)
+    sig_buy = strat.on_bar({"window": df_buy})
+    assert sig_buy.side == "buy"
+    sig_sell = strat.on_bar({"window": df_sell})
     assert sig_sell.side == "sell"


### PR DESCRIPTION
## Summary
- implement order flow imbalance strategy with configurable window and thresholds
- expose the new strategy through CLI and strategy registry
- document order flow usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fd3a4dad8832d8e2a8a23be702942