### PR TITLE
feat: add performance metrics to backtest report

### DIFF
--- a/analysis/backtest_report.py
+++ b/analysis/backtest_report.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+import math
+from statistics import NormalDist
+
+import pandas as pd
+
 
 def generate_report(result: Dict) -> Dict[str, float]:
     """Generate a basic backtest report.
@@ -15,7 +20,9 @@ def generate_report(result: Dict) -> Dict[str, float]:
     Returns
     -------
     Mapping containing ``pnl`` (final equity), ``fill_rate`` and average
-    ``slippage`` per traded unit.
+    ``slippage`` per traded unit.  If an ``equity_curve`` is present in the
+    result, additional statistics ``sharpe``, ``sortino`` and
+    ``deflated_sharpe_ratio`` are also returned.
     """
 
     equity = float(result.get("equity", 0.0))
@@ -37,7 +44,43 @@ def generate_report(result: Dict) -> Dict[str, float]:
         total_slip += slip
     avg_slippage = total_slip / total_filled if total_filled else 0.0
 
-    return {"pnl": equity, "fill_rate": fill_rate, "slippage": avg_slippage}
+    stats = {"pnl": equity, "fill_rate": fill_rate, "slippage": avg_slippage}
+
+    eq_curve = result.get("equity_curve")
+    if eq_curve and len(eq_curve) > 1:
+        # Accept a list of numbers or dicts with an "equity" key
+        if isinstance(eq_curve[0], dict):
+            curve = [float(x.get("equity", 0.0)) for x in eq_curve]
+        else:
+            curve = [float(x) for x in eq_curve]
+        returns = pd.Series(curve).pct_change().dropna()
+        if not returns.empty and returns.std(ddof=0) > 0:
+            daily_sharpe = returns.mean() / returns.std(ddof=0)
+            sharpe = float(daily_sharpe * math.sqrt(252))
+
+            downside = returns[returns < 0].std(ddof=0)
+            sortino = (
+                float(returns.mean() / downside * math.sqrt(252))
+                if downside and downside > 0
+                else 0.0
+            )
+
+            n = returns.shape[0]
+            skew = float(returns.skew())
+            kurt = float(returns.kurtosis())
+            num = daily_sharpe * math.sqrt(n - 1)
+            den = math.sqrt(max(1e-12, 1 - skew * daily_sharpe + (kurt - 1) / 4 * daily_sharpe**2))
+            dsr = NormalDist().cdf(num / den)
+
+            stats.update(
+                {
+                    "sharpe": sharpe,
+                    "sortino": sortino,
+                    "deflated_sharpe_ratio": float(dsr),
+                }
+            )
+
+    return stats
 
 
 __all__ = ["generate_report"]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,6 +10,9 @@ python -m tradingbot.cli ingest --symbol BTC/USDT
 python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \
     --symbol BTC/USDT --strategy breakout_atr
 ```
+Al finalizar se imprimirá un resumen con estadísticas adicionales como
+``sharpe``, ``sortino`` y ``deflated_sharpe_ratio`` junto con ``pnl``,
+``fill_rate`` y ``slippage``.
 
 ## API
 ```bash

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -16,6 +16,7 @@ import sys
 import typer
 
 from ..logging_conf import setup_logging
+from analysis.backtest_report import generate_report
 
 
 app = typer.Typer(add_completion=False, help="Utilities for running TradingBot")
@@ -69,6 +70,7 @@ def backtest(
 
     result = run_backtest_csv({symbol: data}, [(strategy, symbol)])
     typer.echo(result)
+    typer.echo(generate_report(result))
 
 
 @app.command("backtest-cfg")
@@ -102,6 +104,7 @@ def backtest_cfg(config: str) -> None:
         result = run_backtest_csv({symbol: data}, [(strategy, symbol)])
         typer.echo(OmegaConf.to_yaml(cfg))
         typer.echo(result)
+        typer.echo(generate_report(result))
     old_argv = sys.argv
     sys.argv = [sys.argv[0]]
     try:

--- a/tests/test_backtest_report.py
+++ b/tests/test_backtest_report.py
@@ -1,6 +1,8 @@
 import pathlib
 import sys
 
+import pytest
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
@@ -10,7 +12,17 @@ from analysis.backtest_report import generate_report
 
 def test_generate_report_basic():
     result = {
-        "equity": 10.0,
+        "equity": 10.5,
+        "equity_curve": [
+            10.0,
+            9.8,
+            10.2,
+            10.1,
+            10.4,
+            10.3,
+            10.7,
+            10.5,
+        ],
         "orders": [
             {
                 "qty": 1.0,
@@ -29,6 +41,9 @@ def test_generate_report_basic():
         ],
     }
     report = generate_report(result)
-    assert report["pnl"] == 10.0
+    assert report["pnl"] == 10.5
     assert report["fill_rate"] == 1.5 / 2.0
     assert abs(report["slippage"] - 1.0) < 1e-9
+    assert pytest.approx(report["sharpe"], rel=1e-9) == 4.523813861160344
+    assert pytest.approx(report["sortino"], rel=1e-9) == 24.0067220169515
+    assert pytest.approx(report["deflated_sharpe_ratio"], rel=1e-9) == 0.7784159008283134


### PR DESCRIPTION
## Summary
- compute Sharpe, Sortino and deflated Sharpe ratio from equity curve
- document new metrics and expose them via CLI backtest commands
- test backtest report metrics

## Testing
- `pytest -q` *(fails: connect call failed ('::1', 5432) when running async storage tests)*
- `pytest -k 'not async_storage' -q`

------
https://chatgpt.com/codex/tasks/task_e_68a09629f278832d8b07be551a011b7f