### PR TITLE
Add configurable strategy classes and registry entries

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,6 +12,21 @@ python -m tradingbot.cli backtest data/btcusdt_1m.csv --symbol BTC/USDT --strate
 python -m tradingbot.cli report --venue binance_spot_testnet
 ```
 
+## Estrategias disponibles
+
+Las estrategias pueden instanciarse pasando parámetros mediante ``**kwargs``.
+Los nombres que deben utilizarse en la CLI (``--strategy``) o al usar la API
+corresponden al atributo ``name`` de cada clase.
+
+| Estrategia        | Nombre           | Parámetros principales                |
+|-------------------|-----------------|--------------------------------------|
+| Momentum          | ``momentum``    | ``rsi_n`` (int), ``rsi_threshold``    |
+| Mean Reversion    | ``mean_reversion`` | ``rsi_n`` (int), ``upper`` y ``lower`` |
+| Breakout por Vol. | ``breakout_vol``| ``lookback`` (int), ``mult`` (float)  |
+| Triangular Arb.   | ``triangular_arb`` | ``taker_fee_bps``, ``buffer_bps``   |
+| Cash & Carry      | ``cash_and_carry`` | ``threshold`` (float)               |
+
+
 ## API
 
 ```

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -1,16 +1,29 @@
 from .breakout_atr import BreakoutATR
+from .breakout_vol import BreakoutVol
 from .momentum import Momentum
 from .mean_reversion import MeanReversion
+from .arbitrage_triangular import TriangularArb
 from .cash_and_carry import CashAndCarry
 from .order_flow import OrderFlow
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
     BreakoutATR.name: BreakoutATR,
+    BreakoutVol.name: BreakoutVol,
     Momentum.name: Momentum,
     MeanReversion.name: MeanReversion,
+    TriangularArb.name: TriangularArb,
     CashAndCarry.name: CashAndCarry,
     OrderFlow.name: OrderFlow,
 }
 
-__all__ = ["BreakoutATR", "Momentum", "MeanReversion", "CashAndCarry", "OrderFlow", "STRATEGIES"]
+__all__ = [
+    "BreakoutATR",
+    "BreakoutVol",
+    "Momentum",
+    "MeanReversion",
+    "TriangularArb",
+    "CashAndCarry",
+    "OrderFlow",
+    "STRATEGIES",
+]

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from .base import Strategy, Signal
+
+
+class BreakoutVol(Strategy):
+    """Volatility breakout strategy using rolling standard deviation.
+
+    Parameters are supplied via ``**kwargs`` and stored as attributes.  The
+    strategy computes a rolling mean and standard deviation of the close price
+    and generates a ``buy`` signal when price breaks above ``mean + mult *
+    std``.  A ``sell`` signal is produced for a break below ``mean - mult *
+    std``.
+
+    Parameters
+    ----------
+    lookback : int, optional
+        Window size for the rolling statistics, default ``20``.
+    mult : float, optional
+        Multiplier applied to the standard deviation, default ``2``.
+    """
+
+    name = "breakout_vol"
+
+    def __init__(self, **kwargs):
+        self.lookback = kwargs.get("lookback", 20)
+        self.mult = kwargs.get("mult", 2.0)
+
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.lookback + 1:
+            return None
+        closes = df["close"]
+        mean = closes.rolling(self.lookback).mean().iloc[-1]
+        std = closes.rolling(self.lookback).std().iloc[-1]
+        last = closes.iloc[-1]
+        upper = mean + self.mult * std
+        lower = mean - self.mult * std
+        if last > upper:
+            return Signal("buy", 1.0)
+        if last < lower:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -3,12 +3,28 @@ from .base import Strategy, Signal
 from ..data.features import rsi, order_flow_imbalance
 
 class MeanReversion(Strategy):
+    """RSI based mean reversion strategy.
+
+    Parameters are accepted through ``**kwargs`` for easy configuration.
+
+    Parameters
+    ----------
+    rsi_n : int, optional
+        Lookback window for the RSI calculation, by default ``14``.
+    upper : float, optional
+        Upper RSI level above which a ``sell`` signal is triggered, by default
+        ``70``.
+    lower : float, optional
+        Lower RSI level below which a ``buy`` signal is triggered, by default
+        ``30``.
+    """
+
     name = "mean_reversion"
 
-    def __init__(self, rsi_n: int = 14, upper: float = 70.0, lower: float = 30.0):
-        self.rsi_n = rsi_n
-        self.upper = upper
-        self.lower = lower
+    def __init__(self, **kwargs):
+        self.rsi_n = kwargs.get("rsi_n", 14)
+        self.upper = kwargs.get("upper", 70.0)
+        self.lower = kwargs.get("lower", 30.0)
 
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -3,11 +3,25 @@ from .base import Strategy, Signal
 from ..data.features import rsi, order_flow_imbalance
 
 class Momentum(Strategy):
+    """Simple momentum strategy using the Relative Strength Index (RSI).
+
+    Parameters are provided via ``**kwargs`` so the class can be easily
+    instantiated from configuration dictionaries.
+
+    Parameters
+    ----------
+    rsi_n : int, optional
+        Lookback window for the RSI calculation, by default ``14``.
+    rsi_threshold : float, optional
+        Level above which a ``buy`` signal is produced (and mirrored for
+        ``sell``), by default ``60``.
+    """
+
     name = "momentum"
 
-    def __init__(self, rsi_n: int = 14, rsi_threshold: float = 60.0):
-        self.rsi_n = rsi_n
-        self.threshold = rsi_threshold
+    def __init__(self, **kwargs):
+        self.rsi_n = kwargs.get("rsi_n", 14)
+        self.threshold = kwargs.get("rsi_threshold", 60.0)
 
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]


### PR DESCRIPTION
## Summary
- add BreakoutVol and TriangularArb strategies
- allow Momentum, MeanReversion and CashAndCarry to accept kwargs
- document available strategies and register them in STRATEGIES

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe0df3560832d980cff8b99d6124b