### PR TITLE
feat: add secret loader and scope validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,17 @@ docker compose up -d timescaledb
 # 3) Configurar variables
 cp .env.example .env
 # edita .env con tus API keys (retiros desactivados, claves restringidas)
+```
 
+### Claves API sólo-trade
+Genera credenciales con los permisos mínimos:
+
+1. Crea una nueva clave en el panel de la exchange.
+2. Activa únicamente permisos de **lectura** y **trade**.
+3. Deshabilita retiros y, si es posible, restringe por IP.
+4. Guarda `API_KEY` y `API_SECRET` en `~/.secrets` (formato `CLAVE=valor`) o en el archivo `.env`.
+
+```bash
 # 4) Probar backtest de ejemplo (simulado, CSV)
 python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
 

--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -16,6 +16,7 @@ from ..market.exchange_meta import ExchangeMeta
 from ..execution.normalize import adjust_order
 from .binance_errors import parse_binance_error_code
 from ..execution.retry import with_retries, AmbiguousOrderError
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +44,9 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         })
         self.taker_fee_bps = float(os.getenv("TRADING_TAKER_FEE_BPS_FUT", "5.0"))
         self.rest.set_sandbox_mode(testnet)
+
+        # Advertir si faltan scopes necesarios o sobran permisos
+        validate_scopes(self.rest, log)
 
         # Cache de metadatos/filters
         self.meta = ExchangeMeta.binanceusdm_testnet(

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -15,6 +15,7 @@ from ..config import settings
 from ..market.exchange_meta import ExchangeMeta
 from .binance_errors import parse_binance_error_code  # si no lo tienes, ver notas abajo
 from ..execution.retry import with_retries, AmbiguousOrderError
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +37,9 @@ class BinanceSpotAdapter(ExchangeAdapter):
         })
         self.taker_fee_bps = float(os.getenv("TRADING_TAKER_FEE_BPS", "10.0"))
         self.rest.set_sandbox_mode(testnet)
+
+        # Advertir si faltan scopes necesarios o si hay permisos peligrosos
+        validate_scopes(self.rest, log)
 
         self.meta = ExchangeMeta.binance_spot_testnet(
             api_key or settings.binance_api_key,

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover - ccxt optional during tests
     ccxt = None
 
 from .base import ExchangeAdapter
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ class BybitFuturesAdapter(ExchangeAdapter):
         if ccxt is None:
             raise RuntimeError("ccxt no está instalado")
         self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "swap"}})
+        # Validar permisos de la clave
+        validate_scopes(self.rest, log)
 
     async def _to_thread(self, fn, *args, **kwargs):
         return await asyncio.to_thread(fn, *args, **kwargs)

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover - ccxt optional during tests
     ccxt = None
 
 from .base import ExchangeAdapter
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ class BybitSpotAdapter(ExchangeAdapter):
             raise RuntimeError("ccxt no está instalado")
         # enableRateLimit respeta límites de la API
         self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+        # Advertir si la clave carece de permisos de trade o tiene retiros habilitados
+        validate_scopes(self.rest, log)
 
     async def _to_thread(self, fn, *args, **kwargs):
         return await asyncio.to_thread(fn, *args, **kwargs)

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover
     ccxt = None
 
 from .base import ExchangeAdapter
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ class OKXFuturesAdapter(ExchangeAdapter):
             raise RuntimeError("ccxt no está instalado")
         # "swap" cubre contratos perpetuos
         self.rest = ccxt.okx({"enableRateLimit": True, "options": {"defaultType": "swap"}})
+        # Validar permisos disponibles
+        validate_scopes(self.rest, log)
 
     async def _to_thread(self, fn, *args, **kwargs):
         return await asyncio.to_thread(fn, *args, **kwargs)

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover
     ccxt = None
 
 from .base import ExchangeAdapter
+from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ class OKXSpotAdapter(ExchangeAdapter):
         if ccxt is None:
             raise RuntimeError("ccxt no está instalado")
         self.rest = ccxt.okx({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+        # Validar permisos disponibles en la API key
+        validate_scopes(self.rest, log)
 
     async def _to_thread(self, fn, *args, **kwargs):
         return await asyncio.to_thread(fn, *args, **kwargs)

--- a/src/tradingbot/utils/secrets.py
+++ b/src/tradingbot/utils/secrets.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import logging
+from pathlib import Path
+from typing import Optional, Dict, Iterable
+
+# Cargar variables desde un archivo .env local si existe
+
+def _load_env_file(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    if not path.exists():
+        return data
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"')
+    for k, v in data.items():
+        os.environ.setdefault(k, v)
+    return data
+
+# Cargar .env al importar el módulo
+_load_env_file(Path(".env"))
+
+_cached_secrets: Dict[str, str] | None = None
+
+
+def _load_secrets_file() -> Dict[str, str]:
+    global _cached_secrets
+    if _cached_secrets is not None:
+        return _cached_secrets
+    path = Path("~/.secrets").expanduser()
+    secrets: Dict[str, str] = {}
+    if path.exists():
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            secrets[k.strip()] = v.strip().strip('"')
+    _cached_secrets = secrets
+    return secrets
+
+
+def get_secret(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Obtiene un secreto desde variables de entorno, .env o ~/.secrets."""
+    val = os.getenv(key)
+    if val is not None:
+        return val
+    secrets = _load_secrets_file()
+    return secrets.get(key, default)
+
+
+def get_api_credentials(prefix: str) -> tuple[Optional[str], Optional[str]]:
+    prefix = prefix.upper()
+    return get_secret(f"{prefix}_API_KEY"), get_secret(f"{prefix}_API_SECRET")
+
+
+def validate_scopes(
+    exchange,
+    logger: Optional[logging.Logger] = None,
+    required: Iterable[str] = ("read", "trade"),
+    forbidden: Iterable[str] = ("withdraw",),
+) -> None:
+    """Valida scopes de la API key y registra *warnings* si faltan."""
+    log = logger or logging.getLogger(__name__)
+    try:
+        has_perm = getattr(exchange, "has", {}).get("fetchPermissions")
+        if not has_perm:
+            log.warning("exchange %s no soporta fetch_permissions", getattr(exchange, "id", ""))
+            return
+        perms = exchange.fetch_permissions()
+    except Exception as e:  # pragma: no cover - depende del exchange
+        log.warning("no se pudieron obtener permisos: %s", e)
+        return
+
+    for scope in required:
+        if not perms.get(scope):
+            log.warning("API key sin scope requerido '%s'", scope)
+    for scope in forbidden:
+        if perms.get(scope):
+            log.warning("API key con scope no recomendado '%s'", scope)


### PR DESCRIPTION
## Summary
- add utility to load API secrets from .env or ~/.secrets
- warn when adapter credentials lack required scopes or allow withdrawals
- document how to create trade-only API keys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdaa8a3d4832d9e05953ba89d1642