### PR TITLE
feat: add react dashboard with websocket

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -11,6 +11,21 @@ Run the monitoring panel with:
 uvicorn monitoring.panel:app --reload
 ```
 
+Open <http://localhost:8000/> to access a lightweight React dashboard. The
+SPA connects to the `/ws/summary` WebSocket for real‑time metrics, PnL and
+risk updates.
+
+If the trading API is hosted on another URL, set `API_URL` before launching
+the panel so risk endpoints can be polled correctly:
+
+```bash
+API_URL="http://api-host:8000" uvicorn monitoring.panel:app --reload
+```
+
+Customize the look and behaviour of the panel by editing
+`monitoring/static/index.html` (React components) or tweaking the WebSocket
+logic in `monitoring/panel.py`.
+
 The API backing the panel uses HTTP Basic authentication. Configure
 credentials via the `API_USER` and `API_PASS` environment variables
 (default `admin` / `admin`) and supply them when querying the API.

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -1,141 +1,50 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8" />
   <title>TradeBot Monitoring</title>
-  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; }
     section { margin-bottom: 1.5rem; }
-    input { padding: 4px; margin-bottom: 8px; }
   </style>
 </head>
 <body>
-<div id="app">
-  <h1>TradeBot Monitoring</h1>
+  <div id="root"></div>
+  <script>
+    const { useState, useEffect } = React;
 
-  <section>
-    <h2>Metrics Summary</h2>
-    <div v-if="!metrics">Loading...</div>
-    <div v-else>
-      PnL: {{ metrics.pnl }} |
-      Positions: {{ Object.entries(metrics.positions || {}).map(([s,v]) => s + ':' + v).join(', ') }} |
-      Disconnects: {{ metrics.disconnects }} |
-      Avg Market Latency: {{ metrics.avg_market_latency_seconds }} |
-      Avg Order Latency: {{ metrics.avg_order_latency_seconds }} |
-      E2E Latency: {{ metrics.avg_e2e_latency_seconds }} |
-      Maker/Taker Ratio: {{ metrics.avg_maker_taker_ratio }}
-    </div>
-  </section>
+    function App() {
+      const [state, setState] = useState({metrics:null, pnl:null, risk:null});
 
-  <section>
-    <h2>Funding & Basis</h2>
-    <div v-if="!funding || !basis">Loading...</div>
-    <div v-else>
-      Funding: {{ JSON.stringify(funding.funding) }} |
-      Basis: {{ JSON.stringify(basis.basis) }}
-    </div>
-  </section>
+      useEffect(() => {
+        const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+        const ws = new WebSocket(`${protocol}://${location.host}/ws/summary`);
+        ws.onmessage = (evt) => {
+          try { setState(JSON.parse(evt.data)); } catch (e) { console.error(e); }
+        };
+        ws.onerror = console.error;
+        return () => ws.close();
+      }, []);
 
-  <section>
-    <h2>Strategies</h2>
-    <div v-if="!strategies">Loading...</div>
-    <ul v-else>
-      <li v-for="(status, name) in strategies" :key="name">
-        {{ name }}: {{ status }}
-        <button @click="enableStrategy(name)">Enable</button>
-        <button @click="disableStrategy(name)">Disable</button>
-        <input v-model="params[name]" placeholder="{\"key\":\"val\"}" />
-        <button @click="updateParams(name)">Set Params</button>
-      </li>
-    </ul>
-  </section>
+      const section = (title, data) =>
+        React.createElement('section', null,
+          React.createElement('h2', null, title),
+          data ? React.createElement('pre', null, JSON.stringify(data, null, 2)) : 'Loading...'
+        );
 
