### PR TITLE
feat: add dashboard CLI console and docs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,301 +1,108 @@
-# TradingBot MVP (Local)
+# TradeBot
 
-MVP para un bot de trading intradía, scalping y arbitraje en cripto (extensible a otros mercados).
+TradeBot es un bot de trading modular orientado a estrategias intradía,
+scalping y arbitraje sobre criptomonedas.  Incluye todo lo necesario para
+ingerir datos, realizar backtesting y ejecutar estrategias en modo
+``paper`` o real desde una interfaz web.
 
-## Estructura
+## Características principales
 
-```
-tradingbot-mvp/
-├─ requirements.txt
-├─ pyproject.toml
-├─ .env.example
-├─ docker-compose.yml
-├─ README.md
-├─ sql/
-│  └─ schema_timescale.sql
-├─ src/tradingbot/
-│  ├─ __init__.py
-│  ├─ config.py
-│  ├─ logging_conf.py
-│  ├─ bus.py
-│  ├─ types.py
-│  ├─ adapters/
-│  │  ├─ __init__.py
-│  │  ├─ base.py
-│  │  └─ binance.py
-│  ├─ data/
-│  │  ├─ __init__.py
-│  │  ├─ ingestion.py
-│  │  └─ features.py
-│  ├─ storage/
-│  │  ├─ __init__.py
-│  │  ├─ timescale.py
-│  │  └─ quest.py
-│  ├─ strategies/
-│  │  ├─ __init__.py
-│  │  ├─ base.py
-│  │  └─ breakout_atr.py
-│  ├─ risk/
-│  │  ├─ __init__.py
-│  │  └─ manager.py
-│  ├─ execution/
-│  │  ├─ __init__.py
-│  │  ├─ order_types.py
-│  │  └─ router.py
-│  ├─ backtest/
-│  │  ├─ __init__.py
-│  │  └─ event_engine.py
-│  ├─ analysis/
-│  │  ├─ __init__.py
-│  │  └─ backtest_report.py
-│  ├─ apps/
-│  │  ├─ __init__.py
-│  │  └─ api/
-│  │     ├─ __init__.py
-│  │     └─ main.py
-│  └─ cli/
-│     ├─ __init__.py
-│     └─ main.py
-   └─ tests/
-   └─ test_smoke.py
-```
+- Ingesta de datos en tiempo real (WebSocket y REST) para Binance, Bybit,
+  OKX y otros exchanges.
+- Motor de estrategias con ejemplos de momentum, mean reversion, arbitraje
+  triangular y arbitraje spot/perp.
+- Gestión de riesgo y portafolio con límites de exposición y ``kill switch``.
+- Router de ejecución con algoritmos TWAP/VWAP/POV y soporte maker/taker.
+- Backtester vectorizado y motor event‑driven con modelado de slippage.
+- **Panel web** con métricas en vivo y un **ejecutor de comandos CLI** que
+  permite lanzar cualquier comando desde el navegador.
 
-## Documentación
+## Requisitos
 
-La carpeta `docs/` contiene material adicional:
+- Python 3.11+
+- ``git``
+- ``docker`` (opcional, para bases de datos y monitoreo)
 
-- [Arquitectura](docs/architecture.md)
-- [Guía de setup](docs/setup.md)
-- [Ejemplos de uso](docs/examples.md)
-
-## Setup local
+## Instalación rápida
 
 ```bash
-# Crear y activar entorno virtual (Python 3.11+)
-python -m venv .venv && . .venv/bin/activate
+git clone <repo>
+cd TradeBot
+python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-
-# Copiar variables de entorno
-cp .env.example .env  # editar con tus credenciales
-
-# Ejecutar pruebas para verificar la instalación
-pytest
+cp .env.example .env   # completa con tus claves
 ```
 
-> **Nota**: es necesario que el reloj del sistema esté sincronizado. Al iniciar la
-> CLI se consulta un servidor NTP y se muestra una advertencia si el desfase
-> supera el umbral definido en `NTP_OFFSET_THRESHOLD` (por defecto 1s).
+## Ejecución del panel web
 
