### PR TITLE
feat: add walk-forward MLflow CLI

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -161,3 +161,24 @@ wf_results = walk_forward_optimize(
 )
 print(wf_results)
 ```
+
+## Optimización walk-forward con MLflow
+
+La utilidad `bin/walk_forward_example.py` ejecuta un ciclo de optimización
+por ventana y registra los resultados en MLflow.  Primero inicia la interfaz
+de usuario de MLflow:
+
+```bash
+mlflow ui --backend-store-uri ./mlruns
+```
+
+En otra terminal ejecuta la optimización:
+
+```bash
+python bin/walk_forward_example.py data/examples/btcusdt_1m.csv BTC/USDT \
+    --mlflow-uri ./mlruns --experiment walk-forward-demo
+```
+
+Cada ventana queda registrada como un run separado con métricas como
+`test_equity`, `test_sharpe` y `test_drawdown`.  En el dashboard se pueden
+comparar fácilmente los resultados promedio y por ventana.

--- a/src/tradingbot/experiments/mlflow_utils.py
+++ b/src/tradingbot/experiments/mlflow_utils.py
@@ -13,6 +13,8 @@ def start_run(
     run_name: str | None = None,
     params: Dict[str, Any] | None = None,
     tags: Dict[str, str] | None = None,
+    *,
+    nested: bool = False,
 ) -> Iterator[None]:
     """Start an MLflow run under ``experiment`` and log optional params.
 
@@ -26,10 +28,13 @@ def start_run(
         Extra parameters to log once the run starts.
     tags:
         Optional tags for the run.
+    nested:
+        When ``True`` the run is started as a nested run under the currently
+        active MLflow run.
     """
 
     mlflow.set_experiment(experiment)
-    with mlflow.start_run(run_name=run_name, tags=tags):
+    with mlflow.start_run(run_name=run_name, tags=tags, nested=nested):
         if params:
             mlflow.log_params(params)
         yield
@@ -42,3 +47,5 @@ def log_backtest_metrics(result: Dict[str, Any]) -> None:
     mlflow.log_metric("fills", len(result.get("fills", [])))
     if "sharpe" in result:
         mlflow.log_metric("sharpe", float(result["sharpe"]))
+    if "max_drawdown" in result:
+        mlflow.log_metric("max_drawdown", float(result["max_drawdown"]))

--- a/src/tradingbot/experiments/optimization.py
+++ b/src/tradingbot/experiments/optimization.py
@@ -14,6 +14,8 @@ def optimize(
     n_trials: int = 20,
     experiment: str = "optimization",
     direction: str = "maximize",
+    study_name: str | None = None,
+    storage: str | None = None,
 ) -> optuna.study.Study:
     """Run a generic Optuna optimisation for a backtest function.
 
@@ -32,15 +34,38 @@ def optimize(
         MLflow experiment name used to record each trial.
     direction:
         Direction of optimisation (``"maximize"`` or ``"minimize"``).
+    study_name:
+        Optional study name.  If provided together with ``storage`` the study
+        will be resumed if it already exists.
+    storage:
+        Storage URL used by Optuna to persist studies, e.g. ``"sqlite:///db"``.
     """
 
     def objective(trial: optuna.Trial) -> float:
         params = {name: suggest(trial) for name, suggest in param_space.items()}
-        with start_run(experiment, run_name=f"trial_{trial.number}", params=params):
+        with start_run(
+            experiment,
+            run_name=f"trial_{trial.number}",
+            params=params,
+        ):
             result = backtest_fn(params)
             log_backtest_metrics(result)
+            # Store additional metrics in the trial for later analysis
+            trial.set_user_attr("params", params)
+            if "sharpe" in result:
+                trial.set_user_attr("sharpe", float(result["sharpe"]))
+            if "max_drawdown" in result:
+                trial.set_user_attr("max_drawdown", float(result["max_drawdown"]))
             return float(result.get("equity", 0.0))
 
-    study = optuna.create_study(direction=direction)
+    if storage and study_name:
+        study = optuna.create_study(
+            direction=direction,
+            study_name=study_name,
+            storage=storage,
+            load_if_exists=True,
+        )
+    else:
+        study = optuna.create_study(direction=direction)
     study.optimize(objective, n_trials=n_trials)
     return study

--- a/src/tradingbot/experiments/walk_forward.py
+++ b/src/tradingbot/experiments/walk_forward.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any, Dict, List
+
+import mlflow
+
+from .mlflow_utils import start_run
+from ..backtesting.engine import walk_forward_optimize
+
+
+def run_walk_forward_experiment(
+    csv_path: str,
+    symbol: str,
+    strategy: str,
+    param_grid: List[Dict[str, Any]],
+    *,
+    train_size: int | None = None,
+    test_size: int | None = None,
+    n_splits: int | None = None,
+    embargo: float = 0.0,
+    experiment: str = "walk-forward",
+    latency: int = 1,
+    window: int = 120,
+) -> Dict[str, Any]:
+    """Run walk-forward optimisation and log results to MLflow.
+
+    The function executes :func:`walk_forward_optimize` using the provided
+    parameters and records the metrics of each split in individual MLflow runs.
+    An aggregate run summarises the average test metrics to ease comparison in
+    the MLflow UI.
+    """
+
+    results = walk_forward_optimize(
+        csv_path,
+        symbol,
+        strategy,
+        param_grid,
+        train_size=train_size,
+        test_size=test_size,
+        latency=latency,
+        window=window,
+        n_splits=n_splits,
+        embargo=embargo,
+    )
+
+    if not results:
+        return {"results": [], "avg_test_equity": 0.0}
+
+    with start_run(experiment, run_name="walk_forward"):
+        for rec in results:
+            with start_run(
+                experiment,
+                run_name=f"split_{rec['split']}",
+                params=rec.get("params"),
+                nested=True,
+            ):
+                mlflow.log_metric("train_equity", float(rec.get("train_equity", 0.0)))
+                mlflow.log_metric("test_equity", float(rec.get("test_equity", 0.0)))
+                if "train_sharpe" in rec:
+                    mlflow.log_metric("train_sharpe", float(rec["train_sharpe"]))
+                if "test_sharpe" in rec:
+                    mlflow.log_metric("test_sharpe", float(rec["test_sharpe"]))
+                if "train_drawdown" in rec:
+                    mlflow.log_metric("train_drawdown", float(rec["train_drawdown"]))
+                if "test_drawdown" in rec:
+                    mlflow.log_metric("test_drawdown", float(rec["test_drawdown"]))
+
+        avg_test_equity = mean(r.get("test_equity", 0.0) for r in results)
+        mlflow.log_metric("avg_test_equity", avg_test_equity)
+        if any("test_sharpe" in r for r in results):
+            avg_test_sharpe = mean(r.get("test_sharpe", 0.0) for r in results)
+            mlflow.log_metric("avg_test_sharpe", avg_test_sharpe)
+        if any("test_drawdown" in r for r in results):
+            avg_test_drawdown = mean(r.get("test_drawdown", 0.0) for r in results)
+            mlflow.log_metric("avg_test_drawdown", avg_test_drawdown)
+
+    return {"results": results, "avg_test_equity": avg_test_equity}

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -7,6 +7,8 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from tradingbot.backtesting.engine import purged_kfold, walk_forward_optimize
+from tradingbot.experiments.walk_forward import run_walk_forward_experiment
+import mlflow
 
 
 def test_purged_kfold_partitions():
@@ -51,3 +53,34 @@ def test_walk_forward_optimize(tmp_path):
         assert rec["split"] == i
         assert "train_equity" in rec and "test_equity" in rec
         assert rec["params"] is not None
+
+
+def test_walk_forward_mlflow(tmp_path):
+    n = 30
+    df = pd.DataFrame(
+        {
+            "close": [float(i) for i in range(1, n + 1)],
+            "high": [float(i) + 0.5 for i in range(1, n + 1)],
+            "low": [float(i) - 0.5 for i in range(1, n + 1)],
+            "volume": [100.0] * n,
+        }
+    )
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+
+    params = [{"rsi_n": 2, "rsi_threshold": 55}, {"rsi_n": 2, "rsi_threshold": 65}]
+
+    mlflow.set_tracking_uri(str(tmp_path))
+    exp_name = "wf_test"
+    res = run_walk_forward_experiment(
+        str(csv_path),
+        "FOO/USDT",
+        "momentum",
+        params,
+        n_splits=2,
+        experiment=exp_name,
+    )
+    exp = mlflow.get_experiment_by_name(exp_name)
+    assert exp is not None
+    avg = sum(r["test_equity"] for r in res["results"]) / len(res["results"])
+    assert res["avg_test_equity"] == avg


### PR DESCRIPTION
## Summary
- log drawdown and support nested MLflow runs
- add Optuna study resumption and metric logging
- record walk-forward window metrics in MLflow and provide CLI example

## Testing
- `pytest tests/test_walk_forward.py`

------
https://chatgpt.com/codex/tasks/task_e_68a331429f64832dabadc39a1dfa8dd5