### PR TITLE
Docs: expand README and enhance dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,75 +89,53 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env   # completa con tus claves
 ```
+## Configuración inicial
 
-## Ejemplos de uso
+1. Copia `.env.example` a `.env` y completa tus claves API (`BINANCE_KEY`,
+   `BINANCE_SECRET`, etc.). Para pruebas en modo papel puedes dejar los
+   valores vacíos.
+2. (Opcional) Levanta la base de datos y el stack de monitoreo con Docker:
 
-Estos ejemplos utilizan datos de prueba y son seguros para principiantes.
+   ```bash
+   docker-compose up -d
+   ```
 
-### Simular una estrategia de momentum
+3. Inicia el panel web con métricas y consola de comandos:
 
-```bash
-python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
-```
+   ```bash
+   uvicorn monitoring.panel:app --reload --port 8000
+   ```
 
-El comando ejecuta la estrategia de momentum sobre el par BTC/USDT y muestra
-estadísticas como ganancias/pérdidas y número de operaciones.
+   Luego visita `http://localhost:8000` en tu navegador.
 
-### Probar un arbitraje triangular
+## Comandos CLI
 
-```bash
-python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 50
-```
-
-El bot revisa si la ruta BTC→ETH→USDT→BTC en Binance ofrece un beneficio
-mayor a las comisiones usando un capital ficticio de 50 USDT.
-
-## Ejecución del panel web
-
-El panel expone métricas, PnL y una consola para ejecutar comandos de la
-CLI.
+Todos los comandos están disponibles tanto desde la terminal como desde la
+consola del panel web.
 
 ```bash
-uvicorn tradingbot.apps.api.main:app --reload --port 8000
+python -m tradingbot.cli <comando> [opciones]
 ```
 
-Visita `http://localhost:8000` e inicia sesión con las credenciales
-definidas en `API_USER`/`API_PASS` (por defecto `admin`/`admin`).
+| Comando | Descripción | Ejemplo |
+|---------|-------------|---------|
+| `ingest` | Stream de order book a la base de datos | `python -m tradingbot.cli ingest BTC/USDT --depth 20` |
+| `ingest-historical` | Descarga histórica desde Kaiko o CoinAPI | `python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades` |
+| `run-bot` | Ejecuta el bot en vivo o testnet | `python -m tradingbot.cli run-bot --exchange binance --symbol BTC/USDT` |
+| `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr` |
+| `daemon` | Levanta el daemon de trading mediante Hydra | `python -m tradingbot.cli daemon config/config.yaml` |
+| `ingestion-workers` | Workers de funding y open interest | `python -m tradingbot.cli ingestion-workers` |
+| `backtest` | Backtest vectorizado desde CSV | `python -m tradingbot.cli backtest data/ohlcv.csv` |
+| `backtest-cfg` | Backtest desde un YAML de configuración | `python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml` |
+| `walk-forward` | Optimización walk-forward | `python -m tradingbot.cli walk-forward cfg/wf.yaml` |
+| `report` | Resumen de PnL en TimescaleDB | `python -m tradingbot.cli report` |
+| `train-ml` | Entrena una estrategia con ML | `python -m tradingbot.cli train-ml datos.csv target modelo.pkl` |
+| `tri-arb` | Arbitraje triangular | `python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 50` |
+| `cross-arb` | Arbitraje spot vs perp entre exchanges | `python -m tradingbot.cli cross-arb BTC/USDT binance_spot binance_futures` |
+| `run-cross-arb` | Runner de arbitraje usando ExecutionRouter | `python -m tradingbot.cli run-cross-arb BTC/USDT binance_spot binance_futures` |
 
