### PR TITLE
feat: add correlation-based sizing

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -101,7 +101,18 @@ def run_daemon(config: str = "config/config.yaml") -> None:
         strat = BreakoutATR()
         router = ExecutionRouter(adapters=[adapter])
 
-        bot = TradeBotDaemon({"binance": adapter}, [strat], risk, router, [cfg.backtest.symbol])
+        corr_thr = getattr(getattr(cfg, "risk", {}), "correlation_threshold", 0.8)
+        ret_win = getattr(getattr(cfg, "risk", {}), "returns_window", 100)
+
+        bot = TradeBotDaemon(
+            {"binance": adapter},
+            [strat],
+            risk,
+            router,
+            [cfg.backtest.symbol],
+            correlation_threshold=corr_thr,
+            returns_window=ret_win,
+        )
 
         typer.echo(OmegaConf.to_yaml(cfg))
         asyncio.run(bot.run())

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -16,3 +16,6 @@ backtest:
 storage:
   backend: sqlite
   url: "sqlite:///:memory:"
+risk:
+  correlation_threshold: 0.8
+  returns_window: 100

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -52,6 +52,14 @@ class StorageConfig:
 
 
 @dataclass
+class RiskConfig:
+    """Risk management parameters used by strategies/daemon."""
+
+    correlation_threshold: float = 0.8
+    returns_window: int = 100
+
+
+@dataclass
 class AppConfig:
     """Top level application configuration."""
 
@@ -59,6 +67,7 @@ class AppConfig:
     strategies: StrategiesConfig = field(default_factory=StrategiesConfig)
     backtest: BacktestConfig = field(default_factory=BacktestConfig)
     storage: StorageConfig = field(default_factory=StorageConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)
 
 
 # Register configuration so Hydra validates the structure

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -64,6 +64,8 @@ class TradeBotDaemon:
         strategy_paths: Iterable[str] | None = None,
         arb_runners: Iterable[tuple[str, dict]] | None = None,
         balance_interval: float = 60.0,
+        correlation_threshold: float = 0.8,
+        returns_window: int = 100,
     ) -> None:
         self.adapters = adapters
         self.strategies: List[object] = []
@@ -92,6 +94,7 @@ class TradeBotDaemon:
             except Exception as exc:
                 log.warning("runner_load_error", extra={"path": path, "err": str(exc)})
         self.balance_interval = balance_interval
+        self.corr_threshold = float(correlation_threshold)
 
         # initialize position books for all venues/symbols
         for venue in self.adapters:
@@ -108,7 +111,9 @@ class TradeBotDaemon:
         self._tasks: List[asyncio.Task] = []
         self._stop = asyncio.Event()
         self.balances: Dict[str, dict] = {}
-        self.price_history: Dict[str, deque] = defaultdict(lambda: deque(maxlen=100))
+        self.price_history: Dict[str, deque] = defaultdict(
+            lambda: deque(maxlen=returns_window)
+        )
 
         # Bus subscriptions
         self.bus.subscribe("trade", self._dispatch_trade)
@@ -284,10 +289,10 @@ class TradeBotDaemon:
                 rets_list = returns(df_hist).dropna().tolist()
                 if rets_list:
                     returns_dict[sym] = rets_list
+        corr_pairs: Dict[tuple[str, str], float] = {}
         if returns_dict:
             cov_matrix = self.risk.covariance_matrix(returns_dict)
             rets_df = pd.DataFrame(returns_dict)
-            corr_pairs: Dict[tuple[str, str], float] = {}
             cols = list(rets_df.columns)
             for a_idx in range(len(cols)):
                 for b_idx in range(a_idx + 1, len(cols)):
@@ -296,11 +301,14 @@ class TradeBotDaemon:
                     corr = rets_df[a].corr(rets_df[b])
                     if not pd.isna(corr):
                         corr_pairs[(a, b)] = float(corr)
-            self.risk.update_correlation(corr_pairs, 0.8)
-            self.risk.update_covariance(cov_matrix, 0.8)
+            self.risk.update_correlation(corr_pairs, self.corr_threshold)
+            self.risk.update_covariance(cov_matrix, self.corr_threshold)
 
         delta = self.risk.size(side, strength)
         delta += self.risk.size_with_volatility(symbol_vol)
+        delta = self.risk.adjust_size_for_correlation(
+            symbol, delta, corr_pairs, self.corr_threshold
+        )
         if abs(delta) <= 0:
             return
         if price is not None and not self.risk.check_limits(price):


### PR DESCRIPTION
## Summary
- compute historical returns and covariance matrix for all symbols
- expose correlation threshold and window via configuration
- adjust order size for correlations in TradeBotDaemon

## Testing
- `pytest tests/test_risk_manager_extra.py::test_covariance_and_aggregation tests/test_risk_manager_extra.py::test_adjust_size_and_portfolio_risk -q`
- `pytest tests/test_daemon_integration.py::test_daemon_processes_trades tests/test_daemon_integration.py::test_daemon_adjusts_size_for_correlation -q`
- `pytest tests/test_risk_manager_limits.py::test_update_correlation_emits_pause -q`
- `pytest tests/test_daemon_integration.py::test_daemon_adjusts_size_for_correlation -q`


------
https://chatgpt.com/codex/tasks/task_e_68a12d8e5404832db09771b11f8b3a58