### PR TITLE
Add real-run trading mode with safety flag and dry-run

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -236,6 +236,41 @@ def paper_run(
     asyncio.run(run_paper(symbol=symbol, strategy_name=strategy, metrics_port=metrics_port))
 
 
+@app.command("real-run")
+def real_run(
+    exchange: str = typer.Option("binance", help="Exchange name"),
+    market: str = typer.Option("spot", help="Market type (spot or futures)"),
+    symbols: List[str] = typer.Option(["BTC/USDT"], "--symbol", help="Trading symbols"),
+    trade_qty: float = typer.Option(0.001, help="Order size"),
+    leverage: int = typer.Option(1, help="Leverage for futures"),
+    dry_run: bool = typer.Option(False, help="Simulate orders without sending"),
+    i_know_what_im_doing: bool = typer.Option(
+        False,
+        "--i-know-what-im-doing",
+        help="Acknowledge that this will trade on a real exchange",
+    ),
+) -> None:
+    """Run the live trading bot on real exchange endpoints."""
+
+    if not i_know_what_im_doing:
+        raise typer.BadParameter("pass --i-know-what-im-doing to enable real trading")
+
+    setup_logging()
+    from ..live.runner_real import run_live_real
+
+    asyncio.run(
+        run_live_real(
+            exchange=exchange,
+            market=market,
+            symbols=symbols,
+            trade_qty=trade_qty,
+            leverage=leverage,
+            dry_run=dry_run,
+            i_know_what_im_doing=i_know_what_im_doing,
+        )
+    )
+
+
 @app.command("daemon")
 def run_daemon(config: str = "config/config.yaml") -> None:
     """Launch the :class:`TradeBotDaemon` using a Hydra configuration."""

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -1,0 +1,219 @@
+"""Minimal live runner for real exchange trading.
+
+This module is intentionally lightweight and mirrors the structure of
+``runner_testnet`` but connects to real exchange endpoints.  It requires the
+user to acknowledge the danger of live trading via the
+``--i-know-what-im-doing`` flag and pulls API credentials from the ``.env``
+file through :mod:`tradingbot.config`.
+
+The runner features a ``dry_run`` mode that executes orders using the
+``PaperAdapter`` while still streaming real market data.  When ``dry_run`` is
+``False`` orders are forwarded to the corresponding exchange adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Tuple
+
+import pandas as pd
+
+from .runner import BarAggregator
+from ..config import settings
+from ..strategies.breakout_atr import BreakoutATR
+from ..risk.manager import RiskManager
+from ..risk.daily_guard import DailyGuard, GuardLimits
+from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
+from ..execution.paper import PaperAdapter
+
+from ..adapters.binance_spot_ws import BinanceSpotWSAdapter
+from ..adapters.binance_spot import BinanceSpotAdapter
+from ..adapters.binance_ws import BinanceWSAdapter
+from ..adapters.binance_futures import BinanceFuturesAdapter
+from ..adapters.bybit_spot import BybitSpotAdapter as BybitSpotWSAdapter, BybitSpotAdapter
+from ..adapters.okx_spot import OKXSpotAdapter as OKXSpotWSAdapter, OKXSpotAdapter
+from ..adapters.bybit_futures import BybitFuturesAdapter
+from ..adapters.okx_futures import OKXFuturesAdapter
+
+log = logging.getLogger(__name__)
+
+
+AdapterTuple = Tuple[Callable[[], Any], Callable[..., Any], str]
+
+
+# Mapping of (exchange, market) to websocket adapter, execution adapter and
+# venue name.  These are the real counterparts (no ``_testnet`` suffixes).
+ADAPTERS: Dict[Tuple[str, str], AdapterTuple] = {
+    ("binance", "spot"): (BinanceSpotWSAdapter, BinanceSpotAdapter, "binance_spot"),
+    ("binance", "futures"): (BinanceWSAdapter, BinanceFuturesAdapter, "binance_futures"),
+    ("bybit", "spot"): (BybitSpotWSAdapter, BybitSpotAdapter, "bybit_spot"),
+    ("bybit", "futures"): (BybitFuturesAdapter, BybitFuturesAdapter, "bybit_futures"),
+    ("okx", "spot"): (OKXSpotWSAdapter, OKXSpotAdapter, "okx_spot"),
+    ("okx", "futures"): (OKXFuturesAdapter, OKXFuturesAdapter, "okx_futures"),
+}
+
+
+def _get_keys(exchange: str) -> Tuple[str | None, str | None]:
+    """Return API key/secret pair for ``exchange`` from settings."""
+
+    if exchange == "binance":
+        return settings.binance_api_key, settings.binance_api_secret
+    if exchange == "bybit":
+        return settings.bybit_api_key, settings.bybit_api_secret
+    if exchange == "okx":
+        return settings.okx_api_key, settings.okx_api_secret
+    return None, None
+
+
+@dataclass
+class _SymbolConfig:
+    symbol: str
+    trade_qty: float
+
+
+async def _run_symbol(
+    exchange: str,
+    market: str,
+    cfg: _SymbolConfig,
+    leverage: int,
+    dry_run: bool,
+    total_cap_usdt: float,
+    per_symbol_cap_usdt: float,
+    soft_cap_pct: float,
+    soft_cap_grace_sec: int,
+    daily_max_loss_usdt: float,
+    daily_max_drawdown_pct: float,
+    max_consecutive_losses: int,
+) -> None:
+    ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
+    api_key, api_secret = _get_keys(exchange)
+    exec_kwargs: Dict[str, Any] = {"api_key": api_key, "api_secret": api_secret}
+    if market == "futures":
+        exec_kwargs["leverage"] = leverage
+    ws = ws_cls()
+    exec_adapter = exec_cls(**exec_kwargs)
+    agg = BarAggregator()
+    strat = BreakoutATR()
+    risk = RiskManager(max_pos=1.0)
+    guard = PortfolioGuard(
+        GuardConfig(
+            total_cap_usdt=total_cap_usdt,
+            per_symbol_cap_usdt=per_symbol_cap_usdt,
+            venue=venue,
+            soft_cap_pct=soft_cap_pct,
+            soft_cap_grace_sec=soft_cap_grace_sec,
+        )
+    )
+    dguard = DailyGuard(
+        GuardLimits(
+            daily_max_loss_usdt=daily_max_loss_usdt,
+            daily_max_drawdown_pct=daily_max_drawdown_pct,
+            max_consecutive_losses=max_consecutive_losses,
+            halt_action="close_all",
+        ),
+        venue=venue,
+    )
+    broker = PaperAdapter(fee_bps=1.5)
+
+    async for t in ws.stream_trades(cfg.symbol):
+        ts: datetime = t.get("ts") or datetime.now(timezone.utc)
+        px: float = float(t["price"])
+        qty: float = float(t.get("qty") or 0.0)
+        broker.update_last_price(cfg.symbol, px)
+        guard.mark_price(cfg.symbol, px)
+        dguard.on_mark(
+            datetime.now(timezone.utc),
+            equity_now=broker.equity(mark_prices={cfg.symbol: px}),
+        )
+        halted, reason = dguard.check_halt(broker)
+        if halted:
+            log.error("[HALT] motivo=%s", reason)
+            break
+        closed = agg.on_trade(ts, px, qty)
+        if closed is None:
+            continue
+        df: pd.DataFrame = agg.last_n_bars_df(200)
+        if len(df) < 140:
+            continue
+        sig = strat.on_bar({"window": df})
+        if sig is None:
+            continue
+        delta = risk.size(sig.side, sig.strength)
+        if abs(delta) < 1e-9:
+            continue
+        side = "buy" if delta > 0 else "sell"
+        if not risk.check_limits(closed.c):
+            log.warning("RiskManager disabled; kill switch activated")
+            continue
+        action, reason, _ = guard.soft_cap_decision(
+            cfg.symbol, side, abs(cfg.trade_qty), closed.c
+        )
+        if action == "block":
+            log.warning("[PG] Bloqueado %s: %s", cfg.symbol, reason)
+            continue
+        if dry_run:
+            resp = await broker.place_order(cfg.symbol, side, "market", cfg.trade_qty)
+        else:
+            resp = await exec_adapter.place_order(
+                cfg.symbol, side, "market", cfg.trade_qty, mark_price=closed.c
+            )
+        log.info("LIVE FILL %s", resp)
+        risk.add_fill(side, cfg.trade_qty)
+
+
+async def run_live_real(
+    exchange: str = "binance",
+    market: str = "spot",
+    symbols: List[str] | None = None,
+    trade_qty: float = 0.001,
+    leverage: int = 1,
+    dry_run: bool = False,
+    *,
+    i_know_what_im_doing: bool,
+    total_cap_usdt: float = 1000.0,
+    per_symbol_cap_usdt: float = 500.0,
+    soft_cap_pct: float = 0.10,
+    soft_cap_grace_sec: int = 30,
+    daily_max_loss_usdt: float = 100.0,
+    daily_max_drawdown_pct: float = 0.05,
+    max_consecutive_losses: int = 3,
+) -> None:
+    """Run a simple live loop on a real crypto exchange."""
+
+    if not i_know_what_im_doing:
+        raise ValueError("Real trading requires --i-know-what-im-doing flag")
+    key, secret = _get_keys(exchange)
+    if not key or not secret:
+        raise RuntimeError(f"Missing API keys for {exchange} in .env")
+    if (exchange, market) not in ADAPTERS:
+        raise ValueError(f"Unsupported combination {exchange} {market}")
+    symbols = symbols or ["BTC/USDT"]
+    cfgs = [
+        _SymbolConfig(symbol=s.upper().replace("-", "/"), trade_qty=trade_qty)
+        for s in symbols
+    ]
+    tasks = [
+        _run_symbol(
+            exchange,
+            market,
+            c,
+            leverage,
+            dry_run,
+            total_cap_usdt,
+            per_symbol_cap_usdt,
+            soft_cap_pct,
+            soft_cap_grace_sec,
+            daily_max_loss_usdt,
+            daily_max_drawdown_pct,
+            max_consecutive_losses,
+        )
+        for c in cfgs
+    ]
+    await asyncio.gather(*tasks)
+
+
+__all__ = ["run_live_real"]
+

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -120,6 +120,78 @@ async def test_bybit_futures_order(monkeypatch):
     assert inst.orders[0][:4] == (normalize("BTC-USDT"), "buy", "market", 1.0)
 
 
+class DummyExecReal:
+    last_instance = None
+
+    def __init__(self, api_key=None, api_secret=None, leverage=None):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.leverage = leverage
+        self.orders = []
+        DummyExecReal.last_instance = self
+
+    async def place_order(self, symbol, side, type_, qty, mark_price=None):
+        self.orders.append((symbol, side, type_, qty))
+        return {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_run_real(monkeypatch):
+    monkeypatch.setenv("BINANCE_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_API_SECRET", "s")
+    import importlib, sys
+    import tradingbot.config as config
+    config = importlib.reload(config)
+    sys.modules["tradingbot.config"] = config
+    import tradingbot.live.runner_real as rr
+    rr = importlib.reload(rr)
+    monkeypatch.setattr(rr, "BarAggregator", DummyAgg)
+    monkeypatch.setattr(rr, "BreakoutATR", lambda: DummyStrat())
+    monkeypatch.setattr(rr, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rr, "PortfolioGuard", lambda config: DummyPG())
+    monkeypatch.setattr(rr, "DailyGuard", lambda limits, venue: DummyDG())
+    monkeypatch.setattr(rr, "PaperAdapter", DummyBroker)
+    monkeypatch.setitem(
+        rr.ADAPTERS,
+        ("binance", "spot"),
+        (lambda: DummyWS(), DummyExecReal, "binance_spot"),
+    )
+
+    cfg = rr._SymbolConfig(symbol=normalize("BTC-USDT"), trade_qty=1.0)
+    await rr._run_symbol(
+        "binance",
+        "spot",
+        cfg,
+        leverage=1,
+        dry_run=False,
+        total_cap_usdt=1000.0,
+        per_symbol_cap_usdt=500.0,
+        soft_cap_pct=0.1,
+        soft_cap_grace_sec=30,
+        daily_max_loss_usdt=100.0,
+        daily_max_drawdown_pct=0.05,
+        max_consecutive_losses=3,
+    )
+
+    inst = DummyExecReal.last_instance
+    assert inst.api_key == "k"
+    assert inst.orders[0][:4] == (normalize("BTC-USDT"), "buy", "market", 1.0)
+
+
+@pytest.mark.asyncio
+async def test_real_requires_flag(monkeypatch):
+    monkeypatch.setenv("BINANCE_API_KEY", "x")
+    monkeypatch.setenv("BINANCE_API_SECRET", "y")
+    import importlib, sys
+    import tradingbot.config as config
+    config = importlib.reload(config)
+    sys.modules["tradingbot.config"] = config
+    import tradingbot.live.runner_real as rr
+    rr = importlib.reload(rr)
+    with pytest.raises(ValueError):
+        await rr.run_live_real(symbols=["BTC/USDT"], i_know_what_im_doing=False)
+
+
 class DummyExec2(DummyExec):
     pass
 


### PR DESCRIPTION
## Summary
- implement `runner_real` for live exchange trading, loading API keys from `.env` and supporting dry-run mode
- expose new `real-run` CLI command requiring `--i-know-what-im-doing`
- test real-run logic with environment mocks

## Testing
- `pytest tests/test_live_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a363695ac0832da4f47b4199a86a1c