### PR TITLE
feat: add correlation service

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -161,14 +161,12 @@ async def run_live_binance(
         if signal is None:
             continue
 
-        corr_pairs = guard.correlations()
         allowed, reason, delta = risk.check_order(
             symbol,
             signal.side,
             closed.c,
             strength=signal.strength,
             symbol_vol=float(bar.get("volatility", 0.0) or 0.0),
-            correlations=corr_pairs,
             corr_threshold=0.8,
         )
         if not allowed or abs(delta) <= 1e-9:

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -49,20 +49,17 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         qty = cfg.notional / last["spot"]
         spot_side = "buy" if edge > 0 else "sell"
         perp_side = "sell" if edge > 0 else "buy"
-        corr = risk.guard.correlations()
         ok1, _r1, delta1 = risk.check_order(
             cfg.symbol,
             spot_side,
             last["spot"],
             strength=qty,
-            correlations=corr,
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
             last["perp"],
             strength=qty,
-            correlations=corr,
         )
         if not (ok1 and ok2):
             return

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -117,28 +117,24 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
 
                     # Ejecutar 3 patas en PAPER
                     if edge.direction == "b->m":
-                        corr = risk.guard.correlations()
                         checks = [
                             risk.check_order(
                                 f"{cfg.route.base}/{cfg.route.quote}",
                                 "buy",
                                 last["bq"],
                                 strength=q["base_qty"],
-                                correlations=corr,
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.base}",
                                 "buy",
                                 last["mb"],
                                 strength=q["mid_qty"],
-                                correlations=corr,
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.quote}",
                                 "sell",
                                 last["mq"],
                                 strength=q["mid_qty"],
-                                correlations=corr,
                             ),
                         ]
                         if not all(c[0] for c in checks):
@@ -167,28 +163,24 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                             ("sell", f"{cfg.route.mid}/{cfg.route.quote}", abs(checks[2][2]), resp3),
                         ]
                     else:
-                        corr = risk.guard.correlations()
                         checks = [
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.quote}",
                                 "buy",
                                 last["mq"],
                                 strength=q["mid_qty"],
-                                correlations=corr,
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.base}",
                                 "sell",
                                 last["mb"],
                                 strength=q["mid_qty"],
-                                correlations=corr,
                             ),
                             risk.check_order(
                                 f"{cfg.route.base}/{cfg.route.quote}",
                                 "sell",
                                 last["bq"],
                                 strength=q["base_qty"],
-                                correlations=corr,
                             ),
                         ]
                         if not all(c[0] for c in checks):

