### PR TITLE
Add Kaiko and CoinAPI connectors and ingestion support

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,21 @@ archivos CSV dentro de `db/` o directamente en TimescaleDB/QuestDB:
 
 La persistencia se realiza mediante utilidades de `tradingbot.data.ingestion`.
 
+### Claves de API para conectores externos
+
+Algunos proveedores como Kaiko y CoinAPI requieren claves de autenticación.
+Establece las variables de entorno `KAIKO_API_KEY` y `COINAPI_KEY` antes de
+invocar los conectores o scripts que los utilicen:
+
+```bash
+export KAIKO_API_KEY="tu_clave_kaiko"
+export COINAPI_KEY="tu_clave_coinapi"
+```
+
+Los conectores `KaikoConnector` y `CoinAPIConnector` ofrecen métodos
+``fetch_trades`` y ``fetch_order_book`` que pueden emplearse junto a las
+utilidades de `ingestion` para descargar históricos y persistirlos.
+
 ## Servicios con Docker
 Puedes levantar únicamente las bases de datos con los scripts del
 repositorio:

--- a/src/tradingbot/connectors/__init__.py
+++ b/src/tradingbot/connectors/__init__.py
@@ -3,6 +3,8 @@ from .binance import BinanceConnector
 from .bybit import BybitConnector
 from .okx import OKXConnector
 from .deribit import DeribitConnector
+from .kaiko import KaikoConnector
+from .coinapi import CoinAPIConnector
 
 __all__ = [
     "Trade",
@@ -15,4 +17,6 @@ __all__ = [
     "BybitConnector",
     "OKXConnector",
     "DeribitConnector",
+    "KaikoConnector",
+    "CoinAPIConnector",
 ]

--- a/src/tradingbot/connectors/coinapi.py
+++ b/src/tradingbot/connectors/coinapi.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from .base import OrderBook, Trade
+
+
+class CoinAPIConnector:
+    """REST connector for CoinAPI."""
+
+    name = "coinapi"
+    _BASE_URL = "https://rest.coinapi.io/v1"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("COINAPI_KEY", "")
+
+    async def fetch_trades(self, symbol: str, limit: int = 100) -> List[Trade]:
+        url = f"{self._BASE_URL}/trades/{symbol}"
+        headers = {"X-CoinAPI-Key": self.api_key}
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params={"limit": limit}, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+
+        trades: List[Trade] = []
+        for t in data:
+            ts = t.get("time_exchange") or t.get("time_trade") or ""
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else datetime.utcnow()
+            trades.append(
+                Trade(
+                    timestamp=dt,
+                    exchange=self.name,
+                    symbol=symbol,
+                    price=float(t.get("price", 0.0)),
+                    amount=float(t.get("size", 0.0)),
+                    side=t.get("taker_side", ""),
+                )
+            )
+        return trades
+
+    async def fetch_order_book(self, symbol: str, depth: int = 10) -> OrderBook:
+        url = f"{self._BASE_URL}/orderbooks/current/{symbol}"
+        headers = {"X-CoinAPI-Key": self.api_key}
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            payload = resp.json()
+
+        bids_raw = payload.get("bids", [])[:depth]
+        asks_raw = payload.get("asks", [])[:depth]
+        ts = payload.get("time_exchange") or payload.get("time_coinapi") or ""
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else datetime.utcnow()
+        bids = [(float(b.get("price")), float(b.get("size"))) for b in bids_raw]
+        asks = [(float(a.get("price")), float(a.get("size"))) for a in asks_raw]
+        return OrderBook(timestamp=dt, exchange=self.name, symbol=symbol, bids=bids, asks=asks)

--- a/src/tradingbot/connectors/kaiko.py
+++ b/src/tradingbot/connectors/kaiko.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from .base import OrderBook, Trade
+
+
+class KaikoConnector:
+    """Simple Kaiko REST connector."""
+
+    name = "kaiko"
+    _BASE_URL = "https://us.market-api.kaiko.io/v2/data"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("KAIKO_API_KEY", "")
+
+    async def fetch_trades(
+        self, exchange: str, pair: str, limit: int = 100
+    ) -> List[Trade]:
+        """Fetch recent trades for *pair* on *exchange*.
+
+        Parameters match Kaiko's "recent trades" endpoint. Only a subset of the
+        response fields is mapped to :class:`Trade` objects.
+        """
+
+        url = f"{self._BASE_URL}/trades.v1/exchanges/{exchange}/spot/{pair}/recent"
+        headers = {"X-Api-Key": self.api_key}
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params={"limit": limit}, headers=headers)
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+
+        trades: List[Trade] = []
+        for t in data:
+            ts = t.get("timestamp") or t.get("time") or ""
+            # Kaiko timestamps are ISO8601 strings
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else datetime.utcnow()
+            trades.append(
+                Trade(
+                    timestamp=dt,
+                    exchange=exchange,
+                    symbol=pair,
+                    price=float(t.get("price", 0.0)),
+                    amount=float(t.get("amount", 0.0)),
+                    side=t.get("taker_side", ""),
+                )
+            )
+        return trades
+
+    async def fetch_order_book(
+        self, exchange: str, pair: str, depth: int = 10
+    ) -> OrderBook:
+        """Fetch a snapshot of the order book."""
+
+        url = (
+            f"{self._BASE_URL}/order_book.snapshots.v1/exchanges/{exchange}/spot/{pair}/books/latest"
+        )
+        headers = {"X-Api-Key": self.api_key}
+        params = {"depth": depth}
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, headers=headers)
+            resp.raise_for_status()
+            payload = resp.json().get("data", {})
+
+        bids_raw = payload.get("bids", [])[:depth]
+        asks_raw = payload.get("asks", [])[:depth]
+        ts = payload.get("timestamp", "")
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else datetime.utcnow()
+        bids = [(float(p), float(q)) for p, q in bids_raw]
+        asks = [(float(p), float(q)) for p, q in asks_raw]
+        return OrderBook(timestamp=dt, exchange=exchange, symbol=pair, bids=bids, asks=asks)


### PR DESCRIPTION
## Summary
- implement KaikoConnector and CoinAPIConnector with REST methods for trades and order books
- extend ingestion utilities to download and persist data from generic connectors
- document external API keys and add regression tests for new ingestion helpers

## Testing
- `pytest tests/test_data_ingestion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a143cc5160832d88b2b6fcb688b92c