### PR TITLE
feat: support basis data in websocket adapters and poller

### DIFF
--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -96,6 +96,11 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
             return await self.rest.fetch_funding(symbol)
         raise NotImplementedError("Funding no disponible para mercados Spot")
 
+    async def fetch_basis(self, symbol: str):
+        if self.rest:
+            return await self.rest.fetch_basis(symbol)
+        raise NotImplementedError("Basis no disponible para mercados Spot")
+
     async def fetch_oi(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_oi(symbol)

--- a/tests/test_data_pollers.py
+++ b/tests/test_data_pollers.py
@@ -58,11 +58,12 @@ async def test_poll_basis_publishes_and_inserts(monkeypatch):
             return {"ts": ts, "basis": 5.0}
 
     events = []
+    inserted = []
     bus = EventBus()
     bus.subscribe("basis", lambda e: events.append(e))
 
     monkeypatch.setattr("tradingbot.data.basis.get_engine", lambda: "engine")
-    monkeypatch.setattr("tradingbot.data.basis.insert_basis", lambda *a, **k: events.append({"persist": k}))
+    monkeypatch.setattr("tradingbot.data.basis.insert_basis", lambda *a, **k: inserted.append(k))
     monkeypatch.setattr("tradingbot.data.basis._CAN_PG", True)
 
     task = asyncio.create_task(
@@ -73,5 +74,5 @@ async def test_poll_basis_publishes_and_inserts(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert events and any("basis" in e for e in events if "basis" in e)
-    assert any("persist" in e for e in events)
+    assert events and events[0]["basis"] == 5.0
+    assert inserted and inserted[0]["basis"] == 5.0


### PR DESCRIPTION
## Summary
- add `fetch_basis` implementations for Binance websocket adapters
- normalise basis retrieval and polling logic
- test basis capture and persistence

## Testing
- `pytest tests/test_data_pollers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22e8664d4832db5563d393d724c97