### PR TITLE
docs: map blueprint to modules and CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ scalping y arbitraje sobre criptomonedas.  Incluye todo lo necesario para
 ingerir datos, realizar backtesting y ejecutar estrategias en modo
 ``paper`` o real desde una interfaz web.
 
+La correspondencia entre el blueprint original y los módulos del código se documenta en [docs/blueprint_map.md](docs/blueprint_map.md).
+
 ### Explicación para principiantes
 
 Un bot de trading es como un "piloto automático" que compra y vende

--- a/docs/blueprint_map.md
+++ b/docs/blueprint_map.md
@@ -1,0 +1,15 @@
+# Mapa del blueprint
+
+Este documento enlaza los puntos del [blueprint inicial](../blueprint_trading_bot.md) con los módulos que los implementan dentro del repositorio. También se listan los comandos de la CLI asociados a cada capa cuando existen.
+
+| Punto del blueprint | Módulos / archivos relevantes | Comandos de CLI |
+|---------------------|-------------------------------|-----------------|
+| **1. Ingesta de datos** | `adapters/`, `data/ingestion.py`, `workers/` | `python -m tradingbot.cli ingest`, `python -m tradingbot.cli ingest-historical`, `python -m tradingbot.cli ingestion-workers` |
+| **2. Feature engineering** | `data/features.py`, `data/basis.py`, `data/open_interest.py` | – |
+| **3. Señal / estrategia** | `strategies/`, `live/runner*.py` | `run-bot`, `paper-run`, `tri-arb`, `cross-arb`, `run-cross-arb` |
+| **4. Gestión de cartera y riesgo** | `risk/manager.py`, `risk/portfolio_guard.py`, `risk/daily_guard.py` | `run-bot`, `daemon` |
+| **5. Ejecución** | `execution/router.py`, `execution/algos.py`, `execution/order_types.py` | `run-bot --algo`, `run-cross-arb` |
+| **6. Persistencia** | `storage/timescale.py`, `storage/quest.py` | `ingest`, `ingest-historical`, `ingestion-workers`, `report` |
+| **7. Backtesting & simulación** | `backtest/event_engine.py`, `backtesting/engine.py`, `backtesting/vectorbt_wrapper.py` | `backtest`, `backtest-cfg`, `walk-forward`, `paper-run` |
+| **8. Monitoreo & Ops** | `monitoring/panel.py`, `monitoring/metrics.py`, `utils/metrics.py` | `report` |
+


### PR DESCRIPTION
## Summary
- add blueprint_map.md linking blueprint sections to implemented modules and CLI commands
- link README to new blueprint map document

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a35aa56af4832d9faf98238b1b4b66