### PR TITLE
Use portfolio volatility when sizing orders

### DIFF
--- a/src/tradingbot/risk/portfolio_guard.py
+++ b/src/tradingbot/risk/portfolio_guard.py
@@ -83,6 +83,16 @@ class PortfolioGuard:
                     result[(syms[i], syms[j])] = corr
         return result
 
+    def volatility(self, symbol: str) -> float:
+        """Desviación estándar anualizada de los retornos de ``symbol``.
+
+        Si no hay suficientes datos de retornos, retorna ``0.0``.
+        """
+        rets = np.array(self.st.returns.get(symbol, []), dtype=float)
+        if len(rets) < 2:
+            return 0.0
+        return float(np.std(rets) * np.sqrt(365))
+
     # ---- hard caps (como antes) ----
     def would_exceed_caps(self, symbol: str, side: str, add_qty: float, price: float) -> Tuple[bool, str, dict]:
         cur_pos = self.st.positions.get(symbol, 0.0)

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -58,7 +58,7 @@ class RiskService:
         price: float,
         strength: float = 1.0,
         *,
-        symbol_vol: float = 0.0,
+        symbol_vol: float | None = None,
         correlations: Dict[Tuple[str, str], float] | None = None,
         corr_threshold: float = 0.0,
     ) -> tuple[bool, str, float]:
@@ -68,11 +68,14 @@ class RiskService:
         proposed after volatility and correlation adjustments.
         """
 
+        if symbol_vol is None or symbol_vol <= 0:
+            symbol_vol = self.guard.volatility(symbol)
+
         delta = self.rm.size(
             side,
             strength,
             symbol=symbol,
-            symbol_vol=symbol_vol,
+            symbol_vol=symbol_vol or 0.0,
             correlations=correlations or {},
             threshold=corr_threshold,
         )

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -1,6 +1,9 @@
 import pytest
+import numpy as np
 
 from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
 
 
 def test_risk_vol_sizing(synthetic_volatility):
@@ -26,4 +29,16 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
         rm.max_pos, rm.max_pos * rm.vol_target / synthetic_volatility
     )
     expected *= 0.5
+    assert delta == pytest.approx(expected)
+
+
+def test_risk_service_uses_guard_volatility():
+    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
+    rm = RiskManager(max_pos=10, vol_target=0.02)
+    svc = RiskService(rm, guard)
+    guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
+    allowed, _, delta = svc.check_order("BTC", "buy", price=100.0)
+    vol = np.std([0.01, -0.02, 0.03]) * np.sqrt(365)
+    expected = rm.max_pos + min(rm.max_pos, rm.max_pos * rm.vol_target / vol)
+    assert allowed
     assert delta == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add annualised volatility method to `PortfolioGuard`
- use `PortfolioGuard.volatility()` in `RiskService.check_order` when no symbol volatility supplied
- cover volatility sizing path with new tests

## Testing
- `pytest tests/test_risk_vol_sizing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a250841970832db24932d2454cecda