### PR TITLE
feat: add volatility position sizing

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -26,6 +26,7 @@ import numpy as np
 from tradingbot.utils.metrics import RISK_EVENTS, KILL_SWITCH_ACTIVE
 from ..bus import EventBus
 from .limits import RiskLimits, LimitTracker
+from .position_sizing import vol_target
 
 
 @dataclass
@@ -264,8 +265,8 @@ class RiskManager:
         """
         if self.vol_target <= 0 or symbol_vol <= 0:
             return 0.0
-        scale = self.vol_target / symbol_vol
-        target_abs = min(self.max_pos, self.max_pos * scale)
+        budget = self.max_pos * self.vol_target
+        target_abs = vol_target(symbol_vol, budget, self.max_pos)
         sign = 1 if self.pos.qty >= 0 else -1
         target = sign * target_abs
         RISK_EVENTS.labels(event_type="volatility_sizing").inc()

--- a/src/tradingbot/risk/position_sizing.py
+++ b/src/tradingbot/risk/position_sizing.py
@@ -1,0 +1,28 @@
+"""Helpers for position sizing based on volatility targets."""
+
+from __future__ import annotations
+
+
+def vol_target(atr: float, risk_budget: float, notional_cap: float) -> float:
+    """Return target position size for a given volatility estimate.
+
+    Parameters
+    ----------
+    atr:
+        Average true range or volatility estimate of the asset.
+    risk_budget:
+        Maximum notional exposure allowed based on risk appetite.
+    notional_cap:
+        Absolute cap on position size.
+
+    Returns
+    -------
+    float
+        The desired position size capped by ``notional_cap``. If any argument
+        is non-positive, ``0.0`` is returned.
+    """
+    if atr <= 0 or risk_budget <= 0 or notional_cap <= 0:
+        return 0.0
+
+    size = risk_budget / atr
+    return min(size, notional_cap)

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -4,6 +4,7 @@ import numpy as np
 from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 from tradingbot.risk.service import RiskService
+from tradingbot.risk.position_sizing import vol_target
 
 
 def test_risk_vol_sizing(synthetic_volatility):
@@ -13,6 +14,14 @@ def test_risk_vol_sizing(synthetic_volatility):
         rm.max_pos, rm.max_pos * rm.vol_target / synthetic_volatility
     )
     assert delta == pytest.approx(expected)
+
+
+def test_vol_target_basic():
+    assert vol_target(atr=2.0, risk_budget=10.0, notional_cap=20.0) == pytest.approx(5.0)
+
+
+def test_vol_target_caps_notional():
+    assert vol_target(atr=1.0, risk_budget=50.0, notional_cap=30.0) == pytest.approx(30.0)
 
 
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):


### PR DESCRIPTION
## Summary
- add `vol_target` helper for volatility-based position sizing
- reuse helper in `RiskManager.size_with_volatility`
- cover new sizing logic with unit tests

## Testing
- `pytest tests/test_risk_vol_sizing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a363756948832d972d9b882d9b5e71