-  <section>
-    <h2>Slippage (last 24h)</h2>
-    <input v-model="slipSymbol" placeholder="symbol e.g. BTC/USDT" />
-    <div v-if="!slippage">Loading...</div>
-    <div v-else>
-      Mean: {{ slippage.global?.mean?.toFixed(4) ?? 0 }}
-    </div>
-  </section>
-
-  <section>
-    <h2>Intraday PnL</h2>
-    <div v-if="!intraday">Loading...</div>
-    <div v-else>
-      Net: {{ intraday.net.toFixed(2) }}
-    </div>
-  </section>
-</div>
-
-<script>
-const { createApp } = Vue;
-
-createApp({
-  data() {
-    return {
-      metrics: null,
-      funding: null,
-      basis: null,
-      strategies: null,
-      slippage: null,
-      intraday: null,
-      slipSymbol: '',
-      params: {}
-    };
-  },
-  methods: {
-    async fetchMetrics() {
-      this.metrics = await fetch('/metrics/summary').then(r => r.json());
-    },
-    async fetchFunding() {
-      this.funding = await fetch('/funding').then(r => r.json());
-    },
-    async fetchBasis() {
-      this.basis = await fetch('/basis').then(r => r.json());
-    },
-    async fetchStrategies() {
-      const data = await fetch('/strategies/status').then(r => r.json());
-      this.strategies = data.strategies || {};
-    },
-    async fetchSlippage() {
-      const url = '/fills/slippage' + (this.slipSymbol ? '?symbol=' + encodeURIComponent(this.slipSymbol) : '');
-      this.slippage = await fetch(url).then(r => r.json());
-    },
-    async fetchIntraday() {
-      this.intraday = await fetch('/pnl/intraday').then(r => r.json());
-    },
-    async enableStrategy(name) {
-      await fetch(`/strategies/${name}/enable`, { method: 'POST' });
-      this.fetchStrategies();
-    },
-    async disableStrategy(name) {
-      await fetch(`/strategies/${name}/disable`, { method: 'POST' });
-      this.fetchStrategies();
-    },
-    async updateParams(name) {
-      const body = this.params[name] || '{}';
-      try { JSON.parse(body); } catch(e) { alert('Invalid JSON'); return; }
-      await fetch(`/strategies/${name}/params`, { method: 'POST', headers: {'Content-Type':'application/json'}, body });
-    },
-    refresh() {
-      this.fetchMetrics();
-      this.fetchFunding();
-      this.fetchBasis();
-      this.fetchStrategies();
-      this.fetchSlippage();
-      this.fetchIntraday();
+      return React.createElement('div', null, [
+        React.createElement('h1', {key:'h'}, 'TradeBot Monitoring'),
+        section('Metrics Summary', state.metrics),
+        section('PnL', state.pnl),
+        section('Risk', state.risk)
+      ]);
     }
-  },
-  watch: {
-    slipSymbol() { this.fetchSlippage(); }
-  },
-  mounted() {
-    this.refresh();
-    setInterval(this.refresh, 5000);
-  }
-}).mount('#app');
-</script>
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(App));
+  </script>
 </body>
 </html>
+

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -133,6 +133,21 @@ def test_alerts_endpoint(monkeypatch):
     assert data["alerts"] == alerts_list
 
 
+def test_websocket_summary(monkeypatch):
+    client = TestClient(app)
+
+    async def fake_risk():
+        return {"exposure": {"BTCUSD": 1}, "events": []}
+
+    monkeypatch.setattr(panel, "fetch_risk", fake_risk)
+    TRADING_PNL.set(42)
+
+    with client.websocket_connect("/ws/summary") as ws:
+        data = ws.receive_json()
+        assert data["pnl"]["pnl"] == 42
+        assert data["risk"]["exposure"] == {"BTCUSD": 1}
+
+
 def test_api_funding_basis_and_params():
     """Verify funding, basis and strategy param endpoints in the API app."""
 


### PR DESCRIPTION
## Summary
- replace monitoring index.html with lightweight React SPA
- stream metrics, pnl and risk data over new /ws/summary endpoint
- document panel deployment and customization

## Testing
- `pytest tests/test_monitoring_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68a24bff2034832d96e5dd578c574058