### PR TITLE
feat: adopt async ccxt clients in adapters

### DIFF
--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator, Any
 
 try:  # pragma: no cover - ccxt es opcional en tests
-    import ccxt  # type: ignore
+    import ccxt.async_support as ccxt  # type: ignore
 except Exception:  # pragma: no cover - si falta ccxt
     ccxt = None
 

--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator, Optional, Any, Dict
 
 try:
-    import ccxt
+    import ccxt.async_support as ccxt
 except Exception:
     ccxt = None
 
@@ -61,19 +61,9 @@ class BinanceFuturesAdapter(ExchangeAdapter):
             log.warning("load_markets falló: %s", e)
 
         try:
-            self.rest.set_position_mode(False)
+            asyncio.get_event_loop().create_task(self.rest.set_position_mode(False))
         except Exception as e:
             log.debug("No se pudo fijar position_mode (one-way): %s", e)
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
-
-    async def _ensure_leverage(self, symbol: str):
-        try:
-            market = self.rest.market(symbol)
-            await self._to_thread(self.rest.set_leverage, self.leverage, market["symbol"])
-        except Exception as e:
-            log.debug("set_leverage falló: %s", e)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         sym = self.normalize_symbol(symbol)

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator, Optional, Any, Dict
 
 try:
-    import ccxt
+    import ccxt.async_support as ccxt
 except Exception:
     ccxt = None
 
@@ -60,9 +60,6 @@ class BinanceSpotAdapter(ExchangeAdapter):
             log.warning("load_markets spot falló: %s", e)
 
         self.name = "binance_spot_testnet" if testnet else "binance_spot"
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         sym = self.normalize_symbol(symbol)

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -8,10 +8,10 @@ from datetime import datetime, timezone
 from typing import AsyncIterator
 
 try:  # pragma: no cover - optional during tests
-    import ccxt
+    import ccxt.async_support as ccxt
     NetworkError = getattr(ccxt, "NetworkError", Exception)
     ExchangeError = getattr(ccxt, "ExchangeError", Exception)
-except Exception:  # pragma: no cover - ccxt optional during tests
+except Exception:  # pragma: no cover - ccxt optional durante tests
     ccxt = None
     NetworkError = ExchangeError = Exception
 
@@ -56,9 +56,6 @@ class BybitFuturesAdapter(ExchangeAdapter):
             else "wss://stream.bybit.com/v5/public/linear"
         )
         self.name = "bybit_futures_testnet" if testnet else "bybit_futures"
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator
 
 try:
-    import ccxt
+    import ccxt.async_support as ccxt
 except Exception:  # pragma: no cover - ccxt optional during tests
     ccxt = None
 
@@ -30,9 +30,6 @@ class BybitSpotAdapter(ExchangeAdapter):
         self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "spot"}})
         # Advertir si la clave carece de permisos de trade o tiene retiros habilitados
         validate_scopes(self.rest, log)
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://stream.bybit.com/v5/public/spot"
@@ -103,7 +100,7 @@ class BybitSpotAdapter(ExchangeAdapter):
 
     async def place_order(self, symbol: str, side: str, type_: str, qty: float,
                           price: float | None = None) -> dict:
-        return await self._to_thread(self.rest.create_order, symbol, type_, side, qty, price)
+        return await self.rest.create_order(symbol, type_, side, qty, price)
 
     async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
-        return await self._to_thread(self.rest.cancel_order, order_id, symbol)
+        return await self.rest.cancel_order(order_id, symbol)

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator
 
 try:  # pragma: no cover - optional dependency during some tests
-    import ccxt
+    import ccxt.async_support as ccxt
 except Exception:  # pragma: no cover
     ccxt = None
 

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator
 
 try:
-    import ccxt
+    import ccxt.async_support as ccxt
 except Exception:  # pragma: no cover
     ccxt = None
 
@@ -57,9 +57,6 @@ class OKXFuturesAdapter(ExchangeAdapter):
             else "wss://ws.okx.com:8443/ws/v5/public"
         )
         self.name = "okx_futures_testnet" if testnet else "okx_futures"
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url
@@ -175,9 +172,9 @@ class OKXFuturesAdapter(ExchangeAdapter):
         params = {}
         if iceberg_qty is not None:
             params["iceberg"] = iceberg_qty
-        return await self._to_thread(
+        return await self._request(
             self.rest.create_order, symbol, type_, side, qty, price, params
         )
 
     async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:
-        return await self._to_thread(self.rest.cancel_order, order_id, symbol)
+        return await self._request(self.rest.cancel_order, order_id, symbol)

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import AsyncIterator
 
 try:  # pragma: no cover - optional during tests
-    import ccxt
+    import ccxt.async_support as ccxt
     NetworkError = getattr(ccxt, "NetworkError", Exception)
     ExchangeError = getattr(ccxt, "ExchangeError", Exception)
 except Exception:  # pragma: no cover
@@ -33,9 +33,6 @@ class OKXSpotAdapter(ExchangeAdapter):
         self.rest = ccxt.okx({"enableRateLimit": True, "options": {"defaultType": "spot"}})
         # Validar permisos disponibles en la API key
         validate_scopes(self.rest, log)
-
-    async def _to_thread(self, fn, *args, **kwargs):
-        return await asyncio.to_thread(fn, *args, **kwargs)
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://ws.okx.com:8443/ws/v5/public"


### PR DESCRIPTION
## Summary
- migrate adapters to `ccxt.async_support` and drop thread offloading
- handle coroutine requests and client shutdowns in adapter base
- exercise new async API with smoke tests

## Testing
- `pytest tests/test_adapters.py::test_binance_spot_rest_streams tests/test_adapters.py::test_binance_futures_rest_fetch tests/test_adapters.py::test_parsing_funding_and_oi tests/test_adapters.py::test_request_and_close_async_rest`

------
https://chatgpt.com/codex/tasks/task_e_68a1746e7c6c832da5fd75793e25e0d8