### PR TITLE
Add Hydra YAML configs and MLflow logging for backtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,52 @@ python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
 uvicorn tradingbot.apps.api.main:app --reload --port 8080
 ```
 
+## Configuración desde YAML con Hydra
+
+Puedes definir configuraciones complejas en un archivo YAML y ejecutarlas con Hydra.
+
+```yaml
+# data/examples/backtest.yaml
+csv_paths:
+  BTC/USDT: data/examples/btcusdt_1m.csv
+strategies:
+  - [breakout_atr, BTC/USDT]
+latency: 1
+window: 120
+mlflow:
+  run_name: example_backtest
+```
+
+Ejecuta el backtest:
+
+```bash
+python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
+```
+
+## Registro de resultados con MLflow
+
+Si la configuración YAML incluye la sección `mlflow`, los resultados del backtest
+se registrarán automáticamente en un experimento de MLflow (equity final y número de fills).
+
+## Optimización de hiperparámetros con Optuna
+
+```python
+from tradingbot.backtest.event_engine import optimize_strategy_optuna
+
+study = optimize_strategy_optuna(
+    csv_path="data/examples/btcusdt_1m.csv",
+    symbol="BTC/USDT",
+    strategy_name="breakout_atr",
+    param_space={
+        "ema_n": {"type": "int", "low": 10, "high": 40},
+        "atr_n": {"type": "int", "low": 5, "high": 30},
+        "mult": {"type": "float", "low": 1.0, "high": 3.0},
+    },
+    n_trials=20,
+)
+print("Mejores parámetros:", study.best_params)
+```
+
 > **Nota**: este repo es un esqueleto funcional. Los adaptadores WS/REST y ejecución están stubs listos para ser implementados paso a paso.
 
 ## Esquema de datos y carga

--- a/data/examples/backtest.yaml
+++ b/data/examples/backtest.yaml
@@ -1,0 +1,8 @@
+csv_paths:
+  BTC/USDT: data/examples/btcusdt_1m.csv
+strategies:
+  - [breakout_atr, BTC/USDT]
+latency: 1
+window: 120
+mlflow:
+  run_name: example_backtest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ pydantic>=2.7
 pydantic-settings>=2.2
 typer>=0.12
 uvloop>=0.19; platform_system != "Windows"
+hydra-core>=1.3
+
+# Experiment tracking
+mlflow>=2.12
+optuna>=3.5
 
 # Data/Exchanges
 ccxt>=4.3.90

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -3,7 +3,7 @@ import typer, logging, time
 import pandas as pd
 
 from ..logging_conf import setup_logging
-from ..backtest.event_engine import run_backtest_csv
+from ..backtest.event_engine import run_backtest_csv, run_backtest_mlflow
 from ..strategies import STRATEGIES
 from ..risk.manager import RiskManager
 from ..execution.paper import PaperAdapter
@@ -25,7 +25,45 @@ app = typer.Typer(add_completion=False)
 def backtest(data: str, symbol: str = "BTC/USDT", strategy: str = "breakout_atr"):
     """Backtest vectorizado simple desde CSV (columnas: timestamp, open, high, low, close, volume)"""
     setup_logging()
-    res = run_backtest_csv(data, symbol=symbol, strategy=strategy)
+    res = run_backtest_csv({symbol: data}, [(strategy, symbol)])
+    typer.echo(res)
+
+
+@app.command()
+def backtest_cfg(cfg_path: str):
+    """Backtest usando configuración YAML con Hydra."""
+    setup_logging()
+    from pathlib import Path
+    from hydra import compose, initialize
+
+    cfg_file = Path(cfg_path)
+    with initialize(version_base=None, config_path=str(cfg_file.parent)):
+        cfg = compose(config_name=cfg_file.stem)
+
+    csv_paths = {
+        sym: str((cfg_file.parent / Path(path)).resolve())
+        for sym, path in cfg.csv_paths.items()
+    }
+    strategies = [tuple(item) for item in cfg.strategies]
+    latency = int(cfg.get("latency", 1))
+    window = int(cfg.get("window", 120))
+
+    if getattr(cfg, "mlflow", None):
+        run_name = cfg.mlflow.get("run_name", "backtest")
+        res = run_backtest_mlflow(
+            csv_paths,
+            strategies,
+            latency=latency,
+            window=window,
+            run_name=run_name,
+        )
+    else:
+        res = run_backtest_csv(
+            csv_paths,
+            strategies,
+            latency=latency,
+            window=window,
+        )
     typer.echo(res)
 
 @app.command()


### PR DESCRIPTION
## Summary
- allow running backtests from Hydra YAML configs via new `backtest-cfg` CLI command
- log backtest metrics to MLflow and expose Optuna hyperparameter optimization helper
- document workflow and add example YAML config

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689fd3d1c410832daaa5a0725acfba4f