### PR TITLE
Add unit and integration tests for core components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
           pip install -r requirements.txt
       - name: Lint
         run: flake8 . --select=E9,F63,F7 --show-source --statistics
-      - name: Run tests
-        run: pytest --cov=src --cov-report=xml
+      - name: Run unit tests
+        run: pytest --cov=src --cov-report=xml -m "not integration"
+      - name: Run integration tests
+        run: pytest -m integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,7 @@ package-dir = {"" = "src"}
 packages = ["tradingbot"]
 
 [tool.pytest.ini_options]
-markers = ["optional: tests requiring optional dependencies"]
+markers = [
+    "optional: tests requiring optional dependencies",
+    "integration: integration tests",
+]

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -1,0 +1,27 @@
+import datetime as dt
+import pytest
+
+from tradingbot.adapters.base import ExchangeAdapter
+
+
+class DummyAdapter(ExchangeAdapter):
+    async def stream_trades(self, symbol: str):
+        if False:
+            yield {}
+        return
+
+    async def place_order(self, *args, **kwargs):
+        return {}
+
+    async def cancel_order(self, order_id: str):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_normalize_helpers():
+    ad = DummyAdapter()
+    assert ad.normalize_symbol("BTC/USDT") == "BTCUSDT"
+    ts = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    book = ad.normalize_order_book("BTCUSDT", ts, [[1.0, 2.0]], [[3.0, 4.0]])
+    assert book["bid_px"] == [1.0]
+    assert book["ask_qty"] == [4.0]

--- a/tests/test_async_storage.py
+++ b/tests/test_async_storage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from pathlib import Path
+import os
 
 import pytest
 import pytest_asyncio
@@ -11,6 +12,11 @@ from sqlalchemy import text
 from tradingbot.storage import AsyncDBClient
 
 SCHEMA_SQL = Path("db/schema.sql").read_text()
