### PR TITLE
Use stream_order_book API in ingestion

### DIFF
--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -42,7 +42,7 @@ async def run_orderbook_stream(
 ) -> None:
     """Publish and persist order book snapshots."""
     storage = _get_storage(backend)
-    async for d in adapter.stream_orderbook(symbol, depth):
+    async for d in adapter.stream_order_book(symbol, depth):
         ob = OrderBook(
             ts=d.get("ts", datetime.now(timezone.utc)),
             exchange=getattr(adapter, "name", "unknown"),
@@ -93,7 +93,7 @@ async def stream_orderbook(adapter: Any, symbol: str, depth: int = 10, *, backen
     """Stream L2 orderbook snapshots and persist them."""
     storage = _get_storage(backend)
     engine = storage.get_engine()
-    async for d in adapter.stream_orderbook(symbol, depth):
+    async for d in adapter.stream_order_book(symbol, depth):
         data = {
             "ts": d.get("ts", datetime.now(timezone.utc)),
             "exchange": getattr(adapter, "name", "unknown"),

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -25,6 +25,8 @@ class DummyOBAdapter(ExchangeAdapter):
         for snap in self._snapshots:
             yield snap
 
+    stream_order_book = stream_orderbook
+
     async def place_order(self, *args, **kwargs):
         return {}
 
@@ -89,6 +91,8 @@ async def test_stream_orderbook_persists_levels(monkeypatch):
         async def stream_orderbook(self, symbol: str, depth: int):
             yield snapshot
 
+        stream_order_book = stream_orderbook
+
         async def place_order(self, *args, **kwargs):
             return {}
 
@@ -126,6 +130,8 @@ async def test_run_trades_stream_publishes():
         async def stream_orderbook(self, symbol: str, depth: int):
             if False:
                 yield {}
+
+        stream_order_book = stream_orderbook
 
         async def place_order(self, *args, **kwargs):
             return {}


### PR DESCRIPTION
## Summary
- switch order book streaming in ingestion to adapter.stream_order_book
- expose stream_order_book alias on test adapters

## Testing
- `pytest tests/test_data_ingestion.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0a27852c4832da70113e540088a24