### PR TITLE
feat: expose order latency and maker-taker metrics

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -12,7 +12,8 @@
       try {
         const resp = await fetch('/metrics/summary');
         const data = await resp.json();
-        document.getElementById('summary').innerText = `PnL: ${data.pnl} | Disconnects: ${data.disconnects}`;
+        document.getElementById('summary').innerText =
+          `PnL: ${data.pnl} | Disconnects: ${data.disconnects} | Avg Order Latency: ${data.avg_order_latency_seconds} | Maker/Taker Ratio: ${data.avg_maker_taker_ratio}`;
       } catch (err) {
         document.getElementById('summary').innerText = 'Error loading metrics';
       }

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -1,7 +1,13 @@
 from fastapi.testclient import TestClient
 
 from monitoring.panel import app
-from monitoring.metrics import TRADING_PNL, SYSTEM_DISCONNECTS, MARKET_LATENCY
+from monitoring.metrics import (
+    TRADING_PNL,
+    SYSTEM_DISCONNECTS,
+    MARKET_LATENCY,
+    ORDER_LATENCY,
+    MAKER_TAKER_RATIO,
+)
 
 
 def test_panel_endpoints_and_metrics():
@@ -10,6 +16,10 @@ def test_panel_endpoints_and_metrics():
     TRADING_PNL.set(100)
     SYSTEM_DISCONNECTS.inc()
     MARKET_LATENCY.observe(0.5)
+    ORDER_LATENCY.clear()
+    MAKER_TAKER_RATIO.clear()
+    ORDER_LATENCY.labels(venue="test").observe(0.2)
+    MAKER_TAKER_RATIO.labels(venue="test").set(1.5)
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -23,3 +33,5 @@ def test_panel_endpoints_and_metrics():
     data = resp.json()
     assert data["pnl"] == 100.0
     assert data["disconnects"] == 1.0
+    assert data["avg_order_latency_seconds"] == 0.2
+    assert data["avg_maker_taker_ratio"] == 1.5


### PR DESCRIPTION
## Summary
- include ORDER_LATENCY and MAKER_TAKER_RATIO in monitoring metrics summary
- render new latency and maker/taker data on the monitoring dashboard
- test metrics summary exposes latency and maker/taker fields

## Testing
- `pytest` *(fails: tests/test_adapters.py::test_binance_spot_rest_streams, tests/test_async_storage.py::test_insert_and_query_trades, tests/test_async_storage.py::test_insert_and_query_bars, tests/test_async_storage.py::test_insert_and_query_orderbook, tests/test_async_storage.py::test_insert_and_query_funding)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aaa59fc8832d9f33c9b0180eb116