### PR TITLE
feat(storage): add questdb insert helpers for more tables

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -39,3 +39,60 @@ CREATE TABLE IF NOT EXISTS market.funding (
   rate numeric NOT NULL,
   interval_sec int NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS market.open_interest (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  oi numeric NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS market.basis (
+  ts timestamptz NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  basis numeric NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS market.orders (
+  id bigserial PRIMARY KEY,
+  ts timestamptz NOT NULL DEFAULT now(),
+  strategy text NOT NULL,
+  exchange text NOT NULL,
+  symbol text NOT NULL,
+  side text NOT NULL,
+  type text NOT NULL,
+  qty numeric NOT NULL,
+  px numeric,
+  status text NOT NULL,
+  ext_order_id text,
+  notes jsonb
+);
+
+CREATE TABLE IF NOT EXISTS market.tri_signals (
+  id bigserial PRIMARY KEY,
+  ts timestamptz NOT NULL DEFAULT now(),
+  exchange text NOT NULL,
+  base text NOT NULL,
+  mid text NOT NULL,
+  quote text NOT NULL,
+  direction text NOT NULL,
+  edge numeric NOT NULL,
+  notional_quote numeric NOT NULL,
+  taker_fee_bps numeric NOT NULL,
+  buffer_bps numeric NOT NULL,
+  bq numeric NOT NULL,
+  mq numeric NOT NULL,
+  mb numeric NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS market.cross_signals (
+  id bigserial PRIMARY KEY,
+  ts timestamptz NOT NULL DEFAULT now(),
+  symbol text NOT NULL,
+  spot_exchange text NOT NULL,
+  perp_exchange text NOT NULL,
+  spot_px numeric NOT NULL,
+  perp_px numeric NOT NULL,
+  edge numeric NOT NULL
+);

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -146,11 +146,155 @@ def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, inter
         )
 
 
+def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):
+    """Persist an open interest record into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO open_interest (ts, exchange, symbol, oi)
+                VALUES (:ts, :exchange, :symbol, :oi)
+                """
+            ),
+            dict(ts=ts, exchange=exchange, symbol=symbol, oi=oi),
+        )
+
+
+def insert_basis(engine, *, ts, exchange: str, symbol: str, basis: float):
+    """Persist a basis record into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO basis (ts, exchange, symbol, basis)
+                VALUES (:ts, :exchange, :symbol, :basis)
+                """
+            ),
+            dict(ts=ts, exchange=exchange, symbol=symbol, basis=basis),
+        )
+
+
+def insert_order(
+    engine,
+    *,
+    strategy: str,
+    exchange: str,
+    symbol: str,
+    side: str,
+    type_: str,
+    qty: float,
+    px: float | None,
+    status: str,
+    ext_order_id: str | None = None,
+    notes: dict | None = None,
+):
+    """Persist an order record into QuestDB."""
+    payload = dict(
+        strategy=strategy,
+        exchange=exchange,
+        symbol=symbol,
+        side=side,
+        type=type_,
+        qty=qty,
+        px=px,
+        status=status,
+        ext_order_id=ext_order_id,
+        notes=json.dumps(notes) if notes is not None else None,
+    )
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO orders (strategy, exchange, symbol, side, type, qty, px, status, ext_order_id, notes)
+                VALUES (:strategy, :exchange, :symbol, :side, :type, :qty, :px, :status, :ext_order_id, :notes)
+                """
+            ),
+            payload,
+        )
+
+
+def insert_tri_signal(
+    engine,
+    *,
+    exchange: str,
+    base: str,
+    mid: str,
+    quote: str,
+    direction: str,
+    edge: float,
+    notional_quote: float,
+    taker_fee_bps: float,
+    buffer_bps: float,
+    bq: float,
+    mq: float,
+    mb: float,
+):
+    """Persist a triangular arbitrage signal into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO tri_signals (exchange, base, mid, quote, direction, edge, notional_quote, taker_fee_bps, buffer_bps, bq, mq, mb)
+                VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional_quote, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
+                """
+            ),
+            dict(
+                exchange=exchange,
+                base=base,
+                mid=mid,
+                quote=quote,
+                direction=direction,
+                edge=edge,
+                notional_quote=notional_quote,
+                taker_fee_bps=taker_fee_bps,
+                buffer_bps=buffer_bps,
+                bq=bq,
+                mq=mq,
+                mb=mb,
+            ),
+        )
+
+
+def insert_cross_signal(
+    engine,
+    *,
+    symbol: str,
+    spot_exchange: str,
+    perp_exchange: str,
+    spot_px: float,
+    perp_px: float,
+    edge: float,
+):
+    """Persist a cross-exchange arbitrage signal into QuestDB."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO cross_signals (symbol, spot_exchange, perp_exchange, spot_px, perp_px, edge)
+                VALUES (:symbol, :spot_exchange, :perp_exchange, :spot_px, :perp_px, :edge)
+                """
+            ),
+            dict(
+                symbol=symbol,
+                spot_exchange=spot_exchange,
+                perp_exchange=perp_exchange,
+                spot_px=spot_px,
+                perp_px=perp_px,
+                edge=edge,
+            ),
+        )
+
+
 __all__ = [
     "get_engine",
     "insert_trade",
     "insert_orderbook",
     "insert_bar_1m",
     "insert_funding",
+    "insert_open_interest",
+    "insert_basis",
+    "insert_order",
+    "insert_tri_signal",
+    "insert_cross_signal",
 ]
 

--- a/tests/test_async_storage.py
+++ b/tests/test_async_storage.py
@@ -146,3 +146,145 @@ async def test_insert_and_query_funding(client):
     )
     assert float(rows[0]["rate"]) == 0.001
     assert rows[0]["interval_sec"] == 3600
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_open_interest(client):
+    sql = """
+        INSERT INTO market.open_interest (ts, exchange, symbol, oi)
+        VALUES (:ts, :exchange, :symbol, :oi)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.open_interest", sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "oi": 123.0,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT oi FROM market.open_interest WHERE symbol='BTCUSDT'"
+    )
+    assert float(rows[0]["oi"]) == 123.0
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_basis(client):
+    sql = """
+        INSERT INTO market.basis (ts, exchange, symbol, basis)
+        VALUES (:ts, :exchange, :symbol, :basis)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.basis", sql, batch_size=1)
+    await worker.add(
+        {
+            "ts": dt.datetime.utcnow(),
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "basis": 5.0,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT basis FROM market.basis WHERE symbol='BTCUSDT'"
+    )
+    assert float(rows[0]["basis"]) == 5.0
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_orders(client):
+    sql = """
+        INSERT INTO market.orders (strategy, exchange, symbol, side, type, qty, px, status, ext_order_id, notes)
+        VALUES (:strategy, :exchange, :symbol, :side, :type, :qty, :px, :status, :ext_order_id, :notes)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.orders", sql, batch_size=1)
+    await worker.add(
+        {
+            "strategy": "s1",
+            "exchange": "binance",
+            "symbol": "BTCUSDT",
+            "side": "buy",
+            "type": "limit",
+            "qty": 1.0,
+            "px": 100.0,
+            "status": "new",
+            "ext_order_id": "abc",
+            "notes": None,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT strategy, side, qty FROM market.orders WHERE symbol='BTCUSDT'"
+    )
+    assert rows[0]["strategy"] == "s1"
+    assert rows[0]["side"] == "buy"
+    assert float(rows[0]["qty"]) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_tri_signals(client):
+    sql = """
+        INSERT INTO market.tri_signals (exchange, base, mid, quote, direction, edge, notional_quote, taker_fee_bps, buffer_bps, bq, mq, mb)
+        VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional_quote, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.tri_signals", sql, batch_size=1)
+    await worker.add(
+        {
+            "exchange": "binance",
+            "base": "BTC",
+            "mid": "ETH",
+            "quote": "USDT",
+            "direction": "b->m",
+            "edge": 0.001,
+            "notional_quote": 1000.0,
+            "taker_fee_bps": 5.0,
+            "buffer_bps": 1.0,
+            "bq": 1.0,
+            "mq": 2.0,
+            "mb": 0.5,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT base, mid, edge FROM market.tri_signals WHERE quote='USDT'"
+    )
+    assert rows[0]["base"] == "BTC"
+    assert rows[0]["mid"] == "ETH"
+    assert float(rows[0]["edge"]) == 0.001
+
+
+@pytest.mark.asyncio
+async def test_insert_and_query_cross_signals(client):
+    sql = """
+        INSERT INTO market.cross_signals (symbol, spot_exchange, perp_exchange, spot_px, perp_px, edge)
+        VALUES (:symbol, :spot_exchange, :perp_exchange, :spot_px, :perp_px, :edge)
+    """
+    from tradingbot.workers import BatchIngestionWorker
+
+    worker = BatchIngestionWorker(client, "market.cross_signals", sql, batch_size=1)
+    await worker.add(
+        {
+            "symbol": "BTCUSDT",
+            "spot_exchange": "binance",
+            "perp_exchange": "ftx",
+            "spot_px": 100.0,
+            "perp_px": 101.0,
+            "edge": -0.01,
+        }
+    )
+
+    rows = await client.fetch(
+        "SELECT spot_px, perp_px, edge FROM market.cross_signals WHERE symbol='BTCUSDT'"
+    )
+    assert float(rows[0]["spot_px"]) == 100.0
+    assert float(rows[0]["perp_px"]) == 101.0
+    assert float(rows[0]["edge"]) == -0.01


### PR DESCRIPTION
## Summary
- support open interest, basis, orders and arbitrage signal inserts in QuestDB backend
- extend SQL schema and async storage tests for new tables

## Testing
- `pytest tests/test_async_storage.py::test_insert_and_query_open_interest -q` *(fails: Connect call failed ('::1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8896a2c832dba7dda469f8e7820