### PR TITLE
Add cross-exchange runner test with dual testnet fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,18 @@ import pathlib
 import pytest
 
 sys.path.append(str(pathlib.Path(__file__).parent))
-from fixtures.market import synthetic_trades, synthetic_l2, synthetic_volatility  # noqa: F401
+from fixtures.market import (  # noqa: E402, F401
+    synthetic_trades,
+    synthetic_l2,
+    synthetic_volatility,
+    dual_testnet,
+)
 
 # Ensure the src package is importable
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
-from tradingbot.adapters.base import ExchangeAdapter
-from tradingbot.execution.paper import PaperAdapter
+from tradingbot.adapters.base import ExchangeAdapter  # noqa: E402
+from tradingbot.execution.paper import PaperAdapter  # noqa: E402
 
 
 class DummyAdapter(ExchangeAdapter):
@@ -31,7 +36,13 @@ class DummyAdapter(ExchangeAdapter):
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
     ):
-        return {"status": "placed", "symbol": symbol, "side": side, "qty": qty, "price": price}
+        return {
+            "status": "placed",
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": price,
+        }
 
     async def cancel_order(self, order_id: str):
         return {"status": "canceled", "order_id": order_id}

--- a/tests/fixtures/market.py
+++ b/tests/fixtures/market.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+
 @pytest.fixture
 def synthetic_trades():
     """Synthetic trade stream for testing."""
@@ -30,3 +31,42 @@ def synthetic_l2():
 def synthetic_volatility():
     """Synthetic volatility value for tests."""
     return 0.04
+
+
+class DummyMarketAdapter:
+    """Simple adapter emulating spot/perp streams and orders for tests."""
+
+    def __init__(self, name: str, trades: list[dict]):
+        self.name = name
+        self._trades = trades
+        self.orders: list[dict] = []
+        self.state = type("S", (), {"last_px": {}})
+
+    async def stream_trades(self, symbol: str):
+        for t in self._trades:
+            self.state.last_px[symbol] = t["price"]
+            yield t
+
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+    ) -> dict:
+        self.orders.append({"symbol": symbol, "side": side, "qty": qty})
+        return {"status": "filled", "price": self.state.last_px[symbol]}
+
+
+@pytest.fixture
+def dual_testnet():
+    """Return paired spot/perp adapters with simple trade streams."""
+
+    spot_trades = [{"ts": 0, "price": 100.0, "qty": 1.0, "side": "buy"}]
+    perp_trades = [{"ts": 0, "price": 101.0, "qty": 1.0, "side": "buy"}]
+    spot = DummyMarketAdapter("spot", spot_trades)
+    perp = DummyMarketAdapter("perp", perp_trades)
+    return spot, perp


### PR DESCRIPTION
## Summary
- add dummy spot/perp adapters as a reusable `dual_testnet` fixture
- verify `run_cross_exchange` executes both legs and persists orders

## Testing
- `flake8 tests/test_cross_exchange_runner.py tests/fixtures/market.py tests/conftest.py`
- `pytest tests/test_cross_exchange_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22c86cbfc832db1832e1474fab5ec