### PR TITLE
feat: add funding and oi ingestion workers

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -22,3 +22,11 @@ risk:
 balance:
   threshold: 0.0
   assets: []
+
+ingestion:
+  funding:
+    binance_futures:
+      BTC/USDT: 60
+  open_interest:
+    binance_futures:
+      BTC/USDT: 60

--- a/src/tradingbot/data/open_interest.py
+++ b/src/tradingbot/data/open_interest.py
@@ -14,6 +14,26 @@ except Exception:  # pragma: no cover - optional dependency
 log = logging.getLogger(__name__)
 
 
+async def fetch_oi(adapter, symbol: str) -> dict[str, Any]:
+    """Fetch open interest using ``adapter`` and return a normalised mapping."""
+
+    fetch = getattr(adapter, "fetch_open_interest", None) or getattr(adapter, "fetch_oi", None)
+    if fetch is None:
+        raise AttributeError("adapter lacks fetch_open_interest")
+    info: Any = await fetch(symbol)
+    ts_raw = info.get("ts") or info.get("time")
+    if isinstance(ts_raw, (int, float)):
+        ts = datetime.fromtimestamp(ts_raw / 1000, timezone.utc)
+    else:
+        ts = ts_raw or datetime.now(timezone.utc)
+    oi = float(info.get("oi") or info.get("openInterest") or 0.0)
+    return {
+        "ts": ts,
+        "oi": oi,
+        "exchange": getattr(adapter, "name", "unknown"),
+    }
+
+
 async def poll_open_interest(
     adapter,
     symbol: str,
@@ -25,26 +45,23 @@ async def poll_open_interest(
     engine = get_engine() if (persist_pg and _CAN_PG) else None
     while True:
         try:
-            fetch = getattr(adapter, "fetch_open_interest", None) or getattr(adapter, "fetch_oi", None)
-            if fetch is None:
-                raise AttributeError("adapter lacks fetch_open_interest")
-            info: Any = await fetch(symbol)
-            ts_raw = info.get("ts") or info.get("time")
-            if isinstance(ts_raw, (int, float)):
-                ts = datetime.fromtimestamp(ts_raw / 1000, timezone.utc)
-            else:
-                ts = ts_raw or datetime.now(timezone.utc)
-            oi = float(info.get("oi") or info.get("openInterest") or 0.0)
+            info = await fetch_oi(adapter, symbol)
             event = {
-                "ts": ts,
-                "exchange": getattr(adapter, "name", "unknown"),
+                "ts": info["ts"],
+                "exchange": info["exchange"],
                 "symbol": symbol,
-                "oi": oi,
+                "oi": info["oi"],
             }
             await bus.publish("open_interest", event)
             if engine is not None:
                 try:
-                    insert_open_interest(engine, ts=ts, exchange=event["exchange"], symbol=symbol, oi=oi)
+                    insert_open_interest(
+                        engine,
+                        ts=info["ts"],
+                        exchange=event["exchange"],
+                        symbol=symbol,
+                        oi=info["oi"],
+                    )
                 except Exception as e:  # pragma: no cover - logging only
                     log.debug("No se pudo insertar open interest: %s", e)
         except asyncio.CancelledError:  # allow task cancellation

--- a/src/tradingbot/workers/__init__.py
+++ b/src/tradingbot/workers/__init__.py
@@ -1,5 +1,5 @@
 """Background workers used by the bot."""
 
-from .ingestion import BatchIngestionWorker
+from .ingestion import BatchIngestionWorker, funding_worker, open_interest_worker
 
-__all__ = ["BatchIngestionWorker"]
+__all__ = ["BatchIngestionWorker", "funding_worker", "open_interest_worker"]


### PR DESCRIPTION
## Summary
- add async workers to persist funding and open interest using configured backend
- expose workers via CLI with config-driven exchange intervals
- support ingestion settings in YAML config

## Testing
- `pytest tests/test_data_pollers.py -q`
- `pytest -q` *(fails: tests incomplete, process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a16af072cc832db70c41e312a5c367