### PR TITLE
Improve Bybit/OKX adapters with robust order handling and tests

### DIFF
--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -9,10 +9,13 @@ from typing import AsyncIterator
 
 import websockets
 
-try:
+try:  # pragma: no cover - optional during tests
     import ccxt
+    NetworkError = getattr(ccxt, "NetworkError", Exception)
+    ExchangeError = getattr(ccxt, "ExchangeError", Exception)
 except Exception:  # pragma: no cover - ccxt optional during tests
     ccxt = None
+    NetworkError = ExchangeError = Exception
 
 from .base import ExchangeAdapter
 from ..config import settings
@@ -147,9 +150,60 @@ class BybitFuturesAdapter(ExchangeAdapter):
         oi = float(item.get("openInterest", 0.0))
         return {"ts": ts, "oi": oi}
 
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
-                          price: float | None = None) -> dict:
-        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        params = params or {}
+        if post_only:
+            params["postOnly"] = True
+        if time_in_force:
+            params["timeInForce"] = time_in_force
+        backoff = 1.0
+        while True:
+            try:
+                return await self._request(
+                    self.rest.create_order,
+                    symbol,
+                    type_,
+                    side,
+                    qty,
+                    price,
+                    params,
+                )
+            except NetworkError as e:  # pragma: no cover - network paths
+                log.warning("Bybit place_order error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+            except ExchangeError:
+                raise
 
-    async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
-        return await self._to_thread(self.rest.cancel_order, order_id, symbol)
+    async def cancel_order(
+        self,
+        order_id: str,
+        symbol: str | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        params = params or {}
+        backoff = 1.0
+        while True:
+            try:
+                return await self._request(
+                    self.rest.cancel_order,
+                    order_id,
+                    symbol,
+                    params,
+                )
+            except NetworkError as e:  # pragma: no cover - network paths
+                log.warning("Bybit cancel_order error %s, retrying in %.1fs", e, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+            except ExchangeError:
+                raise

--- a/tests/test_adapter_order_retries.py
+++ b/tests/test_adapter_order_retries.py
@@ -1,0 +1,78 @@
+import asyncio
+import pytest
+
+from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.adapters.bybit_futures import BybitFuturesAdapter, ccxt as bybit_ccxt
+from tradingbot.adapters.okx_spot import OKXSpotAdapter
+
+NetworkError = getattr(bybit_ccxt, "NetworkError", Exception)
+
+
+class FlakyRest:
+    """REST stub failing once with ``NetworkError`` then succeeding."""
+
+    def __init__(self):
+        self.order_attempts = 0
+        self.cancel_attempts = 0
+
+    def create_order(self, symbol, type_, side, qty, price=None, params=None):
+        self.order_attempts += 1
+        if self.order_attempts == 1:
+            raise NetworkError("boom")
+        return {"id": "1", "status": "open", "symbol": symbol, "qty": qty, "price": price}
+
+    def cancel_order(self, order_id, symbol=None, params=None):
+        self.cancel_attempts += 1
+        if self.cancel_attempts == 1:
+            raise NetworkError("boom")
+        return {"id": order_id, "status": "canceled"}
+
+
+@pytest.mark.asyncio
+async def test_bybit_place_cancel_retry(monkeypatch, synthetic_l2):
+    async def fast_sleep(_):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    adapter = BybitFuturesAdapter.__new__(BybitFuturesAdapter)
+    ExchangeAdapter.__init__(adapter)
+    adapter.rest = FlakyRest()
+
+    async def _req(fn, *a, **k):
+        return fn(*a, **k)
+
+    adapter._request = _req
+
+    price = float(synthetic_l2["asks"]["price"].iloc[0])
+    res = await adapter.place_order("BTC/USDT", "buy", "limit", 1, price=price)
+    assert res["status"] == "open"
+    cancel = await adapter.cancel_order(res["id"], "BTC/USDT")
+    assert cancel["status"] == "canceled"
+    assert adapter.rest.order_attempts == 2
+    assert adapter.rest.cancel_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_okx_place_cancel_retry(monkeypatch, synthetic_trades):
+    async def fast_sleep(_):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    adapter = OKXSpotAdapter.__new__(OKXSpotAdapter)
+    ExchangeAdapter.__init__(adapter)
+    adapter.rest = FlakyRest()
+
+    async def _req(fn, *a, **k):
+        return fn(*a, **k)
+
+    adapter._request = _req
+
+    qty = float(synthetic_trades.qty.sum())
+    res = await adapter.place_order("BTC/USDT", "buy", "market", qty)
+    assert res["symbol"] == "BTC/USDT"
+    cancel = await adapter.cancel_order(res["id"], "BTC/USDT")
+    assert cancel["status"] == "canceled"
+    assert adapter.rest.order_attempts == 2
+    assert adapter.rest.cancel_attempts == 2


### PR DESCRIPTION
## Summary
- add retry logic and rate-limit aware order management to Bybit and OKX adapters
- support post_only/time_in_force params for place/cancel order
- introduce simulated tests using market fixtures validating retries

## Testing
- `pytest tests/test_adapter_order_retries.py tests/test_adapters.py::test_parsing_funding_and_oi -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f65b02e4832db8980ce9f7b5e3f2