### PR TITLE
Add perpetual poller helper and storage inserts

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,0 +1,39 @@
+# Ejecución como daemon
+
+Ejemplos de configuración para ejecutar los _pollers_ de datos de forma
+continua.
+
+## systemd
+
+```
+[Unit]
+Description=TradingBot perp pollers
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/ruta/a/TradeBot
+ExecStart=/usr/bin/python /ruta/a/poll_perp.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Cron
+
+Archivo `poll_perp.py`:
+
+```
+import asyncio
+from tradingbot.adapters.binance_futures import BinanceFuturesAdapter
+from tradingbot.data.ingestion import poll_perp_metrics
+
+asyncio.run(poll_perp_metrics(BinanceFuturesAdapter(), "BTC/USDT"))
+```
+
+Job de cron que ejecuta cada minuto:
+
+```
+* * * * * cd /ruta/a/TradeBot && /usr/bin/python /ruta/a/poll_perp.py >> /var/log/tradingbot.log 2>&1
+```

--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -345,3 +345,24 @@ async def fetch_bars(adapter: Any, symbol: str, *, timeframe: str = "1m", backen
         except Exception as exc:  # pragma: no cover - logging only
             log.debug("Bar fetch failed: %s", exc)
         await asyncio.sleep(sleep_s)
+
+
+async def poll_perp_metrics(
+    adapter: Any,
+    symbol: str,
+    *,
+    interval: int = 60,
+    backend: Backends = "timescale",
+) -> None:
+    """Run perpetual data pollers concurrently.
+
+    This helper gathers :func:`poll_funding`, :func:`poll_basis` and
+    :func:`poll_open_interest` so that funding rates, basis and open interest
+    are fetched continuously.
+    """
+
+    await asyncio.gather(
+        poll_funding(adapter, symbol, interval=interval, backend=backend),
+        poll_basis(adapter, symbol, interval=interval, backend=backend),
+        poll_open_interest(adapter, symbol, interval=interval, backend=backend),
+    )

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -147,7 +147,7 @@ def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, inter
 
 
 def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):
-    """Persist an open interest record into QuestDB."""
+    """Persist an open interest observation into QuestDB."""
     with engine.begin() as conn:
         conn.execute(
             text(
@@ -161,7 +161,7 @@ def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):
 
 
 def insert_basis(engine, *, ts, exchange: str, symbol: str, basis: float):
-    """Persist a basis record into QuestDB."""
+    """Persist a basis observation into QuestDB."""
     with engine.begin() as conn:
         conn.execute(
             text(

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -34,12 +34,33 @@ def insert_bar_1m(engine, exchange: str, symbol: str, ts, o: float, h: float,
             dict(ts=ts, exchange=exchange, symbol=symbol, o=o, h=h, l=low, c=c, v=v),
         )
 
-def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, interval_sec: int):
+def insert_funding(
+    engine,
+    *,
+    ts,
+    exchange: str,
+    symbol: str,
+    rate: float,
+    interval_sec: int,
+):
+    """Persist a funding rate observation."""
+
     with engine.begin() as conn:
-        conn.execute(text('''
+        conn.execute(
+            text(
+                '''
             INSERT INTO market.funding (ts, exchange, symbol, rate, interval_sec)
             VALUES (:ts, :exchange, :symbol, :rate, :interval_sec)
-        '''), dict(ts=ts, exchange=exchange, symbol=symbol, rate=rate, interval_sec=interval_sec))
+        '''
+            ),
+            dict(
+                ts=ts,
+                exchange=exchange,
+                symbol=symbol,
+                rate=rate,
+                interval_sec=interval_sec,
+            ),
+        )
 
 
 def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):


### PR DESCRIPTION
## Summary
- add poll_perp_metrics to run funding, basis and open interest pollers concurrently
- document systemd and cron setups for continuous pollers
- clarify funding/open interest/basis inserts for TimescaleDB and QuestDB

## Testing
- `pytest tests/test_data_ingestion.py::test_poll_funding_inserts tests/test_storage.py::test_insert_and_read_trade -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15ce9d620832d99e2c5aac08983f7