### PR TITLE
Add depth imbalance and liquidity event strategies

### DIFF
--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -5,6 +5,8 @@ from .mean_reversion import MeanReversion
 from .arbitrage_triangular import TriangularArb
 from .cash_and_carry import CashAndCarry
 from .order_flow import OrderFlow
+from .depth_imbalance import DepthImbalance
+from .liquidity_events import LiquidityEvents
 from .triple_barrier import TripleBarrier
 from .ml_models import MLStrategy
 
@@ -17,6 +19,8 @@ STRATEGIES = {
     TriangularArb.name: TriangularArb,
     CashAndCarry.name: CashAndCarry,
     OrderFlow.name: OrderFlow,
+    DepthImbalance.name: DepthImbalance,
+    LiquidityEvents.name: LiquidityEvents,
     TripleBarrier.name: TripleBarrier,
     MLStrategy.name: MLStrategy,
 }
@@ -29,6 +33,8 @@ __all__ = [
     "TriangularArb",
     "CashAndCarry",
     "OrderFlow",
+    "DepthImbalance",
+    "LiquidityEvents",
     "TripleBarrier",
     "MLStrategy",
     "STRATEGIES",

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import Strategy, Signal, record_signal_metrics
+from ..data.features import depth_imbalance
+
+
+class DepthImbalance(Strategy):
+    """Depth Imbalance strategy.
+
+    Computes the mean depth imbalance over a rolling window and issues
+    directional signals when the average exceeds ``threshold``.
+    """
+
+    name = "depth_imbalance"
+
+    def __init__(self, window: int = 3, threshold: float = 0.2):
+        self.window = window
+        self.threshold = threshold
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        needed = {"bid_qty", "ask_qty"}
+        if not needed.issubset(df.columns) or len(df) < self.window:
+            return None
+        di_series = depth_imbalance(df[list(needed)])
+        di_mean = di_series.iloc[-self.window :].mean()
+        if di_mean > self.threshold:
+            return Signal("buy", 1.0)
+        if di_mean < -self.threshold:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .base import Strategy, Signal, record_signal_metrics
+from ..data.features import book_vacuum, liquidity_gap
+
+
+class LiquidityEvents(Strategy):
+    """React to liquidity vacuum and gap events.
+
+    A wipe on the ask side triggers a buy signal while a wipe on the bid side
+    results in a sell signal.  If no vaciado is detected, the strategy checks
+    for large gaps between the first and second level of the book and trades in
+    the direction of the gap.
+    """
+
+    name = "liquidity_events"
+
+    def __init__(self, vacuum_threshold: float = 0.5, gap_threshold: float = 1.0):
+        self.vacuum_threshold = vacuum_threshold
+        self.gap_threshold = gap_threshold
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        needed = {"bid_qty", "ask_qty", "bid_px", "ask_px"}
+        if not needed.issubset(df.columns) or len(df) < 2:
+            return None
+
+        vac = book_vacuum(df[list({"bid_qty", "ask_qty"})], self.vacuum_threshold).iloc[-1]
+        if vac > 0:
+            return Signal("buy", 1.0)
+        if vac < 0:
+            return Signal("sell", 1.0)
+
+        gap = liquidity_gap(df[list({"bid_px", "ask_px"})], self.gap_threshold).iloc[-1]
+        if gap > 0:
+            return Signal("buy", 1.0)
+        if gap < 0:
+            return Signal("sell", 1.0)
+        return Signal("flat", 0.0)

--- a/tests/test_depth_imbalance.py
+++ b/tests/test_depth_imbalance.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from tradingbot.strategies.depth_imbalance import DepthImbalance
+
+
+def test_depth_imbalance_strategy_buy():
+    df = pd.DataFrame({"bid_qty": [5, 7, 9], "ask_qty": [5, 5, 3]})
+    strat = DepthImbalance(window=2, threshold=0.1)
+    sig = strat.on_bar({"window": df})
+    assert sig is not None and sig.side == "buy"
+
+
+def test_depth_imbalance_strategy_sell():
+    df = pd.DataFrame({"bid_qty": [5, 4, 3], "ask_qty": [5, 6, 7]})
+    strat = DepthImbalance(window=2, threshold=0.1)
+    sig = strat.on_bar({"window": df})
+    assert sig is not None and sig.side == "sell"

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from tradingbot.data.features import book_vacuum, liquidity_gap
+from tradingbot.strategies.liquidity_events import LiquidityEvents
+
+
+def test_book_vacuum_detection():
+    df = pd.DataFrame({"bid_qty": [10, 10], "ask_qty": [10, 4]})
+    events = book_vacuum(df, threshold=0.5)
+    assert list(events) == [0, 1]
+
+
+def test_liquidity_gap_detection():
+    df = pd.DataFrame({
+        "bid_px": [[100, 99], [100, 95]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    events = liquidity_gap(df, threshold=2)
+    assert list(events) == [0, -1]
+
+
+def test_liquidity_events_strategy_buy_vacuum():
+    df = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 4],
+        "bid_px": [[100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2)
+    sig = strat.on_bar({"window": df})
+    assert sig is not None and sig.side == "buy"
+
+
+def test_liquidity_events_strategy_sell_gap():
+    df = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 10],
+        "bid_px": [[100, 99], [100, 90]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=5)
+    sig = strat.on_bar({"window": df})
+    assert sig is not None and sig.side == "sell"


### PR DESCRIPTION
## Summary
- implement depth imbalance strategy emitting signals from average book imbalance
- add liquidity event strategy with book vacuum and gap detection
- extend features with `book_vacuum` and `liquidity_gap` utilities
- include unit tests for new strategies and detectors

## Testing
- `pytest tests/test_depth_imbalance.py tests/test_liquidity_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68a115649224832daec91f5fc02a6263