### PR TITLE
Add ATR EWMA indicator

### DIFF
--- a/src/tradingbot/data/features.py
+++ b/src/tradingbot/data/features.py
@@ -138,6 +138,36 @@ def atr(data: DataLike, n: int = 14) -> pd.Series:
     return tr.rolling(n).mean()
 
 
+def atr_ewma(data: DataLike, n: int = 14) -> pd.Series:
+    """Average True Range using an exponential moving average.
+
+    This variant applies an exponentially weighted moving average (EWMA)
+    to the sequence of true ranges, mirroring the original formulation by
+    Welles Wilder.  It offers a smoother estimate of volatility compared to
+    the simple moving average used in :func:`atr`.
+
+    Parameters
+    ----------
+    data:
+        Source data containing ``high``, ``low`` and ``close`` columns.
+    n:
+        Lookback window for the exponential mean of true ranges.
+
+    Returns
+    -------
+    pandas.Series
+        The EWMA-based ATR values.
+    """
+
+    df = _to_dataframe(data, ["high", "low", "close"])
+    high, low, close = df["high"], df["low"], df["close"]
+    tr = np.maximum(
+        high - low,
+        np.maximum((high - close.shift(1)).abs(), (low - close.shift(1)).abs()),
+    )
+    return tr.ewm(alpha=1 / n, adjust=False).mean()
+
+
 def rsi(data: DataLike, n: int = 14) -> pd.Series:
     """Relative Strength Index of the ``close`` column.
 
@@ -398,6 +428,7 @@ def keltner_channels(
 
 __all__ = [
     "atr",
+    "atr_ewma",
     "rsi",
     "order_flow_imbalance",
     "depth_imbalance",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,6 +7,7 @@ from tradingbot.data.features import (
     depth_imbalance,
     rsi,
     atr,
+    atr_ewma,
     returns,
 )
 
@@ -176,6 +177,18 @@ def test_atr_df(ohlc_df):
 def test_atr_snapshots(ohlc_df, ohlc_snapshots):
     atr_df = atr(ohlc_df, n=3)
     atr_snaps = atr(ohlc_snapshots, n=3)
+    pd.testing.assert_series_equal(atr_df, atr_snaps)
+
+
+def test_atr_ewma_df(ohlc_df):
+    # EWMA variant produces a smoother estimate of true range
+    val = atr_ewma(ohlc_df, n=3).iloc[-1]
+    assert abs(val - 3.6296296296296293) < 1e-9
+
+
+def test_atr_ewma_snapshots(ohlc_df, ohlc_snapshots):
+    atr_df = atr_ewma(ohlc_df, n=3)
+    atr_snaps = atr_ewma(ohlc_snapshots, n=3)
     pd.testing.assert_series_equal(atr_df, atr_snaps)
 
 


### PR DESCRIPTION
## Summary
- implement `atr_ewma` combining Average True Range with exponential moving average
- expose `atr_ewma` via module exports
- test ATR EWMA against fixed OHLC data and snapshot inputs

## Testing
- `pytest tests/test_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68a35a6a7bc0832da9bb808cba8c29e8