### PR TITLE
feat: compute order book imbalance to depth

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -39,6 +39,32 @@ def orderbook_snapshots(orderbook_df):
 
 
 @pytest.fixture
+def l2_snapshots():
+    """Synthetic L2 snapshots with price and quantity depth."""
+
+    return [
+        {
+            "bid_px": [100.0, 99.0],
+            "bid_qty": [5.0, 3.0],
+            "ask_px": [101.0, 102.0],
+            "ask_qty": [8.0, 2.0],
+        },
+        {
+            "bid_px": [100.5, 100.0],
+            "bid_qty": [6.0, 1.0],
+            "ask_px": [101.5, 102.0],
+            "ask_qty": [5.0, 4.0],
+        },
+        {
+            "bid_px": [100.5, 99.5],
+            "bid_qty": [4.0, 2.0],
+            "ask_px": [101.5, 102.5],
+            "ask_qty": [6.0, 3.0],
+        },
+    ]
+
+
+@pytest.fixture
 def close_df():
     return pd.DataFrame({"close": list(range(1, 30))})
 
@@ -106,6 +132,21 @@ def test_depth_imbalance_snapshots(orderbook_snapshots):
         (7 - 6) / (7 + 6),
         (3 - 5) / (3 + 5),
         (4 - 7) / (4 + 7),
+    ]
+    assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
+
+
+def test_order_flow_imbalance_l2(l2_snapshots):
+    ofi = order_flow_imbalance(l2_snapshots, depth=2)
+    assert list(ofi) == [0.0, 13.0, 0.0]
+
+
+def test_depth_imbalance_l2(l2_snapshots):
+    di = depth_imbalance(l2_snapshots, depth=2)
+    expected = [
+        (5 + 3 - (8 + 2)) / (5 + 3 + 8 + 2),
+        (6 + 1 - (5 + 4)) / (6 + 1 + 5 + 4),
+        (4 + 2 - (6 + 3)) / (4 + 2 + 6 + 3),
     ]
     assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
 


### PR DESCRIPTION
## Summary
- extend order flow imbalance and depth imbalance to consume multi-level order books
- allow specifying depth of calculation
- add L2 snapshot tests for imbalance indicators

## Testing
- `pytest tests/test_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10411a630832db7685abf3f5c629a