### PR TITLE
Add make targets for Docker workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 MONITORING_COMPOSE=docker-compose.prod.yml
 
+.PHONY: up down logs
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
 .PHONY: monitoring-up monitoring-down monitoring-update
 
 monitoring-up:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env   # completa con tus claves
 ```
+## Arranque rápido
+
+Inicia y detén los servicios de Docker con el Makefile:
+
+```bash
+make up    # levanta los servicios en segundo plano
+make logs  # sigue los logs de todos los contenedores
+make down  # detiene y elimina los servicios
+```
 ## Configuración inicial
 
 1. Copia `.env.example` a `.env` y completa tus claves API (`BINANCE_KEY`,
@@ -99,7 +108,7 @@ cp .env.example .env   # completa con tus claves
 2. (Opcional) Levanta la base de datos y el stack de monitoreo con Docker:
 
    ```bash
-   docker-compose up -d
+   make up
    ```
 
 3. Inicia el panel web con métricas y consola de comandos:


### PR DESCRIPTION
## Summary
- add `make up`, `down` and `logs` for docker compose
- document quick start workflow with new make commands

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a374621e70832da4602222e6ff45b9