### PR TITLE
feat: add funding and open interest ingestion

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,14 @@ python -m tradingbot.cli backtest-cfg src/tradingbot/config/config.yaml
 python -m tradingbot.cli report --venue binance_spot_testnet
 python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 100
 python -m tradingbot.cli cross-arb BTC/USDT binance_spot binance_futures --threshold 0.001 --notional 50
+python bin/download_history.py funding kaiko BTC-USD --exchange binance --backend csv
+python bin/download_history.py open-interest coinapi BTCUSD --backend csv
 ```
+
+Los nuevos comandos `funding` y `open-interest` de `bin/download_history.py`
+permiten descargar tasas de funding y datos de open interest utilizando
+conectores REST de Kaiko o CoinAPI y persistirlos en TimescaleDB, QuestDB o
+archivos CSV.
 
 `tri-arb` lanza un pequeño lazo de arbitraje triangular en Binance. La ruta se
 especifica como ``BASE-MID-QUOTE`` (p.ej. ``BTC-ETH-USDT``) y ``--notional``

--- a/src/tradingbot/connectors/coinapi.py
+++ b/src/tradingbot/connectors/coinapi.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime
-from typing import List
+from typing import Any, Iterable, List
 
 import httpx
 
-from .base import OrderBook, Trade
+from .base import Funding, OpenInterest, OrderBook, Trade
 
 
 class CoinAPIConnector:
@@ -26,8 +27,9 @@ class CoinAPIConnector:
     name = "coinapi"
     _BASE_URL = "https://rest.coinapi.io/v1"
 
-    def __init__(self, api_key: str | None = None) -> None:
+    def __init__(self, api_key: str | None = None, rate_limit: int = 5) -> None:
         self.api_key = api_key or os.getenv("COINAPI_KEY", "")
+        self._sem = asyncio.Semaphore(rate_limit)
 
     async def fetch_trades(self, symbol: str, limit: int = 100) -> List[Trade]:
         url = f"{self._BASE_URL}/trades/{symbol}"
@@ -68,3 +70,126 @@ class CoinAPIConnector:
         bids = [(float(b.get("price")), float(b.get("size"))) for b in bids_raw]
         asks = [(float(a.get("price")), float(a.get("size"))) for a in asks_raw]
         return OrderBook(timestamp=dt, exchange=self.name, symbol=symbol, bids=bids, asks=asks)
+
+    async def _paginate(
+        self,
+        url: str,
+        params: dict[str, Any],
+        headers: dict[str, str],
+        max_pages: int | None = None,
+    ) -> Iterable[dict]:
+        """Generic pagination helper for CoinAPI REST endpoints."""
+
+        results: list[dict] = []
+        page = 0
+        async with httpx.AsyncClient() as client:
+            next_time: str | None = None
+            while True:
+                req_params = params.copy()
+                if next_time:
+                    req_params["start_time"] = next_time
+                async with self._sem:
+                    resp = await client.get(url, params=req_params, headers=headers)
+                resp.raise_for_status()
+                payload = resp.json()
+                items = payload.get("data") if isinstance(payload, dict) else payload
+                results.extend(items)
+                next_time = payload.get("next_time") if isinstance(payload, dict) else None
+                page += 1
+                if not next_time or (max_pages and page >= max_pages):
+                    break
+        return results
+
+    async def fetch_funding(
+        self,
+        symbol: str,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 1000,
+        max_pages: int | None = None,
+    ) -> List[Funding]:
+        """Fetch historical funding rates for *symbol* using CoinAPI."""
+
+        url = f"{self._BASE_URL}/futures/funding_rates/{symbol}"
+        headers = {"X-CoinAPI-Key": self.api_key}
+        params: dict[str, Any] = {"limit": limit}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
+
+        raw = await self._paginate(url, params, headers, max_pages)
+        records: list[Funding] = []
+        for f in raw:
+            ts = f.get("time_period_start") or f.get("time") or f.get("timestamp") or ""
+            dt = (
+                datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                if isinstance(ts, str) and ts
+                else datetime.utcnow()
+            )
+            records.append(
+                Funding(
+                    timestamp=dt,
+                    exchange=self.name,
+                    symbol=symbol,
+                    rate=float(
+                        f.get("funding_rate")
+                        or f.get("rate")
+                        or f.get("value")
+                        or 0.0
+                    ),
+                )
+            )
+        return records
+
+    async def fetch_open_interest(
+        self,
+        symbol: str,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 1000,
+        max_pages: int | None = None,
+    ) -> List[OpenInterest]:
+        """Fetch historical open interest using CoinAPI."""
+
+        url = f"{self._BASE_URL}/futures/open_interest/{symbol}"
+        headers = {"X-CoinAPI-Key": self.api_key}
+        params: dict[str, Any] = {"limit": limit}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
+
+        raw = await self._paginate(url, params, headers, max_pages)
+        records: list[OpenInterest] = []
+        for r in raw:
+            ts = (
+                r.get("time_period_start")
+                or r.get("time")
+                or r.get("timestamp")
+                or ""
+            )
+            dt = (
+                datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                if isinstance(ts, str) and ts
+                else datetime.utcnow()
+            )
+            records.append(
+                OpenInterest(
+                    timestamp=dt,
+                    exchange=self.name,
+                    symbol=symbol,
+                    oi=float(
+                        r.get("open_interest")
+                        or r.get("openInterest")
+                        or r.get("oi")
+                        or r.get("value")
+                        or 0.0
+                    ),
+                )
+            )
+        return records
+
+    fetch_oi = fetch_open_interest

--- a/tests/test_data_ingestion_batch.py
+++ b/tests/test_data_ingestion_batch.py
@@ -5,7 +5,9 @@ import pytest
 from tradingbot.workers import OrderBookBatchWorker, run_orderbook_ingestion
 from tradingbot.data.ingestion import (
     download_coinapi_open_interest,
+    download_kaiko_open_interest,
     download_funding,
+    download_kaiko_funding,
 )
 
 
@@ -92,7 +94,7 @@ async def test_run_orderbook_ingestion_batches(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_download_open_interest_persists(monkeypatch):
+async def test_download_coinapi_open_interest_persists(monkeypatch):
     ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
 
     class DummyConnector:
@@ -115,6 +117,32 @@ async def test_download_open_interest_persists(monkeypatch):
     )
     await download_coinapi_open_interest(DummyConnector(), "BTCUSDT")
     assert inserted and inserted[0]["oi"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_download_kaiko_open_interest_persists(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    class DummyConnector:
+        name = "dummy"
+
+        async def fetch_open_interest(self, exchange, pair, **params):
+            return [{"timestamp": ts, "oi": 5.0}]
+
+    inserted = []
+
+    class DummyStorage:
+        def get_engine(self):
+            return "engine"
+
+        def insert_open_interest(self, engine, **data):
+            inserted.append(data)
+
+    monkeypatch.setattr(
+        "tradingbot.data.ingestion._get_storage", lambda backend: DummyStorage()
+    )
+    await download_kaiko_open_interest(DummyConnector(), "ex", "BTCUSD")
+    assert inserted and inserted[0]["oi"] == 5.0
 
 
 @pytest.mark.asyncio
@@ -141,3 +169,29 @@ async def test_download_funding_persists(monkeypatch):
     )
     await download_funding(DummyConnector(), "BTCUSDT")
     assert inserted and inserted[0]["rate"] == 0.05
+
+
+@pytest.mark.asyncio
+async def test_download_kaiko_funding_persists(monkeypatch):
+    ts = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    class DummyConnector:
+        name = "dummy"
+
+        async def fetch_funding(self, exchange, pair, **params):
+            return [{"timestamp": ts, "rate": 0.02, "interval_sec": 12}]
+
+    inserted = []
+
+    class DummyStorage:
+        def get_engine(self):
+            return "engine"
+
+        def insert_funding(self, engine, **data):
+            inserted.append(data)
+
+    monkeypatch.setattr(
+        "tradingbot.data.ingestion._get_storage", lambda backend: DummyStorage()
+    )
+    await download_kaiko_funding(DummyConnector(), "ex", "BTCUSD")
+    assert inserted and inserted[0]["rate"] == 0.02


### PR DESCRIPTION
## Summary
- implement Kaiko and CoinAPI funding and open interest REST helpers with pagination and rate limiting
- extend ingestion to persist funding and open interest with retry/batching and new Kaiko helpers
- expose CLI commands and docs examples for downloading funding and open interest

## Testing
- `pytest tests/test_data_ingestion.py tests/test_data_ingestion_batch.py`

------
https://chatgpt.com/codex/tasks/task_e_68a331300594832d90a05bb7e3bdf7c6