### PR TITLE
feat: add exchange connectors

### DIFF
--- a/src/tradingbot/connectors/__init__.py
+++ b/src/tradingbot/connectors/__init__.py
@@ -1,0 +1,14 @@
+from .base import Trade, OrderBook, Funding, ExchangeConnector
+from .binance import BinanceConnector
+from .bybit import BybitConnector
+from .okx import OKXConnector
+
+__all__ = [
+    "Trade",
+    "OrderBook",
+    "Funding",
+    "ExchangeConnector",
+    "BinanceConnector",
+    "BybitConnector",
+    "OKXConnector",
+]

--- a/src/tradingbot/connectors/base.py
+++ b/src/tradingbot/connectors/base.py
@@ -1,0 +1,114 @@
+"""Common connector utilities and data models."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Awaitable, Callable, List, Tuple
+
+import ccxt.async_support as ccxt
+import websockets
+from pydantic import BaseModel
+
+
+class Trade(BaseModel):
+    timestamp: datetime
+    exchange: str
+    symbol: str
+    price: float
+    amount: float
+    side: str
+
+
+class OrderBook(BaseModel):
+    timestamp: datetime
+    exchange: str
+    symbol: str
+    bids: List[Tuple[float, float]]
+    asks: List[Tuple[float, float]]
+
+
+class Funding(BaseModel):
+    timestamp: datetime
+    exchange: str
+    symbol: str
+    rate: float
+
+
+class ExchangeConnector:
+    """Base connector implementing REST helpers and WS streaming."""
+
+    name: str = ""
+
+    def __init__(self, rate_limit: int = 5) -> None:
+        self.rest = getattr(ccxt, self.name)({"enableRateLimit": True})
+        self._sem = asyncio.Semaphore(rate_limit)
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.reconnect_delay = 1
+
+    async def _rest_call(self, fn: Callable[..., Awaitable[Any]], *a, **k) -> Any:
+        async with self._sem:
+            try:
+                return await fn(*a, **k)
+            except Exception as e:  # pragma: no cover - logging only
+                self.log.error("rest_error", extra={"err": str(e)})
+                raise
+
+    async def fetch_trades(self, symbol: str) -> List[Trade]:
+        data = await self._rest_call(self.rest.fetch_trades, symbol)
+        trades: List[Trade] = []
+        for t in data:
+            trades.append(
+                Trade(
+                    timestamp=datetime.fromtimestamp(t["timestamp"] / 1000),
+                    exchange=self.name,
+                    symbol=symbol,
+                    price=float(t["price"]),
+                    amount=float(t["amount"]),
+                    side=t.get("side", ""),
+                )
+            )
+        return trades
+
+    async def fetch_funding(self, symbol: str) -> Funding:
+        data = await self._rest_call(self.rest.fetch_funding_rate, symbol)
+        ts = data.get("timestamp") or data.get("time") or 0
+        if ts > 1e12:  # milliseconds
+            ts /= 1000
+        return Funding(
+            timestamp=datetime.fromtimestamp(ts),
+            exchange=self.name,
+            symbol=symbol,
+            rate=float(
+                data.get("fundingRate")
+                or data.get("rate")
+                or data.get("value")
+                or 0.0
+            ),
+        )
+
+    async def stream_order_book(self, symbol: str):
+        url = self._ws_url(symbol)
+        subscribe = self._ws_subscribe(symbol)
+        while True:
+            try:
+                async with websockets.connect(url) as ws:
+                    await ws.send(subscribe)
+                    while True:
+                        msg = await ws.recv()
+                        yield self._parse_order_book(msg, symbol)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # pragma: no cover - network/streaming
+                self.log.warning("ws_reconnect", extra={"err": str(e)})
+                await asyncio.sleep(self.reconnect_delay)
+
+    # --- methods to be implemented by subclasses ---
+    def _ws_url(self, symbol: str) -> str:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _ws_subscribe(self, symbol: str) -> str:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _parse_order_book(self, msg: str, symbol: str) -> OrderBook:  # pragma: no cover - abstract
+        raise NotImplementedError

--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -1,0 +1,31 @@
+"""Binance connector using CCXT REST and native websockets."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from .base import ExchangeConnector, OrderBook
+
+
+class BinanceConnector(ExchangeConnector):
+    name = "binance"
+
+    def _ws_url(self, symbol: str) -> str:
+        return f"wss://stream.binance.com:9443/ws/{symbol.lower()}@depth"
+
+    def _ws_subscribe(self, symbol: str) -> str:
+        return json.dumps(
+            {"method": "SUBSCRIBE", "params": [f"{symbol.lower()}@depth"], "id": 1}
+        )
+
+    def _parse_order_book(self, msg: str, symbol: str) -> OrderBook:
+        data = json.loads(msg)
+        bids = [(float(p), float(q)) for p, q in data.get("b", [])]
+        asks = [(float(p), float(q)) for p, q in data.get("a", [])]
+        return OrderBook(
+            timestamp=datetime.utcnow(),
+            exchange=self.name,
+            symbol=symbol,
+            bids=bids,
+            asks=asks,
+        )

