### PR TITLE
Add funding and open interest metrics

### DIFF
--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -21,6 +21,8 @@ from tradingbot.utils.metrics import (
     OPEN_POSITIONS,
     MARKET_LATENCY,
     E2E_LATENCY,
+    FUNDING_RATE,
+    OPEN_INTEREST,
 )
 
 # System metrics
@@ -186,9 +188,25 @@ def metrics_summary() -> dict:
         if sample.name == "open_position"
     }
 
+    funding_rates = {
+        sample.labels["symbol"]: sample.value
+        for metric in FUNDING_RATE.collect()
+        for sample in metric.samples
+        if sample.name == "funding_rate"
+    }
+
+    open_interest = {
+        sample.labels["symbol"]: sample.value
+        for metric in OPEN_INTEREST.collect()
+        for sample in metric.samples
+        if sample.name == "open_interest"
+    }
+
     return {
         "pnl": TRADING_PNL._value.get(),
         "positions": positions,
+        "funding_rates": funding_rates,
+        "open_interest": open_interest,
         "disconnects": SYSTEM_DISCONNECTS._value.get(),
         "fills": fill_total,
         "risk_events": risk_total,

--- a/src/tradingbot/data/funding.py
+++ b/src/tradingbot/data/funding.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..bus import EventBus
+from ..utils.metrics import FUNDING_RATE, FUNDING_RATE_HIST
 
 try:  # optional persistence
     from ..storage.timescale import get_engine, insert_funding
@@ -53,6 +54,8 @@ async def poll_funding(adapter, symbol: str, bus: EventBus, interval: int = 60, 
                 "rate": info["rate"],
                 "interval_sec": info["interval_sec"],
             }
+            FUNDING_RATE.labels(symbol=symbol).set(info["rate"])
+            FUNDING_RATE_HIST.labels(symbol=symbol).observe(info["rate"])
             await bus.publish("funding", event)
             if engine is not None:
                 try:

--- a/src/tradingbot/data/open_interest.py
+++ b/src/tradingbot/data/open_interest.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..bus import EventBus
+from ..utils.metrics import OPEN_INTEREST, OPEN_INTEREST_HIST
 
 try:  # optional persistence
     from ..storage.timescale import get_engine, insert_open_interest
@@ -52,6 +53,8 @@ async def poll_open_interest(
                 "symbol": symbol,
                 "oi": info["oi"],
             }
+            OPEN_INTEREST.labels(symbol=symbol).set(info["oi"])
+            OPEN_INTEREST_HIST.labels(symbol=symbol).observe(info["oi"])
             await bus.publish("open_interest", event)
             if engine is not None:
                 try:

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -26,6 +26,7 @@ from ..data.funding import poll_funding
 from ..data.open_interest import poll_open_interest
 from ..data.basis import poll_basis
 from ..execution.balance import rebalance_between_exchanges
+from ..utils.metrics import FUNDING_RATE, OPEN_INTEREST
 
 log = logging.getLogger(__name__)
 
@@ -358,6 +359,9 @@ class TradeBotDaemon:
 
     async def _dispatch_funding(self, evt: dict) -> None:
         """Forward funding events to strategies."""
+        rate = float(evt.get("rate") or 0.0)
+        symbol = evt.get("symbol", "")
+        FUNDING_RATE.labels(symbol=symbol).set(rate)
         for strat in self.strategies:
             handler = getattr(strat, "on_funding", None)
             if handler is None:
@@ -386,6 +390,9 @@ class TradeBotDaemon:
 
     async def _dispatch_open_interest(self, evt: dict) -> None:
         """Forward open interest events to strategies."""
+        oi = float(evt.get("oi") or 0.0)
+        symbol = evt.get("symbol", "")
+        OPEN_INTEREST.labels(symbol=symbol).set(oi)
         for strat in self.strategies:
             handler = getattr(strat, "on_open_interest", None)
             if handler is None:

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -98,6 +98,32 @@ OPEN_POSITIONS = Gauge(
     ["symbol"],
 )
 
+# Funding rate per symbol
+FUNDING_RATE = Gauge(
+    "funding_rate",
+    "Latest funding rate",
+    ["symbol"],
+)
+
+FUNDING_RATE_HIST = Histogram(
+    "funding_rate_distribution",
+    "Distribution of funding rate observations",
+    ["symbol"],
+)
+
+# Open interest per symbol
+OPEN_INTEREST = Gauge(
+    "open_interest",
+    "Current open interest",
+    ["symbol"],
+)
+
+OPEN_INTEREST_HIST = Histogram(
+    "open_interest_distribution",
+    "Distribution of open interest observations",
+    ["symbol"],
+)
+
 # Latency of market data processing
 MARKET_LATENCY = Histogram(
     "market_latency_seconds",


### PR DESCRIPTION
## Summary
- add Prometheus gauges and histograms for funding rate and open interest per symbol
- update funding/open interest pollers and daemon to record new metrics
- expose funding rate and open interest in metrics summary and extend panel tests

## Testing
- `pytest tests/test_monitoring_panel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a22e897c34832d832399e2c2817d4f