### PR TITLE
feat: auto-init binance futures rest adapter

### DIFF
--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -70,6 +70,7 @@ class _DummyDelegate:
 @pytest.mark.asyncio
 async def test_binance_spot_rest_streams():
     adapter = BinanceSpotAdapter.__new__(BinanceSpotAdapter)
+    ExchangeAdapter.__init__(adapter)
     adapter.rest = _DummyRest()
 
     async def _req(fn, *a, **k):

--- a/tests/test_binance_futures_ws_orders.py
+++ b/tests/test_binance_futures_ws_orders.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tradingbot.adapters.binance_futures_ws import BinanceFuturesWSAdapter
+from tradingbot.config import settings
+
+
+@pytest.mark.asyncio
+async def test_place_and_cancel_order_on_testnet():
+    if not (settings.binance_futures_api_key and settings.binance_futures_api_secret):
+        pytest.skip("Binance Futures testnet credentials required")
+    adapter = BinanceFuturesWSAdapter(testnet=settings.binance_futures_testnet)
+    order = await adapter.place_order(
+        "BTC/USDT", "buy", "LIMIT", 0.001, price=100.0
+    )
+    assert order.get("ext_order_id")
+    cancel = await adapter.cancel_order(order["ext_order_id"], symbol="BTC/USDT")
+    assert str(cancel.get("orderId")) == str(order["ext_order_id"])


### PR DESCRIPTION
## Summary
- lazy-init Binance Futures REST adapter inside websocket adapter using env credentials
- add ability to place and cancel orders via websocket adapter
- add integration test for placing and cancelling testnet orders

## Testing
- `pytest tests/test_adapters.py -q`
- `pytest tests/test_binance_futures_ws_orders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0aa96045c832dbe314850d4fd5e9b