### PR TITLE
Add configurable log file handler with JSON formatting

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -4,6 +4,10 @@ from pydantic import Field
 class Settings(BaseSettings):
     env: str = Field(default="dev")
     log_level: str = Field(default="INFO")
+    log_file: str | None = None
+    log_max_bytes: int = Field(default=10 * 1024 * 1024)
+    log_backup_count: int = Field(default=5)
+    log_json: bool = False
     sentry_dsn: str | None = None
 
     # DB

--- a/src/tradingbot/logging_conf.py
+++ b/src/tradingbot/logging_conf.py
@@ -1,4 +1,5 @@
 import logging, sys
+from logging.handlers import RotatingFileHandler
 from .config import settings
 
 try:
@@ -6,13 +7,37 @@ try:
 except Exception:  # pragma: no cover - sentry optional
     sentry_sdk = None
 
+try:  # pragma: no cover - optional dependency
+    from pythonjsonlogger import jsonlogger
+except Exception:
+    jsonlogger = None
+
+
 def setup_logging():
     level = getattr(logging, settings.log_level.upper(), logging.INFO)
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
-    )
+
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+
+    if settings.log_file:
+        handlers.append(
+            RotatingFileHandler(
+                settings.log_file,
+                maxBytes=settings.log_max_bytes,
+                backupCount=settings.log_backup_count,
+            )
+        )
+
+    logging.basicConfig(level=level, handlers=handlers)
+
+    if settings.log_json and jsonlogger is not None:
+        formatter: logging.Formatter = jsonlogger.JsonFormatter()
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+        )
+
+    for handler in handlers:
+        handler.setFormatter(formatter)
 
     if settings.sentry_dsn and sentry_sdk is not None:
         sentry_sdk.init(dsn=settings.sentry_dsn, environment=settings.env)


### PR DESCRIPTION
## Summary
- add optional log file and rotation settings to Settings
- enhance setup_logging with RotatingFileHandler and optional JSON formatting

## Testing
- `pytest tests/test_smoke.py -q` *(fails: ModuleNotFoundError: No module named 'monitoring')*


------
https://chatgpt.com/codex/tasks/task_e_68a29d820520832dad4138ed323200ed