### PR TITLE
feat: expand monitoring with E2E metrics and Sentry

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,3 +37,10 @@ Para el stack completo (API, TimescaleDB, QuestDB, Prometheus y Grafana):
 
 Los archivos de configuración y esquemas se encuentran en `sql/` y
 `monitoring/`.
+
+### Dashboards de Grafana
+Las plantillas de paneles se encuentran en `monitoring/grafana/dashboards/`.
+Al iniciar el stack con `./bin/start_stack.sh` estos dashboards se cargan
+automáticamente. Para cargarlos manualmente en una instalación existente,
+importa los archivos JSON desde la interfaz de Grafana o copia el directorio
+en `/var/lib/grafana/dashboards` y reinicia el servicio.

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -27,3 +27,30 @@ groups:
         annotations:
           summary: System disconnections detected
           description: Disconnections occurred in the last 5m
+
+      - alert: HighE2ELatency
+        expr: histogram_quantile(0.95, sum(rate(e2e_latency_seconds_bucket[5m])) by (le)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High end-to-end latency
+          description: 95th percentile E2E latency above 1s for 5m
+
+      - alert: WebsocketFailures
+        expr: increase(ws_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Websocket failures detected
+          description: WS failures occurred in the last 5m
+
+      - alert: StrategyDown
+        expr: avg_over_time(strategy_up[5m]) < 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Strategy is down
+          description: One or more strategies reported as not running

--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -99,6 +99,30 @@
       ],
       "datasource": "Prometheus",
       "id": 8
+    },
+    {
+      "type": "graph",
+      "title": "E2E latency (95th)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(e2e_latency_seconds_bucket[5m])) by (le, strategy))",
+          "legendFormat": "{{strategy}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 9
+    },
+    {
+      "type": "table",
+      "title": "Strategy status",
+      "targets": [
+        {
+          "expr": "strategy_up",
+          "legendFormat": "{{strategy}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 10
     }
   ],
   "schemaVersion": 16,

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -1,8 +1,57 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
+from typing import Dict, Any
 
 from .metrics import router as metrics_router
+
+# Optional Sentry integration
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.fastapi import FastApiIntegration
+except Exception:  # pragma: no cover - sentry optional
+    sentry_sdk = None
+    FastApiIntegration = None
+
+
+def _load_sentry_config(path: Path) -> Dict[str, Any]:
+    config: Dict[str, Any] = {}
+    if not path.exists():
+        return config
+    raw = path.read_text().splitlines()
+    for line in raw:
+        line = line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        # basic type casting
+        if value.lower() in {"true", "false"}:
+            config[key] = value.lower() == "true"
+        else:
+            try:
+                config[key] = float(value)
+            except ValueError:
+                config[key] = value
+    return config
+
+
+def _init_sentry():  # pragma: no cover - side effects
+    if sentry_sdk is None:
+        return
+    config = _load_sentry_config(Path(__file__).with_name("sentry.yml"))
+    if not config.get("dsn"):
+        return
+    sentry_sdk.init(
+        dsn=config.get("dsn"),
+        environment=config.get("environment"),
+        traces_sample_rate=float(config.get("traces_sample_rate", 1.0)),
+        integrations=[FastApiIntegration()] if FastApiIntegration else None,
+    )
+
+
+_init_sentry()
 
 app = FastAPI(title="TradeBot Monitoring")
 app.include_router(metrics_router)

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -1,3 +1,8 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
 from fastapi.testclient import TestClient
 
 from monitoring.panel import app
@@ -7,6 +12,9 @@ from monitoring.metrics import (
     MARKET_LATENCY,
     ORDER_LATENCY,
     MAKER_TAKER_RATIO,
+    E2E_LATENCY,
+    WS_FAILURES,
+    STRATEGY_UP,
 )
 
 
@@ -18,8 +26,14 @@ def test_panel_endpoints_and_metrics():
     MARKET_LATENCY.observe(0.5)
     ORDER_LATENCY.clear()
     MAKER_TAKER_RATIO.clear()
+    E2E_LATENCY.clear()
+    WS_FAILURES.clear()
+    STRATEGY_UP.clear()
     ORDER_LATENCY.labels(venue="test").observe(0.2)
     MAKER_TAKER_RATIO.labels(venue="test").set(1.5)
+    E2E_LATENCY.labels(strategy="demo").observe(0.3)
+    WS_FAILURES.labels(adapter="demo").inc()
+    STRATEGY_UP.labels(strategy="demo").set(1)
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -35,3 +49,6 @@ def test_panel_endpoints_and_metrics():
     assert data["disconnects"] == 1.0
     assert data["avg_order_latency_seconds"] == 0.2
     assert data["avg_maker_taker_ratio"] == 1.5
+    assert data["avg_e2e_latency_seconds"] == 0.3
+    assert data["ws_failures"] == 1.0
+    assert data["strategies"]["demo"] == 1.0


### PR DESCRIPTION
## Summary
- track end-to-end latency, websocket failures and strategy health in monitoring metrics
- wire Sentry error tracking into monitoring panel
- expose new alerts and Grafana dashboards for latency and strategy status

## Testing
- `pytest tests/test_monitoring_panel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b5673e00832db30fd741d48b29b6