### PR TITLE
Use Deribit websocket adapter for streaming

### DIFF
--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -16,6 +16,8 @@ from ..data.basis import poll_basis
 from ..risk.manager import RiskManager
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
+from ..adapters.deribit import DeribitAdapter
+from ..adapters.deribit_ws import DeribitWSAdapter
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +30,10 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     cfg:
         Configuration with symbol, adapters and trading params.
     """
+    if isinstance(cfg.spot, DeribitAdapter):
+        cfg.spot = DeribitWSAdapter(rest=cfg.spot)
+    if isinstance(cfg.perp, DeribitAdapter):
+        cfg.perp = DeribitWSAdapter(rest=cfg.perp)
 
     router = ExecutionRouter([cfg.spot, cfg.perp])
     bus = EventBus()

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from typing import Dict, Optional
 
 from ..adapters.base import ExchangeAdapter
+from ..adapters.deribit import DeribitAdapter
+from ..adapters.deribit_ws import DeribitWSAdapter
 
 try:
     from ..storage.timescale import get_engine, insert_cross_signal, insert_fill
@@ -37,6 +39,10 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
     offsetting market orders on each venue and persists the opportunity and
     resulting fills into TimescaleDB (if available).
     """
+    if isinstance(cfg.spot, DeribitAdapter):
+        cfg.spot = DeribitWSAdapter(rest=cfg.spot)
+    if isinstance(cfg.perp, DeribitAdapter):
+        cfg.perp = DeribitWSAdapter(rest=cfg.perp)
 
     last: Dict[str, Optional[float]] = {"spot": None, "perp": None}
     balances: Dict[str, float] = {cfg.spot.name: 0.0, cfg.perp.name: 0.0}


### PR DESCRIPTION
## Summary
- Swap Deribit REST adapter for websocket wrapper when initializing adapters
- Wrap Deribit adapters in cross-exchange runners and strategies
- Test that DeribitWSAdapter delegates REST calls for funding, basis, and OI

## Testing
- `pytest` *(fails: process killed)*
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_rest_calls -q`


------
https://chatgpt.com/codex/tasks/task_e_68a260d68690832d93ce6b7be2ed8039