-### Consola de comandos
-
-En la sección **Comandos CLI** del panel puedes ejecutar cualquier comando
-de `tradingbot.cli`.  Ejemplos:
-
-1. Escribe `backtest-cfg data/examples/backtest.yaml` y pulsa **Ejecutar**.
-2. Usa `tri-arb BTC-ETH-USDT --notional 50` para disparar un arbitraje
-   triangular de prueba.
-
-La salida de `stdout` y `stderr` aparecerá debajo del formulario.
-
-## Uso desde la línea de comandos
-
-La CLI está basada en [Typer](https://typer.tiangolo.com/) y ofrece
-subcomandos para las distintas tareas del proyecto.
-
-```bash
-python -m tradingbot.cli --help
-
-# Ingesta de libro de órdenes
-python -m tradingbot.cli ingest BTC/USDT --depth 20
-
-# Descarga histórica desde Kaiko
-python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades
-
-# Backtest a partir de un YAML de configuración
-python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml
-
-# Arbitraje triangular
-python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 50
-```
-
-Todos estos comandos pueden ejecutarse también desde el panel web gracias a
-la nueva sección de **Comandos CLI**.
+La salida de cada comando aparecerá tanto en la terminal como en la consola
+del panel web.
 
 ## Ejecutar pruebas
 

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -2,52 +2,100 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>TradeBot Monitoring</title>
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <title>TradeBot Dashboard</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
   <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    section { margin-bottom: 1.5rem; }
+    body { padding: 20px; }
+    #cli-output { white-space: pre-wrap; }
   </style>
 </head>
 <body>
-  <div id="root"></div>
-  <script>
-    const { useState, useEffect } = React;
+  <section class="section">
+    <h1 class="title">TradeBot Monitoring</h1>
+    <div class="columns">
+      <div class="column">
+        <div id="pnl" class="box" style="height:300px;"></div>
+        <div id="slippage" class="box" style="height:300px;"></div>
+        <div id="latency" class="box" style="height:300px;"></div>
+      </div>
+    </div>
 
-    function App() {
-      const [state, setState] = useState({metrics:null, pnl:null, risk:null});
+    <h2 class="subtitle">Estrategias</h2>
+    <table class="table is-fullwidth is-striped" id="strategy-table">
+      <thead><tr><th>Nombre</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <tbody></tbody>
+    </table>
 
-      useEffect(() => {
-        const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
-        const ws = new WebSocket(`${protocol}://${location.host}/ws/summary`);
-        ws.onmessage = (evt) => {
-          try { setState(JSON.parse(evt.data)); } catch (e) { console.error(e); }
-        };
-        ws.onerror = console.error;
-        return () => ws.close();
-      }, []);
+    <h2 class="subtitle">Comandos CLI</h2>
+    <div class="field has-addons">
+      <div class="control is-expanded">
+        <input id="cli-cmd" class="input" placeholder="backtest-cfg data/examples/backtest.yaml" />
+      </div>
+      <div class="control">
+        <button class="button is-primary" onclick="runCLI()">Ejecutar</button>
+      </div>
+    </div>
+    <pre id="cli-output" class="box"></pre>
+  </section>
 
-      const section = (title, data) =>
-        React.createElement('section', null,
-          React.createElement('h2', null, title),
-          data ? React.createElement('pre', null, JSON.stringify(data, null, 2)) : 'Loading...'
-        );
+<script>
+const pnlTrace = {x: [], y: [], mode: 'lines', name: 'PnL'};
+const slippageTrace = {x: [], y: [], mode: 'lines', name: 'Slippage'};
+const latencyTrace = {x: [], y: [], mode: 'lines', name: 'Latency'};
+Plotly.newPlot('pnl', [pnlTrace], {title: 'PnL'});
+Plotly.newPlot('slippage', [slippageTrace], {title: 'Slippage (bps)'});
+Plotly.newPlot('latency', [latencyTrace], {title: 'Order Latency (s)'});
 
-      return React.createElement('div', null, [
-        React.createElement('h1', {key:'h'}, 'TradeBot Monitoring'),
-        section('Metrics Summary', state.metrics),
-        section('Basis', state.metrics ? state.metrics.basis : null),
-        section('Funding', state.metrics ? state.metrics.funding_rates : null),
-        section('Open Interest', state.metrics ? state.metrics.open_interest : null),
-        section('PnL', state.pnl),
-        section('Risk', state.risk)
-      ]);
+async function updateMetrics(){
+  try {
+    const now = new Date();
+    const pnl = await fetch('/metrics/pnl').then(r => r.json());
+    const slip = await fetch('/metrics/slippage').then(r => r.json());
+    const lat = await fetch('/metrics/latency').then(r => r.json());
+    pnlTrace.x.push(now); pnlTrace.y.push(pnl.pnl || 0);
+    slippageTrace.x.push(now); slippageTrace.y.push(slip.avg_slippage_bps || 0);
+    latencyTrace.x.push(now); latencyTrace.y.push(lat.avg_order_latency_seconds || 0);
+    Plotly.update('pnl', {x: [pnlTrace.x], y: [pnlTrace.y]});
+    Plotly.update('slippage', {x: [slippageTrace.x], y: [slippageTrace.y]});
+    Plotly.update('latency', {x: [latencyTrace.x], y: [latencyTrace.y]});
+  } catch(err){ console.error(err); }
+}
+
+async function updateStrategies(){
+  try {
+    const data = await fetch('/strategies/status').then(r => r.json());
+    const tbody = document.querySelector('#strategy-table tbody');
+    tbody.innerHTML = '';
+    for (const [name, status] of Object.entries(data.strategies || {})){
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${name}</td><td>${status}</td>`+
+        `<td><button class="button is-small" onclick="controlStrategy('${name}','enable')">Run</button>`+
+        `<button class="button is-small is-warning" onclick="controlStrategy('${name}','disable')">Stop</button></td>`;
+      tbody.appendChild(tr);
     }
+  } catch(err){ console.error(err); }
+}
 
-    const root = ReactDOM.createRoot(document.getElementById('root'));
-    root.render(React.createElement(App));
-  </script>
+async function controlStrategy(name, action){
+  await fetch(`/strategies/${name}/${action}`, {method:'POST'});
+  updateStrategies();
+}
+
+async function runCLI(){
+  const cmd = document.getElementById('cli-cmd').value;
+  const res = await fetch('/run-cli', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({command: cmd})
+  });
+  const data = await res.json();
+  document.getElementById('cli-output').textContent = (data.stdout || '') + '\n' + (data.stderr || '');
+}
+
+updateMetrics();
+updateStrategies();
+setInterval(() => {updateMetrics(); updateStrategies();}, 5000);
+</script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- document full CLI usage and setup instructions in README
- add /run-cli endpoint and Bulma-styled dashboard with command runner

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a336ad0508832db1af9739faff68c1