### PR TITLE
Implement Binance adapter streaming and delegation

### DIFF
--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -21,9 +21,10 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
     """
     name = "binance_spot_testnet_ws"
 
-    def __init__(self, ws_base: str | None = None):
+    def __init__(self, ws_base: str | None = None, rest: ExchangeAdapter | None = None):
         # Spot testnet: wss://testnet.binance.vision/stream?streams=
         self.ws_base = ws_base or "wss://testnet.binance.vision/stream?streams="
+        self.rest = rest
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _stream_name(self.normalize_symbol(symbol))
@@ -127,13 +128,21 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
     stream_orderbook = stream_order_book
 
     async def fetch_funding(self, symbol: str):
+        if self.rest:
+            return await self.rest.fetch_funding(symbol)
         raise NotImplementedError("WS adapter no soporta fetch_funding")
 
     async def fetch_oi(self, symbol: str):
+        if self.rest:
+            return await self.rest.fetch_oi(symbol)
         raise NotImplementedError("WS adapter no soporta fetch_oi")
 
     async def place_order(self, *args, **kwargs) -> dict:
+        if self.rest:
+            return await self.rest.place_order(*args, **kwargs)
         raise NotImplementedError("solo streaming")
 
-    async def cancel_order(self, order_id: str) -> dict:
+    async def cancel_order(self, order_id: str, *args, **kwargs) -> dict:
+        if self.rest:
+            return await self.rest.cancel_order(order_id, *args, **kwargs)
         raise NotImplementedError("no aplica en WS")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,6 +6,9 @@ from tradingbot.adapters import (
     OKXFuturesAdapter,
 )
 from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.adapters.binance_spot import BinanceSpotAdapter
+from tradingbot.adapters.binance_futures import BinanceFuturesAdapter
+from tradingbot.adapters.binance_spot_ws import BinanceSpotWSAdapter
 
 
 async def collect_trades(adapter):
@@ -36,3 +39,80 @@ def test_registered_adapters_are_subclasses():
         OKXFuturesAdapter,
     ):
         assert issubclass(cls, ExchangeAdapter)
+
+
+class _DummyRest:
+    def fetch_trades(self, symbol, limit=1):
+        return [{"timestamp": 1000, "price": "1", "amount": "2", "side": "buy"}]
+
+    def fetch_order_book(self, symbol):
+        return {"timestamp": 1000, "bids": [["1", "2"]], "asks": [["3", "4"]]}
+
+
+class _DummyFuturesRest:
+    def fetchFundingRate(self, symbol):
+        return {"rate": 0.01}
+
+    def fetchOpenInterest(self, symbol):
+        return {"oi": 100}
+
+
+class _DummyDelegate:
+    async def fetch_funding(self, symbol):
+        return {"rate": 1}
+
+    async def fetch_oi(self, symbol):
+        return {"oi": 2}
+
+    async def place_order(self, *a, **k):
+        return {"status": "ok"}
+
+    async def cancel_order(self, *a, **k):
+        return {"status": "cancel"}
+
+
+@pytest.mark.asyncio
+async def test_binance_spot_rest_streams():
+    adapter = BinanceSpotAdapter.__new__(BinanceSpotAdapter)
+    adapter.rest = _DummyRest()
+
+    async def _req(fn, *a, **k):
+        return fn(*a, **k)
+
+    adapter._request = _req
+
+    gen = adapter.stream_trades("BTC/USDT")
+    trade = await gen.__anext__()
+    await gen.aclose()
+    assert trade["price"] == 1.0
+
+    gen2 = adapter.stream_order_book("BTC/USDT")
+    book = await gen2.__anext__()
+    await gen2.aclose()
+    assert book["bids"][0][0] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_binance_futures_rest_fetch():
+    adapter = BinanceFuturesAdapter.__new__(BinanceFuturesAdapter)
+    adapter.rest = _DummyFuturesRest()
+
+    async def _req(fn, *a, **k):
+        return fn(*a, **k)
+
+    adapter._request = _req
+
+    funding = await adapter.fetch_funding("BTC/USDT")
+    oi = await adapter.fetch_oi("BTC/USDT")
+    assert funding["rate"] == 0.01
+    assert oi["oi"] == 100
+
+
+@pytest.mark.asyncio
+async def test_ws_delegates_to_rest():
+    rest = _DummyDelegate()
+    ws = BinanceSpotWSAdapter(rest=rest)
+    assert await ws.fetch_funding("BTC/USDT") == {"rate": 1}
+    assert await ws.fetch_oi("BTC/USDT") == {"oi": 2}
+    assert await ws.place_order("BTC/USDT", "buy", "market", 1) == {"status": "ok"}
+    assert await ws.cancel_order("1") == {"status": "cancel"}


### PR DESCRIPTION
## Summary
- add REST polling implementations for trade and order book streams on Binance futures and spot adapters
- allow Binance WS adapters to delegate funding, open interest, and order management to REST adapters
- cover adapter flows with new unit tests

## Testing
- `pytest tests/test_adapters.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fe8512fe4832da29cc9a31b05f19e