### PR TITLE
Add async Timescale batch writer and backfill persistence

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -101,7 +101,7 @@ def backfill(
         ["BTC/USDT"], "--symbols", help="Symbols to download"
     ),
 ) -> None:
-    """Backfill historical data for symbols with rate limiting."""
+    """Backfill OHLCV and trades for symbols with rate limiting."""
 
     setup_logging()
     from ..jobs.backfill import backfill as run_backfill

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -1,3 +1,5 @@
+"""Backfill historical data and persist it using :class:`AsyncTimescaleClient`."""
+
 from __future__ import annotations
 
 import asyncio
@@ -6,28 +8,112 @@ from typing import Sequence
 
 import ccxt.async_support as ccxt
 
+from ..storage.async_timescale import AsyncTimescaleClient
+
+
+INSERT_BAR_SQL = """
+    INSERT INTO market.bars
+        (ts, timeframe, exchange, symbol, o, h, l, c, v)
+    VALUES
+        (:ts, :timeframe, :exchange, :symbol, :o, :h, :l, :c, :v)
+"""
+
+INSERT_TRADE_SQL = """
+    INSERT INTO market.trades
+        (ts, exchange, symbol, px, qty, side, trade_id)
+    VALUES
+        (:ts, :exchange, :symbol, :px, :qty, :side, :trade_id)
+"""
+
+
+async def _retry(func, *args, retries: int = 3, delay: float = 1.0, **kwargs):
+    """Retry *func* with exponential backoff."""
+
+    for attempt in range(1, retries + 1):
+        try:
+            return await func(*args, **kwargs)
+        except Exception:  # pragma: no cover - network errors
+            if attempt >= retries:
+                raise
+            await asyncio.sleep(delay * 2 ** (attempt - 1))
+
 
 async def backfill(days: int, symbols: Sequence[str]) -> None:
-    """Backfill minute bars for ``symbols`` over the past ``days`` days.
-
-    A simple rate limit is enforced between requests based on the exchange's
-    ``rateLimit`` attribute.  Data returned by the exchange is discarded; this
-    helper merely demonstrates sequential API calls with throttling.
-    """
+    """Backfill OHLCV bars and trades for *symbols* over the past *days* days."""
 
     ex = ccxt.binance({"enableRateLimit": False})
+    delay = getattr(ex, "rateLimit", 1000) / 1000
+
+    client = AsyncTimescaleClient()
+    client.register_table("market.bars", INSERT_BAR_SQL)
+    client.register_table("market.trades", INSERT_TRADE_SQL)
+
     end_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
     start_ms = end_ms - int(timedelta(days=days).total_seconds() * 1000)
 
-    for symbol in symbols:
-        since = start_ms
-        while since < end_ms:
-            ohlcvs = await ex.fetch_ohlcv(
-                symbol, timeframe="1m", since=since, limit=1000
-            )
-            await asyncio.sleep(getattr(ex, "rateLimit", 1000) / 1000)
-            if not ohlcvs:
-                break
-            since = ohlcvs[-1][0] + 60_000
-    await ex.close()
+    try:
+        for symbol in symbols:
+            db_symbol = symbol.replace("/", "")
+
+            # --- OHLCV backfill -------------------------------------------------
+            since = start_ms
+            while since < end_ms:
+                ohlcvs = await _retry(
+                    ex.fetch_ohlcv,
+                    symbol,
+                    "1m",
+                    since,
+                    1000,
+                    delay=delay,
+                )
+                await asyncio.sleep(delay)
+                if not ohlcvs:
+                    break
+
+                for ts_ms, o, h, l, c, v in ohlcvs:
+                    await client.add(
+                        "market.bars",
+                        {
+                            "ts": datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
+                            "timeframe": "1m",
+                            "exchange": ex.id,
+                            "symbol": db_symbol,
+                            "o": o,
+                            "h": h,
+                            "l": l,
+                            "c": c,
+                            "v": v,
+                        },
+                    )
+                since = ohlcvs[-1][0] + 60_000
+
+            # --- Trades backfill -----------------------------------------------
+            since = start_ms
+            while since < end_ms:
+                trades = await _retry(
+                    ex.fetch_trades, symbol, since, 1000, delay=delay
+                )
+                await asyncio.sleep(delay)
+                if not trades:
+                    break
+                for t in trades:
+                    await client.add(
+                        "market.trades",
+                        {
+                            "ts": datetime.fromtimestamp(
+                                t["timestamp"] / 1000, tz=timezone.utc
+                            ),
+                            "exchange": ex.id,
+                            "symbol": db_symbol,
+                            "px": t["price"],
+                            "qty": t["amount"],
+                            "side": t.get("side"),
+                            "trade_id": t.get("id"),
+                        },
+                    )
+                since = trades[-1]["timestamp"] + 1
+
+    finally:
+        await client.stop()
+        await ex.close()
 

