### PR TITLE
Implement REST fetch methods for WS adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ Copia `.env.example` a `.env` y completa las claves según corresponda. Variable
 - `ENV`, `LOG_LEVEL`: parámetros de ejecución.
 - `SENTRY_DSN`: opcional para reportar errores a Sentry.
 
+## Límites de consulta por exchange
+
+| Exchange | Límite aproximado | Notas |
+|----------|------------------|-------|
+| Binance Spot | 1200 weight/min (≈20 req/s) | REST público |
+| Binance Futures | 1200 weight/min (≈20 req/s) | USDⓈ-M |
+| Bybit | 50 req/s público, 10 req/s privado | compartir entre endpoints |
+| OKX | 60 req/2s | límite global REST |
+
 ## Uso rápido
 
 ```bash

--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import urllib.request
 import websockets
 from datetime import datetime, timezone
 from typing import AsyncIterator, Iterable
@@ -100,12 +101,26 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
     async def fetch_funding(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_funding(symbol)
-        raise NotImplementedError("WS adapter no soporta fetch_funding")
+        sym = self.normalize_symbol(symbol)
+        url = f"https://fapi.binance.com/fapi/v1/premiumIndex?symbol={sym}"
+
+        def _fetch():
+            with urllib.request.urlopen(url, timeout=10) as resp:
+                return json.loads(resp.read())
+
+        return await self._request(_fetch)
 
     async def fetch_oi(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_oi(symbol)
-        raise NotImplementedError("WS adapter no soporta fetch_oi")
+        sym = self.normalize_symbol(symbol)
+        url = f"https://fapi.binance.com/fapi/v1/openInterest?symbol={sym}"
+
+        def _fetch():
+            with urllib.request.urlopen(url, timeout=10) as resp:
+                return json.loads(resp.read())
+
+        return await self._request(_fetch)
 
     # interfaz ExchangeAdapter (no aplica envío por WS)
     async def place_order(self, *args, **kwargs):

--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -130,12 +130,12 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
     async def fetch_funding(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_funding(symbol)
-        raise NotImplementedError("WS adapter no soporta fetch_funding")
+        raise NotImplementedError("Funding no disponible para mercados Spot")
 
     async def fetch_oi(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_oi(symbol)
-        raise NotImplementedError("WS adapter no soporta fetch_oi")
+        raise NotImplementedError("Open interest no disponible para Spot")
 
     async def place_order(self, *args, **kwargs) -> dict:
         if self.rest:


### PR DESCRIPTION
## Summary
- add internal REST calls for funding rate and open interest in Binance futures WS adapter
- clarify unsupported funding/OI on Binance spot WS adapter
- document exchange rate limits in README
- expand adapter tests for funding and open interest

## Testing
- `pytest` *(fails: tests/test_metrics.py::test_fill_slippage_risk_metrics - AssertionError: assert 11.0 == 1.0)*
- `pytest tests/test_adapters.py`


------
https://chatgpt.com/codex/tasks/task_e_68a001189730832d90359f33e204943e