### PR TITLE
feat: reduce risk on deep drawdowns

### DIFF
--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -30,3 +30,15 @@ def test_adjust_size_and_portfolio_risk():
     assert not rm.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
     assert rm.enabled is False
     assert rm.last_kill_reason == "covariance_limit"
+
+
+def test_de_risk_reduces_exposure():
+    rm = RiskManager(max_pos=10, vol_target=1.0)
+    rm.update_pnl(100)
+    assert rm.max_pos == pytest.approx(10)
+    rm.update_pnl(-30)  # drawdown 30%
+    assert rm.max_pos == pytest.approx(5)
+    assert rm.vol_target == pytest.approx(0.5)
+    rm.update_pnl(-25)  # drawdown 55%
+    assert rm.max_pos == pytest.approx(2.5)
+    assert rm.vol_target == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- add `de_risk` to scale down `max_pos` and `vol_target` on 25% and 50% drawdowns
- invoke `de_risk` from PnL updates and limit checks before engaging kill switch
- test progressive de-risking as losses deepen

## Testing
- `pytest tests/test_risk_manager_extra.py tests/test_risk_manager_limits.py tests/test_risk_vol_sizing.py tests/test_risk.py tests/test_risk_daily_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a255a94594832dbca2555acf0864b9