### PR TITLE
feat: add websocket resiliency

### DIFF
--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -1,8 +1,6 @@
 # src/tradingbot/adapters/binance_ws.py
-import asyncio
 import json
 import logging
-import websockets
 from datetime import datetime, timezone
 from typing import AsyncIterator, Any
 
@@ -12,7 +10,6 @@ except Exception:  # pragma: no cover - si falta ccxt
     ccxt = None
 
 from .base import ExchangeAdapter
-from ..utils.metrics import WS_FAILURES
 
 log = logging.getLogger(__name__)
 
@@ -54,55 +51,32 @@ class BinanceWSAdapter(ExchangeAdapter):
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _binance_symbol_stream(self.normalize_symbol(symbol))
         url = self.ws_base + stream
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Binance trades: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        d = msg.get("data") or {}
-                        # Trade payload (t=trade id, p=price, q=qty, T=trade time ms, m=is buyer maker)
-                        price = float(d.get("p")) if d.get("p") is not None else None
-                        qty = float(d.get("q")) if d.get("q") is not None else None
-                        ts_ms = d.get("T")
-                        side = "sell" if d.get("m") else "buy"  # buyer is maker -> aggressive sell
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        if price is not None:
-                            self.state.last_px[symbol] = price
-                        yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning("WS desconectado (%s). Reintentando en %.1fs ...", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or {}
+            price = float(d.get("p")) if d.get("p") is not None else None
+            qty = float(d.get("q")) if d.get("q") is not None else None
+            ts_ms = d.get("T")
+            side = "sell" if d.get("m") else "buy"
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            if price is not None:
+                self.state.last_px[symbol] = price
+            yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         stream = _binance_symbol_stream(self.normalize_symbol(symbol)).replace("@trade", f"@depth{depth}@100ms")
         url = self.ws_base + stream
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Binance orderbook: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        d = msg.get("data") or msg
-                        bids = d.get("bids") or d.get("b") or []
-                        asks = d.get("asks") or d.get("a") or []
-                        bids_n = [[float(b[0]), float(b[1])] for b in bids]
-                        asks_n = [[float(a[0]), float(a[1])] for a in asks]
-                        ts_ms = d.get("E") or d.get("T")
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
-                        yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning("WS orderbook desconectado (%s). Reintento en %.1fs ...", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or msg
+            bids = d.get("bids") or d.get("b") or []
+            asks = d.get("asks") or d.get("a") or []
+            bids_n = [[float(b[0]), float(b[1])] for b in bids]
+            asks_n = [[float(a[0]), float(a[1])] for a in asks]
+            ts_ms = d.get("E") or d.get("T")
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
+            yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
 
     stream_orderbook = stream_order_book
 

--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -1,14 +1,11 @@
 # src/tradingbot/adapters/binance_futures_ws.py
-import asyncio
 import json
 import logging
 import urllib.request
-import websockets
 from datetime import datetime, timezone
 from typing import AsyncIterator, Iterable
 
 from .base import ExchangeAdapter
-from ..utils.metrics import WS_FAILURES
 from ..config import settings
 
 log = logging.getLogger(__name__)
@@ -55,38 +52,25 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
     async def stream_trades_multi(self, symbols: Iterable[str], channel: str = "aggTrade") -> AsyncIterator[dict]:
         streams = "/".join(_stream_name(self.normalize_symbol(s), channel) for s in symbols)
         url = self.ws_base + streams
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Futures UM testnet multi: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        stream = (msg.get("stream") or "")
-                        d = msg.get("data") or {}
-                        # aggTrade payload: p (price), q (qty), T (trade time), m (is buyer maker)
-                        price = d.get("p") or d.get("price")
-                        qty = d.get("q")
-                        ts_ms = d.get("T") or d.get("E")
-                        if price is None:
-                            continue
-                        symbol_key = stream.split("@")[0].upper()
-                        # map BTCUSDT -> BTC/USDT
-                        base = symbol_key[:-4]   # UM usa siempre *USDT
-                        symbol = f"{base}/USDT"
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            stream = (msg.get("stream") or "")
+            d = msg.get("data") or {}
+            price = d.get("p") or d.get("price")
+            qty = d.get("q")
+            ts_ms = d.get("T") or d.get("E")
+            if price is None:
+                continue
+            symbol_key = stream.split("@")[0].upper()
+            base = symbol_key[:-4]
+            symbol = f"{base}/USDT"
 
-                        price = float(price)
-                        qty = float(qty or 0.0)
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        side = "sell" if d.get("m") else "buy"
-                        self.state.last_px[symbol] = price
-                        yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning("WS futures testnet desconectado (%s). Reintento en %.1fs ...", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+            price = float(price)
+            qty = float(qty or 0.0)
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            side = "sell" if d.get("m") else "buy"
+            self.state.last_px[symbol] = price
+            yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         async for t in self.stream_trades_multi([symbol]):
@@ -95,32 +79,17 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         stream = _stream_name(self.normalize_symbol(symbol), f"depth{depth}@100ms")
         url = self.ws_base + stream
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Futures UM orderbook: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        d = msg.get("data") or msg
-                        bids = d.get("b") or d.get("bids") or []
-                        asks = d.get("a") or d.get("asks") or []
-                        ts_ms = d.get("T") or d.get("E")
-                        bids_n = [[float(b[0]), float(b[1])] for b in bids]
-                        asks_n = [[float(a[0]), float(a[1])] for a in asks]
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
-                        yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning(
-                    "WS futures orderbook desconectado (%s). Reintento en %.1fs ...",
-                    e,
-                    backoff,
-                )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or msg
+            bids = d.get("b") or d.get("bids") or []
+            asks = d.get("a") or d.get("asks") or []
+            ts_ms = d.get("T") or d.get("E")
+            bids_n = [[float(b[0]), float(b[1])] for b in bids]
+            asks_n = [[float(a[0]), float(a[1])] for a in asks]
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
+            yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
 
     stream_orderbook = stream_order_book
 

--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -1,13 +1,10 @@
 # src/tradingbot/adapters/binance_spot_ws.py
-import asyncio
 import json
 import logging
-import websockets
 from datetime import datetime, timezone
 from typing import AsyncIterator, Iterable
 
 from .base import ExchangeAdapter
-from ..utils.metrics import WS_FAILURES
 
 log = logging.getLogger(__name__)
 
@@ -30,31 +27,20 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _stream_name(self.normalize_symbol(symbol))
         url = self.ws_base + stream
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Spot testnet trades: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        d = msg.get("data") or {}
-                        price = d.get("p")
-                        qty = d.get("q")
-                        ts_ms = d.get("T")
-                        if price is None:
-                            continue
-                        price = float(price)
-                        qty = float(qty or 0.0)
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        side = "sell" if d.get("m") else "buy"
-                        self.state.last_px[symbol] = price
-                        yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning("WS spot testnet desconectado (%s). Reintento en %.1fs ...", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or {}
+            price = d.get("p")
+            qty = d.get("q")
+            ts_ms = d.get("T")
+            if price is None:
+                continue
+            price = float(price)
+            qty = float(qty or 0.0)
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            side = "sell" if d.get("m") else "buy"
+            self.state.last_px[symbol] = price
+            yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_trades_multi(self, symbols: Iterable[str]) -> AsyncIterator[dict]:
         """
@@ -63,71 +49,45 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
         """
         streams = "/".join(_stream_name(self.normalize_symbol(s)) for s in symbols)
         url = self.ws_base + streams
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Spot testnet multi: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        stream = (msg.get("stream") or "")
-                        data = msg.get("data") or {}
-                        price = data.get("p")
-                        qty = data.get("q")
-                        ts_ms = data.get("T")
-                        if price is None:
-                            continue
-                        symbol_key = stream.split("@")[0].upper()
-                        if symbol_key.endswith("USDT"):
-                            base = symbol_key[:-4]
-                            symbol = f"{base}/USDT"
-                        else:
-                            candidates = ("USDT","BUSD","BTC","ETH","BNB","FDUSD","TUSD")
-                            match = next((q for q in candidates if symbol_key.endswith(q)), None)
-                            symbol = f"{symbol_key[:-len(match)]}/{match}" if match else symbol_key
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            stream = (msg.get("stream") or "")
+            data = msg.get("data") or {}
+            price = data.get("p")
+            qty = data.get("q")
+            ts_ms = data.get("T")
+            if price is None:
+                continue
+            symbol_key = stream.split("@")[0].upper()
+            if symbol_key.endswith("USDT"):
+                base = symbol_key[:-4]
+                symbol = f"{base}/USDT"
+            else:
+                candidates = ("USDT","BUSD","BTC","ETH","BNB","FDUSD","TUSD")
+                match = next((q for q in candidates if symbol_key.endswith(q)), None)
+                symbol = f"{symbol_key[:-len(match)]}/{match}" if match else symbol_key
 
-                        price = float(price)
-                        qty = float(qty or 0.0)
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        side = "sell" if data.get("m") else "buy"
-                        self.state.last_px[symbol] = price
-                        yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning("WS spot testnet multi desconectado (%s). Reintento en %.1fs ...", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+            price = float(price)
+            qty = float(qty or 0.0)
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            side = "sell" if data.get("m") else "buy"
+            self.state.last_px[symbol] = price
+            yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         stream = _stream_name(self.normalize_symbol(symbol), f"depth{depth}@100ms")
         url = self.ws_base + stream
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    log.info("Conectado WS Spot testnet orderbook: %s", url)
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        d = msg.get("data") or msg
-                        ts_ms = d.get("T") or d.get("E")
-                        bids = d.get("bids") or d.get("b") or []
-                        asks = d.get("asks") or d.get("a") or []
-                        bids_n = [[float(b[0]), float(b[1])] for b in bids]
-                        asks_n = [[float(a[0]), float(a[1])] for a in asks]
-                        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
-                        self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
-                        yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
-            except Exception as e:
-                WS_FAILURES.labels(adapter=self.name).inc()
-                log.warning(
-                    "WS spot testnet orderbook desconectado (%s). Reintento en %.1fs ...",
-                    e,
-                    backoff,
-                )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or msg
+            ts_ms = d.get("T") or d.get("E")
+            bids = d.get("bids") or d.get("b") or []
+            asks = d.get("asks") or d.get("a") or []
+            bids_n = [[float(b[0]), float(b[1])] for b in bids]
+            asks_n = [[float(a[0]), float(a[1])] for a in asks]
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
+            self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
+            yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
 
     stream_orderbook = stream_order_book
 

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -1,13 +1,10 @@
 # src/tradingbot/adapters/bybit_futures.py
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 from typing import AsyncIterator
-
-import websockets
 
 try:  # pragma: no cover - optional during tests
     import ccxt
@@ -66,50 +63,30 @@ class BybitFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        for t in msg.get("data", []) or []:
-                            price = float(t.get("p"))
-                            qty = float(t.get("v", 0))
-                            side = t.get("S", "").lower()
-                            ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
-                            self.state.last_px[symbol] = price
-                            yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:  # pragma: no cover - network paths
-                log.warning("Bybit futures trade WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for t in msg.get("data", []) or []:
+                price = float(t.get("p"))
+                qty = float(t.get("v", 0))
+                side = t.get("S", "").lower()
+                ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
+                self.state.last_px[symbol] = price
+                yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        data = msg.get("data") or {}
-                        if not data:
-                            continue
-                        bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
-                        asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
-                        ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
-                        self.state.order_book[symbol] = {"bids": bids, "asks": asks}
-                        yield self.normalize_order_book(symbol, ts, bids, asks)
-            except Exception as e:  # pragma: no cover - network paths
-                log.warning("Bybit futures book WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            data = msg.get("data") or {}
+            if not data:
+                continue
+            bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
+            asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
+            ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
+            self.state.order_book[symbol] = {"bids": bids, "asks": asks}
+            yield self.normalize_order_book(symbol, ts, bids, asks)
 
     # Backwards compatible alias
     stream_orderbook = stream_order_book

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -1,13 +1,10 @@
 # src/tradingbot/adapters/bybit_spot.py
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 from typing import AsyncIterator
-
-import websockets
 
 try:
     import ccxt
@@ -41,50 +38,30 @@ class BybitSpotAdapter(ExchangeAdapter):
         url = "wss://stream.bybit.com/v5/public/spot"
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        for t in msg.get("data", []) or []:
-                            price = float(t.get("p"))
-                            qty = float(t.get("v", 0))
-                            side = t.get("S", "").lower()
-                            ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
-                            self.state.last_px[symbol] = price
-                            yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:  # pragma: no cover - network paths
-                log.warning("Bybit spot trade WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for t in msg.get("data", []) or []:
+                price = float(t.get("p"))
+                qty = float(t.get("v", 0))
+                side = t.get("S", "").lower()
+                ts = datetime.fromtimestamp(int(t.get("T", 0)) / 1000, tz=timezone.utc)
+                self.state.last_px[symbol] = price
+                yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/spot"
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        data = msg.get("data") or {}
-                        if not data:
-                            continue
-                        bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
-                        asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
-                        ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
-                        self.state.order_book[symbol] = {"bids": bids, "asks": asks}
-                        yield self.normalize_order_book(symbol, ts, bids, asks)
-            except Exception as e:  # pragma: no cover - network paths
-                log.warning("Bybit spot book WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            data = msg.get("data") or {}
+            if not data:
+                continue
+            bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
+            asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
+            ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
+            self.state.order_book[symbol] = {"bids": bids, "asks": asks}
+            yield self.normalize_order_book(symbol, ts, bids, asks)
 
     stream_orderbook = stream_order_book
 

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -1,13 +1,10 @@
 # src/tradingbot/adapters/okx_futures.py
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
 from typing import AsyncIterator
-
-import websockets
 
 try:
     import ccxt
@@ -68,48 +65,28 @@ class OKXFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        for t in msg.get("data", []) or []:
-                            price = float(t.get("px"))
-                            qty = float(t.get("sz", 0))
-                            side = t.get("side", "")
-                            ts = datetime.fromtimestamp(int(t.get("ts", 0)) / 1000, tz=timezone.utc)
-                            self.state.last_px[symbol] = price
-                            yield self.normalize_trade(symbol, ts, price, qty, side)
-            except Exception as e:  # pragma: no cover
-                log.warning("OKX futures trade WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for t in msg.get("data", []) or []:
+                price = float(t.get("px"))
+                qty = float(t.get("sz", 0))
+                side = t.get("side", "")
+                ts = datetime.fromtimestamp(int(t.get("ts", 0)) / 1000, tz=timezone.utc)
+                self.state.last_px[symbol] = price
+                yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
-        backoff = 1.0
-        while True:
-            try:
-                async with websockets.connect(url, ping_interval=20, ping_timeout=20) as ws:
-                    await ws.send(json.dumps(sub))
-                    backoff = 1.0
-                    async for raw in ws:
-                        msg = json.loads(raw)
-                        for d in msg.get("data", []) or []:
-                            bids = [[float(p), float(q)] for p, q, *_ in d.get("bids", [])]
-                            asks = [[float(p), float(q)] for p, q, *_ in d.get("asks", [])]
-                            ts = datetime.fromtimestamp(int(d.get("ts", 0)) / 1000, tz=timezone.utc)
-                            self.state.order_book[symbol] = {"bids": bids, "asks": asks}
-                            yield self.normalize_order_book(symbol, ts, bids, asks)
-            except Exception as e:  # pragma: no cover
-                log.warning("OKX futures book WS error %s, retrying in %.1fs", e, backoff)
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 30.0)
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                bids = [[float(p), float(q)] for p, q, *_ in d.get("bids", [])]
+                asks = [[float(p), float(q)] for p, q, *_ in d.get("asks", [])]
+                ts = datetime.fromtimestamp(int(d.get("ts", 0)) / 1000, tz=timezone.utc)
+                self.state.order_book[symbol] = {"bids": bids, "asks": asks}
+                yield self.normalize_order_book(symbol, ts, bids, asks)
 
     stream_orderbook = stream_order_book
 


### PR DESCRIPTION
## Summary
- improve connector websocket handling with exponential backoff and heartbeats
- add reusable websocket loop for adapters with ping/pong and reconnection
- cover connection drop scenarios with new tests

## Testing
- `pytest tests/test_connectors.py tests/test_adapters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a15ce622f8832d9ef124ee70e1cb16