### PR TITLE
Add trading metrics and monitoring dashboard updates

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -24,16 +24,28 @@ Static assets are served from `monitoring/static/` for a quick HTML view.
 
 ## Grafana dashboards
 
-Provisioning files live under `monitoring/grafana/`. A new dashboard
-`core.json` provides panels for:
+The monitoring stack ships with ready‑to‑use Grafana and Prometheus
+configuration. To launch both services with the provided dashboards and
+data source, run:
+
+```bash
+docker-compose up -d prometheus grafana
+```
+
+Prometheus uses `monitoring/prometheus.yml` to scrape the API and
+monitoring panel. Grafana is provisioned from files under
+`monitoring/grafana/` which includes:
+
+* `datasources/datasource.yml` – Prometheus data source
+* `dashboards/dashboard.yml` – automatic dashboard loading
+* `dashboards/core.json` and `dashboards/tradebot.json` – example panels
+
+The `core.json` dashboard provides panels for:
 
 - Trading PnL
 - End‑to‑end latency (95th percentile)
 - Websocket failures per adapter
 - Kill‑switch status
-
-Place the JSON files in Grafana's dashboards directory or mount the
-folder when running the official container.
 
 ## Alerts
 

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -19,8 +19,11 @@
     <div v-if="!metrics">Loading...</div>
     <div v-else>
       PnL: {{ metrics.pnl }} |
+      Positions: {{ Object.entries(metrics.positions || {}).map(([s,v]) => s + ':' + v).join(', ') }} |
       Disconnects: {{ metrics.disconnects }} |
+      Avg Market Latency: {{ metrics.avg_market_latency_seconds }} |
       Avg Order Latency: {{ metrics.avg_order_latency_seconds }} |
+      E2E Latency: {{ metrics.avg_e2e_latency_seconds }} |
       Maker/Taker Ratio: {{ metrics.avg_maker_taker_ratio }}
     </div>
   </section>

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -68,3 +68,30 @@ MAKER_TAKER_RATIO = Gauge(
     "Ratio of maker to taker orders",
     ["venue"],
 )
+
+# --- Additional high level trading metrics ---
+
+# Current profit and loss in USD
+TRADING_PNL = Gauge(
+    "trading_pnl",
+    "Current trading profit and loss in USD",
+)
+
+# Open position size per symbol
+OPEN_POSITIONS = Gauge(
+    "open_position",
+    "Current open position size",
+    ["symbol"],
+)
+
+# Latency of market data processing
+MARKET_LATENCY = Histogram(
+    "market_latency_seconds",
+    "Latency of market data processing in seconds",
+)
+
+# End-to-end order processing latency
+E2E_LATENCY = Histogram(
+    "e2e_latency_seconds",
+    "End-to-end order processing latency in seconds",
+)

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -10,6 +10,7 @@ from monitoring.metrics import (
     E2E_LATENCY,
     WS_FAILURES,
     STRATEGY_STATE,
+    OPEN_POSITIONS,
 )
 
 
@@ -19,6 +20,8 @@ def test_panel_endpoints_and_metrics():
     TRADING_PNL.set(100)
     SYSTEM_DISCONNECTS.inc()
     MARKET_LATENCY.observe(0.5)
+    OPEN_POSITIONS.clear()
+    OPEN_POSITIONS.labels(symbol="BTCUSD").set(2)
     ORDER_LATENCY.clear()
     MAKER_TAKER_RATIO.clear()
     WS_FAILURES.clear()
@@ -40,7 +43,9 @@ def test_panel_endpoints_and_metrics():
     resp = client.get("/metrics/summary")
     data = resp.json()
     assert data["pnl"] == 100.0
+    assert data["positions"] == {"BTCUSD": 2.0}
     assert data["disconnects"] == 1.0
+    assert data["avg_market_latency_seconds"] == 0.5
     assert data["avg_order_latency_seconds"] == 0.2
     assert data["avg_maker_taker_ratio"] == 1.5
     assert data["avg_e2e_latency_seconds"] == 0.7


### PR DESCRIPTION
## Summary
- expose PnL, open positions, and latency histograms via Prometheus metrics
- surface new metrics in monitoring API and Vue dashboard
- document running Grafana/Prometheus with provided provisioning files

## Testing
- `pytest` *(fails: OSError: Connect call failed / KeyboardInterrupt, 34 passed, 3 skipped, 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f4806530832d98ab8ff2265cf5c0