### PR TITLE
Add monitoring panel endpoints and monitoring docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,45 @@
+# Monitoring
+
+This project ships a minimal monitoring stack to track bot health and
+trading performance.
+
+## FastAPI panel
+
+Run the monitoring panel with:
+
+```bash
+uvicorn monitoring.panel:app --reload
+```
+
+Available endpoints:
+
+- `GET /metrics` – Prometheus metrics.
+- `GET /metrics/summary` – compact JSON snapshot of key metrics.
+- `GET /strategies/status` – current strategy states.
+- `POST /strategies/{name}/{status}` – update a strategy state.
+- `GET /summary` – metrics and strategy states combined.
+- `GET /health` – basic liveness probe.
+
+Static assets are served from `monitoring/static/` for a quick HTML view.
+
+## Grafana dashboards
+
+Provisioning files live under `monitoring/grafana/`. A new dashboard
+`core.json` provides panels for:
+
+- Trading PnL
+- End‑to‑end latency (95th percentile)
+- Websocket failures per adapter
+- Kill‑switch status
+
+Place the JSON files in Grafana's dashboards directory or mount the
+folder when running the official container.
+
+## Alerts
+
+Prometheus alerting rules are defined in `monitoring/alerts.yml`,
+covering negative PnL, high latencies, websocket failures and the
+kill‑switch being triggered.
+
+Load the rules file into Prometheus or Alertmanager to enable basic
+notifications.

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -54,3 +54,12 @@ groups:
         annotations:
           summary: Strategy in error state
           description: One or more strategies reporting error state
+
+      - alert: KillSwitchActivated
+        expr: kill_switch_active > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: Kill switch engaged
+          description: Kill switch has been active for more than 1m

--- a/monitoring/grafana/dashboards/core.json
+++ b/monitoring/grafana/dashboards/core.json
@@ -1,0 +1,63 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "title": "Core Metrics",
+  "schemaVersion": 16,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Trading PnL",
+      "targets": [
+        {
+          "expr": "trading_pnl",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 1,
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "E2E latency (95th)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(e2e_latency_seconds_bucket[5m])) by (le))",
+          "legendFormat": "95th percentile"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 2,
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "WS failures",
+      "targets": [
+        {
+          "expr": "increase(ws_failures_total[5m])",
+          "legendFormat": "{{adapter}}"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 3,
+      "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8}
+    },
+    {
+      "type": "stat",
+      "title": "Kill switch active",
+      "targets": [
+        {
+          "expr": "kill_switch_active",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 4,
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- serve health and combined metrics/strategy summary via FastAPI panel
- add Grafana dashboard for PnL, latency, websocket failures and kill-switch
- configure kill switch alert and document monitoring setup

## Testing
- `pytest` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0df72f024832db8da4b0617570ecd