### PR TITLE
feat: auto close positions on daily guard halt

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -88,7 +88,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         broker.update_last_price(cfg.symbol, px)
         guard.mark_price(cfg.symbol, px)
         dguard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={cfg.symbol: px}))
-        halted, reason = dguard.check_halt()
+        halted, reason = dguard.check_halt(broker)
         if halted:
             log.error("[HALT] motivo=%s", reason)
             break

--- a/src/tradingbot/risk/daily_guard.py
+++ b/src/tradingbot/risk/daily_guard.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone, date
 import logging
 from typing import Dict
+import asyncio
 
 from ..utils.metrics import RISK_EVENTS
 from ..storage import timescale
@@ -64,13 +65,36 @@ class DailyGuard:
         elif delta_rpnl > 0:
             self._consec_losses = 0
 
-    def check_halt(self) -> tuple[bool, str]:
+    def apply_halt_action(self, broker) -> None:
+        """Apply configured halt action through ``broker``.
+
+        If ``halt_action`` is ``"close_all"`` market orders are sent
+        asynchronously to close every open position known by ``broker``.
+        """
+        if broker is None or self.lim.halt_action != "close_all":
+            return
+        try:
+            pos_book = getattr(getattr(broker, "state", object()), "pos", {})
+            place = getattr(broker, "place_order", None)
+            if not pos_book or place is None:
+                return
+            for sym, p in list(pos_book.items()):
+                qty = getattr(p, "qty", 0.0)
+                if abs(qty) <= 0:
+                    continue
+                side = "sell" if qty > 0 else "buy"
+                asyncio.create_task(place(sym, side, "market", abs(qty)))
+        except Exception:  # pragma: no cover - safety guard
+            log.exception("[DG] apply_halt_action failed")
+
+    def check_halt(self, broker=None) -> tuple[bool, str]:
         if self._halted:
             return True, "already_halted"
 
         # Regla 1: pérdida neta diaria
         if self._realized_today <= -abs(self.lim.daily_max_loss_usdt):
             self._halted = True
+            self.apply_halt_action(broker)
             RISK_EVENTS.labels(event_type="daily_max_loss").inc()
             if self._engine is not None:
                 try:
@@ -90,6 +114,7 @@ class DailyGuard:
             dd = (self._equity_peak - self._equity_last) / self._equity_peak
             if dd >= self.lim.daily_max_drawdown_pct:
                 self._halted = True
+                self.apply_halt_action(broker)
                 RISK_EVENTS.labels(event_type="daily_drawdown").inc()
                 if self._engine is not None:
                     try:
@@ -107,6 +132,7 @@ class DailyGuard:
         # Regla 3: racha de pérdidas
         if self._consec_losses >= self.lim.max_consecutive_losses:
             self._halted = True
+            self.apply_halt_action(broker)
             RISK_EVENTS.labels(event_type="consecutive_losses").inc()
             if self._engine is not None:
                 try:
@@ -122,4 +148,3 @@ class DailyGuard:
             return True, "consecutive_losses"
 
         return False, ""
-

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -111,7 +111,7 @@ class RiskService:
         self.daily.on_mark(now, equity_now=broker.equity(mark_prices={symbol: price}))
         if abs(delta_rpnl) > 0:
             self.daily.on_realized_delta(delta_rpnl)
-        halted, reason = self.daily.check_halt()
+        halted, reason = self.daily.check_halt(broker)
         if halted:
             self._persist(f"HALT_{reason}", symbol, f"HALT: {reason}", {})
         return halted, reason

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -53,7 +53,7 @@ class DummyDG:
     def on_mark(self, *a, **k):
         pass
 
-    def check_halt(self):
+    def check_halt(self, broker=None):
         return (False, "")
 
 

--- a/tests/test_risk_daily_guard.py
+++ b/tests/test_risk_daily_guard.py
@@ -1,0 +1,44 @@
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from tradingbot.risk.daily_guard import DailyGuard, GuardLimits
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.storage import timescale
+
+
+@pytest.mark.asyncio
+async def test_daily_guard_close_and_persist(monkeypatch):
+    broker = PaperAdapter()
+    broker.state.cash = 1000.0
+    symbol = "BTC/USDT"
+    broker.update_last_price(symbol, 100.0)
+
+    guard = DailyGuard(
+        GuardLimits(daily_max_drawdown_pct=0.05, halt_action="close_all"),
+        venue="paper",
+        storage_engine="eng",
+    )
+
+    # initialize day with current equity
+    guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 100.0}))
+    await broker.place_order(symbol, "buy", "market", 1)
+
+    broker.update_last_price(symbol, 50.0)
+    guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 50.0}))
+
+    calls = []
+
+    def fake_insert(engine, venue, symbol, kind, message, details=None):
+        calls.append((engine, venue, symbol, kind, message, details))
+
+    monkeypatch.setattr(timescale, "insert_risk_event", fake_insert)
+
+    halted, reason = guard.check_halt(broker)
+    await asyncio.sleep(0)
+
+    assert halted and reason == "daily_drawdown"
+    assert broker.state.pos[symbol].qty == 0
+    assert calls and calls[0][3] == "daily_drawdown"
+    assert calls[0][0] == "eng"


### PR DESCRIPTION
## Summary
- close all broker positions when DailyGuard halts
- log daily guard halts with broker passed through RiskService and runner
- test DailyGuard halt auto-close and persistence

## Testing
- `python3 -m pytest tests/test_risk_daily_guard.py tests/test_risk.py::test_daily_guard_halts_on_loss -q`

------
https://chatgpt.com/codex/tasks/task_e_68a25083029c832d9043889b8539aa9d