### PR TITLE
Add advanced risk management helpers

### DIFF
--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -44,3 +44,42 @@ def test_risk_manager_size_property(signal, pos):
         assert size >= 0
     elif signal == "sell":
         assert size <= 0
+
+
+def test_size_with_volatility_event():
+    from tradingbot.risk.manager import RiskManager
+    from tradingbot.utils.metrics import RISK_EVENTS
+
+    rm = RiskManager(max_pos=10, vol_target=0.02)
+    before = RISK_EVENTS.labels(event_type="volatility_sizing")._value.get()
+    delta = rm.size_with_volatility(0.04)
+    after = RISK_EVENTS.labels(event_type="volatility_sizing")._value.get()
+    assert delta == 5
+    assert after == before + 1
+
+
+def test_update_correlation_limits_exposure():
+    from tradingbot.risk.manager import RiskManager
+    from tradingbot.utils.metrics import RISK_EVENTS
+
+    rm = RiskManager(max_pos=8)
+    pairs = {("BTC", "ETH"): 0.9}
+    before = RISK_EVENTS.labels(event_type="correlation_limit")._value.get()
+    exceeded = rm.update_correlation(pairs, 0.8)
+    after = RISK_EVENTS.labels(event_type="correlation_limit")._value.get()
+    assert exceeded == [("BTC", "ETH")]
+    assert rm.max_pos == 4
+    assert after == before + 1
+
+
+def test_kill_switch_disables():
+    from tradingbot.risk.manager import RiskManager
+    from tradingbot.utils.metrics import RISK_EVENTS
+
+    rm = RiskManager(max_pos=1)
+    before = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
+    rm.kill_switch("manual")
+    after = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
+    assert rm.enabled is False
+    assert rm.last_kill_reason == "manual"
+    assert after == before + 1


### PR DESCRIPTION
## Summary
- add volatility-target sizing to risk manager
- limit correlated exposure and add kill switch with metrics logging
- test new risk manager utilities

## Testing
- `pytest tests/test_risk.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe8553a78832da8151387bb316753