### PR TITLE
feat: expose grafana dashboards and docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -19,6 +19,8 @@ Available endpoints:
 - `POST /strategies/{name}/{status}` – update a strategy state.
 - `GET /summary` – metrics and strategy states combined.
 - `GET /health` – basic liveness probe.
+- `GET /dashboards` – list of Grafana dashboards with direct URLs.
+- `GET /dashboards/{name}` – redirect to a specific Grafana dashboard.
 
 Static assets are served from `monitoring/static/` for a quick HTML view.
 
@@ -39,6 +41,19 @@ monitoring panel. Grafana is provisioned from files under
 * `datasources/datasource.yml` – Prometheus data source
 * `dashboards/dashboard.yml` – automatic dashboard loading
 * `dashboards/core.json` and `dashboards/tradebot.json` – example panels
+
+To build a standalone Grafana image with these files baked in:
+
+```bash
+docker build -t tradebot-grafana monitoring/grafana
+docker run -p 3000:3000 tradebot-grafana
+```
+
+Set `GRAFANA_URL` to point the FastAPI panel to a remote Grafana instance
+if it is not running on `localhost:3000`.
+
+Customize the panel by editing `datasources/datasource.yml` or adding new
+JSON dashboards under `monitoring/grafana/dashboards/`.
 
 The `core.json` dashboard provides panels for:
 

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/grafana:latest
+COPY datasources /etc/grafana/provisioning/datasources
+COPY dashboards /etc/grafana/provisioning/dashboards
+COPY dashboards /var/lib/grafana/dashboards

--- a/monitoring/grafana/dashboards/core.json
+++ b/monitoring/grafana/dashboards/core.json
@@ -4,6 +4,7 @@
   },
   "editable": true,
   "title": "Core Metrics",
+  "uid": "core",
   "schemaVersion": 16,
   "version": 1,
   "panels": [

--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -127,5 +127,6 @@
   ],
   "schemaVersion": 16,
   "title": "TradeBot Metrics",
+  "uid": "tradebot",
   "version": 3
 }

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -1,6 +1,8 @@
 """Monitoring panel exposing metrics and strategy state via FastAPI."""
 
-from fastapi import FastAPI
+import os
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
@@ -23,6 +25,30 @@ if config_path.exists():
 app = FastAPI(title="TradeBot Monitoring")
 app.include_router(metrics_router)
 app.include_router(strategies_router)
+
+
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://localhost:3000")
+GRAFANA_DASHBOARDS = {
+    "core": "core",
+    "tradebot": "tradebot",
+}
+
+
+@app.get("/dashboards")
+def dashboards() -> dict[str, str]:
+    """Return available Grafana dashboards with direct URLs."""
+
+    return {name: f"{GRAFANA_URL}/d/{uid}" for name, uid in GRAFANA_DASHBOARDS.items()}
+
+
+@app.get("/dashboards/{name}")
+def dashboard_link(name: str) -> RedirectResponse:
+    """Redirect to a Grafana dashboard by name."""
+
+    uid = GRAFANA_DASHBOARDS.get(name)
+    if not uid:
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+    return RedirectResponse(f"{GRAFANA_URL}/d/{uid}")
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- add fastapi routes pointing to Grafana dashboards
- provide Dockerfile provisioning datasource and dashboards
- document Grafana setup and customization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a104139fcc832d95bf5a1f7aaafee4