### PR TITLE
feat: show funding and open interest in monitoring panel

### DIFF
--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -189,14 +189,14 @@ def metrics_summary() -> dict:
         if sample.name == "open_position"
     }
 
-    funding_rates = {
+    funding_rates: dict[str, float] = {
         sample.labels["symbol"]: sample.value
         for metric in FUNDING_RATE.collect()
         for sample in metric.samples
         if sample.name == "funding_rate"
     }
 
-    open_interest = {
+    open_interest: dict[str, float] = {
         sample.labels["symbol"]: sample.value
         for metric in OPEN_INTEREST.collect()
         for sample in metric.samples

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -38,6 +38,8 @@
         React.createElement('h1', {key:'h'}, 'TradeBot Monitoring'),
         section('Metrics Summary', state.metrics),
         section('Basis', state.metrics ? state.metrics.basis : null),
+        section('Funding', state.metrics ? state.metrics.funding_rates : null),
+        section('Open Interest', state.metrics ? state.metrics.open_interest : null),
         section('PnL', state.pnl),
         section('Risk', state.risk)
       ]);


### PR DESCRIPTION
## Summary
- display Funding and Open Interest sections in monitoring UI
- ensure metrics summary exposes funding_rates and open_interest
- test websocket and UI for funding/open interest metrics

## Testing
- `pytest tests/test_monitoring_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68a255aaa290832d9ba7fde462bb4dbc