### PR TITLE
feat: add market data backfill CLI

### DIFF
--- a/bin/market_data.py
+++ b/bin/market_data.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""CLI utilities for backfilling market data.
+
+Commands in this module use ``tradingbot.connectors`` (wrapping ``ccxt``)
+for data retrieval and persist the results into TimescaleDB or QuestDB.
+Basic retry and rate limit handling are provided via the connectors and
+``tradingbot.utils.retry.with_retry``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Literal
+
+import ccxt.async_support as ccxt
+import typer
+
+from tradingbot.connectors.binance import BinanceConnector
+from tradingbot.connectors.bybit import BybitConnector
+from tradingbot.connectors.okx import OkxConnector
+from tradingbot.connectors.base import Trade
+from tradingbot.storage import quest as qs_storage
+from tradingbot.storage import timescale as ts_storage
+from tradingbot.utils.retry import with_retry
+
+logging.basicConfig(level=logging.INFO)
+
+Backend = Literal["timescale", "quest"]
+app = typer.Typer(help="Backfill market data into TimescaleDB or QuestDB")
+
+CONNECTORS: dict[str, type] = {
+    "binance": BinanceConnector,
+    "bybit": BybitConnector,
+    "okx": OkxConnector,
+}
+
+
+def _get_storage(backend: Backend):
+    return ts_storage if backend == "timescale" else qs_storage
+
+
+async def _download_trades(
+    exchange: str,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    backend: Backend,
+):
+    log = logging.getLogger("trades")
+    conn_cls = CONNECTORS[exchange]
+    conn = conn_cls()
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+
+    since = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    while since < end_ms:
+        data = await with_retry(conn.rest.fetch_trades, symbol, since=since, limit=1000)
+        if not data:
+            break
+        for t in data:
+            tr = Trade(
+                timestamp=datetime.utcfromtimestamp(t["timestamp"] / 1000),
+                exchange=conn.name,
+                symbol=symbol,
+                price=float(t["price"]),
+                amount=float(t["amount"]),
+                side=t.get("side", ""),
+            )
+            storage.insert_trade(engine, tr)
+        log.info("inserted %d trades up to %s", len(data), tr.timestamp)
+        since = data[-1]["timestamp"] + 1
+    await conn.rest.close()
+
+
+async def _download_bars(
+    exchange: str,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    backend: Backend,
+):
+    log = logging.getLogger("ohlcv")
+    ex_class = getattr(ccxt, exchange)
+    ex = ex_class({"enableRateLimit": True})
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+
+    since = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    while since < end_ms:
+        ohlcvs = await with_retry(
+            ex.fetch_ohlcv, symbol, timeframe="1m", since=since, limit=1000
+        )
+        if not ohlcvs:
+            break
+        for ts_ms, o, h, l, c, v in ohlcvs:
+            ts = datetime.utcfromtimestamp(ts_ms / 1000)
+            storage.insert_bar_1m(engine, exchange, symbol, ts, o, h, l, c, v)
+        log.info("inserted %d bars up to %s", len(ohlcvs), ts)
+        since = ohlcvs[-1][0] + 60_000
+    await ex.close()
+
+
+async def _download_l2(
+    exchange: str,
+    symbol: str,
+    snapshots: int,
+    depth: int,
+    interval: float,
+    backend: Backend,
+):
+    log = logging.getLogger("l2")
+    conn_cls = CONNECTORS[exchange]
+    conn = conn_cls()
+    storage = _get_storage(backend)
+    engine = storage.get_engine()
+
+    for i in range(snapshots):
+        ob = await with_retry(conn.rest.fetch_order_book, symbol, limit=depth)
+        ts = datetime.utcnow()
+        bids = ob.get("bids", [])[:depth]
+        asks = ob.get("asks", [])[:depth]
+        storage.insert_orderbook(
+            engine,
+            ts=ts,
+            exchange=exchange,
+            symbol=symbol,
+            bid_px=[float(p) for p, _ in bids],
+            bid_qty=[float(q) for _, q in bids],
+            ask_px=[float(p) for p, _ in asks],
+            ask_qty=[float(q) for _, q in asks],
+        )
+        log.info("snapshot %d stored at %s", i + 1, ts)
+        await asyncio.sleep(interval)
+    await conn.rest.close()
+
+
+@app.command()
+def trades(
+    exchange: str,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    backend: Backend = "timescale",
+):
+    """Backfill recent trades into storage."""
+    asyncio.run(_download_trades(exchange, symbol, start, end, backend))
+
+
+@app.command()
+def ohlcv(
+    exchange: str,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    backend: Backend = "timescale",
+):
+    """Backfill 1m OHLCV bars."""
+    asyncio.run(_download_bars(exchange, symbol, start, end, backend))
+
+
+@app.command()
+def l2(
+    exchange: str,
+    symbol: str,
+    snapshots: int = 10,
+    depth: int = 10,
+    interval: float = 1.0,
+    backend: Backend = "timescale",
+):
+    """Collect Level 2 order book snapshots."""
+    asyncio.run(_download_l2(exchange, symbol, snapshots, depth, interval, backend))
+
+
+if __name__ == "__main__":
+    app()

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,6 +5,44 @@
 python -m tradingbot.cli ingest --symbol BTC/USDT
 ```
 
+## Backfill y backtesting vectorizado
+1. Levantar una base de datos Timescale o Quest:
+```bash
+./bin/start_timescale.sh    # o ./bin/start_questdb.sh
+```
+2. Descargar datos de mercado usando la utilidad CLI:
+```bash
+# OHLCV
+./bin/market_data.py ohlcv binance BTC/USDT 2024-01-01T00:00:00 2024-01-02T00:00:00
+# Trades
+./bin/market_data.py trades binance BTC/USDT 2024-01-01T00:00:00 2024-01-01T01:00:00
+# Orderbook L2
+./bin/market_data.py l2 binance BTC/USDT --snapshots 60 --interval 1.0
+```
+3. Cargar las barras en pandas y ejecutar un backtest vectorizado:
+```python
+import pandas as pd
+from tradingbot.storage import timescale
+from tradingbot.backtesting.vectorbt_wrapper import run_parameter_sweep
+
+engine = timescale.get_engine()
+bars = pd.read_sql_query(
+    "SELECT ts, o, h, l, c, v FROM market.bars WHERE symbol='BTC/USDT' ORDER BY ts",
+    engine, parse_dates=["ts"],
+).set_index("ts")
+
+def ma_signal(close, fast, slow):
+    import vectorbt as vbt
+    fast_ma = vbt.MA.run(close, fast)
+    slow_ma = vbt.MA.run(close, slow)
+    entries = fast_ma.ma_crossed_above(slow_ma)
+    exits = fast_ma.ma_crossed_below(slow_ma)
+    return entries, exits
+
+stats = run_parameter_sweep(bars, ma_signal, {"fast": [5], "slow": [20]})
+print(stats)
+```
+
 ## Backtest rápido
 ```bash
 python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \


### PR DESCRIPTION
## Summary
- add `bin/market_data.py` CLI to backfill trades, OHLCV and L2 order book data using ccxt connectors
- log progress, include retries and support TimescaleDB/QuestDB
- document full backfill and vectorbt workflow in docs/examples.md

## Testing
- `pytest` *(fails: Multiple exceptions: [Errno 111] Connect call failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b56971fc832da5beb784ea7e37fd