### PR TITLE
Add normalized open interest fetchers for major exchanges

### DIFF
--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -93,15 +93,26 @@ class BybitFuturesAdapter(ExchangeAdapter):
         return await self._request(method, sym)
 
     async def fetch_oi(self, symbol: str):
+        """Return current open interest for ``symbol``.
+
+        Bybit provides the value under the ``public/v5/market/open-interest``
+        endpoint.  The response wraps the data inside ``result.list``.  We
+        normalise it into a lightweight ``{"ts": datetime, "oi": float}``
+        structure.
+        """
+
         sym = self.normalize_symbol(symbol)
-        method = getattr(self.rest, "fetchOpenInterest", None)
-        if method:
-            return await self._request(method, sym)
-        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
-        if hist:
-            data = await self._request(hist, sym)
-            return data[-1] if isinstance(data, list) and data else data
-        raise NotImplementedError("Open interest not supported")
+        method = getattr(self.rest, "publicGetV5MarketOpenInterest", None)
+        if method is None:
+            raise NotImplementedError("Open interest not supported")
+
+        data = await self._request(method, {"category": "linear", "symbol": sym})
+        lst = (data.get("result") or {}).get("list") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(item.get("timestamp", 0))
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        oi = float(item.get("openInterest", 0.0))
+        return {"ts": ts, "oi": oi}
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -93,15 +93,26 @@ class BybitSpotAdapter(ExchangeAdapter):
         return await self._request(method, sym)
 
     async def fetch_oi(self, symbol: str):
+        """Return current open interest for ``symbol``.
+
+        Spot markets do not have an intrinsic open interest, but Bybit's public
+        API exposes it for the corresponding linear contract.  We call the same
+        ``public/v5/market/open-interest`` endpoint used for futures and return
+        the data normalised to ``{"ts": datetime, "oi": float}``.
+        """
+
         sym = self.normalize_symbol(symbol)
-        method = getattr(self.rest, "fetchOpenInterest", None)
-        if method:
-            return await self._request(method, sym)
-        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
-        if hist:
-            data = await self._request(hist, sym)
-            return data[-1] if isinstance(data, list) and data else data
-        raise NotImplementedError("Open interest not supported")
+        method = getattr(self.rest, "publicGetV5MarketOpenInterest", None)
+        if method is None:
+            raise NotImplementedError("Open interest not supported")
+
+        data = await self._request(method, {"category": "linear", "symbol": sym})
+        lst = (data.get("result") or {}).get("list") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(item.get("timestamp", 0))
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        oi = float(item.get("openInterest", 0.0))
+        return {"ts": ts, "oi": oi}
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -91,15 +91,26 @@ class OKXFuturesAdapter(ExchangeAdapter):
         return await self._request(method, sym)
 
     async def fetch_oi(self, symbol: str):
+        """Fetch open interest for the given contract ``symbol``.
+
+        OKX exposes the value through the ``/public/open-interest`` endpoint.
+        The result is a list under ``data`` with the current open interest and
+        timestamp in milliseconds.  We normalise this into
+        ``{"ts": datetime, "oi": float}``.
+        """
+
         sym = self.normalize_symbol(symbol)
-        method = getattr(self.rest, "fetchOpenInterest", None)
-        if method:
-            return await self._request(method, sym)
-        hist = getattr(self.rest, "fetchOpenInterestHistory", None)
-        if hist:
-            data = await self._request(hist, sym)
-            return data[-1] if isinstance(data, list) and data else data
-        raise NotImplementedError("Open interest not supported")
+        method = getattr(self.rest, "publicGetPublicOpenInterest", None)
+        if method is None:
+            raise NotImplementedError("Open interest not supported")
+
+        data = await self._request(method, {"instId": sym})
+        lst = data.get("data") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(item.get("ts", 0))
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        oi = float(item.get("oi", 0.0))
+        return {"ts": ts, "oi": oi}
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,5 +1,5 @@
 import pytest
-import pytest
+from datetime import datetime, timezone
 from tradingbot.adapters import (
     BybitSpotAdapter,
     BybitFuturesAdapter,
@@ -55,8 +55,8 @@ class _DummyFuturesRest:
     def fetchFundingRate(self, symbol):
         return {"rate": 0.01}
 
-    def fetchOpenInterest(self, symbol):
-        return {"oi": 100}
+    def fapiPublicGetOpenInterest(self, params):
+        return {"symbol": params.get("symbol"), "openInterest": "100", "time": 1000}
 
 
 class _DummyDelegate:
@@ -102,7 +102,8 @@ async def test_binance_futures_rest_fetch():
     funding = await adapter.fetch_funding("BTC/USDT")
     oi = await adapter.fetch_oi("BTC/USDT")
     assert funding["rate"] == 0.01
-    assert oi["oi"] == 100
+    assert oi["oi"] == 100.0
+    assert oi["ts"] == datetime.fromtimestamp(1, tz=timezone.utc)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- implement REST-based `fetch_oi` for Binance, Bybit and OKX spot/futures adapters
- return `{"ts": datetime, "oi": float}` for open interest polling
- expand tests to exercise normalized open interest handling

## Testing
- `pytest tests/test_adapters.py::test_binance_futures_rest_fetch -q`
- `pytest tests/test_async_storage.py::test_insert_and_query_trades -q` *(fails: Connect call failed ('::1', 5432))*
- `pytest -q` *(fails: Connect call failed ('::1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68a096296720832dbe6d609172c2940e