### PR TITLE
feat: instrument metrics and persist events

### DIFF
--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Dict
 
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 
 @dataclass
 class TriRoute:
@@ -122,6 +122,7 @@ class TriangularArb(Strategy):
         self.buffer_bps = kwargs.get("buffer_bps", 0.0)
         self.min_edge = kwargs.get("min_edge", 0.0)
 
+    @record_signal_metrics
     def on_bar(self, bar: Dict[str, Dict[str, float]]) -> Optional[Signal]:
         prices = bar.get("prices") if isinstance(bar, dict) else None
         if not prices:

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
+import time
+
+from ..utils.metrics import REQUEST_LATENCY
+from ..storage import timescale
 
 @dataclass
 class Signal:
@@ -13,3 +17,42 @@ class Strategy(ABC):
     @abstractmethod
     def on_bar(self, bar: dict[str, Any]) -> Signal | None:
         ...
+
+
+def record_signal_metrics(fn):
+    """Decorator to time strategy signal generation and persist events.
+
+    It observes ``REQUEST_LATENCY`` for each ``on_bar`` invocation and persists
+    generated signals as orders into Timescale if available. Any persistence
+    errors are silently ignored so strategies remain side-effect free in test
+    environments.
+    """
+
+    def wrapper(self: Strategy, bar: dict[str, Any]) -> Signal | None:  # type: ignore[misc]
+        start = time.monotonic()
+        sig = fn(self, bar)
+        duration = time.monotonic() - start
+        REQUEST_LATENCY.labels(method=self.name, endpoint="on_bar").observe(duration)
+        if sig and sig.side in {"buy", "sell"} and {"exchange", "symbol"} <= bar.keys():
+            try:
+                engine = timescale.get_engine()
+                timescale.insert_order(
+                    engine,
+                    strategy=self.name,
+                    exchange=bar["exchange"],
+                    symbol=bar["symbol"],
+                    side=sig.side,
+                    type_="signal",
+                    qty=float(sig.strength),
+                    px=bar.get("close"),
+                    status="signal",
+                )
+            except Exception:
+                # Persistence is best-effort only
+                pass
+        return sig
+
+    return wrapper
+
+
+__all__ = ["Signal", "Strategy", "record_signal_metrics"]

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import keltner_channels
 
 class BreakoutATR(Strategy):
@@ -10,6 +10,7 @@ class BreakoutATR(Strategy):
         self.atr_n = atr_n
         self.mult = mult
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         # bar should include a small rolling window (as dict of lists) or a pandas row with context
         df: pd.DataFrame = bar["window"]  # expects columns: open, high, low, close, volume

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 
 
 class BreakoutVol(Strategy):
@@ -26,6 +26,7 @@ class BreakoutVol(Strategy):
         self.lookback = kwargs.get("lookback", 20)
         self.mult = kwargs.get("mult", 2.0)
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.lookback + 1:

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 
 try:  # optional persistence
     from ..storage.timescale import get_engine, insert_cross_signal
@@ -57,6 +57,7 @@ class CashAndCarry(Strategy):
         self.cfg = cfg or CashCarryConfig(**kwargs)
         self.engine = get_engine() if (self.cfg.persist_pg and _CAN_PG) else None
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Optional[Signal]:
         spot = bar.get("spot")
         perp = bar.get("perp")

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, order_flow_imbalance
 
 class MeanReversion(Strategy):
@@ -26,6 +26,7 @@ class MeanReversion(Strategy):
         self.upper = kwargs.get("upper", 70.0)
         self.lower = kwargs.get("lower", 30.0)
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.rsi_n + 1:

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, order_flow_imbalance
 
 class Momentum(Strategy):
@@ -23,6 +23,7 @@ class Momentum(Strategy):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.threshold = kwargs.get("rsi_threshold", 60.0)
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.rsi_n + 1:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from .base import Strategy, Signal
+from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import order_flow_imbalance
 
 
@@ -17,6 +17,7 @@ class OrderFlow(Strategy):
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
 
+    @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         needed = {"bid_qty", "ask_qty"}


### PR DESCRIPTION
## Summary
- track fills and persist orders in the execution router
- record strategy latency and persist generated signals
- log risk guard halts and add Timescale storage tests

## Testing
- `pytest tests/test_storage.py tests/test_strategies.py tests/test_execution.py tests/test_risk.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe8575338832dae89b81d37e7254f