### PR TITLE
docs: add database compose files and expand setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,49 @@ tradingbot-mvp/
    └─ test_smoke.py
 ```
 
+## Setup local
+
+```bash
+# Crear y activar entorno virtual (Python 3.11+)
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+
+# Copiar variables de entorno
+cp .env.example .env  # editar con tus credenciales
+
+# Ejecutar pruebas para verificar la instalación
+pytest
+```
+
+## Despliegue con Docker
+
+Para levantar toda la pila de servicios (API, bases de datos, monitoreo):
+
+```bash
+docker compose up -d
+```
+
+Si solo necesitas las bases de datos puedes utilizar los archivos en `sql/`:
+
+```bash
+# TimescaleDB
+docker compose -f sql/docker-compose.timescale.yml up -d
+
+# QuestDB
+docker compose -f sql/docker-compose.questdb.yml up -d
+```
+
+## Variables de entorno
+
+Copia `.env.example` a `.env` y completa las claves según corresponda. Variables principales:
+
+- `BINANCE_API_KEY`, `BINANCE_API_SECRET`: credenciales de Binance Spot.
+- `BYBIT_API_KEY`, `BYBIT_API_SECRET`: credenciales de Bybit Spot.
+- `BINANCE_FUTURES_API_KEY`, `BINANCE_FUTURES_API_SECRET`, `BINANCE_FUTURES_TESTNET`, `BINANCE_FUTURES_LEVERAGE`: acceso a futuros.
+- `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DB`: conexión a la base de datos.
+- `ENV`, `LOG_LEVEL`: parámetros de ejecución.
+- `SENTRY_DSN`: opcional para reportar errores a Sentry.
+
 ## Uso rápido
 
 ```bash
@@ -179,3 +222,17 @@ insert_orderbook(
 Este proyecto expone métricas Prometheus para latencia de APIs, errores de websockets, fills de órdenes, slippage y eventos de riesgo. Los dashboards de ejemplo para Grafana se encuentran en `monitoring/grafana`.
 
 Para reportar excepciones a Sentry, define `SENTRY_DSN` en tu archivo `.env`. La configuración de logging inicializará Sentry automáticamente cuando este valor esté presente.
+
+## CI/CD
+
+El flujo de integración continua se ejecuta con GitHub Actions mediante `.github/workflows/ci.yml`. En cada `push` o `pull_request` se instala Python 3.11, las dependencias del proyecto y se ejecutan las pruebas con `pytest`.
+
+## Scripts de inicio rápido
+
+Algunos comandos útiles para comenzar a experimentar con el proyecto:
+
+```bash
+python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
+python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
+uvicorn tradingbot.apps.api.main:app --reload --port 8080
+```

--- a/sql/docker-compose.questdb.yml
+++ b/sql/docker-compose.questdb.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  questdb:
+    image: questdb/questdb:latest
+    ports:
+      - "9000:9000"   # REST API
+      - "8812:8812"   # PostgreSQL wire protocol
+    volumes:
+      - questdb-data:/root/.questdb
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/health" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+volumes:
+  questdb-data:

--- a/sql/docker-compose.timescale.yml
+++ b/sql/docker-compose.timescale.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  timescaledb:
+    image: timescale/timescaledb:latest-pg16
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=trading
+    ports:
+      - "5432:5432"
+    volumes:
+      - tsdb-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+volumes:
+  tsdb-data:


### PR DESCRIPTION
## Summary
- document local setup steps, Docker deployment and environment variables
- add compose files for TimescaleDB and QuestDB under `sql/`
- describe CI/CD flow and quick-start scripts in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdaa1f528832db4d6a50a730e89e7