### PR TITLE
Add ingestion processes and historical download

### DIFF
--- a/bin/download_history.py
+++ b/bin/download_history.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple historical data downloader.
+
+The script fetches 1-minute OHLCV bars using ``ccxt`` and persists them into
+TimescaleDB or QuestDB depending on the selected backend.
+"""
+
+import asyncio
+from datetime import datetime
+from typing import Literal
+
+import ccxt.async_support as ccxt
+import typer
+
+from tradingbot.storage import timescale as ts_storage
+from tradingbot.storage import quest as qs_storage
+
+Backend = Literal["timescale", "quest"]
+
+app = typer.Typer()
+
+
+def _get_storage(backend: Backend):
+    return ts_storage if backend == "timescale" else qs_storage
+
+
+async def _download_bars(exchange: str, symbol: str, start: datetime, end: datetime, backend: Backend):
+    ex_class = getattr(ccxt, exchange)
+    ex = ex_class()
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+    since = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    while since < end_ms:
+        ohlcvs = await ex.fetch_ohlcv(symbol, timeframe="1m", since=since, limit=1000)
+        if not ohlcvs:
+            break
+        for ts_ms, o, h, l, c, v in ohlcvs:
+            ts = datetime.utcfromtimestamp(ts_ms / 1000)
+            storage.insert_bar_1m(engine, exchange, symbol, ts, o, h, l, c, v)
+        since = ohlcvs[-1][0] + 60_000
+    await ex.close()
+
+
+@app.command()
+def bars(exchange: str, symbol: str, start: datetime, end: datetime, backend: Backend = "timescale"):
+    """Download OHLCV bars into the selected backend."""
+    asyncio.run(_download_bars(exchange, symbol, start, end, backend))
+
+
+if __name__ == "__main__":
+    app()

--- a/sql/schema_quest.sql
+++ b/sql/schema_quest.sql
@@ -1,0 +1,41 @@
+-- QuestDB schema for crypto data
+
+CREATE TABLE IF NOT EXISTS trades (
+    ts TIMESTAMP,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    px DOUBLE,
+    qty DOUBLE,
+    side SYMBOL,
+    trade_id STRING
+) timestamp(ts) PARTITION BY DAY;
+
+CREATE TABLE IF NOT EXISTS orderbook (
+    ts TIMESTAMP,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    bid_px STRING,
+    bid_qty STRING,
+    ask_px STRING,
+    ask_qty STRING
+) timestamp(ts) PARTITION BY DAY;
+
+CREATE TABLE IF NOT EXISTS bars (
+    ts TIMESTAMP,
+    timeframe SYMBOL,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    o DOUBLE,
+    h DOUBLE,
+    l DOUBLE,
+    c DOUBLE,
+    v DOUBLE
+) timestamp(ts) PARTITION BY DAY;
+
+CREATE TABLE IF NOT EXISTS funding (
+    ts TIMESTAMP,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    rate DOUBLE,
+    interval_sec LONG
+) timestamp(ts) PARTITION BY DAY;

--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -1,0 +1,106 @@
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from ..types import Tick, OrderBook, Bar
+from ..storage import timescale as ts_storage
+from ..storage import quest as qs_storage
+
+log = logging.getLogger(__name__)
+
+Backends = Literal["timescale", "quest"]
+
+def _get_storage(backend: Backends):
+    """Return storage module depending on backend name."""
+    return ts_storage if backend == "timescale" else qs_storage
+
+async def stream_trades(adapter: Any, symbol: str, *, backend: Backends = "timescale"):
+    """Stream trades from *adapter* and persist each tick.
+
+    Parameters
+    ----------
+    adapter: object with ``stream_trades`` async generator and ``name`` attribute.
+    symbol: market symbol to subscribe.
+    backend: choose ``"timescale"`` or ``"quest"`` storage backend.
+    """
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+    async for d in adapter.stream_trades(symbol):
+        tick = Tick(
+            ts=d.get("ts", datetime.now(timezone.utc)),
+            exchange=getattr(adapter, "name", "unknown"),
+            symbol=symbol,
+            price=float(d.get("price") or d.get("px") or 0.0),
+            qty=float(d.get("qty") or d.get("size") or 0.0),
+            side=d.get("side"),
+        )
+        try:
+            storage.insert_trade(engine, tick)
+        except Exception as exc:  # pragma: no cover - logging only
+            log.debug("Trade insert failed: %s", exc)
+
+async def stream_orderbook(adapter: Any, symbol: str, depth: int = 10, *, backend: Backends = "timescale"):
+    """Stream L2 orderbook snapshots and persist them."""
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+    async for d in adapter.stream_orderbook(symbol, depth):
+        ob = OrderBook(
+            ts=d.get("ts", datetime.now(timezone.utc)),
+            exchange=getattr(adapter, "name", "unknown"),
+            symbol=symbol,
+            bid_px=d.get("bid_px") or [],
+            bid_qty=d.get("bid_qty") or [],
+            ask_px=d.get("ask_px") or [],
+            ask_qty=d.get("ask_qty") or [],
+        )
+        try:
+            storage.insert_orderbook(
+                engine,
+                ts=ob.ts,
+                exchange=ob.exchange,
+                symbol=ob.symbol,
+                bid_px=ob.bid_px,
+                bid_qty=ob.bid_qty,
+                ask_px=ob.ask_px,
+                ask_qty=ob.ask_qty,
+            )
+        except Exception as exc:  # pragma: no cover - logging only
+            log.debug("Orderbook insert failed: %s", exc)
+
+async def poll_funding(adapter: Any, symbol: str, *, interval: int = 60, backend: Backends = "timescale"):
+    """Poll periodic funding rates and persist them."""
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+    while True:
+        try:
+            info: Any = await adapter.fetch_funding(symbol)
+            ts = info.get("ts", datetime.now(timezone.utc))
+            rate = float(info.get("rate") or info.get("fundingRate") or 0.0)
+            interval_sec = int(info.get("interval_sec") or info.get("interval", 0))
+            storage.insert_funding(
+                engine,
+                ts=ts,
+                exchange=getattr(adapter, "name", "unknown"),
+                symbol=symbol,
+                rate=rate,
+                interval_sec=interval_sec,
+            )
+        except Exception as exc:  # pragma: no cover - logging only
+            log.debug("Funding poll failed: %s", exc)
+        await asyncio.sleep(interval)
+
+async def fetch_bars(adapter: Any, symbol: str, *, timeframe: str = "1m", backend: Backends = "timescale", sleep_s: int = 60):
+    """Periodically fetch OHLCV bars and persist them."""
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+    while True:
+        try:
+            bars = await adapter.fetch_ohlcv(symbol, timeframe=timeframe, limit=1)
+            for ts_ms, o, h, l, c, v in bars:
+                ts = datetime.fromtimestamp(ts_ms / 1000, timezone.utc)
+                bar = Bar(ts=ts, timeframe=timeframe, exchange=getattr(adapter, "name", "unknown"), symbol=symbol, o=o, h=h, l=l, c=c, v=v)
+                storage.insert_bar_1m(engine, bar.exchange, bar.symbol, bar.ts, bar.o, bar.h, bar.l, bar.c, bar.v)
+        except Exception as exc:  # pragma: no cover - logging only
+            log.debug("Bar fetch failed: %s", exc)
+        await asyncio.sleep(sleep_s)

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -117,5 +117,40 @@ def insert_orderbook(
         )
 
 
-__all__ = ["get_engine", "insert_trade", "insert_orderbook"]
+def insert_bar_1m(engine, exchange: str, symbol: str, ts, o: float, h: float,
+                  l: float, c: float, v: float):
+    """Insert a 1-minute bar into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO bars (ts, timeframe, exchange, symbol, o, h, l, c, v)
+                VALUES (:ts, '1m', :exchange, :symbol, :o, :h, :l, :c, :v)
+                """
+            ),
+            dict(ts=ts, exchange=exchange, symbol=symbol, o=o, h=h, l=l, c=c, v=v),
+        )
+
+
+def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, interval_sec: int):
+    """Persist a funding rate record into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO funding (ts, exchange, symbol, rate, interval_sec)
+                VALUES (:ts, :exchange, :symbol, :rate, :interval_sec)
+                """
+            ),
+            dict(ts=ts, exchange=exchange, symbol=symbol, rate=rate, interval_sec=interval_sec),
+        )
+
+
+__all__ = [
+    "get_engine",
+    "insert_trade",
+    "insert_orderbook",
+    "insert_bar_1m",
+    "insert_funding",
+]
 


### PR DESCRIPTION
## Summary
- Stream trades, orderbooks, funding and bars to TimescaleDB or QuestDB
- Add QuestDB schema for trades/orderbook/bars/funding
- Introduce script to download historical OHLCV data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdaaafc50832d809d6462d53883c6