### PR TITLE
feat: monitoring dashboard with metrics and controls

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -49,14 +49,27 @@ Static assets are served from `monitoring/static/` for a quick HTML view.
 
 ### Plotly dashboard
 
-The API also exposes a lightweight dashboard at `/dashboard` which polls
-`/metrics/summary` every few seconds and renders basic graphs using
-Plotly. Launch the API and open the dashboard in a browser:
+The API exposes a lightweight dashboard at `/dashboard` built with Plotly.
+It visualizes PnL, slippage and order latency and lists all strategies with
+buttons to pause or resume them remotely. To launch the API and open the
+dashboard:
 
 ```bash
 uvicorn tradingbot.apps.api.main:app --reload
 # then visit http://localhost:8000/dashboard (use API_USER/API_PASS credentials)
 ```
+
+The dashboard polls the following endpoints every few seconds:
+
+- `GET /metrics/pnl`
+- `GET /metrics/slippage`
+- `GET /metrics/latency`
+- `GET /strategies/status`
+
+When the pause/resume buttons are used the dashboard sends POST requests to
+`/strategies/{name}/disable` or `/strategies/{name}/enable`.
+
+![Dashboard](https://via.placeholder.com/800x400.png?text=Monitoring%20Dashboard)
 
 ## Grafana dashboards
 

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -15,6 +15,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 
 from monitoring.metrics import metrics_summary as _metrics_summary
+from monitoring.metrics import router as metrics_router
 from monitoring.dashboard import router as dashboard_router
 
 from ...storage.timescale import select_recent_fills
@@ -52,6 +53,7 @@ app.add_middleware(
     allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
 )
 
+app.include_router(metrics_router)
 app.include_router(dashboard_router)
 
 


### PR DESCRIPTION
## Summary
- expose metrics endpoints for PnL, slippage, and latency
- add Plotly dashboard with strategy pause/resume controls
- document monitoring setup and link external screenshot

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_metrics.py tests/test_monitoring_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68a28e5234d4832d8178a7afa3d9941e