### PR TITLE
Add paper-run CLI with paper trading metrics

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,6 +9,7 @@ controlar estrategias.  A continuación algunos ejemplos rápidos.
 python -m tradingbot.cli ingest --symbol BTC/USDT
 python -m tradingbot.cli run-bot --symbol BTC/USDT
 python -m tradingbot.cli backtest data/btcusdt_1m.csv --symbol BTC/USDT --strategy breakout_atr
+python -m tradingbot.cli paper-run --strategy breakout_atr --symbol BTC/USDT
 python -m tradingbot.cli backtest-cfg src/tradingbot/config/config.yaml
 python -m tradingbot.cli report --venue binance_spot_testnet
 python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 100
@@ -29,6 +30,13 @@ define el capital en la divisa ``quote``.
 `cross-arb` busca oportunidades de arbitraje entre un mercado spot y otro
 perpetuo utilizando los adapters indicados. El umbral de premium se controla con
 ``--threshold`` y ``--notional`` establece el tamaño por pata.
+
+`paper-run` permite ejecutar cualquier estrategia en modo papel y expone las
+métricas de Prometheus en `http://localhost:8000/metrics`.
+
+```bash
+python -m tradingbot.cli paper-run --strategy breakout_atr --symbol BTC/USDT
+```
 
 El **daemon en vivo** ahora puede ejecutar este arbitraje cruzado de manera
 automática entre Binance, Bybit y OKX.  El proceso concilia periódicamente los

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -190,6 +190,20 @@ def run_bot(
         asyncio.run(run_live_binance(symbol=symbols[0]))
 
 
+@app.command("paper-run")
+def paper_run(
+    symbol: str = typer.Option("BTC/USDT", "--symbol", help="Trading symbol"),
+    strategy: str = typer.Option("breakout_atr", help="Strategy name"),
+    metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
+) -> None:
+    """Run a strategy in paper trading mode with metrics."""
+
+    setup_logging()
+    from ..live.runner_paper import run_paper
+
+    asyncio.run(run_paper(symbol=symbol, strategy_name=strategy, metrics_port=metrics_port))
+
+
 @app.command("daemon")
 def run_daemon(config: str = "config/config.yaml") -> None:
     """Launch the :class:`TradeBotDaemon` using a Hydra configuration."""

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import pytest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import types, sys
+
+# runner_paper indirectly imports a module missing in tests; inject a stub
+binance_ws_stub = types.ModuleType("tradingbot.adapters.binance_ws")
+binance_ws_stub.BinanceWSAdapter = object
+sys.modules.setdefault("tradingbot.adapters.binance_ws", binance_ws_stub)
+
+from tradingbot.live import runner_paper as rp
+
+
+class DummyWS:
+    async def stream_trades(self, symbol):
+        yield {"ts": datetime.now(timezone.utc), "price": 100.0, "qty": 1.0}
+
+
+class DummyAgg:
+    def on_trade(self, ts, px, qty):
+        return SimpleNamespace(c=px)
+
+    def last_n_bars_df(self, n):
+        return pd.DataFrame({"c": [1.0] * 200})
+
+
+class DummyStrat:
+    def on_bar(self, ctx):
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+class DummyRisk:
+    def __init__(self, *a, **k):
+        pass
+
+    def mark_price(self, symbol, price):
+        pass
+
+    def check_order(self, symbol, side, price, strength=1.0, **_):
+        return True, "", 1.0
+
+    def on_fill(self, symbol, side, qty, venue=None):
+        pass
+
+
+class DummyRouter:
+    last_order = None
+
+    def __init__(self, adapters):
+        self.adapters = {"paper": DummyBroker()}
+
+    async def execute(self, order, algo=None, **kwargs):
+        DummyRouter.last_order = order
+        return {"status": "ok"}
+
+
+class DummyBroker:
+    def update_last_price(self, symbol, px):
+        pass
+
+
+class DummyServer:
+    def __init__(self, config):
+        self.should_exit = False
+
+    async def serve(self):
+        return
+
+
+@pytest.mark.asyncio
+async def test_run_paper(monkeypatch):
+    monkeypatch.setattr(rp, "BinanceWSAdapter", lambda: DummyWS())
+    monkeypatch.setattr(rp, "BarAggregator", DummyAgg)
+    monkeypatch.setattr(rp, "STRATEGIES", {"dummy": DummyStrat})
+    monkeypatch.setattr(rp, "RiskManager", lambda *a, **k: None)
+    monkeypatch.setattr(rp, "PortfolioGuard", lambda *a, **k: None)
+    monkeypatch.setattr(rp, "RiskService", lambda *a, **k: DummyRisk())
+    monkeypatch.setattr(rp, "ExecutionRouter", DummyRouter)
+    monkeypatch.setattr(rp, "PaperAdapter", DummyBroker)
+    monkeypatch.setattr(rp.uvicorn, "Server", DummyServer)
+
+    await rp.run_paper(symbol="BTC/USDT", strategy_name="dummy")
+
+    assert DummyRouter.last_order.symbol == "BTC/USDT"


### PR DESCRIPTION
## Summary
- add `paper-run` subcommand to run strategies in paper trading mode and expose metrics
- document paper-run usage and metrics endpoint
- test paper-run flow with stubbed components

## Testing
- `pytest tests/test_paper_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3396e1738832d906744ff67c847f3