--- a/src/tradingbot/connectors/bybit.py
+++ b/src/tradingbot/connectors/bybit.py
@@ -1,0 +1,31 @@
+"""Bybit connector using CCXT REST and native websockets."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from .base import ExchangeConnector, OrderBook
+
+
+class BybitConnector(ExchangeConnector):
+    name = "bybit"
+
+    def _ws_url(self, symbol: str) -> str:
+        # Public spot endpoint
+        return "wss://stream.bybit.com/v5/public/spot"
+
+    def _ws_subscribe(self, symbol: str) -> str:
+        return json.dumps({"op": "subscribe", "args": [f"orderbook.50.{symbol}"]})
+
+    def _parse_order_book(self, msg: str, symbol: str) -> OrderBook:
+        data = json.loads(msg)
+        ob = data.get("data", {})
+        bids = [(float(p), float(q)) for p, q in ob.get("b", ob.get("bids", []))]
+        asks = [(float(p), float(q)) for p, q in ob.get("a", ob.get("asks", []))]
+        return OrderBook(
+            timestamp=datetime.utcnow(),
+            exchange=self.name,
+            symbol=symbol,
+            bids=bids,
+            asks=asks,
+        )

--- a/src/tradingbot/connectors/okx.py
+++ b/src/tradingbot/connectors/okx.py
@@ -1,0 +1,30 @@
+"""OKX connector using CCXT REST and native websockets."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from .base import ExchangeConnector, OrderBook
+
+
+class OKXConnector(ExchangeConnector):
+    name = "okx"
+
+    def _ws_url(self, symbol: str) -> str:
+        return "wss://ws.okx.com:8443/ws/v5/public"
+
+    def _ws_subscribe(self, symbol: str) -> str:
+        return json.dumps({"op": "subscribe", "args": [{"channel": "books", "instId": symbol}]})
+
+    def _parse_order_book(self, msg: str, symbol: str) -> OrderBook:
+        data = json.loads(msg)
+        arg_data = data.get("data", [{}])[0]
+        bids = [(float(p), float(q)) for p, q in arg_data.get("bids", [])]
+        asks = [(float(p), float(q)) for p, q in arg_data.get("asks", [])]
+        return OrderBook(
+            timestamp=datetime.utcnow(),
+            exchange=self.name,
+            symbol=symbol,
+            bids=bids,
+            asks=asks,
+        )

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,88 @@
+import json
+
+import pytest
+
+from tradingbot.connectors import (
+    BinanceConnector,
+    BybitConnector,
+    OKXConnector,
+    OrderBook,
+    Trade,
+    Funding,
+)
+
+
+class DummyRest:
+    def __init__(self, trades, funding):
+        self._trades = trades
+        self._funding = funding
+
+    async def fetch_trades(self, symbol):
+        return self._trades
+
+    async def fetch_funding_rate(self, symbol):
+        return self._funding
+
+
+class DummyWS:
+    def __init__(self, messages):
+        self.messages = messages
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+    async def recv(self):
+        if self.messages:
+            return self.messages.pop(0)
+        raise ConnectionError("closed")
+
+
+@pytest.mark.parametrize(
+    "connector_cls",
+    [BinanceConnector, BybitConnector, OKXConnector],
+)
+@pytest.mark.asyncio
+async def test_rest_normalization(connector_cls):
+    trades = [{"timestamp": 1000, "price": "1", "amount": "2", "side": "buy"}]
+    funding = {"fundingRate": "0.01", "timestamp": 1000}
+    c = connector_cls()
+    c.rest = DummyRest(trades, funding)
+
+    res_trades = await c.fetch_trades("BTC/USDT")
+    assert isinstance(res_trades[0], Trade)
+    assert res_trades[0].price == 1.0
+
+    res_funding = await c.fetch_funding("BTC/USDT")
+    assert isinstance(res_funding, Funding)
+    assert res_funding.rate == 0.01
+
+
+@pytest.mark.asyncio
+async def test_stream_reconnect(monkeypatch, caplog):
+    caplog.set_level("WARNING")
+    c = BinanceConnector()
+    msg1 = json.dumps({"b": [["1", "1"]], "a": [["2", "2"]]})
+    msg2 = json.dumps({"b": [["3", "3"]], "a": [["4", "4"]]})
+    ws_iter = iter([DummyWS([msg1]), DummyWS([msg2])])
+
+    def fake_connect(url):
+        return next(ws_iter)
+
+    monkeypatch.setattr("websockets.connect", fake_connect)
+
+    gen = c.stream_order_book("BTCUSDT")
+    book1 = await gen.__anext__()
+    book2 = await gen.__anext__()
+    assert isinstance(book1, OrderBook)
+    assert book1.bids[0][0] == 1.0
+    assert book2.bids[0][0] == 3.0
+    await gen.aclose()
+
+    assert any("ws_reconnect" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add Pydantic models and base exchange connector with rate limits and reconnection
- implement Binance, Bybit and OKX connectors using CCXT REST and native websockets
- cover connectors with unit tests mocking REST and websocket streams

## Testing
- `pytest tests/test_connectors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a019ecdf68832d9474173bc18e1778