### PR TITLE
feat: add stress parameters and comparative backtest reports

### DIFF
--- a/src/tradingbot/analysis/backtest_report.py
+++ b/src/tradingbot/analysis/backtest_report.py
@@ -107,4 +107,26 @@ def generate_report(result: Dict) -> Dict[str, float]:
     return stats
 
 
-__all__ = ["generate_report"]
+def generate_comparative_report(base: Dict, stressed: Dict) -> Dict[str, Dict[str, float]]:
+    """Generate reports for baseline and stressed results and compare them.
+
+    Parameters
+    ----------
+    base: result dictionary for the baseline scenario.
+    stressed: result dictionary for the stressed scenario.
+
+    Returns
+    -------
+    Mapping containing ``base`` and ``stressed`` reports plus ``delta``
+    differences (``stressed - base``) for each metric present in either
+    report.
+    """
+
+    base_report = generate_report(base)
+    stressed_report = generate_report(stressed)
+    keys = set(base_report) | set(stressed_report)
+    delta = {k: stressed_report.get(k, 0.0) - base_report.get(k, 0.0) for k in keys}
+    return {"base": base_report, "stressed": stressed_report, "delta": delta}
+
+
+__all__ = ["generate_report", "generate_comparative_report"]

--- a/tests/test_backtest_report.py
+++ b/tests/test_backtest_report.py
@@ -7,7 +7,10 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from tradingbot.analysis.backtest_report import generate_report
+from tradingbot.analysis.backtest_report import (
+    generate_comparative_report,
+    generate_report,
+)
 
 
 def test_generate_report_basic():
@@ -52,3 +55,12 @@ def test_generate_report_basic():
     st = report["stress_tests"]
     assert pytest.approx(st["drop_5"], rel=1e-9) == 7.350414198231491
     assert pytest.approx(st["drop_10"], rel=1e-9) == 5.047917222317952
+
+
+def test_generate_comparative_report():
+    base = {"equity": 100.0, "orders": []}
+    stressed = {"equity": 80.0, "orders": []}
+    comp = generate_comparative_report(base, stressed)
+    assert comp["base"]["pnl"] == 100.0
+    assert comp["stressed"]["pnl"] == 80.0
+    assert comp["delta"]["pnl"] == -20.0

--- a/tests/test_stress_engine.py
+++ b/tests/test_stress_engine.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+import pytest
+from types import SimpleNamespace
+
+from tradingbot.backtesting.engine import SlippageModel, StressConfig, run_backtest_csv
+from tradingbot.strategies import STRATEGIES
+
+
+class BuyOnceStrategy:
+    name = "buyonce"
+
+    def __init__(self):
+        self.sent = False
+
+    def on_bar(self, context):
+        if self.sent:
+            return None
+        self.sent = True
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+def _make_csv(tmp_path):
+    rng = pd.date_range("2021-01-01", periods=5, freq="T")
+    df = pd.DataFrame(
+        {
+            "timestamp": rng.view("int64") // 10**9,
+            "open": 100.0,
+            "high": 100.5,
+            "low": 99.5,
+            "close": 100.0,
+            "volume": 1000,
+        }
+    )
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_latency_and_spread_stress(tmp_path, monkeypatch):
+    csv_path = _make_csv(tmp_path)
+    monkeypatch.setitem(STRATEGIES, "buyonce", BuyOnceStrategy)
+    strategies = [("buyonce", "SYM")]
+    data = {"SYM": str(csv_path)}
+
+    base = run_backtest_csv(
+        data,
+        strategies,
+        latency=1,
+        window=1,
+        slippage=SlippageModel(volume_impact=0.0),
+    )
+
+    stressed = run_backtest_csv(
+        data,
+        strategies,
+        latency=1,
+        window=1,
+        slippage=SlippageModel(volume_impact=0.0),
+        stress=StressConfig(latency=2.0, spread=2.0),
+    )
+
+    base_order = base["orders"][0]
+    stress_order = stressed["orders"][0]
+
+    assert base_order["latency"] == 1
+    assert stress_order["latency"] == 2
+
+    base_slip = base_order["avg_price"] - base_order["place_price"]
+    stress_slip = stress_order["avg_price"] - stress_order["place_price"]
+    assert pytest.approx(stress_slip, rel=1e-9) == base_slip * 2


### PR DESCRIPTION
## Summary
- allow slippage model to scale spread via `spread_mult`
- add `StressConfig` to event-driven engine with latency and spread multipliers
- provide comparative backtest reports and tests for stress scenarios

## Testing
- `pytest tests/test_backtesting_integration.py tests/test_walk_forward.py tests/test_latency_integration.py tests/test_stress_engine.py tests/test_backtest_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15cf30348832db95c406d0a4e188e