### PR TITLE
Add integration tests for recorded data flow and stress scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run unit tests
         run: pytest --cov=src --cov-report=xml -m "not integration"
       - name: Run integration tests
-        run: pytest -m integration
+        run: pytest tests -m integration

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -1,0 +1,23 @@
+# Integration Test Scenarios
+
+Este documento describe los escenarios de pruebas de integración añadidos para
+simular el flujo completo del bot de trading con datos grabados y para someter
+a estrés el motor de backtesting.
+
+## Flujo completo con datos grabados
+
+Se utiliza el conjunto `data/examples/btcusdt_1m.csv` junto a una estrategia que
+intenta comprar en cada barra. El `RiskManager` limita la posición máxima a una
+unidad, por lo que solo se ejecuta una orden. El resultado esperado es un PnL de
+aproximadamente `2.85` unidades, calculado como la diferencia entre el precio
+de cierre final y el precio promedio de la orden ejecutada. Cualquier intento de
+exceder el límite de riesgo es rechazado.
+
+## Prueba de estrés de latencia y spreads
+
+El segundo escenario ejecuta el mismo flujo bajo un `StressConfig` que duplica la
+latencia y multiplica el spread por `2`. El motor debe seguir generando fills y
+la latencia reportada en las órdenes debe reflejar el incremento.
+
+Ambas pruebas están marcadas con `@pytest.mark.integration` y se ejecutan
+automáticamente en CI mediante `pytest -m integration`.

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+from types import SimpleNamespace
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine, SlippageModel
+from tradingbot.strategies import STRATEGIES
+
+
+class AlwaysBuyStrategy:
+    name = "alwaysbuy"
+
+    def on_bar(self, context):
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+@pytest.mark.integration
+def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
+    df = pd.read_csv("data/examples/btcusdt_1m.csv")
+    monkeypatch.setitem(STRATEGIES, "alwaysbuy", AlwaysBuyStrategy)
+    engine = EventDrivenBacktestEngine(
+        {"BTC/USDT": df},
+        [("alwaysbuy", "BTC/USDT")],
+        latency=1,
+        window=1,
+        slippage=SlippageModel(volume_impact=0.0),
+    )
+    risk = engine.risk[("alwaysbuy", "BTC/USDT")]
+    risk.max_pos = 1.0
+    result = engine.run()
+    assert len(result["fills"]) == 1
+    avg_price = result["orders"][0]["avg_price"]
+    expected_pnl = df["close"].iloc[-1] - avg_price
+    assert pytest.approx(result["equity"], rel=1e-4) == expected_pnl
+    assert risk.pos.qty == 1.0

--- a/tests/integration/test_stress_resilience.py
+++ b/tests/integration/test_stress_resilience.py
@@ -1,0 +1,50 @@
+import pytest
+from types import SimpleNamespace
+
+from tradingbot.backtesting.engine import SlippageModel, StressConfig, run_backtest_csv
+from tradingbot.strategies import STRATEGIES
+
+
+class BuyOnceStrategy:
+    name = "buyonce"
+
+    def __init__(self):
+        self.sent = False
+
+    def on_bar(self, context):
+        if self.sent:
+            return None
+        self.sent = True
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+@pytest.mark.integration
+def test_engine_resilient_under_stress(monkeypatch):
+    csv_path = "data/examples/btcusdt_1m.csv"
+    monkeypatch.setitem(STRATEGIES, "buyonce", BuyOnceStrategy)
+    strategies = [("buyonce", "SYM")]
+    data = {"SYM": csv_path}
+
+    base = run_backtest_csv(
+        data,
+        strategies,
+        latency=1,
+        window=1,
+        slippage=SlippageModel(volume_impact=0.0),
+    )
+
+    stressed = run_backtest_csv(
+        data,
+        strategies,
+        latency=1,
+        window=1,
+        slippage=SlippageModel(volume_impact=0.0),
+        stress=StressConfig(latency=2.0, spread=2.0),
+    )
+    base_order = base["orders"][0]
+    stress_order = stressed["orders"][0]
+
+    assert base_order["latency"] == 1
+    assert stress_order["latency"] == 2
+
+    assert stressed["slippage"] == pytest.approx(base["slippage"] * 4)


### PR DESCRIPTION
## Summary
- add integration test exercising a full recorded trade flow validating fills, PnL and risk limits
- add stress-resilience test doubling latency and spread
- document integration scenarios and ensure CI runs them

## Testing
- `pytest tests -m integration`

------
https://chatgpt.com/codex/tasks/task_e_68a28e5ca6e0832d9e81194bb8cee8a7