### PR TITLE
feat: add latency and balance limits to arbitrage

### DIFF
--- a/tests/test_arbitrage_triangular.py
+++ b/tests/test_arbitrage_triangular.py
@@ -23,3 +23,11 @@ def test_triangular_arb_flat_when_incomplete_prices():
     sig = strat.on_bar({"prices": {"bq": 100.0, "mq": None, "mb": 2.0}})
     assert sig.side == "flat"
     assert sig.strength == pytest.approx(0.0)
+
+
+def test_triangular_arb_with_fees():
+    strat = TriangularArb(taker_fee_bps=10.0)
+    prices = {"bq": 100.0, "mq": 210.0, "mb": 2.0}
+    sig = strat.on_bar({"prices": prices})
+    assert sig.side == "buy"
+    assert sig.strength == pytest.approx(0.046853, rel=1e-3)


### PR DESCRIPTION
## Summary
- add latency, notional/size caps and balance checks for cross-exchange arb
- allow latency and size caps in triangular arb helpers
- document parameters and test fee scenarios

## Testing
- `pytest tests/test_arbitrage_triangular.py tests/test_cross_exchange_arbitrage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35a721c2c832da41b75a81d3819b8