### PR TITLE
Add MLflow helpers and Optuna optimization utilities

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,6 +127,43 @@ results = walk_forward_optimize(
 print(results)
 ```
 
+## MLflow y Optuna
+
+El módulo `tradingbot.experiments` incluye helpers para registrar backtests en
+**MLflow** y ejecutar optimizaciones genéricas con **Optuna**.
+
+```python
+from tradingbot.backtesting.engine import run_backtest_mlflow
+
+res = run_backtest_mlflow(
+    {"BTC/USDT": "data/examples/btcusdt_1m.csv"},
+    [("breakout_atr", "BTC/USDT")],
+    run_name="demo",
+)
+print(res["sharpe"])
+```
+
+Para búsquedas de hiperparámetros:
+
+```python
+from tradingbot.experiments import optimize
+from tradingbot.backtesting.engine import run_backtest_csv
+
+param_space = {
+    "window": lambda t: t.suggest_int("window", 50, 150),
+}
+
+def backtest(params):
+    return run_backtest_csv(
+        {"BTC/USDT": "data/examples/btcusdt_1m.csv"},
+        [("breakout_atr", "BTC/USDT")],
+        window=params["window"],
+    )
+
+study = optimize(param_space, backtest, n_trials=5)
+print(study.best_params)
+```
+
 ## Interfaz mínima de monitoreo
 
 `monitoring/panel.py` levanta una aplicación FastAPI que expone las métricas en

--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -122,7 +122,7 @@ class ExchangeAdapter(ABC):
                             yield msg
                     finally:
                         ping_task.cancel()
-                        with contextlib.suppress(Exception):
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
                             await ping_task
             except asyncio.CancelledError:
                 raise

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -1,6 +1,7 @@
 # src/tradingbot/adapters/bybit_futures.py
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -1,6 +1,7 @@
 # src/tradingbot/adapters/okx_spot.py
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone

--- a/src/tradingbot/backtest/event_engine.py
+++ b/src/tradingbot/backtest/event_engine.py
@@ -1,3 +1,17 @@
-"""Deprecated: use :mod:`tradingbot.backtesting.engine` instead."""
+"""Compatibility wrappers for the event-driven backtest engine with MLflow."""
 
-from ..backtesting.engine import *  # noqa: F401,F403
+from ..backtesting.engine import (
+    EventDrivenBacktestEngine,
+    SlippageModel,
+    StressConfig,
+    run_backtest_csv,
+    run_backtest_mlflow,
+)
+
+__all__ = [
+    "EventDrivenBacktestEngine",
+    "SlippageModel",
+    "StressConfig",
+    "run_backtest_csv",
+    "run_backtest_mlflow",
+]

--- a/src/tradingbot/experiments/__init__.py
+++ b/src/tradingbot/experiments/__init__.py
@@ -1,0 +1,6 @@
+"""Experiment helpers for MLflow tracking and hyperparameter search."""
+
+from .mlflow_utils import start_run, log_backtest_metrics
+from .optimization import optimize
+
+__all__ = ["start_run", "log_backtest_metrics", "optimize"]

--- a/src/tradingbot/experiments/mlflow_utils.py
+++ b/src/tradingbot/experiments/mlflow_utils.py
@@ -1,0 +1,44 @@
+"""Utilities for working with MLflow runs in backtests."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
+
+import mlflow
+
+
+@contextmanager
+def start_run(
+    experiment: str,
+    run_name: str | None = None,
+    params: Dict[str, Any] | None = None,
+    tags: Dict[str, str] | None = None,
+) -> Iterator[None]:
+    """Start an MLflow run under ``experiment`` and log optional params.
+
+    Parameters
+    ----------
+    experiment:
+        Name of the experiment to use (created if it does not exist).
+    run_name:
+        Optional run name displayed in the UI.
+    params:
+        Extra parameters to log once the run starts.
+    tags:
+        Optional tags for the run.
+    """
+
+    mlflow.set_experiment(experiment)
+    with mlflow.start_run(run_name=run_name, tags=tags):
+        if params:
+            mlflow.log_params(params)
+        yield
+
+
+def log_backtest_metrics(result: Dict[str, Any]) -> None:
+    """Log common backtest metrics to the active MLflow run."""
+
+    mlflow.log_metric("equity", float(result.get("equity", 0.0)))
+    mlflow.log_metric("fills", len(result.get("fills", [])))
+    if "sharpe" in result:
+        mlflow.log_metric("sharpe", float(result["sharpe"]))

--- a/src/tradingbot/experiments/optimization.py
+++ b/src/tradingbot/experiments/optimization.py
@@ -1,0 +1,46 @@
+"""Generic Optuna optimisation helpers."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+import optuna
+
+from .mlflow_utils import log_backtest_metrics, start_run
+
+
+def optimize(
+    param_space: Dict[str, Callable[[optuna.Trial], Any]],
+    backtest_fn: Callable[[Dict[str, Any]], Dict[str, Any]],
+    n_trials: int = 20,
+    experiment: str = "optimization",
+    direction: str = "maximize",
+) -> optuna.study.Study:
+    """Run a generic Optuna optimisation for a backtest function.
+
+    Parameters
+    ----------
+    param_space:
+        Mapping of parameter names to callables that accept an Optuna
+        ``Trial`` and return the suggested value.
+    backtest_fn:
+        Callable executed on each trial receiving the sampled params and
+        returning a result dictionary with an ``equity`` field and optional
+        ``sharpe``.
+    n_trials:
+        Number of optimisation trials to execute.
+    experiment:
+        MLflow experiment name used to record each trial.
+    direction:
+        Direction of optimisation (``"maximize"`` or ``"minimize"``).
+    """
+
+    def objective(trial: optuna.Trial) -> float:
+        params = {name: suggest(trial) for name, suggest in param_space.items()}
+        with start_run(experiment, run_name=f"trial_{trial.number}", params=params):
+            result = backtest_fn(params)
+            log_backtest_metrics(result)
+            return float(result.get("equity", 0.0))
+
+    study = optuna.create_study(direction=direction)
+    study.optimize(objective, n_trials=n_trials)
+    return study


### PR DESCRIPTION
## Summary
- add `tradingbot.experiments` module with MLflow helpers and Optuna optimizer
- log equity, fills and Sharpe ratio to MLflow from backtests
- fix adapter asyncio handling and expose MLflow helpers in legacy event engine
- document MLflow/Optuna usage examples

## Testing
- `pytest tests/test_adapter_order_retries.py::test_bybit_place_cancel_retry tests/test_adapter_order_retries.py::test_okx_place_cancel_retry -q`
- `pytest tests/test_backtesting_integration.py::test_event_engine_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16aecb974832da8e1d37b9e7b3cb1