### PR TITLE
Add Kaiko & CoinAPI fetch helpers and CLI command

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -95,61 +95,63 @@ def ingest_historical(
     if source.lower() == "kaiko":
         from ..connectors.kaiko import KaikoConnector
         from ..data.ingestion import (
-            download_kaiko_trades,
-            download_kaiko_order_book,
+            fetch_trades_kaiko,
+            fetch_orderbook_kaiko,
             download_kaiko_open_interest,
             download_funding,
         )
 
-        connector = KaikoConnector()
         if kind == "orderbook":
             asyncio.run(
-                download_kaiko_order_book(
-                    connector, exchange, symbol, backend=backend, depth=depth
+                fetch_orderbook_kaiko(
+                    exchange, symbol, backend=backend, depth=depth
                 )
             )
         elif kind == "open_interest":
+            connector = KaikoConnector()
             asyncio.run(
                 download_kaiko_open_interest(
                     connector, exchange, symbol, backend=backend, limit=limit
                 )
             )
         elif kind == "funding":
+            connector = KaikoConnector()
             asyncio.run(download_funding(connector, symbol, backend=backend))
         else:
             asyncio.run(
-                download_kaiko_trades(
-                    connector, exchange, symbol, backend=backend, limit=limit
+                fetch_trades_kaiko(
+                    exchange, symbol, backend=backend, limit=limit
                 )
             )
     elif source.lower() == "coinapi":
         from ..connectors.coinapi import CoinAPIConnector
         from ..data.ingestion import (
-            download_coinapi_trades,
-            download_coinapi_order_book,
+            fetch_trades_coinapi,
+            fetch_orderbook_coinapi,
             download_coinapi_open_interest,
             download_funding,
         )
 
-        connector = CoinAPIConnector()
         if kind == "orderbook":
             asyncio.run(
-                download_coinapi_order_book(
-                    connector, symbol, backend=backend, depth=depth
+                fetch_orderbook_coinapi(
+                    symbol, backend=backend, depth=depth
                 )
             )
         elif kind == "open_interest":
+            connector = CoinAPIConnector()
             asyncio.run(
                 download_coinapi_open_interest(
                     connector, symbol, backend=backend, limit=limit
                 )
             )
         elif kind == "funding":
+            connector = CoinAPIConnector()
             asyncio.run(download_funding(connector, symbol, backend=backend))
         else:
             asyncio.run(
-                download_coinapi_trades(
-                    connector, symbol, backend=backend, limit=limit
+                fetch_trades_coinapi(
+                    symbol, backend=backend, limit=limit
                 )
             )
     else:  # pragma: no cover - CLI validation


### PR DESCRIPTION
## Summary
- add high-level helpers `fetch_trades_kaiko` and `fetch_trades_coinapi` with matching order book fetchers
- wire CLI `ingest-historical` command to new helpers for Timescale/QuestDB/CSV

## Testing
- `pytest tests/test_data_ingestion.py::test_download_trades_connector tests/test_data_ingestion.py::test_download_order_book_connector -q`


------
https://chatgpt.com/codex/tasks/task_e_68a260d6baf4832db05eb2e464e49f47