### PR TITLE
Add lightweight Plotly monitoring dashboard

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -32,6 +32,17 @@ Available endpoints:
 
 Static assets are served from `monitoring/static/` for a quick HTML view.
 
+### Plotly dashboard
+
+The API also exposes a lightweight dashboard at `/dashboard` which polls
+`/metrics/summary` every few seconds and renders basic graphs using
+Plotly. Launch the API and open the dashboard in a browser:
+
+```bash
+uvicorn tradingbot.apps.api.main:app --reload
+# then visit http://localhost:8000/dashboard (use API_USER/API_PASS credentials)
+```
+
 ## Grafana dashboards
 
 The monitoring stack ships with ready‑to‑use Grafana, Prometheus and

--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+_HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>TradeBot Dashboard</title>
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+</head>
+<body>
+<h1>TradeBot Metrics Dashboard</h1>
+<div id="pnl" style="width:100%;height:400px;"></div>
+<div id="fills" style="width:100%;height:400px;"></div>
+<script>
+const pnlTrace = {x: [], y: [], mode: 'lines', name: 'PnL'};
+const fillsTrace = {x: [], y: [], mode: 'lines', name: 'Fills'};
+Plotly.newPlot('pnl', [pnlTrace], {title: 'PnL'});
+Plotly.newPlot('fills', [fillsTrace], {title: 'Fills'});
+async function fetchData(){
+  try {
+    const resp = await fetch('/metrics/summary');
+    const data = await resp.json();
+    const now = new Date();
+    pnlTrace.x.push(now);
+    pnlTrace.y.push(data.pnl || 0);
+    fillsTrace.x.push(now);
+    fillsTrace.y.push(data.fills || 0);
+    Plotly.update('pnl', {x: [pnlTrace.x], y: [pnlTrace.y]});
+    Plotly.update('fills', {x: [fillsTrace.x], y: [fillsTrace.y]});
+  } catch(err) {
+    console.error('Error fetching metrics', err);
+  }
+}
+setInterval(fetchData, 5000);
+fetchData();
+</script>
+</body>
+</html>
+"""
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+async def dashboard() -> HTMLResponse:
+    """Serve a simple Plotly dashboard polling /metrics/summary."""
+    return HTMLResponse(content=_HTML)

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -11,6 +11,7 @@ import secrets
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from monitoring.metrics import metrics_summary as _metrics_summary
+from monitoring.dashboard import router as dashboard_router
 
 from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
@@ -46,6 +47,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
 )
+
+app.include_router(dashboard_router)
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- add Plotly-powered dashboard polling `/metrics/summary`
- expose dashboard under `/dashboard` with existing basic auth
- document dashboard deployment instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1edf49a44832d8be1c73c6fb0a6a3