### PR TITLE
Add simple strategy modules with common signal interface

### DIFF
--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -1,0 +1,46 @@
+"""Simple spread based arbitrage strategy."""
+
+import pandas as pd
+
+
+def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
+    """Generate arbitrage signals for backtesting.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Data with ``asset_a`` and ``asset_b`` price columns.
+    params : dict
+        Parameters including ``threshold``, ``position_size``, ``stop_loss``,
+        ``take_profit``, ``fee`` and ``slippage``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Data with generated signals and risk management levels.
+    """
+
+    df = data.copy()
+    threshold = params.get("threshold", 0.0)
+    position_size = params.get("position_size", 1)
+    fee = params.get("fee", 0.0)
+    slippage = params.get("slippage", 0.0)
+    sl_pct = params.get("stop_loss", 0.0)
+    tp_pct = params.get("take_profit", 0.0)
+
+    spread = df["asset_a"] - df["asset_b"]
+    df["signal"] = 0
+    df.loc[spread > threshold, "signal"] = -1
+    df.loc[spread < -threshold, "signal"] = 1
+
+    df["position"] = df["signal"].shift(1).fillna(0) * position_size
+    df["stop_loss"] = df["asset_a"] * (1 - sl_pct)
+    df["take_profit"] = df["asset_a"] * (1 + tp_pct)
+    df["fee"] = df["position"].abs() * fee
+    df["slippage"] = df["position"].abs() * slippage
+
+    return df[["signal", "position", "stop_loss", "take_profit", "fee", "slippage"]]
+
+
+__all__ = ["generate_signals"]
+

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -41,3 +41,29 @@ class MeanReversion(Strategy):
         if last_rsi < self.lower and ofi_val >= 0:
             return Signal("buy", 1.0)
         return Signal("flat", 0.0)
+
+
+def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
+    """Generate mean reversion signals for backtesting."""
+
+    df = data.copy()
+    window = params.get("window", 14)
+    threshold = params.get("threshold", 0.0)
+    position_size = params.get("position_size", 1)
+    fee = params.get("fee", 0.0)
+    slippage = params.get("slippage", 0.0)
+    sl_pct = params.get("stop_loss", 0.0)
+    tp_pct = params.get("take_profit", 0.0)
+
+    ma = df["price"].rolling(window).mean()
+    df["signal"] = 0
+    df.loc[df["price"] < ma - threshold, "signal"] = 1
+    df.loc[df["price"] > ma + threshold, "signal"] = -1
+
+    df["position"] = df["signal"].shift(1).fillna(0) * position_size
+    df["stop_loss"] = df["price"] * (1 - sl_pct)
+    df["take_profit"] = df["price"] * (1 + tp_pct)
+    df["fee"] = df["position"].abs() * fee
+    df["slippage"] = df["position"].abs() * slippage
+
+    return df[["signal", "position", "stop_loss", "take_profit", "fee", "slippage"]]

--- a/tests/test_basic_strategies.py
+++ b/tests/test_basic_strategies.py
@@ -1,0 +1,77 @@
+import pandas as pd
+
+from tradingbot.strategies import momentum, mean_reversion
+import tradingbot.strategies.arbitrage as arbitrage
+
+
+def backtest(data: pd.DataFrame, signals: pd.DataFrame, price_col: str) -> float:
+    returns = data[price_col].pct_change().fillna(0)
+    pnl = signals["position"] * returns - signals["fee"] - signals["slippage"]
+    return pnl.cumsum().iloc[-1]
+
+
+def test_momentum_backtest():
+    data = pd.DataFrame({"price": list(range(1, 11))})
+    base_params = {
+        "window": 2,
+        "position_size": 1,
+        "stop_loss": 0.05,
+        "take_profit": 0.1,
+    }
+    pnl_no_fee = backtest(
+        data,
+        momentum.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
+        "price",
+    )
+    pnl_fee = backtest(
+        data,
+        momentum.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),
+        "price",
+    )
+    assert pnl_fee <= pnl_no_fee
+
+
+def test_mean_reversion_backtest():
+    data = pd.DataFrame({"price": [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]})
+    base_params = {
+        "window": 2,
+        "threshold": 0.1,
+        "position_size": 1,
+        "stop_loss": 0.05,
+        "take_profit": 0.1,
+    }
+    pnl_no_fee = backtest(
+        data,
+        mean_reversion.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
+        "price",
+    )
+    pnl_fee = backtest(
+        data,
+        mean_reversion.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),
+        "price",
+    )
+    assert pnl_fee <= pnl_no_fee
+
+
+def test_arbitrage_backtest():
+    data = pd.DataFrame(
+        {"asset_a": [1, 2, 1, 2, 1, 2, 1, 2], "asset_b": [1, 1, 1, 1, 1, 1, 1, 1]}
+    )
+    base_params = {
+        "threshold": 0.0,
+        "position_size": 1,
+        "stop_loss": 0.05,
+        "take_profit": 0.1,
+    }
+    pnl_no_fee = backtest(
+        data,
+        arbitrage.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
+        "asset_a",
+    )
+    pnl_fee = backtest(
+        data,
+        arbitrage.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),
+        "asset_a",
+    )
+    assert pnl_fee <= pnl_no_fee
+


### PR DESCRIPTION
## Summary
- add generate_signals implementations for momentum and mean-reversion strategies
- introduce arbitrage strategy module with unified signal interface and risk controls
- add quick backtest tests using simulated data including fee and slippage handling

## Testing
- `pytest tests/test_basic_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a019f3325c832d9203533997d1b1cb