### PR TITLE
Add trade streaming support and tests

### DIFF
--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook
+from .base import ExchangeConnector, OrderBook, Trade
 
 
 class BinanceConnector(ExchangeConnector):
@@ -28,4 +28,26 @@ class BinanceConnector(ExchangeConnector):
             symbol=symbol,
             bids=bids,
             asks=asks,
+        )
+
+    def _ws_trades_url(self, symbol: str) -> str:
+        return f"wss://stream.binance.com:9443/ws/{symbol.lower()}@trade"
+
+    def _ws_trades_subscribe(self, symbol: str) -> str:
+        return json.dumps(
+            {"method": "SUBSCRIBE", "params": [f"{symbol.lower()}@trade"], "id": 1}
+        )
+
+    def _parse_trade(self, msg: str, symbol: str) -> Trade:
+        data = json.loads(msg)
+        ts = data.get("T") or data.get("t") or 0
+        if ts > 1e12:
+            ts /= 1000
+        return Trade(
+            timestamp=datetime.fromtimestamp(ts),
+            exchange=self.name,
+            symbol=symbol,
+            price=float(data.get("p", 0.0)),
+            amount=float(data.get("q", 0.0)),
+            side="sell" if data.get("m") else "buy",
         )

--- a/src/tradingbot/connectors/bybit.py
+++ b/src/tradingbot/connectors/bybit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook
+from .base import ExchangeConnector, OrderBook, Trade
 
 
 class BybitConnector(ExchangeConnector):
@@ -28,4 +28,26 @@ class BybitConnector(ExchangeConnector):
             symbol=symbol,
             bids=bids,
             asks=asks,
+        )
+
+    def _ws_trades_url(self, symbol: str) -> str:
+        # Public spot endpoint
+        return "wss://stream.bybit.com/v5/public/spot"
+
+    def _ws_trades_subscribe(self, symbol: str) -> str:
+        return json.dumps({"op": "subscribe", "args": [f"publicTrade.{symbol}"]})
+
+    def _parse_trade(self, msg: str, symbol: str) -> Trade:
+        data = json.loads(msg)
+        trade_data = (data.get("data") or [{}])[0]
+        ts = trade_data.get("t") or trade_data.get("T") or 0
+        if ts > 1e12:
+            ts /= 1000
+        return Trade(
+            timestamp=datetime.fromtimestamp(ts),
+            exchange=self.name,
+            symbol=symbol,
+            price=float(trade_data.get("p", 0.0)),
+            amount=float(trade_data.get("v", 0.0)),
+            side=(trade_data.get("S") or trade_data.get("side", "")).lower(),
         )

--- a/src/tradingbot/connectors/okx.py
+++ b/src/tradingbot/connectors/okx.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook
+from .base import ExchangeConnector, OrderBook, Trade
 
 
 class OKXConnector(ExchangeConnector):
@@ -27,4 +27,27 @@ class OKXConnector(ExchangeConnector):
             symbol=symbol,
             bids=bids,
             asks=asks,
+        )
+
+    def _ws_trades_url(self, symbol: str) -> str:
+        return "wss://ws.okx.com:8443/ws/v5/public"
+
+    def _ws_trades_subscribe(self, symbol: str) -> str:
+        return json.dumps({"op": "subscribe", "args": [{"channel": "trades", "instId": symbol}]})
+
+    def _parse_trade(self, msg: str, symbol: str) -> Trade:
+        data = json.loads(msg)
+        trade = (data.get("data") or [{}])[0]
+        ts = trade.get("ts") or trade.get("t") or 0
+        if ts > 1e12:
+            ts = int(ts) / 1000
+        else:
+            ts = int(ts)
+        return Trade(
+            timestamp=datetime.fromtimestamp(ts),
+            exchange=self.name,
+            symbol=symbol,
+            price=float(trade.get("px", 0.0)),
+            amount=float(trade.get("sz", 0.0)),
+            side=trade.get("side", ""),
         )


### PR DESCRIPTION
## Summary
- add trade streaming framework to base connector
- implement trade WebSocket handling for Binance, Bybit and OKX connectors
- test continuous trade streaming for all connectors

## Testing
- `python -m pytest tests/test_connectors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0aa999278832d8830846eaef8031c