### PR TITLE
Add system metrics and dashboards

### DIFF
--- a/monitoring/grafana/dashboards/core.json
+++ b/monitoring/grafana/dashboards/core.json
@@ -59,6 +59,45 @@
       "datasource": "Prometheus",
       "id": 4,
       "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        {
+          "expr": "process_cpu_percent",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 5,
+      "gridPos": {"x": 0, "y": 16, "w": 8, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        {
+          "expr": "process_memory_bytes",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 6,
+      "gridPos": {"x": 8, "y": 16, "w": 8, "h": 8}
+    },
+    {
+      "type": "stat",
+      "title": "Process Uptime",
+      "targets": [
+        {
+          "expr": "process_uptime_seconds",
+          "legendFormat": ""
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 7,
+      "gridPos": {"x": 16, "y": 16, "w": 8, "h": 8}
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ asyncpg>=0.29
 # Monitoring
 prometheus-client>=0.20
 sentry-sdk>=1.40
+psutil>=5.9
 
 # Testing
 pytest>=8.0


### PR DESCRIPTION
## Summary
- add Prometheus gauges for CPU, memory and uptime using psutil
- expose system metrics in monitoring summary endpoint
- visualize CPU, memory and uptime in Grafana core dashboard

## Testing
- `pytest`
- `flake8 monitoring/metrics.py monitoring/panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68a217754cf0832da470a99084eb94fe