### PR TITLE
Use buy/sell terminology in CashAndCarry strategy

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,8 @@ corresponden al atributo ``name`` de cada clase.
 | Cash & Carry      | ``cash_and_carry`` | ``threshold`` (float)               |
 
 
+La estrategia Cash & Carry genera señales ``buy`` cuando el funding es positivo y la base supera el umbral indicado, o ``sell`` cuando el funding es negativo y la base cae por debajo de dicho umbral.
+
 ## API
 
 ```

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -67,10 +67,10 @@ class CashAndCarry(Strategy):
         basis = (perp - spot) / spot
         if funding > 0 and basis > self.cfg.threshold:
             self._persist_signal(basis, spot, perp)
-            return Signal("long", basis)
+            return Signal("buy", basis)
         if funding < 0 and basis < -self.cfg.threshold:
             self._persist_signal(basis, spot, perp)
-            return Signal("short", -basis)
+            return Signal("sell", -basis)
         return Signal("flat", 0.0)
 
     def _persist_signal(self, basis: float, spot_px: float, perp_px: float) -> None:

--- a/tests/test_cash_and_carry.py
+++ b/tests/test_cash_and_carry.py
@@ -35,8 +35,8 @@ def test_cash_and_carry_strategy():
     cfg = CashCarryConfig(symbol="BTCUSDT", threshold=0.0001)
     strat = CashAndCarry(cfg)
     sig_long = strat.on_bar({"spot": 100.0, "perp": 101.0, "funding": 0.001})
-    assert sig_long and sig_long.side == "long"
+    assert sig_long and sig_long.side == "buy"
     sig_short = strat.on_bar({"spot": 100.0, "perp": 99.0, "funding": -0.001})
-    assert sig_short and sig_short.side == "short"
+    assert sig_short and sig_short.side == "sell"
     sig_flat = strat.on_bar({"spot": 100.0, "perp": 100.0, "funding": 0.0001})
     assert sig_flat and sig_flat.side == "flat"


### PR DESCRIPTION
## Summary
- switch CashAndCarry signals from `long`/`short` to `buy`/`sell`
- update cash and carry tests for new signal names
- document Cash & Carry signal behavior in usage guide

## Testing
- `pytest -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*
- `pytest tests/test_cash_and_carry.py tests/test_execution.py tests/test_risk.py tests/test_router_orders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a08c2fd64c832dabc2aeb704a7bf09