### PR TITLE
docs: expand README with beginner guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ scalping y arbitraje sobre criptomonedas.  Incluye todo lo necesario para
 ingerir datos, realizar backtesting y ejecutar estrategias en modo
 ``paper`` o real desde una interfaz web.
 
+### Explicación para principiantes
+
+Un bot de trading es como un "piloto automático" que compra y vende
+criptomonedas siguiendo un conjunto de reglas.  Tú defines las reglas y el
+programa las ejecuta de forma rápida y sin emociones.  TradeBot ya trae
+estrategias listas para usar y permite probarlas sin arriesgar dinero
+gracias al **paper trading** (simulación).
+
 ## Características principales
 
 - Ingesta de datos en tiempo real (WebSocket y REST) para Binance, Bybit,
@@ -16,6 +24,55 @@ ingerir datos, realizar backtesting y ejecutar estrategias en modo
 - Backtester vectorizado y motor event‑driven con modelado de slippage.
 - **Panel web** con métricas en vivo y un **ejecutor de comandos CLI** que
   permite lanzar cualquier comando desde el navegador.
+
+## Exchanges y pares soportados
+
+- **Exchanges**: [Binance](https://www.binance.com),
+  [Bybit](https://www.bybit.com) y [OKX](https://www.okx.com).  El diseño es
+  modular y pueden añadirse más.
+- **Mercados**: pares spot y contratos perpetuos disponibles en esos
+  exchanges.
+- **Pares populares**: BTC/USDT, ETH/USDT, BNB/USDT, SOL/USDT y cualquier
+  otro listado por los exchanges anteriores.
+
+## Estrategias incluidas
+
+Cada estrategia se puede ejecutar en modo simulación o real.  A
+continuación se explica la idea teórica y cómo la implementa TradeBot.
+
+### Momentum intradía
+**Idea**: cuando un precio sube con fuerza, suele seguir subiendo a corto
+plazo.
+**Implementación**: el bot calcula el retorno de los últimos minutos y
+compra si supera un umbral; vende cuando el impulso se agota o cambia de
+signo.
+
+### Mean reversion
+**Idea**: los precios tienden a volver a su promedio después de moverse
+demasiado.
+**Implementación**: se calcula una media móvil y su desviación.  Si el
+precio está muy por encima, se vende; si está por debajo, se compra.
+
+### Breakout de volatilidad
+**Idea**: tras un periodo de calma, un movimiento brusco puede iniciar una
+nuevo recorrido de precios.
+**Implementación**: se observa la volatilidad (ATR) y se activan órdenes
+cuando el precio rompe un canal predefinido.
+
+### Arbitraje triangular
+**Idea**: en un mismo exchange, las tasas de cambio entre tres pares pueden
+quedar desalineadas.  Al hacer la ruta A→B→C→A se obtiene una ganancia
+sin exposición direccional.
+**Implementación**: el bot revisa continuamente rutas como BTC‑ETH‑USDT y
+ejecuta las tres operaciones si el beneficio neto supera las comisiones.
+
+### Arbitraje entre exchanges / cash‑and‑carry
+**Idea**: un mismo activo puede tener precios distintos entre exchanges o
+entre mercado spot y perp.  Comprar donde está barato y vender donde está
+caro permite capturar la diferencia o el pago de funding.
+**Implementación**: el bot compara precios de los exchanges conectados y
+abre posiciones opuestas (spot vs perp o exchange vs exchange) cuando la
+brecha supera un umbral configurado.
 
 ## Requisitos
 
@@ -32,6 +89,28 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env   # completa con tus claves
 ```
+
+## Ejemplos de uso
+
+Estos ejemplos utilizan datos de prueba y son seguros para principiantes.
+
+### Simular una estrategia de momentum
+
+```bash
+python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
+```
+
+El comando ejecuta la estrategia de momentum sobre el par BTC/USDT y muestra
+estadísticas como ganancias/pérdidas y número de operaciones.
+
+### Probar un arbitraje triangular
+
+```bash
+python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 50
+```
+
+El bot revisa si la ruta BTC→ETH→USDT→BTC en Binance ofrece un beneficio
+mayor a las comisiones usando un capital ficticio de 50 USDT.
 
 ## Ejecución del panel web
 


### PR DESCRIPTION
## Summary
- expand README with a beginner-friendly explanation of TradeBot
- document supported exchanges, pairs and built-in strategies
- add simple usage examples for momentum and triangular arbitrage

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a28b84d6a0832db3fb387615aaa808