### PR TITLE
Add funding, open interest, and basis polling with event routing

### DIFF
--- a/src/tradingbot/data/basis.py
+++ b/src/tradingbot/data/basis.py
@@ -1,0 +1,47 @@
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ..bus import EventBus
+
+try:  # optional persistence
+    from ..storage.timescale import get_engine, insert_basis
+    _CAN_PG = True
+except Exception:  # pragma: no cover - optional dependency
+    _CAN_PG = False
+
+log = logging.getLogger(__name__)
+
+
+async def poll_basis(
+    adapter,
+    symbol: str,
+    bus: EventBus,
+    interval: int = 60,
+    persist_pg: bool = False,
+) -> None:
+    """Poll periodic basis values and publish on the event bus."""
+    engine = get_engine() if (persist_pg and _CAN_PG) else None
+    while True:
+        try:
+            info: Any = await adapter.fetch_basis(symbol)
+            ts = info.get("ts") or datetime.now(timezone.utc)
+            basis = float(info.get("basis") or 0.0)
+            event = {
+                "ts": ts,
+                "exchange": getattr(adapter, "name", "unknown"),
+                "symbol": symbol,
+                "basis": basis,
+            }
+            await bus.publish("basis", event)
+            if engine is not None:
+                try:
+                    insert_basis(engine, ts=ts, exchange=event["exchange"], symbol=symbol, basis=basis)
+                except Exception as e:  # pragma: no cover - logging only
+                    log.debug("No se pudo insertar basis: %s", e)
+        except asyncio.CancelledError:  # allow task cancellation
+            raise
+        except Exception as e:  # pragma: no cover - logging only
+            log.warning("poll_basis error: %s", e)
+        await asyncio.sleep(interval)

--- a/src/tradingbot/data/open_interest.py
+++ b/src/tradingbot/data/open_interest.py
@@ -1,0 +1,54 @@
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ..bus import EventBus
+
+try:  # optional persistence
+    from ..storage.timescale import get_engine, insert_open_interest
+    _CAN_PG = True
+except Exception:  # pragma: no cover - optional dependency
+    _CAN_PG = False
+
+log = logging.getLogger(__name__)
+
+
+async def poll_open_interest(
+    adapter,
+    symbol: str,
+    bus: EventBus,
+    interval: int = 60,
+    persist_pg: bool = False,
+) -> None:
+    """Poll periodic open interest and publish on the event bus."""
+    engine = get_engine() if (persist_pg and _CAN_PG) else None
+    while True:
+        try:
+            fetch = getattr(adapter, "fetch_open_interest", None) or getattr(adapter, "fetch_oi", None)
+            if fetch is None:
+                raise AttributeError("adapter lacks fetch_open_interest")
+            info: Any = await fetch(symbol)
+            ts_raw = info.get("ts") or info.get("time")
+            if isinstance(ts_raw, (int, float)):
+                ts = datetime.fromtimestamp(ts_raw / 1000, timezone.utc)
+            else:
+                ts = ts_raw or datetime.now(timezone.utc)
+            oi = float(info.get("oi") or info.get("openInterest") or 0.0)
+            event = {
+                "ts": ts,
+                "exchange": getattr(adapter, "name", "unknown"),
+                "symbol": symbol,
+                "oi": oi,
+            }
+            await bus.publish("open_interest", event)
+            if engine is not None:
+                try:
+                    insert_open_interest(engine, ts=ts, exchange=event["exchange"], symbol=symbol, oi=oi)
+                except Exception as e:  # pragma: no cover - logging only
+                    log.debug("No se pudo insertar open interest: %s", e)
+        except asyncio.CancelledError:  # allow task cancellation
+            raise
+        except Exception as e:  # pragma: no cover - logging only
+            log.warning("poll_open_interest error: %s", e)
+        await asyncio.sleep(interval)

--- a/tests/test_daemon_routing.py
+++ b/tests/test_daemon_routing.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+from tradingbot.bus import EventBus
+from tradingbot.live.daemon import TradeBotDaemon
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.risk.manager import RiskManager
+
+
+class DummyAdapter:
+    name = "dummy"
+
+    async def stream_trades(self, symbol: str):
+        if False:
+            yield {}
+
+
+class DummyStrategy:
+    def __init__(self):
+        self.funding = []
+        self.basis = []
+
+    def on_funding(self, evt):
+        self.funding.append(evt)
+
+    def on_basis(self, evt):
+        self.basis.append(evt)
+
+
+@pytest.mark.asyncio
+async def test_daemon_routes_funding_and_basis():
+    bus = EventBus()
+    risk = RiskManager(bus=bus)
+    router = ExecutionRouter([])
+    strat = DummyStrategy()
+    daemon = TradeBotDaemon({"d": DummyAdapter()}, [strat], risk, router, symbols=["BTCUSDT"])
+
+    await bus.publish("funding", {"rate": 1})
+    await bus.publish("basis", {"basis": 2})
+
+    assert strat.funding and strat.funding[0]["rate"] == 1
+    assert strat.basis and strat.basis[0]["basis"] == 2

--- a/tests/test_data_pollers.py
+++ b/tests/test_data_pollers.py
@@ -1,0 +1,77 @@
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from tradingbot.bus import EventBus
+from tradingbot.data.open_interest import poll_open_interest
+from tradingbot.data.basis import poll_basis
+
+
+@pytest.mark.asyncio
+async def test_poll_open_interest_publishes_and_inserts(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    class DummyAdapter:
+        name = "dummy"
+
+        async def fetch_open_interest(self, symbol: str):
+            return {"ts": ts, "oi": 10.0}
+
+    events = []
+    bus = EventBus()
+    bus.subscribe("open_interest", lambda e: events.append(e))
+
+    inserted = []
+
+    class DummyStorage:
+        def get_engine(self):
+            return "engine"
+
+        def insert_open_interest(self, engine, **data):
+            inserted.append(data)
+
+    monkeypatch.setattr("tradingbot.data.open_interest.get_engine", lambda: "engine")
+    monkeypatch.setattr("tradingbot.data.open_interest.insert_open_interest", lambda *a, **k: inserted.append(k))
+    monkeypatch.setattr("tradingbot.data.open_interest._CAN_PG", True)
+
+    task = asyncio.create_task(
+        poll_open_interest(DummyAdapter(), "BTCUSDT", bus, interval=0, persist_pg=True)
+    )
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events and events[0]["oi"] == 10.0
+    assert inserted and inserted[0]["oi"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_poll_basis_publishes_and_inserts(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    class DummyAdapter:
+        name = "dummy"
+
+        async def fetch_basis(self, symbol: str):
+            return {"ts": ts, "basis": 5.0}
+
+    events = []
+    bus = EventBus()
+    bus.subscribe("basis", lambda e: events.append(e))
+
+    monkeypatch.setattr("tradingbot.data.basis.get_engine", lambda: "engine")
+    monkeypatch.setattr("tradingbot.data.basis.insert_basis", lambda *a, **k: events.append({"persist": k}))
+    monkeypatch.setattr("tradingbot.data.basis._CAN_PG", True)
+
+    task = asyncio.create_task(
+        poll_basis(DummyAdapter(), "BTCUSDT", bus, interval=0, persist_pg=True)
+    )
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events and any("basis" in e for e in events if "basis" in e)
+    assert any("persist" in e for e in events)


### PR DESCRIPTION
## Summary
- poll and publish open interest and basis data with optional TimescaleDB persistence
- extend daemon and cross-exchange runner to schedule funding/open interest/basis tasks and route events to strategies
- add tests for new pollers and event routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a12d8c3370832d8202f1f5fbec2cf0