### PR TITLE
Add vectorbt wrapper for parameter sweeps

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -29,3 +29,27 @@ uvicorn tradingbot.apps.api.main:app --reload --port 8000
 ## Notebook
 Consulta el notebook [docs/notebooks/breakout_atr.ipynb](notebooks/breakout_atr.ipynb)
 para ver un flujo de trabajo completo de un backtest.
+
+## Barrido de parámetros con vectorbt
+Se requiere instalar la dependencia opcional `vectorbt`.
+
+```python
+import numpy as np
+import pandas as pd
+from tradingbot.backtesting.vectorbt_wrapper import run_parameter_sweep
+
+def ma_signal(close, fast, slow):
+    import vectorbt as vbt
+    fast_ma = vbt.MA.run(close, fast)
+    slow_ma = vbt.MA.run(close, slow)
+    entries = fast_ma.ma_crossed_above(slow_ma)
+    exits = fast_ma.ma_crossed_below(slow_ma)
+    return entries, exits
+
+price = pd.Series(np.linspace(1, 2, 100))
+data = pd.DataFrame({"close": price})
+params = {"fast": [5, 10], "slow": [20]}
+
+stats = run_parameter_sweep(data, ma_signal, params)
+print(stats)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,12 @@ authors = [{name="Tu Nombre", email="you@example.com"}]
 requires-python = ">=3.11"
 dependencies = []
 
+[project.optional-dependencies]
+vectorbt = ["vectorbt>=0.26"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = ["tradingbot"]
+
+[tool.pytest.ini_options]
+markers = ["optional: tests requiring optional dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,4 @@ httpx>=0.27
 flake8>=7.0
 
 # Backtesting helpers
-vectorbtpro==0.0.0; python_version == "0"  # placeholder si se usa luego
+vectorbt>=0.26; python_version == "0"  # optional dependency

--- a/src/tradingbot/backtesting/vectorbt_wrapper.py
+++ b/src/tradingbot/backtesting/vectorbt_wrapper.py
@@ -1,0 +1,87 @@
+"""Thin wrapper around vectorbt to perform parameter sweeps.
+
+The wrapper accepts OHLCV data and a strategy ``signal`` function.  It
+evaluates the strategy for every combination in ``param_grid`` using
+``vectorbt`` and returns a DataFrame with basic performance metrics.
+
+The dependency on ``vectorbt`` is optional; an informative ``RuntimeError`` is
+raised if it is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, Tuple, Any
+
+import pandas as pd
+
+__all__ = ["run_parameter_sweep"]
+
+
+def run_parameter_sweep(
+    ohlcv: pd.DataFrame,
+    signal_func: Callable[..., Tuple[pd.Series, pd.Series]],
+    param_grid: Dict[str, Iterable],
+    *,
+    price_col: str = "close",
+    portfolio_kwargs: Dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Run a vectorbt backtest over all parameter combinations.
+
+    Parameters
+    ----------
+    ohlcv:
+        DataFrame containing at least the ``price_col`` column.
+    signal_func:
+        Callable that receives the price Series and parameters, returning
+        entry and exit boolean Series.
+    param_grid:
+        Mapping of parameter names to iterables of values to sweep.
+    price_col:
+        Column in ``ohlcv`` to use as the price series. Defaults to ``close``.
+    portfolio_kwargs:
+        Additional kwargs forwarded to ``vectorbt.Portfolio.from_signals``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Metrics ``sharpe_ratio``, ``max_drawdown`` and ``total_return`` indexed
+        by the parameter combinations.
+    """
+
+    try:  # pragma: no cover - optional dependency
+        import vectorbt as vbt  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError("vectorbt is not installed") from exc
+
+    close = ohlcv[price_col]
+    param_names = list(param_grid.keys())
+
+    def apply_func(close, *args):
+        params = dict(zip(param_names, args))
+        return signal_func(close, **params)
+
+    factory = vbt.IndicatorFactory(
+        input_names=["close"],
+        param_names=param_names,
+        output_names=["entries", "exits"],
+    )
+    indicator = factory.from_apply_func(apply_func)
+    ind = indicator.run(close, **param_grid)
+
+    freq = None
+    if isinstance(ohlcv.index, pd.DatetimeIndex):
+        freq = pd.infer_freq(ohlcv.index)
+    if freq is None:
+        freq = "1D"
+
+    pf_kwargs = dict(portfolio_kwargs or {})
+    pf = vbt.Portfolio.from_signals(
+        close, ind.entries, ind.exits, freq=freq, **pf_kwargs
+    )
+    metrics = pd.concat(
+        [pf.sharpe_ratio(), pf.max_drawdown(), pf.total_return()], axis=1
+    )
+    metrics.columns = ["sharpe_ratio", "max_drawdown", "total_return"]
+    metrics.index.set_names(list(param_grid.keys()), inplace=True)
+    return metrics
+

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -79,6 +79,25 @@ def test_run_vectorbt_basic():
     assert list(stats.index.names) == ["fast", "slow"]
 
 
+@pytest.mark.optional
+def test_vectorbt_wrapper_param_sweep():
+    vbt_local = pytest.importorskip("vectorbt")
+    from tradingbot.backtesting.vectorbt_wrapper import run_parameter_sweep
+
+    def ma_signal(close, window):
+        ma = vbt_local.MA.run(close, window).ma
+        entries = close > ma
+        exits = close < ma
+        return entries, exits
+
+    price = pd.Series(np.linspace(1, 2, 50))
+    data = pd.DataFrame({"close": price})
+    params = {"window": [2, 4]}
+    stats = run_parameter_sweep(data, ma_signal, params)
+    assert not stats.empty
+    assert list(stats.index.names) == ["window"]
+
+
 class OneShotStrategy:
     name = "oneshot"
 


### PR DESCRIPTION
## Summary
- add optional `vectorbt` dependency and expose as extra
- implement `run_parameter_sweep` helper around vectorbt
- document usage example and add optional test

## Testing
- `pytest tests/test_backtest_engine.py::test_vectorbt_wrapper_param_sweep -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac696ea0832db47e882e193cf864