### PR TITLE
feat: add iceberg quantity support to futures adapters

### DIFF
--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -100,6 +100,7 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         client_order_id: str | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        iceberg_qty: float | None = None,
     ):
         """
         UM Futures: idempotencia + retries + reconciliación.
@@ -122,6 +123,8 @@ class BinanceFuturesAdapter(ExchangeAdapter):
                 }
                 if reduce_only:
                     params["reduceOnly"] = True
+                if iceberg_qty is not None:
+                    params["icebergQty"] = float(iceberg_qty)
                 if send_type == "LIMIT":
                     if price is None:
                         raise ValueError("LIMIT requiere price")

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -159,6 +159,7 @@ class BybitFuturesAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        iceberg_qty: float | None = None,
         params: dict | None = None,
     ) -> dict:
         params = params or {}
@@ -166,6 +167,8 @@ class BybitFuturesAdapter(ExchangeAdapter):
             params["postOnly"] = True
         if time_in_force:
             params["timeInForce"] = time_in_force
+        if iceberg_qty is not None:
+            params["iceberg"] = iceberg_qty
         backoff = 1.0
         while True:
             try:

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -149,9 +149,21 @@ class OKXFuturesAdapter(ExchangeAdapter):
         oi = float(item.get("oi", 0.0))
         return {"ts": ts, "oi": oi}
 
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
-                          price: float | None = None) -> dict:
-        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        iceberg_qty: float | None = None,
+    ) -> dict:
+        params = {}
+        if iceberg_qty is not None:
+            params["iceberg"] = iceberg_qty
+        return await self._to_thread(
+            self.rest.create_order, symbol, type_, side, qty, price, params
+        )
 
     async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
         return await self._to_thread(self.rest.cancel_order, order_id, symbol)

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import inspect
 from collections import defaultdict
 from typing import Dict, Iterable, List, Tuple
 
@@ -161,7 +162,13 @@ class ExecutionRouter:
             time_in_force=order.time_in_force,
         )
         if order.iceberg_qty is not None:
-            kwargs["iceberg_qty"] = order.iceberg_qty
+            sig = inspect.signature(adapter.place_order)
+            params = sig.parameters
+            if (
+                "iceberg_qty" in params
+                or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+            ):
+                kwargs["iceberg_qty"] = order.iceberg_qty
 
         res = await adapter.place_order(**kwargs)
         latency = time.monotonic() - start

--- a/tests/test_iceberg_translation.py
+++ b/tests/test_iceberg_translation.py
@@ -1,0 +1,60 @@
+import pytest
+
+from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.adapters.binance_futures import BinanceFuturesAdapter
+from tradingbot.adapters.bybit_futures import BybitFuturesAdapter
+from tradingbot.adapters.okx_futures import OKXFuturesAdapter
+
+
+class DummyRestBinance:
+    def __init__(self):
+        self.params = None
+
+    async def futures_order_new(self, **params):
+        self.params = params
+        return {"orderId": "1", "clientOrderId": params.get("newClientOrderId")}
+
+
+class DummyRestCreate:
+    def __init__(self):
+        self.args = None
+
+    def create_order(self, symbol, type_, side, qty, price, params):
+        self.args = (symbol, type_, side, qty, price, params)
+        return {"id": "1"}
+
+
+@pytest.mark.asyncio
+async def test_binance_translates_iceberg():
+    adapter = BinanceFuturesAdapter.__new__(BinanceFuturesAdapter)
+    ExchangeAdapter.__init__(adapter)
+    adapter.rest = DummyRestBinance()
+    adapter.leverage = 1
+    adapter.testnet = True
+    adapter.taker_fee_bps = 0.0
+    res = await adapter.place_order(
+        "BTC/USDT", "buy", "limit", 1.0, price=100.0, iceberg_qty=0.5
+    )
+    assert adapter.rest.params["icebergQty"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_bybit_translates_iceberg():
+    adapter = BybitFuturesAdapter.__new__(BybitFuturesAdapter)
+    ExchangeAdapter.__init__(adapter)
+    adapter.rest = DummyRestCreate()
+    res = await adapter.place_order(
+        "BTC/USDT", "buy", "limit", 1.0, price=100.0, iceberg_qty=0.5
+    )
+    assert adapter.rest.args[5]["iceberg"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_okx_translates_iceberg():
+    adapter = OKXFuturesAdapter.__new__(OKXFuturesAdapter)
+    ExchangeAdapter.__init__(adapter)
+    adapter.rest = DummyRestCreate()
+    res = await adapter.place_order(
+        "BTC/USDT", "buy", "limit", 1.0, price=100.0, iceberg_qty=0.5
+    )
+    assert adapter.rest.args[5]["iceberg"] == 0.5


### PR DESCRIPTION
## Summary
- add `iceberg_qty` support to Binance, Bybit and OKX futures adapters
- route iceberg quantity only to adapters that accept it
- test iceberg quantity translation for futures adapters

## Testing
- `python -m pytest tests/test_iceberg_translation.py tests/test_router_orders.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1040dc1d0832dac705945b12f4bcd