### PR TITLE
feat: integrate sentry monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
     command: uvicorn tradingbot.apps.api.main:app --host 0.0.0.0 --port 8000
     volumes:
       - ./src:/app/src
+    environment:
+      - SENTRY_ENABLED=${SENTRY_ENABLED:-false}
+      - SENTRY_DSN=${SENTRY_DSN:-}
+      - SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT:-development}
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- init Sentry from YAML and env vars in daemon startup
- capture uncaught task exceptions and report to Sentry
- add Sentry configuration env vars to docker-compose

## Testing
- `pytest` *(failed: ran partially, 4 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a2021947d0832db452cecad9e7df5d