### PR TITLE
Add OFI mean reversion strategy with YAML thresholds

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -4,7 +4,12 @@ exchanges:
 
 strategies:
   default: breakout_atr
-  params: {}
+  params:
+    mean_rev_ofi:
+      ofi_window: 20
+      zscore_threshold: 1.0
+      vol_window: 20
+      vol_threshold: 0.01
 
 backtest:
   data: data/examples/btcusdt_1m.csv

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -9,6 +9,7 @@ from .depth_imbalance import DepthImbalance
 from .liquidity_events import LiquidityEvents
 from .triple_barrier import TripleBarrier
 from .ml_models import MLStrategy
+from .mean_rev_ofi import MeanRevOFI
 
 # Registry of available strategies, useful for CLI/backtests
 STRATEGIES = {
@@ -23,6 +24,7 @@ STRATEGIES = {
     LiquidityEvents.name: LiquidityEvents,
     TripleBarrier.name: TripleBarrier,
     MLStrategy.name: MLStrategy,
+    MeanRevOFI.name: MeanRevOFI,
 }
 
 __all__ = [
@@ -37,5 +39,6 @@ __all__ = [
     "LiquidityEvents",
     "TripleBarrier",
     "MLStrategy",
+    "MeanRevOFI",
     "STRATEGIES",
 ]

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+from .base import Strategy, Signal, record_signal_metrics
+from ..data.features import order_flow_imbalance, returns
+
+
+class MeanRevOFI(Strategy):
+    """Mean reversion strategy based on OFI z-score and volatility.
+
+    Generates inverse signals: when buying pressure (positive OFI z-score)
+    exceeds a threshold under low volatility, a ``sell`` signal is emitted and
+    vice versa.
+
+    Parameters
+    ----------
+    ofi_window : int, optional
+        Lookback window for the OFI rolling statistics, by default ``20``.
+    zscore_threshold : float, optional
+        Absolute z-score required to trigger a trade, by default ``1.0``.
+    vol_window : int, optional
+        Window for the volatility estimation of log returns, by default ``20``.
+    vol_threshold : float, optional
+        Maximum volatility allowed to take a position, by default ``0.01``.
+    """
+
+    name = "mean_rev_ofi"
+
+    def __init__(
+        self,
+        ofi_window: int = 20,
+        zscore_threshold: float = 1.0,
+        vol_window: int = 20,
+        vol_threshold: float = 0.01,
+    ) -> None:
+        self.ofi_window = ofi_window
+        self.zscore_threshold = zscore_threshold
+        self.vol_window = vol_window
+        self.vol_threshold = vol_threshold
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        needed = {"bid_qty", "ask_qty", "close"}
+        min_len = max(self.ofi_window, self.vol_window) + 1
+        if not needed.issubset(df.columns) or len(df) < min_len:
+            return None
+
+        ofi_series = order_flow_imbalance(df[["bid_qty", "ask_qty"]])
+        rolling_mean = ofi_series.rolling(self.ofi_window).mean()
+        rolling_std = ofi_series.rolling(self.ofi_window).std(ddof=0).replace(0, np.nan)
+        zscore = ((ofi_series - rolling_mean) / rolling_std).iloc[-1]
+
+        vol = returns(df).rolling(self.vol_window).std().iloc[-1]
+
+        if pd.isna(zscore) or pd.isna(vol) or vol >= self.vol_threshold:
+            return Signal("flat", 0.0)
+
+        if zscore > self.zscore_threshold:
+            return Signal("sell", 1.0)
+        if zscore < -self.zscore_threshold:
+            return Signal("buy", 1.0)
+        return Signal("flat", 0.0)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import yaml
 from tradingbot.strategies.breakout_atr import BreakoutATR
 from tradingbot.strategies.order_flow import OrderFlow
+from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
 from hypothesis import given, strategies as st
 
 
@@ -28,6 +30,39 @@ def test_order_flow_signals():
     assert sig_buy.side == "buy"
     sig_sell = strat.on_bar({"window": df_sell})
     assert sig_sell.side == "sell"
+
+
+def test_mean_rev_ofi_signals():
+    cfg = yaml.safe_load(
+        """
+ofi_window: 2
+zscore_threshold: 0.5
+vol_window: 2
+vol_threshold: 1.0
+"""
+    )
+    strat = MeanRevOFI(**cfg)
+
+    df_sell = pd.DataFrame(
+        {
+            "bid_qty": [1, 2, 10],
+            "ask_qty": [3, 1, 0],
+            "close": [100, 100, 100],
+        }
+    )
+    df_buy = pd.DataFrame(
+        {
+            "bid_qty": [3, 1, 0],
+            "ask_qty": [1, 2, 10],
+            "close": [100, 100, 100],
+        }
+    )
+
+    sig_sell = strat.on_bar({"window": df_sell})
+    assert sig_sell.side == "sell"
+
+    sig_buy = strat.on_bar({"window": df_buy})
+    assert sig_buy.side == "buy"
 
 
 @given(start=st.floats(1, 10), inc=st.floats(0.1, 5))


### PR DESCRIPTION
## Summary
- implement `MeanRevOFI` strategy using OFI z-score and volatility filters
- expose strategy in registry and add default YAML parameters
- cover inverse-signal behaviour with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35a70dab4832dbdcbcd2912dd25ea