+
+pytestmark = pytest.mark.integration
+
+if not os.environ.get("PG_TEST", ""):
+    pytest.skip("PostgreSQL not available", allow_module_level=True)
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.strategies import STRATEGIES
+
+
+class DummyStrategy:
+    name = "dummy"
+
+    def on_bar(self, bar):
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+@pytest.mark.integration
+def test_event_engine_runs(tmp_path, monkeypatch):
+    rng = pd.date_range("2021-01-01", periods=5, freq="T")
+    price = np.linspace(100, 104, num=5)
+    df = pd.DataFrame({
+        "timestamp": rng.view("int64") // 10**9,
+        "open": price,
+        "high": price + 0.5,
+        "low": price - 0.5,
+        "close": price,
+        "volume": 1000,
+    })
+    data = {"SYM": df}
+    monkeypatch.setitem(STRATEGIES, "dummy", DummyStrategy)
+    engine = EventDrivenBacktestEngine(data, [("dummy", "SYM")], latency=1, window=1)
+    res = engine.run()
+    assert "equity" in res
+    assert len(res["fills"]) > 0

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+import asyncio
+import pytest
+
+from tradingbot.live.daemon import TradeBotDaemon
+from tradingbot.risk.manager import RiskManager
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.strategies.base import Signal
+from tradingbot.bus import EventBus
+
+
+class FeedAdapter:
+    def __init__(self, trades):
+        self._trades = trades
+        class Rest:
+            async def fetch_balance(self_inner):
+                return {}
+        self.rest = Rest()
+
+    async def stream_trades(self, symbol):
+        for t in self._trades:
+            yield {"symbol": symbol, **t}
+            await asyncio.sleep(0)
+
+
+class AlwaysBuy:
+    name = "always_buy"
+
+    def on_trade(self, trade):
+        return Signal("buy", 1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_daemon_processes_trades():
+    trades = [{"price": 100.0, "qty": 1.0, "side": "buy"}, {"price": 101.0, "qty": 1.0, "side": "buy"}]
+    adapter = FeedAdapter(trades)
+    paper = PaperAdapter()
+    paper.update_last_price("BTCUSDT", 100.0)
+    router = ExecutionRouter(paper)
+    bus = EventBus()
+    risk = RiskManager(max_pos=5, bus=bus)
+    daemon = TradeBotDaemon({"feed": adapter}, [AlwaysBuy()], risk, router, ["BTCUSDT"])
+    task = asyncio.create_task(daemon.run())
+    await asyncio.sleep(0.3)
+    daemon._stop.set()
+    await task
+    assert risk.pos.qty > 0

--- a/tests/test_execution_router_extra.py
+++ b/tests/test_execution_router_extra.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tradingbot.execution.order_types import Order
+from tradingbot.execution.router import ExecutionRouter
+
+
+class DummyAdapter:
+    def __init__(self, name="a"):
+        self.name = name
+        self.state = type("S", (), {"order_book": {}, "last_px": {}})()
+
+    async def place_order(self, **kwargs):
+        return {"status": "ok", **kwargs}
+
+
+@pytest.mark.asyncio
+async def test_best_venue_fallback():
+    a = DummyAdapter("a")
+    b = DummyAdapter("b")
+    router = ExecutionRouter([a, b])
+    order = Order(symbol="X", side="buy", type_="market", qty=1.0)
+    selected = await router.best_venue(order)
+    assert selected is a
+
+
+@pytest.mark.asyncio
+async def test_unknown_algo_raises():
+    adapter = DummyAdapter()
+    router = ExecutionRouter(adapter)
+    order = Order(symbol="X", side="buy", type_="market", qty=1.0)
+    with pytest.raises(ValueError):
+        await router.execute(order, algo="foo")

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
+
+def test_mean_reversion_on_bar_signals():
+    df_down = pd.DataFrame({"close": list(range(20, 0, -1))})
+    df_up = pd.DataFrame({"close": list(range(1, 21))})
+    strat = MeanReversion(rsi_n=5, upper=70, lower=30)
+    sig_buy = strat.on_bar({"window": df_down})
+    sig_sell = strat.on_bar({"window": df_up})
+    assert sig_buy.side == "buy"
+    assert sig_sell.side == "sell"
+
+def test_mean_reversion_generate_signals():
+    df = pd.DataFrame({"price": [1, 2, 3, 4, 3, 2, 1, 2, 3]})
+    params = {"window": 3, "threshold": 0.5, "position_size": 1}
+    res = generate_signals(df, params)
+    assert {"signal", "position", "stop_loss", "take_profit", "fee", "slippage"} <= set(res.columns)
+    assert len(res) == len(df)

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from tradingbot.risk.manager import RiskManager
+
+
+def test_covariance_and_aggregation():
+    rm = RiskManager()
+    returns = {"A": [0.1, 0.2, 0.15], "B": [0.05, 0.07, 0.06]}
+    cov = rm.covariance_matrix(returns)
+    assert pytest.approx(cov[("A", "A")]) == np.var(returns["A"], ddof=1)
+    assert pytest.approx(cov[("A", "B")]) == np.cov(returns["A"], returns["B"])[0, 1]
+
+    rm.update_position("ex1", "BTC", 1.0)
+    rm.update_position("ex2", "BTC", -0.3)
+    agg = rm.aggregate_positions()
+    assert agg["BTC"] == pytest.approx(0.7)
+
+
+def test_adjust_size_and_portfolio_risk():
+    rm = RiskManager(max_pos=2)
+    corr = {("A", "B"): 0.9}
+    size = rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
+    assert size == pytest.approx(1.0)
+    size2 = rm.adjust_size_for_correlation("A", 2.0, corr, 0.95)
+    assert size2 == 2.0
+
+    cov = {("BTC", "BTC"): 0.04}
+    assert rm.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
+    assert not rm.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
+    assert rm.enabled is False
+    assert rm.last_kill_reason == "covariance_limit"


### PR DESCRIPTION
## Summary
- add adapter, strategy, risk manager and router unit tests
- introduce integration tests for backtesting engine and live daemon
- configure CI to run unit and integration test suites separately

## Testing
- `pytest tests/test_adapter_base.py tests/test_mean_reversion.py tests/test_risk_manager_extra.py tests/test_execution_router_extra.py -q`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68a0f48f7600832da5a07769c1e57e8c