### PR TITLE
feat: add order book features with L2 snapshot support

### DIFF
--- a/src/tradingbot/data/features.py
+++ b/src/tradingbot/data/features.py
@@ -1,26 +1,76 @@
+"""Feature engineering utilities.
+
+This module exposes a small collection of indicators that can operate on a
+``pandas.DataFrame`` or on an iterable of Level 2 snapshots (dictionaries with
+columns such as ``bid_qty``/``ask_qty`` or ``high``/``low``/``close``).  The
+helpers normalise the input so that downstream functions can focus purely on
+the numerical computations.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence, Any, Union
+
 import numpy as np
 import pandas as pd
 
-def atr(df: pd.DataFrame, n: int = 14) -> pd.Series:
-    high, low, close = df['high'], df['low'], df['close']
-    tr = np.maximum(high - low, np.maximum(abs(high - close.shift(1)), abs(low - close.shift(1))))
-    return tr.rolling(n).mean()
 
-def keltner_channels(df: pd.DataFrame, ema_n: int = 20, atr_n: int = 14, mult: float = 1.5):
-    ema = df['close'].ewm(span=ema_n, adjust=False).mean()
-    _atr = atr(df, atr_n)
-    upper = ema + mult * _atr
-    lower = ema - mult * _atr
-    return upper, lower
+DataLike = Union[pd.DataFrame, Iterable[Mapping[str, Any]]]
 
 
-def rsi(df: pd.DataFrame, n: int = 14) -> pd.Series:
-    """Relative Strength Index of the ``close`` column.
+def _to_dataframe(data: DataLike, columns: Sequence[str]) -> pd.DataFrame:
+    """Normalise ``data`` into a :class:`~pandas.DataFrame`.
 
-    Uses an exponential moving average formulation which closely follows
-    the original indicator.  Values are bounded between 0 and 100.
+    Parameters
+    ----------
+    data:
+        Either a DataFrame with the required ``columns`` or an iterable of
+        mapping objects (e.g. L2 snapshots).  When lists/arrays are encountered
+        in the mapping values, the first element is used which corresponds to
+        the top of book.
+    columns:
+        Columns to extract from the input.
     """
 
+    if isinstance(data, pd.DataFrame):
+        return data.loc[:, columns]
+
+    rows = []
+    for snap in data:
+        row = {}
+        for col in columns:
+            val = snap.get(col)
+            if isinstance(val, (list, tuple, np.ndarray, pd.Series)):
+                row[col] = val[0] if len(val) > 0 else np.nan
+            else:
+                row[col] = val
+        rows.append(row)
+    return pd.DataFrame(rows, columns=columns)
+
+
+def atr(data: DataLike, n: int = 14) -> pd.Series:
+    """Average True Range.
+
+    ``data`` must provide ``high``, ``low`` and ``close`` fields.
+    """
+
+    df = _to_dataframe(data, ["high", "low", "close"])
+    high, low, close = df["high"], df["low"], df["close"]
+    tr = np.maximum(
+        high - low,
+        np.maximum((high - close.shift(1)).abs(), (low - close.shift(1)).abs()),
+    )
+    return tr.rolling(n).mean()
+
+
+def rsi(data: DataLike, n: int = 14) -> pd.Series:
+    """Relative Strength Index of the ``close`` column.
+
+    Uses an exponential moving average formulation which closely follows the
+    original indicator.  Values are bounded between 0 and 100.
+    """
+
+    df = _to_dataframe(data, ["close"])
     delta = df["close"].diff()
     gain = delta.clip(lower=0)
     loss = -delta.clip(upper=0)
@@ -31,53 +81,56 @@ def rsi(df: pd.DataFrame, n: int = 14) -> pd.Series:
     return rsi.fillna(100)
 
 
