### PR TITLE
Add tests for arbitrage strategy, risk manager limits, and execution router metrics

### DIFF
--- a/tests/test_arbitrage_triangular.py
+++ b/tests/test_arbitrage_triangular.py
@@ -1,0 +1,25 @@
+import pytest
+from tradingbot.strategies.arbitrage_triangular import TriangularArb
+
+
+def test_triangular_arb_buy_signal():
+    strat = TriangularArb()
+    prices = {"bq": 100.0, "mq": 210.0, "mb": 2.0}
+    sig = strat.on_bar({"prices": prices})
+    assert sig.side == "buy"
+    assert sig.strength == pytest.approx(0.05)
+
+
+def test_triangular_arb_sell_signal():
+    strat = TriangularArb()
+    prices = {"bq": 210.0, "mq": 100.0, "mb": 2.0}
+    sig = strat.on_bar({"prices": prices})
+    assert sig.side == "sell"
+    assert sig.strength == pytest.approx(0.05)
+
+
+def test_triangular_arb_flat_when_incomplete_prices():
+    strat = TriangularArb()
+    sig = strat.on_bar({"prices": {"bq": 100.0, "mq": None, "mb": 2.0}})
+    assert sig.side == "flat"
+    assert sig.strength == pytest.approx(0.0)

--- a/tests/test_execution_router_slippage.py
+++ b/tests/test_execution_router_slippage.py
@@ -1,0 +1,58 @@
+import pytest
+
+from tradingbot.execution.order_types import Order
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.utils.metrics import SLIPPAGE
+
+
+class MockAdapter:
+    def __init__(self, name, order_book=None, fee_bps=0.0, latency=0.0, last_px=None, fill_price=None):
+        self.name = name
+        self.state = type("S", (), {"order_book": order_book or {}, "last_px": last_px or {}})
+        self.fee_bps = fee_bps
+        self.latency = latency
+        self.fill_price = fill_price
+
+    async def place_order(self, **kwargs):
+        price = self.fill_price if self.fill_price is not None else kwargs.get("price")
+        return {**kwargs, "status": "filled", "price": price}
+
+
+@pytest.mark.asyncio
+async def test_router_selects_lowest_cost_venue():
+    ob1 = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(101.0, 1.0)]}}
+    ob2 = {"XYZ": {"bids": [(99.5, 1.0)], "asks": [(100.5, 1.0)]}}
+    a1 = MockAdapter("a1", order_book=ob1, fee_bps=10.0, latency=5.0)
+    a2 = MockAdapter("a2", order_book=ob2, fee_bps=0.0, latency=20.0)
+    router = ExecutionRouter([a1, a2])
+    order = Order(symbol="XYZ", side="buy", type_="market", qty=1.0)
+    selected = await router.best_venue(order)
+    assert selected is a2
+
+
+@pytest.mark.asyncio
+async def test_router_records_slippage_metric():
+    SLIPPAGE.clear()
+    ob = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(100.0, 1.0)]}}
+    adapter = MockAdapter(
+        "m",
+        order_book=ob,
+        last_px={"XYZ": 100.0},
+        fill_price=101.0,
+    )
+    router = ExecutionRouter(adapter)
+    order = Order(symbol="XYZ", side="buy", type_="limit", qty=1.0, price=100.0)
+    await router.execute(order)
+    samples = list(SLIPPAGE.collect())[0].samples
+    count_sample = [
+        s
+        for s in samples
+        if s.name == "order_slippage_bps_count" and s.labels["symbol"] == "XYZ" and s.labels["side"] == "buy"
+    ][0]
+    sum_sample = [
+        s
+        for s in samples
+        if s.name == "order_slippage_bps_sum" and s.labels["symbol"] == "XYZ" and s.labels["side"] == "buy"
+    ][0]
+    assert count_sample.value == 1.0
+    assert sum_sample.value == pytest.approx(100.0)

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -1,0 +1,27 @@
+from tradingbot.risk.manager import RiskManager
+
+
+def test_stop_loss_sets_reason():
+    rm = RiskManager(max_pos=1, stop_loss_pct=0.05)
+    rm.set_position(1)
+    assert rm.check_limits(100)
+    assert not rm.check_limits(94)
+    assert rm.enabled is False
+    assert rm.last_kill_reason == "stop_loss"
+
+
+def test_drawdown_sets_reason():
+    rm = RiskManager(max_pos=1, max_drawdown_pct=0.05)
+    rm.set_position(1)
+    assert rm.check_limits(100)
+    assert rm.check_limits(110)
+    assert not rm.check_limits(104)
+    assert rm.enabled is False
+    assert rm.last_kill_reason == "drawdown"
+
+
+def test_manual_kill_switch_records_reason():
+    rm = RiskManager(max_pos=1)
+    rm.kill_switch("manual")
+    assert rm.enabled is False
+    assert rm.last_kill_reason == "manual"


### PR DESCRIPTION
## Summary
- add unit tests for TriangularArb strategy covering buy, sell, and flat signals
- verify RiskManager stop-loss, drawdown, and manual kill-switch reasons
- test ExecutionRouter venue selection and slippage metrics using mocked adapters

## Testing
- `pytest tests/test_arbitrage_triangular.py tests/test_risk_manager_limits.py tests/test_execution_router_slippage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0962a6044832d94e7733755f0ceeb