### PR TITLE
Add slippage and risk metrics to monitoring

### DIFF
--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -63,9 +63,45 @@
       ],
       "datasource": "Prometheus",
       "id": 5
+    },
+    {
+      "type": "stat",
+      "title": "Fills (5m)",
+      "targets": [
+        {
+          "expr": "sum(increase(order_fills_total[5m]))",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 6
+    },
+    {
+      "type": "stat",
+      "title": "Avg slippage bps (5m)",
+      "targets": [
+        {
+          "expr": "sum(rate(order_slippage_bps_sum[5m])) / sum(rate(order_slippage_bps_count[5m]))",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 7
+    },
+    {
+      "type": "stat",
+      "title": "Risk events (5m)",
+      "targets": [
+        {
+          "expr": "sum(increase(risk_events_total[5m]))",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 8
     }
   ],
   "schemaVersion": 16,
   "title": "TradeBot Metrics",
-  "version": 2
+  "version": 3
 }

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, Response
 from prometheus_client import Gauge, Histogram, Counter, generate_latest, CONTENT_TYPE_LATEST
 
+# Reuse detailed execution metrics
+from tradingbot.utils.metrics import FILL_COUNT, SLIPPAGE, RISK_EVENTS
+
 # Trading metrics
 TRADING_PNL = Gauge(
     "trading_pnl",
@@ -31,7 +34,39 @@ def metrics() -> Response:
 @router.get("/metrics/summary")
 def metrics_summary() -> dict:
     """Return a minimal summary of key metrics."""
+
+    # Aggregate fills across all symbols/sides
+    fill_total = sum(
+        sample.value
+        for metric in FILL_COUNT.collect()
+        for sample in metric.samples
+        if sample.name.endswith("_total")
+    )
+
+    # Aggregate risk events across all event types
+    risk_total = sum(
+        sample.value
+        for metric in RISK_EVENTS.collect()
+        for sample in metric.samples
+        if sample.name.endswith("_total")
+    )
+
+    # Compute average slippage in basis points
+    slippage_samples = [
+        sample
+        for metric in SLIPPAGE.collect()
+        for sample in metric.samples
+    ]
+    slippage_sum = sum(s.value for s in slippage_samples if s.name.endswith("_sum"))
+    slippage_count = sum(
+        s.value for s in slippage_samples if s.name.endswith("_count")
+    )
+    avg_slippage = slippage_sum / slippage_count if slippage_count else 0.0
+
     return {
         "pnl": TRADING_PNL._value.get(),
         "disconnects": SYSTEM_DISCONNECTS._value.get(),
+        "fills": fill_total,
+        "risk_events": risk_total,
+        "avg_slippage_bps": avg_slippage,
     }

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import time
 from starlette.requests import Request
 
+from monitoring.metrics import metrics_summary as _metrics_summary
+
 from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 
@@ -45,6 +47,12 @@ def health():
 @app.get("/metrics")
 def metrics():
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/metrics/summary")
+def metrics_summary():
+    """Expose a summarized view of key metrics."""
+    return _metrics_summary()
 
 @app.get("/tri/signals")
 def tri_signals(limit: int = Query(100, ge=1, le=1000)):


### PR DESCRIPTION
## Summary
- Aggregate fills, slippage and risk events in monitoring metrics summary
- Expose `/metrics/summary` endpoint through API
- Provide Grafana panels for fills, slippage and risk events

## Testing
- `PYTHONPATH=src:. pytest tests/test_monitoring_panel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a28d0f28832d89d25a3a3a4ac2ea