### PR TITLE
Add CLI training command for MLStrategy

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -75,6 +75,11 @@ python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \
     --symbol BTC/USDT --strategy triple_barrier
 ```
 
+## Entrenar modelo ML
+```bash
+python -m tradingbot.cli train-ml datos.csv objetivo modelo.joblib
+```
+
 ## API
 ```bash
 uvicorn tradingbot.apps.api.main:app --reload --port 8000

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -402,6 +402,32 @@ def report(venue: str = "binance_spot_testnet") -> None:
     typer.echo(summary)
 
 
+@app.command("train-ml")
+def train_ml(
+    data: str = typer.Argument(..., help="Ruta al CSV con los datos de entrenamiento"),
+    target: str = typer.Argument(..., help="Nombre de la columna objetivo"),
+    output: str = typer.Argument(..., help="Ruta donde guardar el modelo entrenado"),
+) -> None:
+    """Entrena un modelo :class:`MLStrategy` y lo guarda en disco."""
+
+    setup_logging()
+    import pandas as pd
+    from ..strategies.ml_models import MLStrategy
+
+    df = pd.read_csv(data)
+    if target not in df.columns:
+        raise typer.BadParameter(
+            f"Columna objetivo '{target}' no encontrada en {data}"
+        )
+    y = df[target].to_numpy()
+    X = df.drop(columns=[target]).to_numpy()
+
+    strat = MLStrategy()
+    strat.train(X, y)
+    strat.save_model(output)
+    typer.echo(f"Modelo guardado en {output}")
+
+
 @app.command("tri-arb")
 def tri_arb(
     route: str = typer.Argument(..., help="Ruta BASE-MID-QUOTE, ej. BTC-ETH-USDT"),


### PR DESCRIPTION
## Summary
- add `train-ml` CLI command to train and save MLStrategy models
- document ML training command usage example

## Testing
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a21777fdec832d9f39c4b82653f8a4