### PR TITLE
Add basis fetch for Bybit futures

### DIFF
--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -128,6 +128,42 @@ class BybitFuturesAdapter(ExchangeAdapter):
         rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
         return {"ts": ts_dt, "rate": rate}
 
+    async def fetch_basis(self, symbol: str):
+        """Return the basis (mark - index) for ``symbol``.
+
+        Bybit exposes both the mark and index prices via the
+        ``v5/market/premium-index-price`` endpoint.  The response nests the
+        data under ``result.list``.  We fetch both prices and return their
+        difference along with the corresponding timestamp.  If the REST
+        adapter does not implement this endpoint, ``NotImplementedError`` is
+        raised to signal that the venue does not support basis retrieval.
+        """
+
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "publicGetV5MarketPremiumIndexPrice", None)
+        if method is None:
+            raise NotImplementedError("Basis not supported")
+
+        data = await self._request(method, {"category": "linear", "symbol": sym})
+        lst = (data.get("result") or {}).get("list") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(item.get("timestamp") or item.get("ts") or data.get("time", 0))
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        mark_px = float(
+            item.get("markPrice")
+            or item.get("mark_price")
+            or data.get("markPrice")
+            or 0.0
+        )
+        index_px = float(
+            item.get("indexPrice")
+            or item.get("index_price")
+            or data.get("indexPrice")
+            or 0.0
+        )
+        basis = mark_px - index_px
+        return {"ts": ts, "basis": basis}
+
     async def fetch_oi(self, symbol: str):
         """Return current open interest for ``symbol``.
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -187,6 +187,15 @@ class _DummyBybitRest:
     def publicGetV5MarketOpenInterest(self, params):
         return {"result": {"list": [{"timestamp": 1000, "openInterest": "100"}]}}
 
+    def publicGetV5MarketPremiumIndexPrice(self, params):
+        return {
+            "result": {
+                "list": [
+                    {"timestamp": 1000, "markPrice": "105", "indexPrice": "100"}
+                ]
+            }
+        }
+
 
 class _DummyOKXRest:
     def fetchFundingRate(self, symbol):
@@ -222,6 +231,21 @@ async def test_parsing_funding_and_oi(adapter_cls, rest_cls, rate, oi):
     oi_res = await adapter.fetch_oi("BTC/USDT")
     assert oi_res["oi"] == oi
     assert oi_res["ts"] == datetime.fromtimestamp(1, tz=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_bybit_futures_fetch_basis():
+    adapter = BybitFuturesAdapter.__new__(BybitFuturesAdapter)
+    adapter.rest = _DummyBybitRest()
+
+    async def _req(fn, *a, **k):
+        return fn(*a, **k)
+
+    adapter._request = _req
+
+    basis = await adapter.fetch_basis("BTC/USDT")
+    assert basis["basis"] == 5.0
+    assert basis["ts"] == datetime.fromtimestamp(1, tz=timezone.utc)
 
 
 class _DummyDeribitRest:


### PR DESCRIPTION
## Summary
- implement `fetch_basis` in Bybit futures adapter using premium-index-price endpoint
- add unit test verifying basis calculation for Bybit futures

## Testing
- `pytest tests/test_adapters.py::test_bybit_futures_fetch_basis -q`


------
https://chatgpt.com/codex/tasks/task_e_68a11fc2adc8832d9c0cc9a6a548ed90