### PR TITLE
Add triple barrier ML strategy and CLI integration

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,6 +11,13 @@ python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \
     --symbol BTC/USDT --strategy breakout_atr
 ```
 
+## Estrategia Triple Barrier
+Requiere ``scikit-learn`` para entrenar el modelo de gradient boosting.
+```bash
+python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \
+    --symbol BTC/USDT --strategy triple_barrier
+```
+
 ## API
 ```bash
 uvicorn tradingbot.apps.api.main:app --reload --port 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ hydra-core>=1.3
 mlflow>=2.12
 optuna>=3.5
 
+# Machine learning
+scikit-learn>=1.4
+
 # Data/Exchanges
 ccxt>=4.3.90
 websockets>=12.0

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -5,6 +5,7 @@ from .mean_reversion import MeanReversion
 from .arbitrage_triangular import TriangularArb
 from .cash_and_carry import CashAndCarry
 from .order_flow import OrderFlow
+from .triple_barrier import TripleBarrier
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
@@ -15,6 +16,7 @@ STRATEGIES = {
     TriangularArb.name: TriangularArb,
     CashAndCarry.name: CashAndCarry,
     OrderFlow.name: OrderFlow,
+    TripleBarrier.name: TripleBarrier,
 }
 
 __all__ = [
@@ -25,5 +27,6 @@ __all__ = [
     "TriangularArb",
     "CashAndCarry",
     "OrderFlow",
+    "TripleBarrier",
     "STRATEGIES",
 ]

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -1,0 +1,107 @@
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier
+
+from .base import Strategy, Signal, record_signal_metrics
+
+
+def triple_barrier_labels(
+    prices: pd.Series,
+    horizon: int = 5,
+    upper_pct: float = 0.02,
+    lower_pct: float = 0.02,
+) -> pd.Series:
+    """Generate triple-barrier labels for a price series.
+
+    Parameters
+    ----------
+    prices: pd.Series
+        Series of prices.
+    horizon: int, optional
+        Number of future bars to inspect, by default ``5``.
+    upper_pct: float, optional
+        Upper barrier percentage, by default ``0.02``.
+    lower_pct: float, optional
+        Lower barrier percentage, by default ``0.02``.
+
+    Returns
+    -------
+    pd.Series
+        Labels ``1`` if the upper barrier is hit first, ``-1`` for the
+        lower barrier, or ``0`` if neither is reached within the horizon.
+    """
+
+    labels = pd.Series(0, index=prices.index, dtype=int)
+    n = len(prices)
+    for i in range(n - 1):
+        start = prices.iloc[i]
+        upper = start * (1 + upper_pct)
+        lower = start * (1 - lower_pct)
+        end = min(i + 1 + horizon, n)
+        future = prices.iloc[i + 1:end]
+        hit_upper = future[future >= upper]
+        hit_lower = future[future <= lower]
+        if not hit_upper.empty and not hit_lower.empty:
+            first_up = hit_upper.index[0]
+            first_down = hit_lower.index[0]
+            labels.iloc[i] = 1 if first_up < first_down else -1
+        elif not hit_upper.empty:
+            labels.iloc[i] = 1
+        elif not hit_lower.empty:
+            labels.iloc[i] = -1
+    return labels
+
+
+class TripleBarrier(Strategy):
+    """Strategy using triple-barrier labeling and a gradient boosting model."""
+
+    name = "triple_barrier"
+
+    def __init__(
+        self,
+        horizon: int = 5,
+        upper_pct: float = 0.02,
+        lower_pct: float = 0.02,
+        training_window: int = 200,
+    ) -> None:
+        self.horizon = int(horizon)
+        self.upper_pct = float(upper_pct)
+        self.lower_pct = float(lower_pct)
+        self.training_window = int(training_window)
+        self.model = GradientBoostingClassifier()
+        self.fitted = False
+
+    def _prepare_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        returns = df["close"].pct_change().fillna(0)
+        feat = pd.DataFrame(
+            {
+                "ret": returns,
+                "ret_mean": returns.rolling(5).mean().fillna(0),
+                "ret_std": returns.rolling(5).std().fillna(0),
+            }
+        )
+        return feat
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.training_window:
+            return None
+        features = self._prepare_features(df)
+        if not self.fitted:
+            labels = triple_barrier_labels(
+                df["close"], self.horizon, self.upper_pct, self.lower_pct
+            )
+            X = features.iloc[:-1]
+            y = labels.iloc[:-1]
+            if y.nunique() > 1:
+                self.model.fit(X, y)
+                self.fitted = True
+            else:
+                return None
+        x_last = features.iloc[[-1]]
+        pred = self.model.predict(x_last)[0]
+        if pred == 1:
+            return Signal("buy", 1.0)
+        if pred == -1:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)


### PR DESCRIPTION
## Summary
- implement triple-barrier strategy with label generator and gradient boosting classifier
- expose strategy through registry so CLI backtests accept `--strategy triple_barrier`
- document usage in examples and add scikit-learn dependency

## Testing
- `PYTHONPATH=src python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv --symbol BTC/USDT --strategy triple_barrier`
- `PYTHONPATH=src pytest -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68a0962afefc832d9b23024b597d40d4