### PR TITLE
Add async DB clients and ingestion workers

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,41 @@
+CREATE SCHEMA IF NOT EXISTS market;
+
+CREATE TABLE IF NOT EXISTS market.trades (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  px numeric NOT NULL,
+  qty numeric NOT NULL,
+  side text,
+  trade_id text
+);
+
+CREATE TABLE IF NOT EXISTS market.orderbook (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  bid_px numeric[] NOT NULL,
+  bid_qty numeric[] NOT NULL,
+  ask_px numeric[] NOT NULL,
+  ask_qty numeric[] NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS market.bars (
+  ts timestamptz NOT NULL,
+  timeframe text NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  o numeric,
+  h numeric,
+  l numeric,
+  c numeric,
+  v numeric
+);
+
+CREATE TABLE IF NOT EXISTS market.funding (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  rate numeric NOT NULL,
+  interval_sec int NOT NULL
+);

--- a/src/tradingbot/storage/__init__.py
+++ b/src/tradingbot/storage/__init__.py
@@ -10,8 +10,15 @@ from ..config import settings
 
 if settings.db_backend.lower() == "questdb":
     from .quest import get_engine, insert_trade, insert_orderbook  # noqa: F401
+    from .async_quest import AsyncQuestDBClient as AsyncDBClient  # noqa: F401
 else:  # default to timescale
     from .timescale import get_engine, insert_trade, insert_orderbook  # noqa: F401
+    from .async_timescale import AsyncTimescaleClient as AsyncDBClient  # noqa: F401
 
-__all__ = ["get_engine", "insert_trade", "insert_orderbook"]
+__all__ = [
+    "get_engine",
+    "insert_trade",
+    "insert_orderbook",
+    "AsyncDBClient",
+]
 

--- a/src/tradingbot/storage/async_quest.py
+++ b/src/tradingbot/storage/async_quest.py
@@ -1,0 +1,18 @@
+"""Asynchronous client for QuestDB using PostgreSQL wire protocol."""
+
+from __future__ import annotations
+
+from ..config import settings
+from .async_timescale import AsyncTimescaleClient
+
+
+class AsyncQuestDBClient(AsyncTimescaleClient):
+    """QuestDB shares the PostgreSQL protocol so we reuse the Timescale client."""
+
+    def __init__(self, dsn: str | None = None) -> None:
+        if dsn is None:
+            dsn = (
+                f"postgresql+asyncpg://{settings.questdb_user}:{settings.questdb_password}"  # noqa: E501
+                f"@{settings.questdb_host}:{settings.questdb_port}/{settings.questdb_db}"  # noqa: E501
+            )
+        super().__init__(dsn)

--- a/src/tradingbot/storage/async_timescale.py
+++ b/src/tradingbot/storage/async_timescale.py
@@ -1,0 +1,48 @@
+"""Asynchronous client for TimescaleDB."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy import text
+
+from ..config import settings
+
+
+class AsyncTimescaleClient:
+    """Minimal async wrapper around SQLAlchemy for TimescaleDB."""
+
+    def __init__(self, dsn: str | None = None) -> None:
+        if dsn is None:
+            dsn = (
+                f"postgresql+asyncpg://{settings.pg_user}:{settings.pg_password}"
+                f"@{settings.pg_host}:{settings.pg_port}/{settings.pg_db}"
+            )
+        self._dsn = dsn
+        self._engine: AsyncEngine | None = None
+
+    async def connect(self) -> AsyncEngine:
+        if self._engine is None:
+            self._engine = create_async_engine(self._dsn, pool_pre_ping=True)
+        return self._engine
+
+    async def close(self) -> None:
+        if self._engine is not None:
+            await self._engine.dispose()
+            self._engine = None
+
+    async def executemany(self, sql: str, rows: Iterable[dict[str, Any]]) -> None:
+        """Execute *sql* for multiple *rows* in a single transaction."""
+        rows = list(rows)
+        if not rows:
+            return
+        engine = await self.connect()
+        async with engine.begin() as conn:
+            await conn.execute(text(sql), rows)
+
+    async def fetch(self, sql: str) -> list[dict[str, Any]]:
+        engine = await self.connect()
+        async with engine.connect() as conn:
+            res = await conn.execute(text(sql))
+            return [dict(r) for r in res.mappings().all()]

--- a/src/tradingbot/workers/__init__.py
+++ b/src/tradingbot/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Background workers used by the bot."""
+
+from .ingestion import BatchIngestionWorker
+
+__all__ = ["BatchIngestionWorker"]

--- a/src/tradingbot/workers/ingestion.py
+++ b/src/tradingbot/workers/ingestion.py
@@ -1,0 +1,58 @@
+"""Ingestion workers that batch writes to storage with retries and metrics."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from prometheus_client import Counter
+
+log = logging.getLogger(__name__)
+
+rows_inserted = Counter(
+    "ingestion_rows_inserted", "Rows successfully persisted", ["table"]
+)
+failed_batches = Counter(
+    "ingestion_failed_batches", "Batches that failed permanently", ["table"]
+)
+
+
+class BatchIngestionWorker:
+    """Collects rows and writes them to storage in batches."""
+
+    def __init__(
+        self,
+        client,
+        table: str,
+        insert_sql: str,
+        batch_size: int = 100,
+        max_retries: int = 3,
+    ) -> None:
+        self.client = client
+        self.table = table
+        self.insert_sql = insert_sql
+        self.batch_size = batch_size
+        self.max_retries = max_retries
+        self._buffer: list[dict] = []
+
+    async def add(self, row: dict) -> None:
+        self._buffer.append(row)
+        if len(self._buffer) >= self.batch_size:
+            await self.flush()
+
+    async def flush(self) -> None:
+        if not self._buffer:
+            return
+        batch = self._buffer
+        self._buffer = []
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                await self.client.executemany(self.insert_sql, batch)
+                rows_inserted.labels(self.table).inc(len(batch))
+                return
+            except Exception as exc:  # pragma: no cover - logging
+                log.warning("insert failed attempt %s: %s", attempt, exc)
+                if attempt >= self.max_retries:
+                    failed_batches.labels(self.table).inc()
+                    raise
+                await asyncio.sleep(0.5 * 2 ** (attempt - 1))

--- a/tests/test_async_storage.py
+++ b/tests/test_async_storage.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import text
+
+from tradingbot.storage import AsyncDBClient
+
+SCHEMA_SQL = Path("db/schema.sql").read_text()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def engine():
+    dsn = "postgresql+asyncpg://postgres:postgres@localhost/tradebot_test"
+    eng = create_async_engine(dsn, echo=False)
+    async with eng.begin() as conn:
+        for stmt in SCHEMA_SQL.split(";"):
+            s = stmt.strip()
+            if s:
+                await conn.execute(text(s))
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(engine):
+    cli = AsyncDBClient(dsn="postgresql+asyncpg://postgres:postgres@localhost/tradebot_test")
+    await cli.connect()
+    yield cli
+    await cli.close()
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_trades(client):
+    worker_sql = """
+        INSERT INTO market.trades (ts, exchange, symbol, px, qty, side, trade_id)
+        VALUES (:ts, :exchange, :symbol, :px, :qty, :side, :trade_id)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.trades", worker_sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "px": 100.0,
+            "qty": 1.0,
+            "side": "buy",
+            "trade_id": "1",
+        }
+    )
+
+    rows = await client.fetch("SELECT exchange, symbol, px, qty FROM market.trades")
+    assert rows[0]["exchange"] == "binance"
+    assert rows[0]["symbol"] == "BTCUSDT"
+    assert float(rows[0]["px"]) == 100.0
+    assert float(rows[0]["qty"]) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_bars(client):
+    sql = """
+        INSERT INTO market.bars (ts, timeframe, exchange, symbol, o, h, l, c, v)
+        VALUES (:ts, :timeframe, :exchange, :symbol, :o, :h, :l, :c, :v)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.bars", sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "timeframe": "1m",
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "o": 100,
+            "h": 110,
+            "l": 90,
+            "c": 105,
+            "v": 10,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT timeframe, o, c, v FROM market.bars WHERE symbol='BTCUSDT'"
+    )
+    assert rows[0]["timeframe"] == "1m"
+    assert float(rows[0]["o"]) == 100
+    assert float(rows[0]["c"]) == 105
+    assert float(rows[0]["v"]) == 10
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_orderbook(client):
+    sql = """
+        INSERT INTO market.orderbook (ts, exchange, symbol, bid_px, bid_qty, ask_px, ask_qty)
+        VALUES (:ts, :exchange, :symbol, :bid_px, :bid_qty, :ask_px, :ask_qty)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.orderbook", sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "bid_px": [100.0, 99.5],
+            "bid_qty": [1.0, 0.5],
+            "ask_px": [100.5, 101.0],
+            "ask_qty": [0.8, 1.2],
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT bid_px, ask_px FROM market.orderbook WHERE symbol='BTCUSDT'"
+    )
+    assert rows[0]["bid_px"] == [100.0, 99.5]
+    assert rows[0]["ask_px"] == [100.5, 101.0]
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_funding(client):
+    sql = """
+        INSERT INTO market.funding (ts, exchange, symbol, rate, interval_sec)
+        VALUES (:ts, :exchange, :symbol, :rate, :interval_sec)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.funding", sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "rate": 0.001,
+            "interval_sec": 3600,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT rate, interval_sec FROM market.funding WHERE symbol='BTCUSDT'"
+    )
+    assert float(rows[0]["rate"]) == 0.001
+    assert rows[0]["interval_sec"] == 3600


### PR DESCRIPTION
## Summary
- Define market data tables in `db/schema.sql`
- Introduce asynchronous TimescaleDB and QuestDB clients
- Add batch ingestion workers with retries and metrics
- Provide tests for async storage insert/query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a019edbadc832db0514fab6e3c93db