### PR TITLE
Add monitoring for depth, reconnections, and slippage

### DIFF
--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -63,3 +63,30 @@ groups:
         annotations:
           summary: Kill switch engaged
           description: Kill switch has been active for more than 1m
+
+      - alert: LowOrderBookDepth
+        expr: min_over_time(order_book_min_depth[5m]) < 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Order book depth below threshold
+          description: Minimum order book depth under 10 units for 5m
+
+      - alert: WebsocketReconnections
+        expr: increase(ws_reconnections_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Websocket reconnections detected
+          description: Websocket reconnected in the last 5m
+
+      - alert: ExcessiveSlippage
+        expr: histogram_quantile(0.95, sum(rate(order_slippage_bps_bucket[5m])) by (le)) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Excessive order slippage
+          description: 95th percentile slippage above 10 bps for 5m

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -10,10 +10,12 @@ from tradingbot.utils.metrics import (
     MAKER_TAKER_RATIO,
     KILL_SWITCH_ACTIVE,
     WS_FAILURES,
+    WS_RECONNECTS,
     TRADING_PNL,
     OPEN_POSITIONS,
     MARKET_LATENCY,
     E2E_LATENCY,
+    ORDER_BOOK_MIN_DEPTH,
 )
 
 # System metrics

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -21,6 +21,13 @@ WS_FAILURES = Counter(
     ["adapter"],
 )
 
+# Websocket reconnections by adapter
+WS_RECONNECTS = Counter(
+    "ws_reconnections_total",
+    "Total websocket reconnections",
+    ["adapter"],
+)
+
 # Order fills by symbol and side
 FILL_COUNT = Counter(
     "order_fills",
@@ -39,6 +46,13 @@ SLIPPAGE = Histogram(
 QUEUE_POSITION = Histogram(
     "order_queue_position_ratio",
     "Fraction of existing liquidity ahead of the order at best price level",
+    ["symbol", "side"],
+)
+
+# Minimum depth available at top of book
+ORDER_BOOK_MIN_DEPTH = Gauge(
+    "order_book_min_depth",
+    "Minimum order book depth at best price level",
     ["symbol", "side"],
 )
 

--- a/tests/test_monitoring_alerts.py
+++ b/tests/test_monitoring_alerts.py
@@ -1,0 +1,40 @@
+import yaml
+
+from tradingbot.utils.metrics import ORDER_BOOK_MIN_DEPTH, WS_RECONNECTS
+
+
+def test_alerts_and_metrics_definitions():
+    with open("monitoring/alerts.yml", "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    rules = [rule for group in config.get("groups", []) for rule in group.get("rules", [])]
+    rule_names = {rule["alert"]: rule for rule in rules}
+
+    assert "LowOrderBookDepth" in rule_names
+    assert "WebsocketReconnections" in rule_names
+    assert "ExcessiveSlippage" in rule_names
+
+    assert "order_book_min_depth" in rule_names["LowOrderBookDepth"]["expr"]
+    assert "ws_reconnections_total" in rule_names["WebsocketReconnections"]["expr"]
+    assert "order_slippage_bps" in rule_names["ExcessiveSlippage"]["expr"]
+
+    ORDER_BOOK_MIN_DEPTH.clear()
+    WS_RECONNECTS.clear()
+
+    ORDER_BOOK_MIN_DEPTH.labels(symbol="BTCUSD", side="bid").set(5)
+    depth_samples = list(ORDER_BOOK_MIN_DEPTH.collect())[0].samples
+    depth_sample = [
+        s for s in depth_samples
+        if s.name == "order_book_min_depth"
+        and s.labels["symbol"] == "BTCUSD"
+        and s.labels["side"] == "bid"
+    ][0]
+    assert depth_sample.value == 5
+
+    WS_RECONNECTS.labels(adapter="test").inc()
+    ws_samples = list(WS_RECONNECTS.collect())[0].samples
+    ws_sample = [
+        s for s in ws_samples
+        if s.name == "ws_reconnections_total" and s.labels["adapter"] == "test"
+    ][0]
+    assert ws_sample.value == 1.0


### PR DESCRIPTION
## Summary
- track websocket reconnections and minimum book depth via new Prometheus metrics
- trigger alerts for low depth, WS reconnections, and excessive slippage
- test alert configuration and metric instrumentation

## Testing
- `PYTHONPATH=. pytest tests/test_monitoring_alerts.py tests/test_monitoring_panel.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68a11567d3e8832dbf9bb279aec3cd96