-def order_flow_imbalance(df: pd.DataFrame) -> pd.Series:
+def order_flow_imbalance(data: DataLike) -> pd.Series:
     """Compute Order Flow Imbalance (OFI) using top of book changes.
 
-    The implementation follows a simplified formulation where OFI is the
-    difference between changes in bid and ask queue sizes.  Positive values
-    indicate buying pressure while negative values indicate selling pressure.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        DataFrame with columns ``bid_qty`` and ``ask_qty`` representing the
-        top of book quantities.
-
-    Returns
-    -------
-    pd.Series
-        Series of OFI values aligned with ``df``'s index.
+    ``data`` must expose ``bid_qty`` and ``ask_qty`` fields representing the
+    top of book queue sizes.
     """
 
-    bid_delta = df['bid_qty'].diff().fillna(0)
-    ask_delta = df['ask_qty'].diff().fillna(0)
+    df = _to_dataframe(data, ["bid_qty", "ask_qty"])
+    bid_delta = df["bid_qty"].diff().fillna(0)
+    ask_delta = df["ask_qty"].diff().fillna(0)
     return bid_delta - ask_delta
 
 
-def depth_imbalance(df: pd.DataFrame) -> pd.Series:
+def depth_imbalance(data: DataLike) -> pd.Series:
     """Depth imbalance between bid and ask queues.
 
     Defined as ``(bid_qty - ask_qty) / (bid_qty + ask_qty)``.  Values are
-    bounded between -1 and 1 where positive numbers indicate a larger bid
-    queue (buy side) and negative numbers indicate a larger ask queue (sell
-    side).
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        DataFrame with columns ``bid_qty`` and ``ask_qty``.
-
-    Returns
-    -------
-    pd.Series
-        Depth imbalance series.
+    bounded between -1 and 1 where positive numbers indicate a larger bid queue
+    (buy side) and negative numbers indicate a larger ask queue (sell side).
     """
 
-    bid_qty = df['bid_qty']
-    ask_qty = df['ask_qty']
+    df = _to_dataframe(data, ["bid_qty", "ask_qty"])
+    bid_qty = df["bid_qty"]
+    ask_qty = df["ask_qty"]
     denom = bid_qty + ask_qty
-    # Avoid division by zero
-    denom = denom.replace(0, np.nan)
+    denom = denom.replace(0, np.nan)  # avoid division by zero
     return (bid_qty - ask_qty) / denom
+
+
+def keltner_channels(
+    data: DataLike,
+    ema_n: int = 20,
+    atr_n: int = 14,
+    mult: float = 1.5,
+):
+    """Keltner channel upper/lower bounds."""
+
+    df = _to_dataframe(data, ["close", "high", "low"])
+    ema = df["close"].ewm(span=ema_n, adjust=False).mean()
+    _atr = atr(df, atr_n)
+    upper = ema + mult * _atr
+    lower = ema - mult * _atr
+    return upper, lower
+
+
+__all__ = [
+    "atr",
+    "rsi",
+    "order_flow_imbalance",
+    "depth_imbalance",
+    "keltner_channels",
+]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,32 +1,128 @@
 import pandas as pd
-from tradingbot.data.features import order_flow_imbalance, depth_imbalance, rsi
+import pytest
 
