### PR TITLE
feat: add basis fetching for bybit and okx spot

### DIFF
--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -76,6 +76,41 @@ class BybitSpotAdapter(ExchangeAdapter):
         rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
         return {"ts": ts_dt, "rate": rate}
 
+    async def fetch_basis(self, symbol: str):
+        """Return the basis (mark - index) for ``symbol``.
+
+        Even though spot markets do not trade a perpetual contract, Bybit
+        exposes the mark and index price of the corresponding linear contract
+        via ``public/v5/market/premium-index-price``.  We reuse that endpoint to
+        compute the difference and return it normalised as
+        ``{"ts": datetime, "basis": float}``.
+        """
+
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "publicGetV5MarketPremiumIndexPrice", None)
+        if method is None:
+            raise NotImplementedError("Basis not supported")
+
+        data = await self._request(method, {"category": "linear", "symbol": sym})
+        lst = (data.get("result") or {}).get("list") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(item.get("timestamp") or item.get("ts") or data.get("time", 0))
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        mark_px = float(
+            item.get("markPrice")
+            or item.get("mark_price")
+            or data.get("markPrice")
+            or 0.0
+        )
+        index_px = float(
+            item.get("indexPrice")
+            or item.get("index_price")
+            or data.get("indexPrice")
+            or 0.0
+        )
+        basis = mark_px - index_px
+        return {"ts": ts, "basis": basis}
+
     async def fetch_oi(self, symbol: str):
         """Return current open interest for ``symbol``.
 


### PR DESCRIPTION
## Summary
- add basis retrieval via Bybit premium index and OKX tickers
- cover new basis fetch in adapter tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1edf87e1c832d944b848b05d99664