### PR TITLE
feat: extend adapters api

### DIFF
--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -27,7 +27,7 @@ class BinanceWSAdapter(ExchangeAdapter):
         self.ws_base = ws_base or "wss://stream.binance.com:9443/stream?streams="
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
-        stream = _binance_symbol_stream(symbol)
+        stream = _binance_symbol_stream(self.normalize_symbol(symbol))
         url = self.ws_base + stream
         backoff = 1.0
         while True:
@@ -44,12 +44,45 @@ class BinanceWSAdapter(ExchangeAdapter):
                         ts_ms = d.get("T")
                         side = "sell" if d.get("m") else "buy"  # buyer is maker -> aggressive sell
                         ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        yield {"ts": ts, "price": price, "qty": qty, "side": side}
+                        yield self.normalize_trade(symbol, ts, price, qty, side)
             except Exception as e:
                 WS_FAILURES.labels(adapter=self.name).inc()
                 log.warning("WS desconectado (%s). Reintentando en %.1fs ...", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        stream = _binance_symbol_stream(self.normalize_symbol(symbol)).replace("@trade", f"@depth{depth}@100ms")
+        url = self.ws_base + stream
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
+                    log.info("Conectado WS Binance orderbook: %s", url)
+                    backoff = 1.0
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        d = msg.get("data") or msg
+                        bids = d.get("bids") or d.get("b") or []
+                        asks = d.get("asks") or d.get("a") or []
+                        bids_n = [[float(b[0]), float(b[1])] for b in bids]
+                        asks_n = [[float(a[0]), float(a[1])] for a in asks]
+                        ts_ms = d.get("E") or d.get("T")
+                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+                        yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
+            except Exception as e:
+                WS_FAILURES.labels(adapter=self.name).inc()
+                log.warning("WS orderbook desconectado (%s). Reintento en %.1fs ...", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+
+    stream_orderbook = stream_order_book
+
+    async def fetch_funding(self, symbol: str):
+        raise NotImplementedError("WS adapter no soporta fetch_funding")
+
+    async def fetch_oi(self, symbol: str):
+        raise NotImplementedError("WS adapter no soporta fetch_oi")
 
     async def place_order(self, *args, **kwargs) -> dict:
         raise NotImplementedError("BinanceWSAdapter no gestiona órdenes")

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -162,3 +162,20 @@ class BinanceSpotAdapter(ExchangeAdapter):
                     "fill_price": None,
                     "raw": {"error": "reconcile_failed"},
                 }
+
+    async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
+        raise NotImplementedError("Usa BinanceSpotWSAdapter para order book")
+
+    async def fetch_funding(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchFundingRate", None)
+        if method is None:
+            raise NotImplementedError("Funding no soportado en spot")
+        return await self._request(method, sym)
+
+    async def fetch_oi(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchOpenInterest", None)
+        if method:
+            return await self._request(method, sym)
+        raise NotImplementedError("Open interest no soportado")

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -34,7 +34,8 @@ class BybitFuturesAdapter(ExchangeAdapter):
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/linear"
-        sub = {"op": "subscribe", "args": [f"publicTrade.{symbol}"]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
         backoff = 1.0
         while True:
             try:
@@ -48,15 +49,16 @@ class BybitFuturesAdapter(ExchangeAdapter):
                             qty = float(t.get("v", 0))
                             side = t.get("S", "").lower()
                             ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
-                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+                            yield self.normalize_trade(symbol, ts, price, qty, side)
             except Exception as e:  # pragma: no cover - network paths
                 log.warning("Bybit futures trade WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
 
-    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+    async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/linear"
-        sub = {"op": "subscribe", "args": [f"orderbook.1.{symbol}"]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
         backoff = 1.0
         while True:
             try:
@@ -71,11 +73,32 @@ class BybitFuturesAdapter(ExchangeAdapter):
                         bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
                         asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
                         ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
-                        yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+                        yield self.normalize_order_book(symbol, ts, bids, asks)
             except Exception as e:  # pragma: no cover - network paths
                 log.warning("Bybit futures book WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    # Backwards compatible alias
+    stream_orderbook = stream_order_book
+
+    async def fetch_funding(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchFundingRate", None)
+        if method is None:  # pragma: no cover - depends on ccxt support
+            raise NotImplementedError("Funding not supported")
+        return await self._request(method, sym)
+
+    async def fetch_oi(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchOpenInterest", None)
+        if method:
+            return await self._request(method, sym)
+        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
+        if hist:
+            data = await self._request(hist, sym)
+            return data[-1] if isinstance(data, list) and data else data
+        raise NotImplementedError("Open interest not supported")
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -35,7 +35,8 @@ class BybitSpotAdapter(ExchangeAdapter):
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/spot"
-        sub = {"op": "subscribe", "args": [f"publicTrade.{symbol}"]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
         backoff = 1.0
         while True:
             try:
@@ -49,15 +50,16 @@ class BybitSpotAdapter(ExchangeAdapter):
                             qty = float(t.get("v", 0))
                             side = t.get("S", "").lower()
                             ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
-                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+                            yield self.normalize_trade(symbol, ts, price, qty, side)
             except Exception as e:  # pragma: no cover - network paths
                 log.warning("Bybit spot trade WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
 
-    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+    async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/spot"
-        sub = {"op": "subscribe", "args": [f"orderbook.1.{symbol}"]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
         backoff = 1.0
         while True:
             try:
@@ -72,11 +74,31 @@ class BybitSpotAdapter(ExchangeAdapter):
                         bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
                         asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
                         ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
-                        yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+                        yield self.normalize_order_book(symbol, ts, bids, asks)
             except Exception as e:  # pragma: no cover - network paths
                 log.warning("Bybit spot book WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    stream_orderbook = stream_order_book
+
+    async def fetch_funding(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchFundingRate", None)
+        if method is None:
+            raise NotImplementedError("Funding not supported")
+        return await self._request(method, sym)
+
+    async def fetch_oi(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchOpenInterest", None)
+        if method:
+            return await self._request(method, sym)
+        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
+        if hist:
+            data = await self._request(hist, sym)
+            return data[-1] if isinstance(data, list) and data else data
+        raise NotImplementedError("Open interest not supported")
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -34,7 +34,8 @@ class OKXSpotAdapter(ExchangeAdapter):
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://ws.okx.com:8443/ws/v5/public"
-        sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": symbol}]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
         backoff = 1.0
         while True:
             try:
@@ -48,15 +49,16 @@ class OKXSpotAdapter(ExchangeAdapter):
                             qty = float(t.get("sz", 0))
                             side = t.get("side", "")
                             ts = datetime.fromtimestamp(int(t.get("ts", 0)) / 1000, tz=timezone.utc)
-                            yield {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
+                            yield self.normalize_trade(symbol, ts, price, qty, side)
             except Exception as e:  # pragma: no cover
                 log.warning("OKX spot trade WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
 
-    async def stream_orderbook(self, symbol: str) -> AsyncIterator[dict]:
+    async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://ws.okx.com:8443/ws/v5/public"
-        sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": symbol}]}
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
         backoff = 1.0
         while True:
             try:
@@ -69,11 +71,31 @@ class OKXSpotAdapter(ExchangeAdapter):
                             bids = [[float(p), float(q)] for p, q, *_ in d.get("bids", [])]
                             asks = [[float(p), float(q)] for p, q, *_ in d.get("asks", [])]
                             ts = datetime.fromtimestamp(int(d.get("ts", 0)) / 1000, tz=timezone.utc)
-                            yield {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+                            yield self.normalize_order_book(symbol, ts, bids, asks)
             except Exception as e:  # pragma: no cover
                 log.warning("OKX spot book WS error %s, retrying in %.1fs", e, backoff)
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
+
+    stream_orderbook = stream_order_book
+
+    async def fetch_funding(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchFundingRate", None)
+        if method is None:
+            raise NotImplementedError("Funding not supported")
+        return await self._request(method, sym)
+
+    async def fetch_oi(self, symbol: str):
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "fetchOpenInterest", None)
+        if method:
+            return await self._request(method, sym)
+        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
+        if hist:
+            data = await self._request(hist, sym)
+            return data[-1] if isinstance(data, list) and data else data
+        raise NotImplementedError("Open interest not supported")
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:


### PR DESCRIPTION
## Summary
- add rate limiting and normalization helpers to `ExchangeAdapter`
- implement order book/funding/open-interest endpoints across adapters with exponential reconnection
- provide default unimplemented methods so simple adapters can instantiate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fdaad4a64832d9a0ce6e0df162b81