### PR TITLE
Add optional execution algorithms to router

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -6,6 +6,18 @@ high level commands used throughout the project.  The commands
 are intentionally lightweight so importing the module does not
 require heavy third party dependencies until a command is
 executed.
+
+Examples
+--------
+The execution router supports simple algorithms directly from the
+CLI by passing ``--algo`` and its parameters.  For instance::
+
+    tradingbot run-bot --algo twap --slices 4
+    tradingbot run-bot --algo vwap --volumes 1 2 3
+    tradingbot run-bot --algo pov --participation-rate 0.5
+
+These examples illustrate how an order could be executed using
+TWAP, VWAP or POV strategies.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- allow `ExecutionRouter.execute` to delegate to TWAP, VWAP and POV algorithms
- document CLI examples for using `--algo` with router
- test router execution for TWAP, VWAP and POV algorithms

## Testing
- `pytest tests/test_execution.py::test_twap_splits_orders tests/test_execution.py::test_vwap_distribution tests/test_execution.py::test_pov_participates -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0aaa1bca8832d999211ec679eb29c