-## Despliegue con Docker
-
-Para levantar toda la pila de servicios (API, bases de datos, monitoreo):
+El panel expone métricas, PnL y una consola para ejecutar comandos de la
+CLI.
 
 ```bash
-docker compose up -d
+uvicorn tradingbot.apps.api.main:app --reload --port 8000
 ```
 
-También puedes utilizar los scripts de ayuda en `bin/`:
+Visita `http://localhost:8000` e inicia sesión con las credenciales
+definidas en `API_USER`/`API_PASS` (por defecto `admin`/`admin`).
+
+### Consola de comandos
+
+En la sección **Comandos CLI** del panel puedes ejecutar cualquier comando
+de `tradingbot.cli`.  Ejemplos:
+
+1. Escribe `backtest-cfg data/examples/backtest.yaml` y pulsa **Ejecutar**.
+2. Usa `tri-arb BTC-ETH-USDT --notional 50` para disparar un arbitraje
+   triangular de prueba.
+
+La salida de `stdout` y `stderr` aparecerá debajo del formulario.
+
+## Uso desde la línea de comandos
+
+La CLI está basada en [Typer](https://typer.tiangolo.com/) y ofrece
+subcomandos para las distintas tareas del proyecto.
 
 ```bash
-./bin/start_timescale.sh   # sólo TimescaleDB
-./bin/start_questdb.sh     # sólo QuestDB
-./bin/start_stack.sh       # stack completo
-```
+python -m tradingbot.cli --help
 
-Si solo necesitas las bases de datos puedes utilizar los archivos en `sql/`:
+# Ingesta de libro de órdenes
+python -m tradingbot.cli ingest BTC/USDT --depth 20
 
-```bash
-# TimescaleDB
-docker compose -f sql/docker-compose.timescale.yml up -d
+# Descarga histórica desde Kaiko
+python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades
 
-# QuestDB
-docker compose -f sql/docker-compose.questdb.yml up -d
-```
-
-## Variables de entorno
-
-Copia `.env.example` a `.env` y completa las claves según corresponda. Variables principales:
-
-- `BINANCE_API_KEY`, `BINANCE_API_SECRET`: credenciales de Binance Spot.
-- `BYBIT_API_KEY`, `BYBIT_API_SECRET`: credenciales de Bybit Spot.
-- `BINANCE_FUTURES_API_KEY`, `BINANCE_FUTURES_API_SECRET`, `BINANCE_FUTURES_TESTNET`, `BINANCE_FUTURES_LEVERAGE`: acceso a futuros.
-- `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DB`: conexión a la base de datos.
-- `ENV`, `LOG_LEVEL`: parámetros de ejecución.
-- `SENTRY_DSN`: opcional para reportar errores a Sentry.
-
-Consulta [docs/security.md](docs/security.md) para buenas prácticas de gestión de claves API.
-
-## Límites de consulta por exchange
-
-| Exchange | Límite aproximado | Notas |
-|----------|------------------|-------|
-| Binance Spot | 1200 weight/min (≈20 req/s) | REST público |
-| Binance Futures | 1200 weight/min (≈20 req/s) | USDⓈ-M |
-| Bybit | 50 req/s público, 10 req/s privado | compartir entre endpoints |
-| OKX | 60 req/2s | límite global REST |
-
-## Uso rápido
-
-```bash
-# 1) Crear entorno (recomendado python 3.11+)
-python -m venv .venv && . .venv/bin/activate  # (Windows: .venv\Scripts\activate)
-pip install -r requirements.txt
-
-# 2) Levantar TimescaleDB (opcional pero recomendado)
-docker compose up -d timescaledb
-
-# 3) Configurar variables
-cp .env.example .env
-# edita .env con tus API keys (retiros desactivados, claves restringidas)
-```
-
-### Claves API sólo-trade
-Genera credenciales con los permisos mínimos:
-
-1. Crea una nueva clave en el panel de la exchange.
-2. Activa únicamente permisos de **lectura** y **trade**.
-3. Deshabilita retiros y, si es posible, restringe por IP.
-4. Guarda `API_KEY` y `API_SECRET` en `~/.secrets` (formato `CLAVE=valor`) o en el archivo `.env`.
-
-```bash
-# 4) Probar backtest de ejemplo (simulado, CSV)
-python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
-
-# 4b) Estrategia Order Flow (CSV con `bid_qty` y `ask_qty`)
-python -m tradingbot.cli backtest --data /path/to/orderbook.csv --strategy order_flow
-
-# 5) Iniciar API de control/monitoreo
-uvicorn tradingbot.apps.api.main:app --reload --port 8080
-```
-
-## Configuración desde YAML con Hydra
-
-Puedes definir configuraciones complejas en un archivo YAML y ejecutarlas con Hydra.
-
-```yaml
-# data/examples/backtest.yaml
-csv_paths:
-  BTC/USDT: data/examples/btcusdt_1m.csv
-strategies:
-  - [breakout_atr, BTC/USDT]
-latency: 1
-window: 120
-mlflow:
-  run_name: example_backtest
-```
-
-Ejecuta el backtest:
-
-```bash
+# Backtest a partir de un YAML de configuración
 python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
+
+# Arbitraje triangular
+python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 50
 ```
 
-## Registro de resultados con MLflow
+Todos estos comandos pueden ejecutarse también desde el panel web gracias a
+la nueva sección de **Comandos CLI**.
 
-Si la configuración YAML incluye la sección `mlflow`, los resultados del backtest
-se registrarán automáticamente en un experimento de MLflow (equity final y número de fills).
+## Ejecutar pruebas
 
-## Optimización de hiperparámetros con Optuna
-
-```python
-from tradingbot.backtest.event_engine import optimize_strategy_optuna
-
-study = optimize_strategy_optuna(
-    csv_path="data/examples/btcusdt_1m.csv",
-    symbol="BTC/USDT",
-    strategy_name="breakout_atr",
-    param_space={
-        "ema_n": {"type": "int", "low": 10, "high": 40},
-        "atr_n": {"type": "int", "low": 5, "high": 30},
-        "mult": {"type": "float", "low": 1.0, "high": 3.0},
-    },
-    n_trials=20,
-)
-print("Mejores parámetros:", study.best_params)
-```
-
-> **Nota**: este repo es un esqueleto funcional. Los adaptadores WS/REST y ejecución están stubs listos para ser implementados paso a paso.
-
-## Estrategias
-
-### Order Flow
-
-Estrategia basada en el indicador *Order Flow Imbalance* (OFI). Calcula el
-promedio del OFI en una ventana configurable y genera señales de compra o venta
-cuando supera los umbrales definidos (`buy_threshold`, `sell_threshold`).
-
-Ejemplo de uso con el CLI:
+El proyecto incluye una batería extensa de tests.  En entornos con recursos
+limitados puede ejecutarse una versión reducida:
 
 ```bash
-python -m tradingbot.cli backtest --data /path/to/orderbook.csv --strategy order_flow
+PYTHONPATH=src:. pytest tests/test_smoke.py
 ```
 
-El CSV debe contener las columnas `bid_qty` y `ask_qty`.
+## Estructura del proyecto
 
-### Ingesta de Open Interest
-
-Los adaptadores de exchanges (`Binance`, `Bybit`, `OKX`, etc.) exponen el método
-`fetch_oi` para consultar el *open interest*. Para almacenar periódicamente este
-dato en TimescaleDB se puede lanzar la tarea `poll_open_interest` para cada
-exchange/símbolo:
-
-```python
-import asyncio
-from tradingbot.adapters.binance_futures import BinanceFuturesAdapter
-from tradingbot.data.ingestion import poll_open_interest
-
-adapter = BinanceFuturesAdapter(api_key, api_secret)
-asyncio.create_task(poll_open_interest(adapter, "BTC/USDT"))
-
-# Repetir con otros adaptadores: BybitFuturesAdapter, OKXFuturesAdapter, etc.
+```
+TradeBot/
+├─ src/tradingbot/          # Código fuente del bot
+├─ monitoring/              # Métricas y paneles de observabilidad
+├─ docs/                    # Documentación adicional
+├─ tests/                   # Pruebas unitarias e integración
+└─ data/, sql/, bin/, etc.  # Scripts y ejemplos
 ```
 
-## Esquema de datos y carga
+---
 
-El archivo `sql/schema_timescale.sql` crea el esquema `market` con tablas básicas para el almacenamiento de mercado:
+Este repositorio es una base extensible.  Añade tus propias estrategias y
+conectores según sea necesario y utilízalo tanto para uso personal como para
+compartirlo con terceros.
 
-- `trades`: ejecuciones individuales
-- `orderbook`: snapshots del libro de órdenes (`bid_px`, `bid_qty`, `ask_px`, `ask_qty`)
-- `bars`: agregados OHLCV
-- `funding`: tasas de funding de perps
-- `open_interest`: interés abierto por exchange/símbolo
-
-Para cargar la estructura en una instancia de TimescaleDB:
-
-```bash
-psql -h localhost -U postgres -f sql/schema_timescale.sql
-```
-
-Luego puedes insertar datos desde Python utilizando los helpers:
-
-```python
-from tradingbot.storage.timescale import get_engine, insert_funding, insert_orderbook
-
-engine = get_engine()
-insert_funding(engine, ts=..., exchange="binance", symbol="BTCUSDT", rate=0.0001, interval_sec=3600)
-insert_orderbook(
-    engine,
-    ts=..., exchange="binance", symbol="BTCUSDT",
-    bid_px=[...], bid_qty=[...], ask_px=[...], ask_qty=[...],
-)
-```
-
-## Monitoreo y alertas
-
-Este proyecto expone métricas Prometheus para latencia de APIs, errores de websockets, fills de órdenes, slippage y eventos de riesgo. Los dashboards de ejemplo para Grafana se encuentran en `monitoring/grafana`.
-
-Para reportar excepciones a Sentry, define `SENTRY_DSN` en tu archivo `.env`. La configuración de logging inicializará Sentry automáticamente cuando este valor esté presente.
-
-## CI/CD
-
-El flujo de integración continua se ejecuta con GitHub Actions mediante `.github/workflows/ci.yml`. En cada `push` o `pull_request` se instala Python 3.11, las dependencias del proyecto y se ejecutan las pruebas con `pytest`.
-
-## Scripts de inicio rápido
-
-Algunos comandos útiles para comenzar a experimentar con el proyecto:
-
-```bash
-python -m tradingbot.cli backtest --data ./data/examples/btcusdt_1m.csv
-python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
-uvicorn tradingbot.apps.api.main:app --reload --port 8080
-```

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -22,10 +22,13 @@
     .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
     .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
     .kv .k { font-size:12px; color:#94a3b8 }
-    .kv .v { font-size:18px; margin-top:4px }
-  </style>
-</head>
-<body>
+      .kv .v { font-size:18px; margin-top:4px }
+      button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
+      button:hover { background:#1d4ed8; }
+      textarea { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
+    </style>
+  </head>
+  <body>
   <h1>TradingBot Dashboard</h1>
   <div class="muted" id="health">Comprobando estado…</div>
 
@@ -121,11 +124,18 @@
   <div class="card" style="margin-top:16px">
       <h2>PnL (Spot) – Serie temporal</h2>
       <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
-      <div style="padding:10px">
-        <canvas id="chart-pnl-fut" height="120"></canvas>
-      </div>
+    <div style="padding:10px">
+      <canvas id="chart-pnl-fut" height="120"></canvas>
     </div>
   </div>
+  <div class="card" style="margin-top:16px">
+    <h2>Comandos CLI</h2>
+    <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
+    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
+    <button id="cli-run" style="margin-top:8px">Ejecutar</button>
+    <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+</div>
 <script>
 const api = (path) => `${location.origin}${path}`;
 let pnlChart;
@@ -356,20 +366,37 @@ async function refreshPnlChart(){
   }catch(e){}
 }
 
-async function refreshPnlChartFut(){
-  try{
-    // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
-    const r = await fetch(api("/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6"));
-    const j = await r.json();
-    const pts = j.points || [];
-    const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
-    const upnl = pts.map(p => p.upnl || 0);
-    const rpnl = pts.map(p => p.rpnl || 0);
-    const net  = pts.map(p => p.net || 0);
-    const ctx = document.getElementById("chart-pnl-fut").getContext("2d");
-    buildPnlChart(ctx, labels, upnl, rpnl, net);
-  }catch(e){}
-}
+  async function refreshPnlChartFut(){
+    try{
+      // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
+      const r = await fetch(api("/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6"));
+      const j = await r.json();
+      const pts = j.points || [];
+      const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
+      const upnl = pts.map(p => p.upnl || 0);
+      const rpnl = pts.map(p => p.rpnl || 0);
+      const net  = pts.map(p => p.net || 0);
+      const ctx = document.getElementById("chart-pnl-fut").getContext("2d");
+      buildPnlChart(ctx, labels, upnl, rpnl, net);
+    }catch(e){}
+  }
+
+  async function runCli(){
+    const cmd = document.getElementById("cli-input").value;
+    if(!cmd.trim()) return;
+    try{
+      const r = await fetch(api("/cli/run"), {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({command: cmd})
+      });
+      const j = await r.json();
+      const out = (j.stdout || "") + (j.stderr ? "\n"+j.stderr : "");
+      document.getElementById("cli-output").textContent = out;
+    }catch(e){
+      document.getElementById("cli-output").textContent = String(e);
+    }
+  }
 // boot
 refreshHealth(); refreshSummary(); refreshTables();
 setInterval(refreshExposure, 5000); refreshExposure();
@@ -378,11 +405,13 @@ setInterval(refreshSpotPnL, 5000); refreshSpotPnL();
 setInterval(refreshFutureSpotPnL, 5000); refreshFutureSpotPnL();
 setInterval(refreshPnlChart, 10000); refreshPnlChart();
 setInterval(refreshPnlChartFut, 10000); refreshPnlChartFut();
-setInterval(refreshHealth, 5000);
-setInterval(refreshSummary, 5000);
-setInterval(refreshTables, 5000);
+  setInterval(refreshHealth, 5000);
+  setInterval(refreshSummary, 5000);
+  setInterval(refreshTables, 5000);
 
-</script>
+  document.getElementById("cli-run").addEventListener("click", runCli);
+
+  </script>
 </body>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </html>

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,12 +3,28 @@ from fastapi.testclient import TestClient
 from tradingbot.apps.api.main import app
 
 
+def _client() -> TestClient:
+    """Return a client authenticated with the default credentials."""
+
+    headers = {"Authorization": "Basic YWRtaW46YWRtaW4="}
+    return TestClient(app, headers=headers)
+
+
 def test_smoke():
     assert 2 + 2 == 4
 
 
 def test_metrics_endpoint_exposed():
-    client = TestClient(app)
+    client = _client()
     resp = client.get("/metrics")
     assert resp.status_code == 200
     assert "python_info" in resp.text
+
+
+def test_cli_endpoint_runs_help():
+    client = _client()
+    resp = client.post("/cli/run", json={"command": "--help"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["returncode"] == 0
+    assert "Usage" in body.get("stdout", "")


### PR DESCRIPTION
## Summary
- allow executing any `tradingbot.cli` command through a new `/cli/run` API endpoint and dashboard console
- restyle dashboard with button/textarea support
- rewrite README with step-by-step usage guide and examples

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a281333a60832db3d211d5d11736b1