### PR TITLE
feat: add book analytics streams

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -94,6 +94,85 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
 
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Yield best bid/ask updates derived from order book snapshots."""
+
+        async for ob in self.stream_order_book(symbol, depth=1):
+            bid_px = ob.get("bid_px", [])
+            ask_px = ob.get("ask_px", [])
+            bid_qty = ob.get("bid_qty", [])
+            ask_qty = ob.get("ask_qty", [])
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": bid_px[0] if bid_px else None,
+                "bid_qty": bid_qty[0] if bid_qty else 0.0,
+                "ask_px": ask_px[0] if ask_px else None,
+                "ask_qty": ask_qty[0] if ask_qty else 0.0,
+            }
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield order book deltas relative to the previous snapshot."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol, depth):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                prev_bids = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                prev_asks = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if prev_bids.get(p) != q]
+                delta_bids += [[p, 0.0] for p in prev_bids.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if prev_asks.get(p) != q]
+                delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream funding rate updates for ``symbol``."""
+
+        stream = _stream_name(normalize(symbol), "markPrice@1s")
+        url = self.ws_base + stream
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or msg
+            rate = d.get("r") or d.get("fundingRate")
+            if rate is None:
+                continue
+            ts_ms = d.get("E") or d.get("T") or 0
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            yield {
+                "symbol": symbol,
+                "ts": ts,
+                "rate": float(rate),
+                "interval_sec": int(d.get("i") or 0),
+            }
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream open interest updates for ``symbol``."""
+
+        stream = _stream_name(normalize(symbol), "openInterest")
+        url = self.ws_base + stream
+        async for raw in self._ws_messages(url):
+            msg = json.loads(raw)
+            d = msg.get("data") or msg
+            oi = d.get("oi") or d.get("openInterest")
+            if oi is None:
+                continue
+            ts_ms = d.get("E") or d.get("T") or 0
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            yield {"symbol": symbol, "ts": ts, "oi": float(oi)}
+
     async def fetch_funding(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_funding(symbol)

--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -92,6 +92,50 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
 
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream best bid/ask for *symbol* using order book snapshots."""
+
+        async for ob in self.stream_order_book(symbol, depth=1):
+            bid_px = ob.get("bid_px", [])
+            ask_px = ob.get("ask_px", [])
+            bid_qty = ob.get("bid_qty", [])
+            ask_qty = ob.get("ask_qty", [])
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": bid_px[0] if bid_px else None,
+                "bid_qty": bid_qty[0] if bid_qty else 0.0,
+                "ask_px": ask_px[0] if ask_px else None,
+                "ask_qty": ask_qty[0] if ask_qty else 0.0,
+            }
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Stream order book deltas compared to the previous snapshot."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol, depth):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                prev_bids = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                prev_asks = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if prev_bids.get(p) != q]
+                delta_bids += [[p, 0.0] for p in prev_bids.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if prev_asks.get(p) != q]
+                delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
     async def fetch_funding(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_funding(symbol)

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -85,6 +85,88 @@ class BybitWSAdapter(ExchangeAdapter):
 
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream best bid/ask updates for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol, depth=1):
+            bid_px = ob.get("bid_px", [])
+            ask_px = ob.get("ask_px", [])
+            bid_qty = ob.get("bid_qty", [])
+            ask_qty = ob.get("ask_qty", [])
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": bid_px[0] if bid_px else None,
+                "bid_qty": bid_qty[0] if bid_qty else 0.0,
+                "ask_px": ask_px[0] if ask_px else None,
+                "ask_qty": ask_qty[0] if ask_qty else 0.0,
+            }
+
+    async def stream_book_delta(self, symbol: str, depth: int = 1) -> AsyncIterator[dict]:
+        """Stream order book deltas compared to the previous snapshot."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol, depth):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                prev_bids = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                prev_asks = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if prev_bids.get(p) != q]
+                delta_bids += [[p, 0.0] for p in prev_bids.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if prev_asks.get(p) != q]
+                delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream funding rate updates for ``symbol``."""
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"fundingRate.{sym}"]}
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                rate = d.get("fundingRate") or d.get("rate")
+                if rate is None:
+                    continue
+                ts_ms = int(d.get("timestamp") or d.get("ts") or 0)
+                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                interval = int(d.get("fundingRateInterval") or 0)
+                yield {
+                    "symbol": symbol,
+                    "ts": ts,
+                    "rate": float(rate),
+                    "interval_sec": interval,
+                }
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream open interest updates for ``symbol``."""
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"openInterest.{sym}"]}
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                oi = d.get("openInterest") or d.get("oi")
+                if oi is None:
+                    continue
+                ts_ms = int(d.get("timestamp") or d.get("ts") or 0)
+                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                yield {"symbol": symbol, "ts": ts, "oi": float(oi)}
+
     # ------------------------------------------------------------------
     async def fetch_funding(self, symbol: str):
         """Return current funding rate for ``symbol`` via REST."""

--- a/src/tradingbot/adapters/okx_ws.py
+++ b/src/tradingbot/adapters/okx_ws.py
@@ -77,6 +77,88 @@ class OKXWSAdapter(ExchangeAdapter):
 
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream best bid/ask levels for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol, depth=1):
+            bid_px = ob.get("bid_px", [])
+            ask_px = ob.get("ask_px", [])
+            bid_qty = ob.get("bid_qty", [])
+            ask_qty = ob.get("ask_qty", [])
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": bid_px[0] if bid_px else None,
+                "bid_qty": bid_qty[0] if bid_qty else 0.0,
+                "ask_px": ask_px[0] if ask_px else None,
+                "ask_qty": ask_qty[0] if ask_qty else 0.0,
+            }
+
+    async def stream_book_delta(self, symbol: str, depth: int = 5) -> AsyncIterator[dict]:
+        """Stream order book deltas relative to previous snapshots."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol, depth):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                prev_bids = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                prev_asks = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if prev_bids.get(p) != q]
+                delta_bids += [[p, 0.0] for p in prev_bids.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if prev_asks.get(p) != q]
+                delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream funding rate updates for ``symbol``."""
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [{"channel": "funding-rate", "instId": sym}]}
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                rate = d.get("fundingRate") or d.get("fundingRate")
+                if rate is None:
+                    continue
+                ts_ms = int(d.get("ts", 0))
+                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                interval = int(d.get("fundingInterval") or 0)
+                yield {
+                    "symbol": symbol,
+                    "ts": ts,
+                    "rate": float(rate),
+                    "interval_sec": interval,
+                }
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream open interest updates for ``symbol``."""
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [{"channel": "open-interest", "instId": sym}]}
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                oi = d.get("oi") or d.get("openInterest")
+                if oi is None:
+                    continue
+                ts_ms = int(d.get("ts", 0))
+                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                yield {"symbol": symbol, "ts": ts, "oi": float(oi)}
+
     # ------------------------------------------------------------------
     async def fetch_funding(self, symbol: str):
         if not self.rest:


### PR DESCRIPTION
## Summary
- stream BBA and book deltas across websocket adapters
- expose streaming funding and open interest on derivative venues
- persist BBA/book deltas and extend CLI ingestion modes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3723aee8c832d97f57d232adb16fe