### PR TITLE
feat: add NTP time offset check

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ cp .env.example .env  # editar con tus credenciales
 pytest
 ```
 
+> **Nota**: es necesario que el reloj del sistema esté sincronizado. Al iniciar la
+> CLI se consulta un servidor NTP y se muestra una advertencia si el desfase
+> supera el umbral definido en `NTP_OFFSET_THRESHOLD` (por defecto 1s).
+
 ## Despliegue con Docker
 
 Para levantar toda la pila de servicios (API, bases de datos, monitoreo):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pydantic-settings>=2.2
 typer>=0.12
 uvloop>=0.19; platform_system != "Windows"
 hydra-core>=1.3
+ntplib>=0.4
 
 # Experiment tracking
 mlflow>=2.12

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -23,6 +23,7 @@ TWAP, VWAP or POV strategies.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 from typing import List
@@ -31,6 +32,21 @@ import typer
 
 from ..logging_conf import setup_logging
 from tradingbot.analysis.backtest_report import generate_report
+from tradingbot.utils.time_sync import check_ntp_offset
+
+
+_OFFSET_THRESHOLD = float(os.getenv("NTP_OFFSET_THRESHOLD", "1.0"))
+try:
+    _offset = check_ntp_offset()
+    if abs(_offset) > _OFFSET_THRESHOLD:
+        logging.warning(
+            "System clock offset %.3fs exceeds threshold %.2fs."
+            " Please synchronize your clock.",
+            _offset,
+            _OFFSET_THRESHOLD,
+        )
+except Exception as exc:  # pragma: no cover - network failures
+    logging.debug("Failed to check NTP offset: %s", exc)
 
 
 app = typer.Typer(add_completion=False, help="Utilities for running TradingBot")

--- a/src/tradingbot/utils/time_sync.py
+++ b/src/tradingbot/utils/time_sync.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import ntplib
+
+
+def check_ntp_offset(server: str = "pool.ntp.org") -> float:
+    """Return clock offset in seconds with respect to an NTP server.
+
+    Parameters
+    ----------
+    server:
+        Hostname of the NTP server to query.
+    Returns
+    -------
+    float
+        Offset in seconds between the local clock and the server time.
+    """
+    client = ntplib.NTPClient()
+    response = client.request(server, version=3)
+    return response.offset


### PR DESCRIPTION
## Summary
- add utility to query NTP server for clock offset
- warn in CLI when system clock drifts beyond `NTP_OFFSET_THRESHOLD`
- document system clock sync requirement and add ntplib dependency

## Testing
- `PYTHONPATH=. pytest tests/test_smoke.py -q` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a2021554b4832d9479f39e2a18b1a4