### PR TITLE
docs: add setup guides and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio
+      - name: Lint
+        run: flake8 . --select=E9,F63,F7 --show-source --statistics
       - name: Run tests
-        run: pytest
+        run: pytest --cov=src --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -53,9 +53,17 @@ tradingbot-mvp/
 │  └─ cli/
 │     ├─ __init__.py
 │     └─ main.py
-└─ tests/
+   └─ tests/
    └─ test_smoke.py
 ```
+
+## Documentación
+
+La carpeta `docs/` contiene material adicional:
+
+- [Arquitectura](docs/architecture.md)
+- [Guía de setup](docs/setup.md)
+- [Ejemplos de uso](docs/examples.md)
 
 ## Setup local
 
@@ -77,6 +85,14 @@ Para levantar toda la pila de servicios (API, bases de datos, monitoreo):
 
 ```bash
 docker compose up -d
+```
+
+También puedes utilizar los scripts de ayuda en `bin/`:
+
+```bash
+./bin/start_timescale.sh   # sólo TimescaleDB
+./bin/start_questdb.sh     # sólo QuestDB
+./bin/start_stack.sh       # stack completo
 ```
 
 Si solo necesitas las bases de datos puedes utilizar los archivos en `sql/`:

--- a/bin/start_questdb.sh
+++ b/bin/start_questdb.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/.."
+docker compose -f sql/docker-compose.questdb.yml up -d

--- a/bin/start_stack.sh
+++ b/bin/start_stack.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/.."
+docker compose up -d

--- a/bin/start_timescale.sh
+++ b/bin/start_timescale.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR/.."
+docker compose -f sql/docker-compose.timescale.yml up -d

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,31 @@
+# Arquitectura
+
+El proyecto sigue una arquitectura modular orientada a eventos.
+Cada componente expone interfaces sencillas para facilitar el
+reemplazo o la extensión.
+
+```
+src/tradingbot/
+├── adapters/      # Acceso a exchanges y fuentes de datos
+├── data/          # Ingesta y transformaciones
+├── strategies/    # Lógica de trading
+├── execution/     # Envío de órdenes y simulaciones
+├── risk/          # Gestión de riesgo y salvaguardas
+├── storage/       # Persistencia (TimescaleDB, QuestDB, etc.)
+├── backtest/      # Motor de backtesting
+├── apps/          # Puntos de entrada (API, panel)
+└── cli/           # Comandos de línea de uso frecuente
+```
+
+Los módulos se comunican mediante un bus de eventos (`bus.py`) lo
+que permite desacoplar la generación de señales de la ejecución y
+el almacenamiento.
+
+La carpeta `sql/` contiene los esquemas de base de datos y ejemplos
+de `docker-compose` para levantar servicios individuales. El stack
+completo de demostración se levanta con `docker-compose.yml` en la
+raíz del repositorio.
+
+Para una explicación detallada de los componentes y su interacción
+consulta [docs/usage.md](usage.md) y los ejemplos de
+[docs/examples.md](examples.md).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,21 @@
+# Ejemplos de Uso
+
+## Ingesta de datos
+```bash
+python -m tradingbot.cli ingest --symbol BTC/USDT
+```
+
+## Backtest rápido
+```bash
+python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \
+    --symbol BTC/USDT --strategy breakout_atr
+```
+
+## API
+```bash
+uvicorn tradingbot.apps.api.main:app --reload --port 8000
+```
+
+## Notebook
+Consulta el notebook [docs/notebooks/breakout_atr.ipynb](notebooks/breakout_atr.ipynb)
+para ver un flujo de trabajo completo de un backtest.

--- a/docs/notebooks/breakout_atr.ipynb
+++ b/docs/notebooks/breakout_atr.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Backtest de Breakout ATR\n",
+    "Ejemplo básico de ejecución en notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tradingbot.backtest.event_engine import run_backtest\n",
+    "result = run_backtest(\n",
+    "    csv_path=\"data/examples/btcusdt_1m.csv\",\n",
+    "    symbol=\"BTC/USDT\",\n",
+    "    strategy_name=\"breakout_atr\",\n",
+    ")\n",
+    "result"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,38 @@
+# Guía de Setup
+
+## Requisitos
+- Python 3.11+
+- Docker y Docker Compose
+
+## Entorno local
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # completar credenciales
+```
+
+Ejecuta las pruebas para verificar la instalación:
+```bash
+pytest
+```
+
+## Servicios con Docker
+Puedes levantar únicamente las bases de datos con los scripts del
+repositorio:
+
+```bash
+# TimescaleDB
+./bin/start_timescale.sh
+
+# QuestDB
+./bin/start_questdb.sh
+```
+
+Para el stack completo (API, TimescaleDB, QuestDB, Prometheus y Grafana):
+
+```bash
+./bin/start_stack.sh
+```
+
+Los archivos de configuración y esquemas se encuentran en `sql/` y
+`monitoring/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,14 @@ prometheus-client>=0.20
 sentry-sdk>=1.40
 
 # Testing
+pytest>=8.0
 pytest-asyncio>=0.23
+pytest-cov>=5.0
 hypothesis>=6.0
+httpx>=0.27
+
+# Linting
+flake8>=7.0
 
 # Backtesting helpers
 vectorbtpro==0.0.0; python_version == "0"  # placeholder si se usa luego


### PR DESCRIPTION
## Summary
- expand README with documentation links and docker helper scripts
- add architecture, setup and examples docs plus notebook
- add docker helper scripts and CI workflow with lint and coverage

## Testing
- `flake8 . --select=E9,F63,F7 --show-source --statistics`
- `pytest --cov=src --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68a01a051678832dbab17ac12fde5e6c