### PR TITLE
Add purged cross-validation utility and reporting

### DIFF
--- a/src/tradingbot/analysis/backtest_report.py
+++ b/src/tradingbot/analysis/backtest_report.py
@@ -69,6 +69,10 @@ def generate_report(result: Dict) -> Dict[str, float]:
         "avg_latency": avg_latency,
     }
 
+    cv_metric = result.get("purged_cv")
+    if cv_metric is not None:
+        stats["purged_cv"] = float(cv_metric)
+
     eq_curve = result.get("equity_curve")
     if eq_curve and len(eq_curve) > 1:
         # Accept a list of numbers or dicts with an "equity" key

--- a/src/tradingbot/backtesting/purged_cv.py
+++ b/src/tradingbot/backtesting/purged_cv.py
@@ -1,0 +1,126 @@
+"""Purged cross-validation utilities.
+
+This module provides a simple generator to create purged cross-validation
+splits as described by López de Prado.  It also exposes a helper to run a
+cross‑validation cycle on a strategy class with arbitrary parameters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generator, Iterable, List, Sequence, Tuple, Type, Any, Dict
+
+import pandas as pd
+
+
+__all__ = ["purged_splits", "run_purged_cv"]
+
+
+def purged_splits(
+    n_samples: int,
+    n_splits: int,
+    embargo: float = 0.0,
+) -> Generator[Tuple[List[int], List[int]], None, None]:
+    """Yield purged cross‑validation splits.
+
+    Parameters
+    ----------
+    n_samples:
+        Total number of observations.
+    n_splits:
+        Number of folds.
+    embargo:
+        Fraction of observations to exclude on each side of the test set to
+        avoid look‑ahead bias.  ``embargo=0.01`` removes 1% of samples before
+        and after the test window from the training indices.
+    """
+
+    if n_splits < 2:
+        raise ValueError("n_splits must be at least 2")
+
+    indices = list(range(n_samples))
+    fold_sizes = [n_samples // n_splits] * n_splits
+    for i in range(n_samples % n_splits):
+        fold_sizes[i] += 1
+
+    embargo_size = int(n_samples * embargo)
+    current = 0
+    for fold_size in fold_sizes:
+        start, stop = current, current + fold_size
+        test_idx = indices[start:stop]
+        train_idx: List[int] = []
+        left_end = max(0, start - embargo_size)
+        if left_end > 0:
+            train_idx.extend(indices[:left_end])
+        right_start = min(n_samples, stop + embargo_size)
+        if right_start < n_samples:
+            train_idx.extend(indices[right_start:])
+        yield train_idx, test_idx
+        current = stop
+
+
+@dataclass
+class _FoldResult:
+    """Internal container to store per‑fold metrics."""
+
+    train_idx: Sequence[int]
+    test_idx: Sequence[int]
+    equity: float
+
+
+def run_purged_cv(
+    data: pd.DataFrame,
+    strategy_cls: Type[Any],
+    params: Dict[str, Any] | None = None,
+    *,
+    n_splits: int = 5,
+    embargo: float = 0.0,
+) -> Dict[str, Any]:
+    """Execute purged cross‑validation for ``strategy_cls``.
+
+    The ``strategy_cls`` is expected to implement ``fit`` and ``predict``
+    methods.  ``fit`` receives the training ``DataFrame`` while ``predict``
+    receives the test ``DataFrame`` and must return an iterable of position
+    values (e.g. ``1`` for long, ``-1`` for short, ``0`` for flat).  The
+    evaluation computes the cumulative return assuming positions are held for
+    one period.
+
+    Returns
+    -------
+    dict
+        Mapping containing the list of fold results under ``folds`` and the
+        average test equity as ``purged_cv``.
+    """
+
+    params = params or {}
+    fold_results: List[_FoldResult] = []
+
+    for train_idx, test_idx in purged_splits(len(data), n_splits, embargo):
+        train_df = data.iloc[train_idx]
+        test_df = data.iloc[test_idx]
+
+        strategy = strategy_cls(**params)
+        fit = getattr(strategy, "fit", None)
+        if callable(fit):
+            fit(train_df)
+
+        predict = getattr(strategy, "predict", None)
+        if not callable(predict):
+            raise AttributeError("strategy_cls must define a 'predict' method")
+        preds = pd.Series(predict(test_df), index=test_df.index).astype(float)
+
+        # Align predictions with next period returns
+        returns = test_df["close"].pct_change().shift(-1).fillna(0.0)
+        equity = float((1.0 + preds * returns).prod())
+        fold_results.append(_FoldResult(train_idx, test_idx, equity))
+
+    avg_equity = (
+        sum(fr.equity for fr in fold_results) / len(fold_results)
+        if fold_results
+        else 0.0
+    )
+
+    return {
+        "folds": [fr.__dict__ for fr in fold_results],
+        "purged_cv": avg_equity,
+    }

--- a/tests/test_purged_cv.py
+++ b/tests/test_purged_cv.py
@@ -1,0 +1,45 @@
+import sys
+import pathlib
+import pandas as pd
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from tradingbot.backtesting.purged_cv import purged_splits, run_purged_cv
+from tradingbot.analysis.backtest_report import generate_report
+
+
+class DummyStrategy:
+    def fit(self, data):
+        # no training required for the dummy strategy
+        pass
+
+    def predict(self, data):
+        # always hold a long position
+        return pd.Series(1, index=data.index)
+
+
+def test_purged_splits_basic():
+    n = 20
+    splits = list(purged_splits(n, n_splits=4, embargo=0.1))
+    assert len(splits) == 4
+    embargo_size = int(n * 0.1)
+    for train_idx, test_idx in splits:
+        test_start, test_end = test_idx[0], test_idx[-1]
+        embargo_range = set(
+            range(max(0, test_start - embargo_size), min(n, test_end + embargo_size + 1))
+        )
+        assert embargo_range.isdisjoint(train_idx)
+
+
+def test_run_purged_cv_and_report():
+    n = 30
+    df = pd.DataFrame({"close": [1.1 ** i for i in range(n)]})
+    result = run_purged_cv(df, DummyStrategy, {}, n_splits=3, embargo=0.1)
+    expected = 1.1 ** 9  # each test window yields 9 returns of 10%
+    assert pytest.approx(result["purged_cv"], rel=1e-12) == expected
+
+    report = generate_report({"equity": 0.0, "orders": [], "purged_cv": result["purged_cv"]})
+    assert pytest.approx(report["purged_cv"], rel=1e-12) == expected


### PR DESCRIPTION
## Summary
- add `purged_cv` utility with purged split generator and cross-validation runner
- expose purged CV metric in `generate_report`
- cover purged CV workflow with unit tests

## Testing
- `pytest tests/test_purged_cv.py tests/test_backtest_report.py tests/test_walk_forward.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1edf29618832db329afdf771c572f