### PR TITLE
feat: support basis polling across venues

### DIFF
--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -214,6 +214,16 @@ class BinanceSpotAdapter(ExchangeAdapter):
         rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
         return {"ts": ts_dt, "rate": rate}
 
+    async def fetch_basis(self, symbol: str):
+        """Spot markets no tienen *basis* definida.
+
+        Se implementa únicamente para cumplir la interfaz del adaptador y
+        lanzar un ``NotImplementedError`` claro indicando que Binance Spot no
+        ofrece este dato.
+        """
+
+        raise NotImplementedError("Basis no soportado en spot")
+
     async def fetch_oi(self, symbol: str):
         """Fetch futures open interest for the given spot ``symbol``.
 

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -102,6 +102,15 @@ class OKXSpotAdapter(ExchangeAdapter):
         rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
         return {"ts": ts_dt, "rate": rate}
 
+    async def fetch_basis(self, symbol: str):
+        """Spot en OKX no ofrece una métrica de *basis*.
+
+        La función existe únicamente para cumplir con la interfaz y dejar
+        explícito que este dato no está disponible en el venue.
+        """
+
+        raise NotImplementedError("Basis not supported in spot markets")
+
     async def fetch_oi(self, symbol: str):
         """Fetch open interest for the corresponding instrument.
 


### PR DESCRIPTION
## Summary
- support basis calculation for Binance and OKX futures adapters
- document lack of basis data on Binance and OKX spot venues
- exercise funding/basis polling against Timescale and Quest backends

## Testing
- `pytest tests/test_data_ingestion.py::test_poll_funding_inserts tests/test_data_ingestion.py::test_poll_basis_inserts -q`

------
https://chatgpt.com/codex/tasks/task_e_68a10410180c832d88f3059abecec66c