--- a/src/tradingbot/storage/async_timescale.py
+++ b/src/tradingbot/storage/async_timescale.py
@@ -1,19 +1,59 @@
-"""Asynchronous client for TimescaleDB."""
+"""Asynchronous client for TimescaleDB with queued batch writes."""
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+import asyncio
+import time
+from collections import defaultdict
+from typing import Any, Iterable, Optional
 
+from prometheus_client import Histogram
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy import text
 
 from ..config import settings
 
 
-class AsyncTimescaleClient:
-    """Minimal async wrapper around SQLAlchemy for TimescaleDB."""
+# Latency of batch writes grouped by table name
+BATCH_LATENCY = Histogram(
+    "async_storage_batch_latency_seconds",
+    "Latency of batch writes to the database",
+    ["table"],
+)
 
-    def __init__(self, dsn: str | None = None) -> None:
+
+class AsyncTimescaleClient:
+    """Asynchronous SQLAlchemy client with an internal batching queue."""
+
+    def __init__(
+        self,
+        dsn: str | None = None,
+        *,
+        batch_size: int = 100,
+        queue_maxsize: int = 1000,
+        flush_interval: float = 1.0,
+        insert_sql: Optional[dict[str, str]] = None,
+    ) -> None:
+        """Create a new client.
+
+        Parameters
+        ----------
+        dsn:
+            Database connection string.  If ``None`` it is built from
+            :mod:`tradingbot.config.settings`.
+        batch_size:
+            Maximum number of rows written per batch.
+        queue_maxsize:
+            Maximum size of the internal queue before backpressure blocks
+            producers.  ``asyncio.Queue`` handles the waiting automatically.
+        flush_interval:
+            Seconds between automatic flushes of partial batches.
+        insert_sql:
+            Mapping of table name to ``INSERT`` statement used by
+            :meth:`add`.  Additional tables can be registered later via
+            :meth:`register_table`.
+        """
+
         if dsn is None:
             dsn = (
                 f"postgresql+asyncpg://{settings.pg_user}:{settings.pg_password}"
@@ -22,6 +62,18 @@ class AsyncTimescaleClient:
         self._dsn = dsn
         self._engine: AsyncEngine | None = None
 
+        self.batch_size = batch_size
+        self.flush_interval = flush_interval
+        self._queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._worker_task: asyncio.Task | None = None
+        self._closed = False
+
+        self._insert_sql: dict[str, str] = insert_sql.copy() if insert_sql else {}
+
+    # ------------------------------------------------------------------
+    # Connection management
     async def connect(self) -> AsyncEngine:
         if self._engine is None:
             self._engine = create_async_engine(self._dsn, pool_pre_ping=True)
@@ -32,8 +84,83 @@ class AsyncTimescaleClient:
             await self._engine.dispose()
             self._engine = None
 
+    # ------------------------------------------------------------------
+    # Public API
+    def register_table(self, table: str, sql: str) -> None:
+        """Register ``INSERT`` SQL for *table* used by :meth:`add`."""
+
+        self._insert_sql[table] = sql
+
+    async def add(self, table: str, row: dict[str, Any]) -> None:
+        """Queue *row* for asynchronous persistence.
+
+        ``row`` is buffered until ``batch_size`` is reached or ``flush_interval``
+        elapses.  Backpressure is handled by ``asyncio.Queue`` which blocks when
+        the queue exceeds ``queue_maxsize``.
+        """
+
+        if table not in self._insert_sql:
+            raise KeyError(f"Unknown table: {table}")
+        await self._queue.put((table, row))
+        if self._worker_task is None or self._worker_task.done():
+            self._worker_task = asyncio.create_task(self._worker())
+
+    async def flush(self) -> None:
+        """Flush all pending rows to the database."""
+
+        await self._queue.join()
+
+    async def stop(self) -> None:
+        """Flush pending rows and stop the background worker."""
+
+        self._closed = True
+        await self.flush()
+        if self._worker_task is not None:
+            await self._worker_task
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    async def _worker(self) -> None:
+        """Background task consuming the queue and writing batches."""
+
+        try:
+            while not (self._closed and self._queue.empty()):
+                batch: list[tuple[str, dict[str, Any]]] = []
+                try:
+                    item = await asyncio.wait_for(
+                        self._queue.get(), timeout=self.flush_interval
+                    )
+                    batch.append(item)
+                except asyncio.TimeoutError:
+                    pass
+
+                while len(batch) < self.batch_size:
+                    try:
+                        batch.append(self._queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                if not batch:
+                    continue
+
+                grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+                for table, row in batch:
+                    grouped[table].append(row)
+
+                for table, rows in grouped.items():
+                    sql = self._insert_sql[table]
+                    start = time.perf_counter()
+                    await self.executemany(sql, rows)
+                    BATCH_LATENCY.labels(table).observe(time.perf_counter() - start)
+
+                for _ in batch:
+                    self._queue.task_done()
+        finally:  # pragma: no cover - worker cleanup
+            pass
+
+    # Low level helpers -------------------------------------------------
     async def executemany(self, sql: str, rows: Iterable[dict[str, Any]]) -> None:
-        """Execute *sql* for multiple *rows* in a single transaction."""
         rows = list(rows)
         if not rows:
             return

--- a/tests/test_backfill_persistence.py
+++ b/tests/test_backfill_persistence.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import text
+
+
+SCHEMA_SQL = Path("db/schema.sql").read_text()
+
+pytestmark = pytest.mark.integration
+
+if not os.environ.get("PG_TEST", ""):
+    pytest.skip("PostgreSQL not available", allow_module_level=True)
+
+
+class DummyExchange:
+    rateLimit = 0
+    id = "dummy"
+
+    def __init__(self) -> None:
+        self._ohlcv_used = False
+        self._trades_used = False
+
+    async def fetch_ohlcv(self, symbol, timeframe, since, limit):  # noqa: ANN001
+        if self._ohlcv_used:
+            return []
+        self._ohlcv_used = True
+        # Single bar
+        return [[since, 1.0, 2.0, 0.5, 1.5, 10.0]]
+
+    async def fetch_trades(self, symbol, since, limit):  # noqa: ANN001
+        if self._trades_used:
+            return []
+        self._trades_used = True
+        return [
+            {
+                "timestamp": since,
+                "price": 1.0,
+                "amount": 2.0,
+                "side": "buy",
+                "id": "t1",
+            }
+        ]
+
+    async def close(self) -> None:  # pragma: no cover - nothing to do
+        pass
+
+
+@pytest_asyncio.fixture(scope="module")
+async def setup_db():
+    dsn = "postgresql+asyncpg://postgres:postgres@localhost/tradebot_test"
+    eng = create_async_engine(dsn, echo=False)
+    async with eng.begin() as conn:
+        for stmt in SCHEMA_SQL.split(";"):
+            s = stmt.strip()
+            if s:
+                await conn.execute(text(s))
+    yield
+    await eng.dispose()
+
+
+@pytest.mark.asyncio
+async def test_backfill_persists_data(monkeypatch, setup_db):
+    monkeypatch.setenv("PG_HOST", "localhost")
+    monkeypatch.setenv("PG_USER", "postgres")
+    monkeypatch.setenv("PG_PASSWORD", "postgres")
+    monkeypatch.setenv("PG_DB", "tradebot_test")
+
+    from tradingbot.jobs import backfill as job_backfill
+
+    monkeypatch.setattr(job_backfill.ccxt, "binance", lambda *_, **__: DummyExchange())
+
+    await job_backfill.backfill(days=1, symbols=["BTC/USDT"])
+
+    from tradingbot.storage.async_timescale import AsyncTimescaleClient
+
+    client = AsyncTimescaleClient(
+        dsn="postgresql+asyncpg://postgres:postgres@localhost/tradebot_test"
+    )
+    bars = await client.fetch("SELECT symbol, o, v FROM market.bars")
+    trades = await client.fetch("SELECT symbol, px, qty FROM market.trades")
+    await client.close()
+
+    assert bars and bars[0]["symbol"] == "BTCUSDT"
+    assert trades and trades[0]["symbol"] == "BTCUSDT"
+


### PR DESCRIPTION
## Summary
- implement `AsyncTimescaleClient` with queue-based batching, backpressure and latency metrics
- rewrite backfill job to persist OHLCV and trades with rate limiting and retries
- expose new backfill routine through CLI and test persistence

## Testing
- `pytest -q` *(killed: process out of memory)*
- `pytest tests/test_backfill_persistence.py -q` *(skipped: PostgreSQL not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a3725fe448832dbaec1638aa9661b2