### PR TITLE
Add production monitoring stack with Grafana provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+MONITORING_COMPOSE=docker-compose.prod.yml
+
+.PHONY: monitoring-up monitoring-down monitoring-update
+
+monitoring-up:
+	docker-compose -f $(MONITORING_COMPOSE) up -d
+
+monitoring-down:
+	docker-compose -f $(MONITORING_COMPOSE) down
+
+monitoring-update:
+	docker-compose -f $(MONITORING_COMPOSE) pull
+	docker-compose -f $(MONITORING_COMPOSE) up -d --remove-orphans

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    depends_on:
+      - alertmanager
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/data
+    ports:
+      - "9093:9093"
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./monitoring/grafana/users:/etc/grafana/provisioning/users
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:
+  alertmanager-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,10 +60,13 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
       - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./monitoring/grafana/users:/etc/grafana/provisioning/users
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
     depends_on:
       - prometheus

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -162,3 +162,43 @@ docker-compose up -d --force-recreate prometheus alertmanager
 
 The monitoring panel exposes active alerts at `GET /alerts` and also
 includes them in `GET /summary`.
+
+## Production deployment
+
+The `docker-compose.prod.yml` file launches Prometheus, Alertmanager and
+Grafana with persistent volumes. Grafana credentials are read from the
+`GF_ADMIN_USER` and `GF_ADMIN_PASSWORD` environment variables, and
+dashboards, data sources and users under `monitoring/grafana/` are provisioned
+automatically.
+
+Run the stack:
+
+```bash
+make monitoring-up
+```
+
+Update to the latest images:
+
+```bash
+make monitoring-update
+```
+
+Stop all services:
+
+```bash
+make monitoring-down
+```
+
+Prometheus retention can be tuned with `PROMETHEUS_RETENTION` (defaults to
+`30d`).
+
+### TLS and authentication
+
+Enable HTTPS in Grafana by setting `GF_SERVER_PROTOCOL=https` and providing
+`GF_SERVER_CERT_FILE` and `GF_SERVER_CERT_KEY`. User sign-ups are disabled via
+`GF_USERS_ALLOW_SIGN_UP=false`; additional accounts can be defined in
+`monitoring/grafana/users/users.yml`.
+
+Prometheus and Alertmanager do not ship with TLS or authentication. Place
+them behind a reverse proxy such as Nginx or Traefik configured with TLS
+certificates and optional HTTP basic authentication to secure access.

--- a/monitoring/grafana/users/users.yml
+++ b/monitoring/grafana/users/users.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+users:
+  - name: viewer
+    email: viewer@example.com
+    login: viewer
+    password: viewerpass
+    isAdmin: false


### PR DESCRIPTION
## Summary
- add `docker-compose.prod.yml` to run Prometheus, Alertmanager and Grafana with persistent volumes and configurable credentials
- provision Grafana dashboards, datasources and sample users; add Makefile targets for managing the stack
- document production deployment with TLS/authentication guidance

## Testing
- `pytest` *(fails: process killed)*
- `make -n monitoring-up`


------
https://chatgpt.com/codex/tasks/task_e_68a33139dd54832d96860af351c783db