### PR TITLE
feat: improve monitoring instrumentation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,3 +37,10 @@ Para el stack completo (API, TimescaleDB, QuestDB, Prometheus y Grafana):
 
 Los archivos de configuración y esquemas se encuentran en `sql/` y
 `monitoring/`.
+
+## Dashboards de Grafana
+Los dashboards listos para usar están en `monitoring/grafana/dashboards/`.
+Al ejecutar `./bin/start_stack.sh` se provisionan automáticamente.
+Para una instancia de Grafana existente copia `tradebot.json` al
+directorio de dashboards (`/var/lib/grafana/dashboards`) y `dashboard.yml`
+al directorio de provisioning (`/etc/grafana/provisioning/dashboards/`).

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -27,3 +27,30 @@ groups:
         annotations:
           summary: System disconnections detected
           description: Disconnections occurred in the last 5m
+
+      - alert: HighE2ELatency
+        expr: histogram_quantile(0.95, sum(rate(e2e_latency_seconds_bucket[5m])) by (le)) > 2
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: High end-to-end latency
+          description: 95th percentile E2E latency above 2s for 5m
+
+      - alert: WebsocketFailures
+        expr: increase(ws_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Websocket failures detected
+          description: Websocket errors occurred in the last 5m
+
+      - alert: StrategyError
+        expr: sum(strategy_state == 2) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Strategy in error state
+          description: One or more strategies reporting error state

--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -99,6 +99,30 @@
       ],
       "datasource": "Prometheus",
       "id": 8
+    },
+    {
+      "type": "graph",
+      "title": "E2E latency (95th)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(e2e_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "95th percentile"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 9
+    },
+    {
+      "type": "stat",
+      "title": "Strategy states",
+      "targets": [
+        {
+          "expr": "strategy_state",
+          "legendFormat": "{{strategy}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 10
     }
   ],
   "schemaVersion": 16,

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -2,8 +2,18 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
+import yaml
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+
 from .metrics import router as metrics_router
 from .strategies import router as strategies_router
+
+config_path = Path(__file__).with_name("sentry.yml")
+if config_path.exists():
+    with config_path.open() as f:
+        config = yaml.safe_load(f)
+    sentry_sdk.init(integrations=[FastApiIntegration()], **config)
 
 app = FastAPI(title="TradeBot Monitoring")
 app.include_router(metrics_router)

--- a/monitoring/strategies.py
+++ b/monitoring/strategies.py
@@ -2,9 +2,13 @@
 
 from fastapi import APIRouter
 
+from .metrics import STRATEGY_STATE
+
 router = APIRouter()
 
 _state: dict[str, str] = {}
+
+_STATE_MAP = {"stopped": 0, "running": 1, "error": 2}
 
 
 @router.get("/strategies/status")
@@ -19,6 +23,8 @@ def set_strategy_status(name: str, status: str) -> dict:
     """Update the status of a strategy."""
 
     _state[name] = status
+    metric_value = _STATE_MAP.get(status.lower(), -1)
+    STRATEGY_STATE.labels(strategy=name).set(metric_value)
     return {"strategy": name, "status": status}
 
 

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -7,6 +7,9 @@ from monitoring.metrics import (
     MARKET_LATENCY,
     ORDER_LATENCY,
     MAKER_TAKER_RATIO,
+    E2E_LATENCY,
+    WS_FAILURES,
+    STRATEGY_STATE,
 )
 
 
@@ -18,8 +21,13 @@ def test_panel_endpoints_and_metrics():
     MARKET_LATENCY.observe(0.5)
     ORDER_LATENCY.clear()
     MAKER_TAKER_RATIO.clear()
+    WS_FAILURES.clear()
+    STRATEGY_STATE.clear()
     ORDER_LATENCY.labels(venue="test").observe(0.2)
     MAKER_TAKER_RATIO.labels(venue="test").set(1.5)
+    E2E_LATENCY.observe(0.7)
+    WS_FAILURES.labels(adapter="test").inc()
+    STRATEGY_STATE.labels(strategy="alpha").set(1)
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -35,3 +43,6 @@ def test_panel_endpoints_and_metrics():
     assert data["disconnects"] == 1.0
     assert data["avg_order_latency_seconds"] == 0.2
     assert data["avg_maker_taker_ratio"] == 1.5
+    assert data["avg_e2e_latency_seconds"] == 0.7
+    assert data["ws_failures"] == 1.0
+    assert data["strategy_states"] == {"alpha": 1.0}


### PR DESCRIPTION
## Summary
- add E2E latency, websocket failure and strategy state metrics with summary reporting
- wire Sentry into monitoring panel and extend alert/graphing configs
- document Grafana dashboard provisioning and validate with smoke tests

## Testing
- `PYTHONPATH=. pytest tests/test_monitoring_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0c75de988832dae7e91a993c091ef