### PR TITLE
feat: add volatility-based sizing helper

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -25,6 +25,7 @@ import numpy as np
 
 from tradingbot.utils.metrics import RISK_EVENTS, KILL_SWITCH_ACTIVE
 from ..bus import EventBus
+from .position_sizing import vol_target as _vol_target
 
 
 @dataclass
@@ -248,8 +249,8 @@ class RiskManager:
         """
         if self.vol_target <= 0 or symbol_vol <= 0:
             return 0.0
-        scale = self.vol_target / symbol_vol
-        target_abs = min(self.max_pos, self.max_pos * scale)
+        risk_budget = self.max_pos * self.vol_target
+        target_abs = _vol_target(symbol_vol, risk_budget, self.max_pos)
         sign = 1 if self.pos.qty >= 0 else -1
         target = sign * target_abs
         RISK_EVENTS.labels(event_type="volatility_sizing").inc()

--- a/src/tradingbot/risk/position_sizing.py
+++ b/src/tradingbot/risk/position_sizing.py
@@ -1,0 +1,30 @@
+"""Funciones auxiliares para dimensionar posiciones."""
+
+from __future__ import annotations
+
+
+def vol_target(atr: float, risk_budget: float, notional_cap: float) -> float:
+    """Calcula tamaño de posición basado en volatilidad (ATR).
+
+    Parameters
+    ----------
+    atr: float
+        Medida de volatilidad actual (p.ej. ATR).
+    risk_budget: float
+        Riesgo monetario asignado para la operación.
+    notional_cap: float
+        Exposición nominal máxima permitida.
+
+    Returns
+    -------
+    float
+        Tamaño de posición absoluto que respeta ``notional_cap``.
+    """
+    if atr <= 0:
+        return 0.0
+    atr = float(atr)
+    risk_budget = abs(risk_budget)
+    notional_cap = abs(notional_cap)
+    size = risk_budget / atr
+    return min(notional_cap, size)
+

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -4,6 +4,37 @@ import numpy as np
 from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 from tradingbot.risk.service import RiskService
+from tradingbot.risk.position_sizing import vol_target
+
+
+def test_vol_target_function(synthetic_volatility):
+    size = vol_target(synthetic_volatility, risk_budget=0.2, notional_cap=10)
+    assert size == pytest.approx(5.0)
+
+
+def test_vol_target_respects_cap(synthetic_volatility):
+    size = vol_target(synthetic_volatility, risk_budget=1.0, notional_cap=10)
+    assert size == pytest.approx(10.0)
+
+
+def test_size_with_volatility_calls_vol_target(monkeypatch, synthetic_volatility):
+    called = {}
+
+    def fake_vol_target(atr, risk_budget, notional_cap):
+        called["args"] = (atr, risk_budget, notional_cap)
+        return 3.0
+
+    monkeypatch.setattr("tradingbot.risk.manager._vol_target", fake_vol_target)
+
+    rm = RiskManager(max_pos=10, vol_target=0.02)
+    delta = rm.size_with_volatility(synthetic_volatility)
+
+    assert called["args"] == (
+        synthetic_volatility,
+        rm.max_pos * rm.vol_target,
+        rm.max_pos,
+    )
+    assert delta == pytest.approx(3.0)
 
 
 def test_risk_vol_sizing(synthetic_volatility):


### PR DESCRIPTION
## Summary
- add reusable `vol_target` position sizing helper
- refactor `RiskManager.size_with_volatility` to rely on helper
- expand volatility sizing tests

## Testing
- `pytest tests/test_risk_vol_sizing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35a86f8a0832dbe22496bbf52a697