### PR TITLE
feat: advanced execution router

### DIFF
--- a/src/tradingbot/execution/algos.py
+++ b/src/tradingbot/execution/algos.py
@@ -45,6 +45,7 @@ class TWAP:
                 price=order.price,
                 post_only=order.post_only,
                 time_in_force=order.time_in_force,
+                iceberg_qty=order.iceberg_qty,
             )
             res = await self.router.execute(child)
             results.append(res)
@@ -78,6 +79,7 @@ class VWAP:
                 price=order.price,
                 post_only=order.post_only,
                 time_in_force=order.time_in_force,
+                iceberg_qty=order.iceberg_qty,
             )
             res = await self.router.execute(child)
             results.append(res)
@@ -114,6 +116,7 @@ class POV:
                 price=order.price,
                 post_only=order.post_only,
                 time_in_force=order.time_in_force,
+                iceberg_qty=order.iceberg_qty,
             )
             res = await self.router.execute(child)
             results.append(res)

--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -9,3 +9,4 @@ class Order:
     price: float | None = None
     post_only: bool = False
     time_in_force: str | None = None
+    iceberg_qty: float | None = None

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -96,6 +96,7 @@ class PaperAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        iceberg_qty: float | None = None,
     ) -> dict:
         order_id = self._next_order_id()
         last = self.state.last_px.get(symbol)
@@ -112,7 +113,8 @@ class PaperAdapter(ExchangeAdapter):
             elif side == "sell" and price is not None and price <= last:
                 px_exec = last
             else:
-                return {"status": "new", "order_id": order_id, "note": "limit no cruzó; no simulo book"}
+                status = "canceled" if time_in_force in {"IOC", "FOK"} else "new"
+                return {"status": status, "order_id": order_id, "note": "limit no cruzó; no simulo book"}
         else:
             return {"status": "rejected", "reason": "type_not_supported", "order_id": order_id}
 

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -1,21 +1,101 @@
+"""Execution router with venue selection and basic metrics."""
+
+from __future__ import annotations
+
 import logging
+import time
+from collections import defaultdict
+from typing import Dict, Iterable
+
 from .order_types import Order
+from ..utils.metrics import SLIPPAGE, ORDER_LATENCY, MAKER_TAKER_RATIO
 
 log = logging.getLogger(__name__)
 
-class ExecutionRouter:
-    def __init__(self, adapter):
-        self.adapter = adapter
 
+class ExecutionRouter:
+    """Route orders to the best venue and track execution metrics."""
+
+    def __init__(self, adapters: Iterable):
+        if isinstance(adapters, dict):
+            self.adapters: Dict[str, object] = adapters  # type: ignore[assignment]
+        elif isinstance(adapters, (list, tuple, set)):
+            self.adapters = {
+                getattr(ad, "name", f"venue{i}"): ad for i, ad in enumerate(adapters)
+            }
+        else:  # single adapter
+            self.adapters = {getattr(adapters, "name", "default"): adapters}
+
+        self._maker_counts = defaultdict(int)
+        self._taker_counts = defaultdict(int)
+
+    # ------------------------------------------------------------------
+    async def best_venue(self, order: Order):
+        """Select venue with best last price for the order side."""
+        selected = None
+        best_px = None
+        for adapter in self.adapters.values():
+            price = getattr(getattr(adapter, "state", None), "last_px", {}).get(order.symbol)
+            if price is None:
+                continue
+            if order.side == "buy":
+                if best_px is None or price < best_px:
+                    best_px = price
+                    selected = adapter
+            else:
+                if best_px is None or price > best_px:
+                    best_px = price
+                    selected = adapter
+        if selected is None:
+            selected = next(iter(self.adapters.values()))
+        return selected
+
+    # ------------------------------------------------------------------
     async def execute(self, order: Order) -> dict:
-        log.info("Routing order %s", order)
-        # Algunos adapters son síncronos por dentro (ccxt); todos exponen async place_order
-        return await self.adapter.place_order(
+        adapter = await self.best_venue(order)
+        venue = getattr(adapter, "name", "unknown")
+        log.info("Routing order %s via %s", order, venue)
+
+        start = time.monotonic()
+        kwargs = dict(
             symbol=order.symbol,
             side=order.side,
             type_=order.type_,
             qty=order.qty,
             price=order.price,
             post_only=order.post_only,
-            time_in_force=order.time_in_force
+            time_in_force=order.time_in_force,
         )
+        if order.iceberg_qty is not None:
+            kwargs["iceberg_qty"] = order.iceberg_qty
+
+        res = await adapter.place_order(**kwargs)
+        latency = time.monotonic() - start
+        ORDER_LATENCY.labels(venue=venue).observe(latency)
+
+        exec_price = res.get("price")
+        expected = order.price
+        if expected is None:
+            expected = getattr(getattr(adapter, "state", None), "last_px", {}).get(order.symbol)
+        if exec_price is not None and expected:
+            bps = (exec_price - expected) / expected * 10000
+            if bps != 0:
+                SLIPPAGE.labels(symbol=order.symbol, side=order.side).observe(bps)
+
+        maker = order.post_only or (
+            order.type_.lower() == "limit" and order.time_in_force not in {"IOC", "FOK"}
+        )
+        if maker:
+            self._maker_counts[venue] += 1
+        else:
+            self._taker_counts[venue] += 1
+        maker_c = self._maker_counts[venue]
+        taker_c = self._taker_counts[venue]
+        ratio = maker_c / taker_c if taker_c else float(maker_c)
+        MAKER_TAKER_RATIO.labels(venue=venue).set(ratio)
+
+        return res
+
+
+__all__ = ["ExecutionRouter"]
+

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, Gauge
 
 # Latency of HTTP requests by method and endpoint
 REQUEST_LATENCY = Histogram(
@@ -40,4 +40,18 @@ RISK_EVENTS = Counter(
     "risk_events",
     "Total risk management events",
     ["event_type"],
+)
+
+# Execution latency by venue
+ORDER_LATENCY = Histogram(
+    "order_execution_latency_seconds",
+    "Latency of order execution in seconds",
+    ["venue"],
+)
+
+# Maker/taker ratio per venue
+MAKER_TAKER_RATIO = Gauge(
+    "maker_taker_ratio",
+    "Ratio of maker to taker orders",
+    ["venue"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ class DummyAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        iceberg_qty: float | None = None,
     ):
         return {"status": "placed", "symbol": symbol, "side": side, "qty": qty, "price": price}
 


### PR DESCRIPTION
## Summary
- add ExecutionRouter with venue selection, slippage estimation and Prometheus metrics
- support advanced order types including IOC/FOK/iceberg
- expose latency and maker/taker ratio metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fe1003fd4832dbd604bd6695754e8