### PR TITLE
feat: add funding and open interest support

### DIFF
--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook, Trade
+from .base import ExchangeConnector, OrderBook, Trade, Funding, OpenInterest
 
 
 class BinanceConnector(ExchangeConnector):
@@ -51,3 +51,23 @@ class BinanceConnector(ExchangeConnector):
             amount=float(data.get("q", 0.0)),
             side="sell" if data.get("m") else "buy",
         )
+
+    async def fetch_funding(self, symbol: str) -> Funding:
+        """Fetch the current funding rate for ``symbol``.
+
+        This simply proxies to the :class:`ExchangeConnector` implementation
+        which in turn delegates to the underlying CCXT client.  The method is
+        defined explicitly so that callers can rely on its presence for the
+        Binance connector.
+        """
+
+        return await super().fetch_funding(symbol)
+
+    async def fetch_open_interest(self, symbol: str) -> OpenInterest:
+        """Fetch open interest for ``symbol``.
+
+        Binance does not expose a dedicated endpoint in this connector so we
+        fall back to the generic CCXT helper provided by the base class.
+        """
+
+        return await super().fetch_open_interest(symbol)

--- a/src/tradingbot/connectors/bybit.py
+++ b/src/tradingbot/connectors/bybit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook, Trade
+from .base import ExchangeConnector, OrderBook, Trade, Funding, OpenInterest
 
 
 class BybitConnector(ExchangeConnector):
@@ -51,6 +51,16 @@ class BybitConnector(ExchangeConnector):
             amount=float(trade_data.get("v", 0.0)),
             side=(trade_data.get("S") or trade_data.get("side", "")).lower(),
         )
+
+    async def fetch_funding(self, symbol: str) -> Funding:
+        """Return funding information for ``symbol`` using CCXT."""
+
+        return await super().fetch_funding(symbol)
+
+    async def fetch_open_interest(self, symbol: str) -> OpenInterest:
+        """Return open interest for ``symbol`` using CCXT."""
+
+        return await super().fetch_open_interest(symbol)
 
     # ------------------------------------------------------------------
     # Trading helpers

--- a/src/tradingbot/connectors/okx.py
+++ b/src/tradingbot/connectors/okx.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
-from .base import ExchangeConnector, OrderBook, Trade
+from .base import ExchangeConnector, OrderBook, Trade, Funding, OpenInterest
 
 
 class OKXConnector(ExchangeConnector):
@@ -51,6 +51,16 @@ class OKXConnector(ExchangeConnector):
             amount=float(trade.get("sz", 0.0)),
             side=trade.get("side", ""),
         )
+
+    async def fetch_funding(self, symbol: str) -> Funding:
+        """Retrieve funding data for ``symbol`` using CCXT."""
+
+        return await super().fetch_funding(symbol)
+
+    async def fetch_open_interest(self, symbol: str) -> OpenInterest:
+        """Retrieve open interest for ``symbol`` using CCXT."""
+
+        return await super().fetch_open_interest(symbol)
 
     # ------------------------------------------------------------------
     # Trading helpers

--- a/tests/test_data_pollers.py
+++ b/tests/test_data_pollers.py
@@ -5,7 +5,9 @@ import pytest
 
 from tradingbot.bus import EventBus
 from tradingbot.data.open_interest import poll_open_interest
+from tradingbot.data.funding import poll_funding
 from tradingbot.data.basis import poll_basis
+from tradingbot.connectors import Funding, OpenInterest
 
 
 @pytest.mark.asyncio
@@ -16,7 +18,9 @@ async def test_poll_open_interest_publishes_and_inserts(monkeypatch):
         name = "dummy"
 
         async def fetch_open_interest(self, symbol: str):
-            return {"ts": ts, "oi": 10.0}
+            return OpenInterest(
+                timestamp=ts, exchange="dummy", symbol=symbol, oi=10.0
+            )
 
     events = []
     bus = EventBus()
@@ -45,6 +49,43 @@ async def test_poll_open_interest_publishes_and_inserts(monkeypatch):
 
     assert events and events[0]["oi"] == 10.0
     assert inserted and inserted[0]["oi"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_poll_funding_publishes_and_inserts(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    class DummyAdapter:
+        name = "dummy"
+
+        async def fetch_funding(self, symbol: str):
+            return Funding(
+                timestamp=ts, exchange="dummy", symbol=symbol, rate=0.01
+            )
+
+    events = []
+    bus = EventBus()
+    bus.subscribe("funding", lambda e: events.append(e))
+
+    inserted = []
+
+    monkeypatch.setattr("tradingbot.data.funding.get_engine", lambda: "engine")
+    monkeypatch.setattr(
+        "tradingbot.data.funding.insert_funding",
+        lambda *a, **k: inserted.append(k),
+    )
+    monkeypatch.setattr("tradingbot.data.funding._CAN_PG", True)
+
+    task = asyncio.create_task(
+        poll_funding(DummyAdapter(), "BTCUSDT", bus, interval=0, persist_pg=True)
+    )
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events and events[0]["rate"] == 0.01
+    assert inserted and inserted[0]["rate"] == 0.01
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose fetch_funding and fetch_open_interest in Binance/Bybit/OKX connectors
- normalise funding and open interest pollers to accept connector models
- test funding and open interest ingestion

## Testing
- `pytest tests/test_connectors.py::test_rest_normalization tests/test_data_pollers.py::test_poll_funding_publishes_and_inserts tests/test_data_pollers.py::test_poll_open_interest_publishes_and_inserts -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24c0bb7bc832d83ec86309d5815b0