### PR TITLE
Randomize WS reconnect delay in ExchangeConnector

### DIFF
--- a/src/tradingbot/connectors/base.py
+++ b/src/tradingbot/connectors/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import random
 from datetime import datetime
 from typing import Any, Awaitable, Callable, List, Tuple
 
@@ -163,7 +164,8 @@ class ExchangeConnector:
                 raise
             except Exception as e:  # pragma: no cover - network/streaming
                 self.log.warning("ws_reconnect", extra={"err": str(e)})
-                await asyncio.sleep(backoff)
+                delay = backoff * random.uniform(0.5, 1.5)
+                await asyncio.sleep(delay)
                 backoff = min(backoff * 2, 60)
 
     async def stream_trades(self, symbol: str):
@@ -189,7 +191,8 @@ class ExchangeConnector:
                 raise
             except Exception as e:  # pragma: no cover - network/streaming
                 self.log.warning("ws_reconnect", extra={"err": str(e)})
-                await asyncio.sleep(backoff)
+                delay = backoff * random.uniform(0.5, 1.5)
+                await asyncio.sleep(delay)
                 backoff = min(backoff * 2, 60)
 
     # --- methods to be implemented by subclasses ---

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -111,7 +111,8 @@ async def test_stream_reconnect(monkeypatch, caplog):
     await gen.aclose()
 
     assert any("ws_reconnect" in r.message for r in caplog.records)
-    assert [s for s in sleeps if s >= 1] == [1]
+    assert len(sleeps) == 1
+    assert 0.5 <= sleeps[0] <= 1.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add jittered backoff to ExchangeConnector order book and trade streaming reconnects
- update connector tests for randomized reconnect delay

## Testing
- `pytest tests/test_connectors.py::test_stream_reconnect tests/test_connectors.py::test_trade_stream_reconnect -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2b32f6a1c832d9ff37166a257a111