### PR TITLE
feat: expose pnl and positions endpoints

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -11,10 +11,17 @@ Run the monitoring panel with:
 uvicorn monitoring.panel:app --reload
 ```
 
+The API backing the panel uses HTTP Basic authentication. Configure
+credentials via the `API_USER` and `API_PASS` environment variables
+(default `admin` / `admin`) and supply them when querying the API.
+
 Available endpoints:
 
 - `GET /metrics` – Prometheus metrics.
 - `GET /metrics/summary` – compact JSON snapshot of key metrics.
+- `GET /pnl` – current trading PnL.
+- `GET /positions` – open positions by symbol.
+- `GET /kill-switch` – kill switch active flag.
 - `GET /strategies/status` – current strategy states.
 - `POST /strategies/{name}/{status}` – update a strategy state.
 - `GET /summary` – metrics and strategy states combined.
@@ -44,6 +51,7 @@ panel's `/dashboards` endpoint. The directory currently includes:
 * `datasources/datasource.yml` – Prometheus data source
 * `dashboards/dashboard.yml` – automatic dashboard loading
 * `dashboards/core.json` and `dashboards/tradebot.json` – example panels
+* `dashboards/pnl_positions.json` – PnL, kill‑switch and open positions
 
 To build a standalone Grafana image with these files baked in:
 

--- a/monitoring/grafana/dashboards/pnl_positions.json
+++ b/monitoring/grafana/dashboards/pnl_positions.json
@@ -1,0 +1,40 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "title": "PnL & Positions",
+  "uid": "pnlpos",
+  "schemaVersion": 16,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Trading PnL",
+      "targets": [
+        {"expr": "trading_pnl", "legendFormat": ""}
+      ],
+      "datasource": "Prometheus",
+      "id": 1,
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "stat",
+      "title": "Kill switch active",
+      "targets": [
+        {"expr": "kill_switch_active", "legendFormat": ""}
+      ],
+      "datasource": "Prometheus",
+      "id": 2,
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "Open Positions",
+      "targets": [
+        {"expr": "open_position", "legendFormat": "{{symbol}}"}
+      ],
+      "datasource": "Prometheus",
+      "id": 3,
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,23 @@
+import importlib
+
+import os
+from fastapi.testclient import TestClient
+
+
+def get_app():
+    import tradingbot.apps.api.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_basic_auth(monkeypatch):
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+    app = get_app()
+    client = TestClient(app)
+
+    resp = client.get("/health")
+    assert resp.status_code == 401
+
+    resp = client.get("/health", auth=("u", "p"))
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose PnL, open positions and kill-switch status from monitoring panel
- add basic HTTP auth to API via API_USER/API_PASS
- provide Grafana dashboard consuming new metrics and document setup

## Testing
- `PYTHONPATH=. pytest tests/test_monitoring_panel.py tests/test_api_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68a16afddc64832da742219f7fd9f236