--- a/src/tradingbot/risk/correlation_service.py
+++ b/src/tradingbot/risk/correlation_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Tuple
+import math
+
+import pandas as pd
+
+
+class CorrelationService:
+    """Maintain rolling log returns and compute symbol correlations.
+
+    Prices are fed via :meth:`update_price`, which stores log returns
+    for each symbol.  :meth:`get_correlations` returns a mapping of
+    ``{(sym_a, sym_b): corr}`` for all symbol pairs using data within the
+    configured rolling window.
+    """
+
+    def __init__(self, window: timedelta | None = None) -> None:
+        self.window = window or timedelta(hours=1)
+        self._last_price: Dict[str, float] = {}
+        self._returns = pd.DataFrame()
+
+    def update_price(
+        self,
+        symbol: str,
+        price: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        """Record new ``price`` for ``symbol`` and store its log return."""
+        if timestamp is None:
+            timestamp = datetime.now(timezone.utc)
+        # normalise timestamp to second resolution for cross-symbol alignment
+        ts = timestamp.replace(microsecond=0)
+        prev = self._last_price.get(symbol)
+        self._last_price[symbol] = price
+        if prev is None or prev <= 0 or price <= 0:
+            return
+        ret = math.log(price / prev)
+        # append return
+        self._returns.loc[ts, symbol] = ret
+        # trim window
+        cutoff = ts - self.window
+        if len(self._returns.index):
+            self._returns = self._returns.loc[self._returns.index >= cutoff]
+
+    def get_correlations(self) -> Dict[Tuple[str, str], float]:
+        """Compute pairwise correlations of returns within the window."""
+        if self._returns.empty:
+            return {}
+        now = datetime.now(timezone.utc)
+        recent = self._returns.loc[self._returns.index >= (now - self.window)]
+        if recent.shape[0] < 2:
+            return {}
+        corr = recent.corr()
+        result: Dict[Tuple[str, str], float] = {}
+        cols = list(corr.columns)
+        for i, a in enumerate(cols):
+            for b in cols[i + 1 :]:
+                val = corr.at[a, b]
+                if not pd.isna(val):
+                    result[(a, b)] = float(val)
+        return result

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -1,0 +1,73 @@
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tradingbot.risk.correlation_service import CorrelationService
+from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+
+
+def _feed_series(svc: CorrelationService, symbol: str, start: datetime, returns: list[float]) -> None:
+    price = 100.0
+    svc.update_price(symbol, price, start)
+    ts = start
+    for r in returns:
+        ts += timedelta(minutes=1)
+        price *= math.exp(r)
+        svc.update_price(symbol, price, ts)
+
+
+def test_correlation_service_basic():
+    svc = CorrelationService(window=timedelta(hours=1))
+    now = datetime.now(timezone.utc)
+    rets = [0.01, -0.02, 0.03]
+    _feed_series(svc, "AAA", now, rets)
+    _feed_series(svc, "BBB", now, rets)
+    corrs = svc.get_correlations()
+    assert corrs[("AAA", "BBB")] == pytest.approx(1.0)
+
+
+def test_correlation_service_window_rolls():
+    svc = CorrelationService(window=timedelta(minutes=30))
+    now = datetime.now(timezone.utc)
+    # datos antiguos fuera de ventana
+    svc.update_price("AAA", 100.0, now - timedelta(minutes=40))
+    svc.update_price("BBB", 100.0, now - timedelta(minutes=40))
+    svc.update_price("AAA", 101.0, now - timedelta(minutes=35))
+    svc.update_price("BBB", 99.0, now - timedelta(minutes=35))
+    assert svc.get_correlations() == {}
+    # datos recientes dentro de ventana
+    svc.update_price("AAA", 102.0, now - timedelta(minutes=10))
+    svc.update_price("BBB", 102.0, now - timedelta(minutes=10))
+    svc.update_price("AAA", 103.0, now - timedelta(minutes=5))
+    svc.update_price("BBB", 103.0, now - timedelta(minutes=5))
+    corrs = svc.get_correlations()
+    assert corrs[("AAA", "BBB")] == pytest.approx(1.0)
+
+
+def test_risk_service_uses_correlation_service():
+    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
+    rm = RiskManager(max_pos=10, vol_target=0.02)
+    corr = CorrelationService()
+    svc = RiskService(rm, guard, corr_service=corr)
+    now = datetime.now(timezone.utc)
+    price_btc = 100.0
+    price_eth = 200.0
+    corr.update_price("BTC", price_btc, now)
+    corr.update_price("ETH", price_eth, now)
+    price_btc *= math.exp(0.01)
+    price_eth *= math.exp(0.01)
+    corr.update_price("BTC", price_btc, now + timedelta(seconds=1))
+    corr.update_price("ETH", price_eth, now + timedelta(seconds=1))
+    price_btc *= math.exp(0.02)
+    price_eth *= math.exp(0.02)
+    corr.update_price("BTC", price_btc, now + timedelta(seconds=2))
+    corr.update_price("ETH", price_eth, now + timedelta(seconds=2))
+    guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
+    symbol_vol = guard.volatility("BTC")
+    base = rm.size("buy", symbol="BTC", symbol_vol=symbol_vol)
+    allowed, _, delta = svc.check_order("BTC", "buy", price=price_btc, corr_threshold=0.8)
+    assert allowed
+    assert delta == pytest.approx(base * 0.5)


### PR DESCRIPTION
## Summary
- add CorrelationService to compute rolling log return correlations
- integrate correlation lookups in RiskService and simplify runners
- test correlation calculations and risk integration

## Testing
- `pytest tests/test_risk_vol_sizing.py tests/test_correlation_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a28e4d9aa0832d88808202b3e88635