### PR TITLE
Add monitoring docs and metrics smoke test

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,3 +35,18 @@ POST /strategies/{name}/stop
 GET  /strategies/status
 ```
 
+## Panel y monitoreo
+
+El repositorio incluye un `docker-compose.yml` que levanta la API junto con
+TimescaleDB, Prometheus y Grafana para visualización.
+
+```bash
+docker compose up
+```
+
+Una vez levantados los servicios:
+
+* API y dashboard estático: <http://localhost:8000> (`/metrics` expone métricas de Prometheus)
+* Prometheus: <http://localhost:9090>
+* Grafana: <http://localhost:3000> (usuario `admin`, contraseña `admin`)
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,14 @@
+from fastapi.testclient import TestClient
+
+from tradingbot.apps.api.main import app
+
+
 def test_smoke():
     assert 2 + 2 == 4
+
+
+def test_metrics_endpoint_exposed():
+    client = TestClient(app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "python_info" in resp.text


### PR DESCRIPTION
## Summary
- Describe how to run monitoring stack and access Grafana/Prometheus
- Add smoke test asserting `/metrics` endpoint is exposed

## Testing
- `pytest tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe85aa120832da99ebd0d43f5d1d0