### PR TITLE
Integrate volatility and correlation sizing

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -34,14 +34,8 @@ def record_signal_metrics(fn):
         duration = time.monotonic() - start
         REQUEST_LATENCY.labels(method=self.name, endpoint="on_bar").observe(duration)
 
-        if sig and sig.side in {"buy", "sell"}:
-            # Optional risk-based sizing with volatility adjustment
-            risk = getattr(self, "risk", None)
-            if risk is not None:
-                vol = float(bar.get("volatility", 0.0) or 0.0)
-                delta = risk.size(sig.side, sig.strength)
-                delta += risk.size_with_volatility(vol)
-                sig.strength = delta
+        # Risk-based sizing is now handled within ``RiskService.check_order``
+        # so strategy signals keep their original strength here.
 
         if sig and sig.side in {"buy", "sell"} and {"exchange", "symbol"} <= bar.keys():
             try:

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -61,7 +61,7 @@ def test_risk_service_updates_and_persists(monkeypatch):
     svc.update_position("ex2", "BTC", -0.4)
     agg = svc.aggregate_positions()
     assert agg["BTC"] == pytest.approx(0.6)
-    allowed, _ = svc.check_order("BTC", "buy", 2.0, 1.0)
+    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, strength=2.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
 


### PR DESCRIPTION
## Summary
- extend `RiskManager.size` to apply volatility targeting and correlation trimming
- route sizing through `RiskService.check_order` and return adjusted deltas
- add unit tests covering combined volatility and correlation sizing

## Testing
- `pytest tests/test_risk_vol_sizing.py tests/test_risk_manager_limits.py`


------
https://chatgpt.com/codex/tasks/task_e_68a22c7e4914832da1d57ee3e39b5384