### PR TITLE
feat(api): add risk control endpoints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,18 @@ import pathlib
 import pytest
 
 sys.path.append(str(pathlib.Path(__file__).parent))
+root_dir = pathlib.Path(__file__).resolve().parents[1]
+if str(root_dir) not in sys.path:
+    sys.path.append(str(root_dir))
+# Ensure the src package is importable
+sys.path.append(str(root_dir / "src"))
+
 from fixtures.market import (  # noqa: E402, F401
     synthetic_trades,
     synthetic_l2,
     synthetic_volatility,
     dual_testnet,
 )
-
-# Ensure the src package is importable
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from tradingbot.adapters.base import ExchangeAdapter  # noqa: E402
 from tradingbot.execution.paper import PaperAdapter  # noqa: E402


### PR DESCRIPTION
## Summary
- add `/risk/halt` endpoint to publish halt reasons on event bus
- add `/risk/reset` endpoint to reset risk manager state
- extend tests to cover new risk endpoints and adjust path setup

## Testing
- `pytest tests/test_api_auth.py tests/test_risk_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2b33348d8832db1c70c8232fa9735