### PR TITLE
Add Donchian channel indicator

### DIFF
--- a/src/tradingbot/data/features.py
+++ b/src/tradingbot/data/features.py
@@ -380,6 +380,18 @@ def returns(data: DataLike, log: bool = True) -> pd.Series:
     return pd.Series(out, index=df.index, name="returns")
 
 
+def donchian_channels(data: DataLike, n: int = 20):
+    """Donchian channel upper/lower bounds."""
+
+    if n < 1:
+        raise ValueError("n must be at least 1")
+
+    df = _to_dataframe(data, ["high", "low"])
+    upper = df["high"].rolling(n).max()
+    lower = df["low"].rolling(n).min()
+    return upper, lower
+
+
 def keltner_channels(
     data: DataLike,
     ema_n: int = 20,
@@ -405,5 +417,6 @@ __all__ = [
     "liquidity_gap",
     "returns",
     "keltner_channels",
+    "donchian_channels",
 ]
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -8,6 +8,7 @@ from tradingbot.data.features import (
     rsi,
     atr,
     returns,
+    donchian_channels,
 )
 
 
@@ -190,5 +191,20 @@ def test_returns_snapshots(price_df, price_snapshots):
     ret_df = returns(price_df)
     ret_snaps = returns(price_snapshots)
     pd.testing.assert_series_equal(ret_df, ret_snaps)
+
+
+def test_donchian_channels_df(ohlc_df):
+    upper, lower = donchian_channels(ohlc_df, n=3)
+    expected_upper = pd.Series([np.nan, np.nan, 14, 14, 15], name="high")
+    expected_lower = pd.Series([np.nan, np.nan, 7, 8, 8], name="low")
+    pd.testing.assert_series_equal(upper, expected_upper)
+    pd.testing.assert_series_equal(lower, expected_lower)
+
+
+def test_donchian_channels_snapshots(ohlc_df, ohlc_snapshots):
+    u_df, l_df = donchian_channels(ohlc_df, n=3)
+    u_snaps, l_snaps = donchian_channels(ohlc_snapshots, n=3)
+    pd.testing.assert_series_equal(u_df, u_snaps)
+    pd.testing.assert_series_equal(l_df, l_snaps)
 
 


### PR DESCRIPTION
## Summary
- implement Donchian channel feature returning upper/lower bands
- add deterministic tests for Donchian channel output

## Testing
- `pytest tests/test_features.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35a69b324832dbe8631c96706e91e