### PR TITLE
Use DeribitWSAdapter for streaming with REST delegation

### DIFF
--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -49,6 +49,11 @@ class DeribitWSAdapter(ExchangeAdapter):
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         """Stream order book snapshots from Deribit."""
 
+        if self.rest and hasattr(self.rest, "stream_order_book"):
+            async for ob in self.rest.stream_order_book(symbol, depth):
+                yield ob
+            return
+
         channel = f"book.{depth}.{symbol}"
         sub = {
             "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
- Delegate `stream_order_book` to underlying REST adapter when present
- Pass REST adapter into `DeribitWSAdapter` and add delegation tests

## Testing
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing -q`
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_to_rest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2661263d0832d883de0545c553a1e