### PR TITLE
Add basis metrics and monitoring integration

### DIFF
--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -22,6 +22,7 @@ from tradingbot.utils.metrics import (
     MARKET_LATENCY,
     E2E_LATENCY,
     FUNDING_RATE,
+    BASIS,
     OPEN_INTEREST,
 )
 
@@ -202,11 +203,19 @@ def metrics_summary() -> dict:
         if sample.name == "open_interest"
     }
 
+    basis = {
+        sample.labels["symbol"]: sample.value
+        for metric in BASIS.collect()
+        for sample in metric.samples
+        if sample.name == "basis"
+    }
+
     return {
         "pnl": TRADING_PNL._value.get(),
         "positions": positions,
         "funding_rates": funding_rates,
         "open_interest": open_interest,
+        "basis": basis,
         "disconnects": SYSTEM_DISCONNECTS._value.get(),
         "fills": fill_total,
         "risk_events": risk_total,

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -37,6 +37,7 @@
       return React.createElement('div', null, [
         React.createElement('h1', {key:'h'}, 'TradeBot Monitoring'),
         section('Metrics Summary', state.metrics),
+        section('Basis', state.metrics ? state.metrics.basis : null),
         section('PnL', state.pnl),
         section('Risk', state.risk)
       ]);

--- a/src/tradingbot/data/basis.py
+++ b/src/tradingbot/data/basis.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ..bus import EventBus
+from ..utils.metrics import BASIS, BASIS_HIST
 
 try:  # optional persistence
     from ..storage.timescale import get_engine, insert_basis
@@ -53,6 +54,8 @@ async def poll_basis(
                 "symbol": symbol,
                 "basis": info["basis"],
             }
+            BASIS.labels(symbol=symbol).set(info["basis"])
+            BASIS_HIST.labels(symbol=symbol).observe(info["basis"])
             await bus.publish("basis", event)
             if engine is not None:
                 try:

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -26,7 +26,7 @@ from ..data.funding import poll_funding
 from ..data.open_interest import poll_open_interest
 from ..data.basis import poll_basis
 from ..execution.balance import rebalance_between_exchanges
-from ..utils.metrics import FUNDING_RATE, OPEN_INTEREST
+from ..utils.metrics import BASIS, FUNDING_RATE, OPEN_INTEREST
 
 log = logging.getLogger(__name__)
 
@@ -407,6 +407,9 @@ class TradeBotDaemon:
 
     async def _dispatch_basis(self, evt: dict) -> None:
         """Forward basis events to strategies."""
+        value = float(evt.get("basis") or 0.0)
+        symbol = evt.get("symbol", "")
+        BASIS.labels(symbol=symbol).set(value)
         for strat in self.strategies:
             handler = getattr(strat, "on_basis", None)
             if handler is None:

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -111,6 +111,19 @@ FUNDING_RATE_HIST = Histogram(
     ["symbol"],
 )
 
+# Basis per symbol
+BASIS = Gauge(
+    "basis",
+    "Latest basis value",
+    ["symbol"],
+)
+
+BASIS_HIST = Histogram(
+    "basis_distribution",
+    "Distribution of basis observations",
+    ["symbol"],
+)
+
 # Open interest per symbol
 OPEN_INTEREST = Gauge(
     "open_interest",

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -22,6 +22,7 @@ from monitoring.metrics import (
     KILL_SWITCH_ACTIVE,
     FUNDING_RATE,
     OPEN_INTEREST,
+    BASIS,
 )
 from tradingbot.apps.api.main import app as api_app
 
@@ -48,6 +49,8 @@ def test_panel_endpoints_and_metrics():
     FUNDING_RATE.labels(symbol="BTCUSD").set(0.01)
     OPEN_INTEREST.clear()
     OPEN_INTEREST.labels(symbol="BTCUSD").set(1000)
+    BASIS.clear()
+    BASIS.labels(symbol="BTCUSD").set(5)
 
     resp = client.get("/")
     assert resp.status_code == 200
@@ -58,6 +61,7 @@ def test_panel_endpoints_and_metrics():
     assert "trading_pnl" in resp.text
     assert "funding_rate" in resp.text
     assert "open_interest" in resp.text
+    assert "basis" in resp.text
 
     resp = client.get("/metrics/summary")
     data = resp.json()
@@ -65,6 +69,7 @@ def test_panel_endpoints_and_metrics():
     assert data["positions"] == {"BTCUSD": 2.0}
     assert data["funding_rates"] == {"BTCUSD": 0.01}
     assert data["open_interest"] == {"BTCUSD": 1000.0}
+    assert data["basis"] == {"BTCUSD": 5.0}
     assert data["disconnects"] == 1.0
     assert data["avg_market_latency_seconds"] == 0.5
     assert data["avg_order_latency_seconds"] == 0.2


### PR DESCRIPTION
## Summary
- track latest basis values via Prometheus gauge and histogram
- expose basis metrics through data poller, daemon dispatch and monitoring API
- display basis values on monitoring dashboard and add test coverage

## Testing
- `pytest tests/test_data_pollers.py tests/test_monitoring_panel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25084a398832db6986921190bc811