-def test_order_flow_imbalance():
-    df = pd.DataFrame({
-        'bid_qty': [5, 7, 3, 4],
-        'ask_qty': [8, 6, 5, 7],
+from tradingbot.data.features import (
+    order_flow_imbalance,
+    depth_imbalance,
+    rsi,
+    atr,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+
+
+@pytest.fixture
+def orderbook_df():
+    return pd.DataFrame({
+        "bid_qty": [5, 7, 3, 4],
+        "ask_qty": [8, 6, 5, 7],
     })
-    ofi = order_flow_imbalance(df)
+
+
+@pytest.fixture
+def orderbook_snapshots(orderbook_df):
+    """Synthetic L2 snapshots with quantities stored as arrays."""
+
+    snaps = []
+    for _, row in orderbook_df.iterrows():
+        snaps.append(
+            {
+                "bid_qty": [row.bid_qty, row.bid_qty - 1],
+                "ask_qty": [row.ask_qty, row.ask_qty + 1],
+            }
+        )
+    return snaps
+
+
+@pytest.fixture
+def close_df():
+    return pd.DataFrame({"close": list(range(1, 30))})
+
+
+@pytest.fixture
+def close_snapshots(close_df):
+    return close_df.to_dict(orient="records")
+
+
+@pytest.fixture
+def ohlc_df():
+    return pd.DataFrame(
+        {
+            "high": [10, 11, 14, 13, 15],
+            "low": [7, 9, 10, 8, 12],
+            "close": [9, 10, 12, 11, 14],
+        }
+    )
+
+
+@pytest.fixture
+def ohlc_snapshots(ohlc_df):
+    return ohlc_df.to_dict(orient="records")
+
+
+# ---------------------------------------------------------------------------
+# Order book features
+
+
+def test_order_flow_imbalance_df(orderbook_df):
+    ofi = order_flow_imbalance(orderbook_df)
     assert list(ofi) == [0, 4, -3, -1]
 
-def test_depth_imbalance():
-    df = pd.DataFrame({
-        'bid_qty': [5, 7, 3, 4],
-        'ask_qty': [8, 6, 5, 7],
-    })
-    di = depth_imbalance(df)
+
+def test_order_flow_imbalance_snapshots(orderbook_snapshots):
+    ofi = order_flow_imbalance(orderbook_snapshots)
+    assert list(ofi) == [0, 4, -3, -1]
+
+
+def test_depth_imbalance_df(orderbook_df):
+    di = depth_imbalance(orderbook_df)
     expected = [
-        (5-8)/(5+8),
-        (7-6)/(7+6),
-        (3-5)/(3+5),
-        (4-7)/(4+7),
+        (5 - 8) / (5 + 8),
+        (7 - 6) / (7 + 6),
+        (3 - 5) / (3 + 5),
+        (4 - 7) / (4 + 7),
     ]
     assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
 
 
-def test_rsi_range():
-    df = pd.DataFrame({"close": list(range(1, 30))})
-    values = rsi(df, 14)
-    # RSI is bounded between 0 and 100 and increases for a strong uptrend
-    assert values.iloc[-1] > 70
+def test_depth_imbalance_snapshots(orderbook_snapshots):
+    di = depth_imbalance(orderbook_snapshots)
+    expected = [
+        (5 - 8) / (5 + 8),
+        (7 - 6) / (7 + 6),
+        (3 - 5) / (3 + 5),
+        (4 - 7) / (4 + 7),
+    ]
+    assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
+
+
+# ---------------------------------------------------------------------------
+# Momentum / volatility indicators
+
+
+def test_rsi_range(close_df):
+    values = rsi(close_df, 14)
+    assert values.iloc[-1] > 70  # strong uptrend
     assert values.dropna().between(0, 100).all()
+
+
+def test_rsi_snapshots(close_df, close_snapshots):
+    rsi_df = rsi(close_df, 14)
+    rsi_snaps = rsi(close_snapshots, 14)
+    pd.testing.assert_series_equal(rsi_df, rsi_snaps)
+
+
+def test_atr_df(ohlc_df):
+    # Last value should be the average of the last three true ranges
+    val = atr(ohlc_df, n=3).iloc[-1]
+    assert abs(val - 4.333333333333333) < 1e-9
+
+
+def test_atr_snapshots(ohlc_df, ohlc_snapshots):
+    atr_df = atr(ohlc_df, n=3)
+    atr_snaps = atr(ohlc_snapshots, n=3)
+    pd.testing.assert_series_equal(atr_df, atr_snaps)
+
+


### PR DESCRIPTION
## Summary
- support DataFrame or L2 snapshot inputs for feature calculations
- add indicators: order_flow_imbalance, depth_imbalance, rsi and atr
- cover features with synthetic unit tests for both input formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fdaaa7128832d97323836f9a37fe2