### PR TITLE
Add real trading runner with dry-run and safety flag

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -204,6 +204,30 @@ def paper_run(
     asyncio.run(run_paper(symbol=symbol, strategy_name=strategy, metrics_port=metrics_port))
 
 
+@app.command("real-run")
+def real_run(
+    symbol: str = typer.Option("BTC/USDT", "--symbol", help="Trading symbol"),
+    trade_qty: float = typer.Option(0.001, help="Order size"),
+    dry_run: bool = typer.Option(False, help="Execute without sending real orders"),
+    i_know_what_im_doing: bool = typer.Option(
+        ..., "--i-know-what-im-doing", help="Acknowledge live trading risk"
+    ),
+) -> None:
+    """Run the live trader against real exchange endpoints."""
+
+    setup_logging()
+    from ..live.runner_real import run_real
+
+    asyncio.run(
+        run_real(
+            symbol=symbol,
+            trade_qty=trade_qty,
+            dry_run=dry_run,
+            i_know_what_im_doing=i_know_what_im_doing,
+        )
+    )
+
+
 @app.command("daemon")
 def run_daemon(config: str = "config/config.yaml") -> None:
     """Launch the :class:`TradeBotDaemon` using a Hydra configuration."""

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import os
+import logging
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - fallback if package missing
+    def load_dotenv() -> None:  # type: ignore
+        """Fallback no-op if python-dotenv is not installed."""
+        return
+
+from ..adapters.binance_spot_ws import BinanceSpotWSAdapter
+from ..adapters.binance_spot import BinanceSpotAdapter
+from ..execution.paper import PaperAdapter
+
+log = logging.getLogger(__name__)
+
+
+async def run_real(
+    symbol: str = "BTC/USDT",
+    trade_qty: float = 0.001,
+    *,
+    dry_run: bool = False,
+    i_know_what_im_doing: bool = False,
+) -> None:
+    """Run a very small live trading loop against real endpoints.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair to operate.
+    trade_qty:
+        Quantity to trade when a tick is received.
+    dry_run:
+        If ``True`` the :class:`PaperAdapter` is used instead of a real
+        exchange adapter and no real orders are sent.
+    i_know_what_im_doing:
+        Mandatory confirmation flag to avoid accidental live runs.
+    """
+
+    if not i_know_what_im_doing:
+        raise RuntimeError("Refusing to trade live without --i-know-what-im-doing")
+
+    load_dotenv()
+    api_key = os.getenv("BINANCE_API_KEY")
+    api_secret = os.getenv("BINANCE_API_SECRET")
+
+    ws = BinanceSpotWSAdapter()
+    broker = PaperAdapter() if dry_run else BinanceSpotAdapter(api_key=api_key, api_secret=api_secret)
+
+    async for _ in ws.stream_trades(symbol):
+        await broker.place_order(symbol, "buy", "market", trade_qty)
+        break

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -1,8 +1,9 @@
 import pandas as pd
+import pandas as pd
 import pytest
 from datetime import datetime, timezone
 from types import SimpleNamespace
-import importlib, sys, types
+import importlib, sys, types, os
 
 # runner_testnet indirectly imports a module missing in tests; inject a stub
 binance_ws_stub = types.ModuleType("tradingbot.adapters.binance_ws")
@@ -10,6 +11,7 @@ binance_ws_stub.BinanceWSAdapter = object
 sys.modules.setdefault("tradingbot.adapters.binance_ws", binance_ws_stub)
 
 from tradingbot.live import runner_testnet as rt
+from tradingbot.live import runner_real as rr
 
 
 class DummyWS:
@@ -158,3 +160,83 @@ async def test_okx_futures_order(monkeypatch):
     assert inst.leverage == 7
     assert inst.testnet is True
     assert inst.orders[0][:4] == ("BTC/USDT", "buy", "market", 1.0)
+
+
+class RealWS:
+    async def stream_trades(self, symbol):
+        yield {"price": 100.0}
+
+
+class RealPaper:
+    last_instance = None
+
+    def __init__(self):
+        self.orders = []
+        RealPaper.last_instance = self
+
+    async def place_order(self, symbol, side, type_, qty):
+        self.orders.append((symbol, side, type_, qty))
+
+
+class RealExec:
+    last_instance = None
+
+    def __init__(self, api_key=None, api_secret=None):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.orders = []
+        RealExec.last_instance = self
+
+    async def place_order(self, symbol, side, type_, qty):
+        self.orders.append((symbol, side, type_, qty))
+
+
+@pytest.mark.asyncio
+async def test_run_real_requires_confirmation():
+    with pytest.raises(RuntimeError):
+        await rr.run_real(i_know_what_im_doing=False)
+
+
+@pytest.mark.asyncio
+async def test_run_real_dry_run(monkeypatch):
+    monkeypatch.setattr(rr, "BinanceSpotWSAdapter", lambda: RealWS())
+    monkeypatch.setattr(rr, "PaperAdapter", RealPaper)
+
+    def _fail_exec(*a, **k):
+        raise AssertionError("real adapter should not be used in dry run")
+
+    monkeypatch.setattr(rr, "BinanceSpotAdapter", _fail_exec)
+
+    calls = {"dotenv": 0}
+
+    def fake_load():
+        calls["dotenv"] += 1
+        os.environ["BINANCE_API_KEY"] = "k"
+        os.environ["BINANCE_API_SECRET"] = "s"
+
+    monkeypatch.setattr(rr, "load_dotenv", fake_load)
+
+    await rr.run_real(dry_run=True, i_know_what_im_doing=True)
+
+    assert calls["dotenv"] == 1
+    assert RealPaper.last_instance.orders[0][:4] == ("BTC/USDT", "buy", "market", 0.001)
+
+
+@pytest.mark.asyncio
+async def test_run_real_real_mode(monkeypatch):
+    monkeypatch.setattr(rr, "BinanceSpotWSAdapter", lambda: RealWS())
+    monkeypatch.setattr(rr, "PaperAdapter", lambda: (_ for _ in ()).throw(AssertionError))
+    monkeypatch.setattr(rr, "BinanceSpotAdapter", RealExec)
+
+    def fake_load():
+        os.environ["BINANCE_API_KEY"] = "livek"
+        os.environ["BINANCE_API_SECRET"] = "lives"
+
+    monkeypatch.setattr(rr, "load_dotenv", fake_load)
+
+    await rr.run_real(dry_run=False, i_know_what_im_doing=True)
+
+    inst = RealExec.last_instance
+    assert inst.api_key == "livek"
+    assert inst.api_secret == "lives"
+    assert inst.orders[0][:4] == ("BTC/USDT", "buy", "market", 0.001)


### PR DESCRIPTION
## Summary
- add `runner_real` module that loads API keys from `.env`, supports dry-run, and requires explicit `--i-know-what-im-doing` confirmation
- expose new `real-run` CLI command for live trading
- cover real runner behavior with unit tests using mocks

## Testing
- `pytest tests/test_live_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35aa13710832dbf891bade934290f