### PR TITLE
feat: add historical ingestion CLI and connectors

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,6 +5,14 @@
 python -m tradingbot.cli ingest --symbol BTC/USDT
 ```
 
+### Ingesta histórica
+```bash
+# Trades desde Kaiko
+python -m tradingbot.cli ingest-historical kaiko BTC-USDT --exchange binance --kind trades
+# Order books desde CoinAPI
+python -m tradingbot.cli ingest-historical coinapi BTC/USD --kind orderbook --depth 20
+```
+
 ## Trading en vivo en Testnet
 ```bash
 python -m tradingbot.cli run-bot --exchange binance --market spot --symbol BTC/USDT


### PR DESCRIPTION
## Summary
- add Kaiko and CoinAPI helpers for downloading trades and order books
- expose `ingest-historical` CLI to persist data via Timescale/Quest
- document historical ingestion usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a17469b29c832d949149419559cafd