### PR TITLE
feat: flatten order book snapshots

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -50,7 +50,34 @@ class ExchangeAdapter(ABC):
         return {"symbol": symbol, "ts": ts, "price": price, "qty": qty, "side": side}
 
     def normalize_order_book(self, symbol, ts, bids, asks) -> dict:
-        return {"symbol": symbol, "ts": ts, "bids": bids, "asks": asks}
+        """Return a flattened order book snapshot.
+
+        Parameters
+        ----------
+        symbol: str
+            Market symbol of the snapshot.
+        ts: datetime
+            Timestamp of the book.
+        bids, asks: list[list[float, float]]
+            Price/quantity tuples as provided by the venue.
+
+        The result splits the price and quantity levels into separate lists
+        so downstream code can persist them without additional conversions.
+        """
+
+        bid_px = [float(p) for p, _ in bids]
+        bid_qty = [float(q) for _, q in bids]
+        ask_px = [float(p) for p, _ in asks]
+        ask_qty = [float(q) for _, q in asks]
+
+        return {
+            "symbol": symbol,
+            "ts": ts,
+            "bid_px": bid_px,
+            "bid_qty": bid_qty,
+            "ask_px": ask_px,
+            "ask_qty": ask_qty,
+        }
 
     # ------------------------------------------------------------------
     # Abstract API

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -85,7 +85,8 @@ async def test_binance_spot_rest_streams():
     gen2 = adapter.stream_order_book("BTC/USDT")
     book = await gen2.__anext__()
     await gen2.aclose()
-    assert book["bids"][0][0] == 1.0
+    assert book["bid_px"][0] == 1.0
+    assert book["bid_qty"][0] == 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_data_ingest.py
+++ b/tests/test_data_ingest.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from tradingbot.adapters.base import ExchangeAdapter
 from tradingbot.bus import EventBus
 from tradingbot.data.ingest import run_orderbook_stream
-from tradingbot.storage import timescale
+from tradingbot.data import ingestion
 from tradingbot.types import OrderBook
 
 
@@ -60,3 +60,48 @@ async def test_run_orderbook_stream_persists(monkeypatch):
     assert len(inserted) == 1
     assert inserted[0]["symbol"] == "BTC/USDT"
     assert inserted[0]["bid_px"] == [100.0, 99.5]
+
+
+@pytest.mark.asyncio
+async def test_stream_orderbook_persists_levels(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    snapshot = {
+        "ts": ts,
+        "bid_px": [100.0, 99.5],
+        "bid_qty": [1.0, 2.0],
+        "ask_px": [100.5, 101.0],
+        "ask_qty": [1.5, 2.5],
+    }
+
+    class DummyAdapter(ExchangeAdapter):
+        name = "dummy"
+
+        async def stream_trades(self, symbol: str):
+            if False:
+                yield {}
+
+        async def stream_orderbook(self, symbol: str, depth: int):
+            yield snapshot
+
+        async def place_order(self, *args, **kwargs):
+            return {}
+
+        async def cancel_order(self, order_id: str):
+            return {}
+
+    inserted = []
+
+    class DummyStorage:
+        def get_engine(self):
+            return "engine"
+
+        def insert_orderbook(self, engine, **data):
+            inserted.append(data)
+
+    monkeypatch.setattr(ingestion, "_get_storage", lambda backend: DummyStorage())
+
+    await ingestion.stream_orderbook(DummyAdapter(), "BTC/USDT", depth=5)
+
+    assert len(inserted) == 1
+    assert inserted[0]["bid_px"] == [100.0, 99.5]
+    assert inserted[0]["ask_qty"] == [1.5, 2.5]


### PR DESCRIPTION
## Summary
- normalise order books into separate bid/ask price and quantity lists
- streamline ingestion to persist order books without extra conversion
- add tests ensuring adapters and ingestion handle new snapshot format

## Testing
- `pytest` *(fails: tests/test_async_storage.py::test_insert_and_query_trades - OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0))*


------
https://chatgpt.com/codex/tasks/task_e_68a08c240320832da97b938c57a498c4