### PR TITLE
feat: add OFI wrapper and update imports

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from ..risk.manager import RiskManager
 from ..strategies import STRATEGIES
-from ..data.features import returns, order_flow_imbalance
+from ..data.features import returns, calc_ofi
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class SlippageModel:
             ofi_val = float(bar["order_flow_imbalance"])
         elif {"bid_qty", "ask_qty"}.issubset(bar.index):
             ofi_val = float(
-                order_flow_imbalance(
+                calc_ofi(
                     pd.DataFrame([[bar["bid_qty"], bar["ask_qty"]]], columns=["bid_qty", "ask_qty"])
                 ).iloc[-1]
             )

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics
-from ..data.features import order_flow_imbalance, returns
+from ..data.features import calc_ofi, returns
 
 
 class MeanRevOFI(Strategy):
@@ -46,7 +46,7 @@ class MeanRevOFI(Strategy):
         if not needed.issubset(df.columns) or len(df) < min_len:
             return None
 
-        ofi_series = order_flow_imbalance(df[["bid_qty", "ask_qty"]])
+        ofi_series = calc_ofi(df[["bid_qty", "ask_qty"]])
         rolling_mean = ofi_series.rolling(self.ofi_window).mean()
         rolling_std = ofi_series.rolling(self.ofi_window).std(ddof=0).replace(0, np.nan)
         zscore = ((ofi_series - rolling_mean) / rolling_std).iloc[-1]

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
-from ..data.features import rsi, order_flow_imbalance
+from ..data.features import rsi, calc_ofi
 
 class MeanReversion(Strategy):
     """RSI based mean reversion strategy.
@@ -35,7 +35,7 @@ class MeanReversion(Strategy):
         last_rsi = rsi_series.iloc[-1]
         ofi_val = 0.0
         if {"bid_qty", "ask_qty"}.issubset(df.columns):
-            ofi_val = order_flow_imbalance(df[["bid_qty", "ask_qty"]]).iloc[-1]
+            ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
         if last_rsi > self.upper and ofi_val <= 0:
             return Signal("sell", 1.0)
         if last_rsi < self.lower and ofi_val >= 0:

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
-from ..data.features import rsi, order_flow_imbalance
+from ..data.features import rsi, calc_ofi
 
 class Momentum(Strategy):
     """Simple momentum strategy using the Relative Strength Index (RSI).
@@ -32,7 +32,7 @@ class Momentum(Strategy):
         last_rsi = rsi_series.iloc[-1]
         ofi_val = 0.0
         if {"bid_qty", "ask_qty"}.issubset(df.columns):
-            ofi_val = order_flow_imbalance(df[["bid_qty", "ask_qty"]]).iloc[-1]
+            ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
         if last_rsi > self.threshold and ofi_val >= 0:
             return Signal("buy", 1.0)
         if last_rsi < 100 - self.threshold and ofi_val <= 0:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
-from ..data.features import order_flow_imbalance
+from ..data.features import calc_ofi
 
 
 class OrderFlow(Strategy):
@@ -23,7 +23,7 @@ class OrderFlow(Strategy):
         needed = {"bid_qty", "ask_qty"}
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
-        ofi_series = order_flow_imbalance(df[list(needed)])
+        ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
         if ofi_mean > self.buy_threshold:
             return Signal("buy", 1.0)

--- a/tests/test_execution_router_slippage.py
+++ b/tests/test_execution_router_slippage.py
@@ -5,7 +5,7 @@ from tradingbot.execution.router import ExecutionRouter
 from tradingbot.execution.slippage import impact_by_depth, queue_position
 from tradingbot.utils.metrics import SLIPPAGE
 from tradingbot.backtesting.engine import SlippageModel
-from tradingbot.data.features import order_flow_imbalance
+from tradingbot.data.features import calc_ofi
 import pandas as pd
 
 
@@ -126,7 +126,7 @@ def test_slippage_model_ofi_impact():
             "ask_qty": [1.0, 1.0],
         }
     )
-    df["order_flow_imbalance"] = order_flow_imbalance(df[["bid_qty", "ask_qty"]])
+    df["order_flow_imbalance"] = calc_ofi(df[["bid_qty", "ask_qty"]])
     bar = df.iloc[1]
     model = SlippageModel(volume_impact=0.0, spread_mult=0.0, ofi_impact=0.5)
     price = 100.0

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from tradingbot.data.features import (
+    calc_ofi,
     order_flow_imbalance,
     depth_imbalance,
     rsi,
@@ -106,13 +107,15 @@ def ohlc_snapshots(ohlc_df):
 # Order book features
 
 
-def test_order_flow_imbalance_df(orderbook_df):
-    ofi = order_flow_imbalance(orderbook_df)
+@pytest.mark.parametrize("func", [order_flow_imbalance, calc_ofi])
+def test_order_flow_imbalance_df(orderbook_df, func):
+    ofi = func(orderbook_df)
     assert list(ofi) == [0, 4, -3, -1]
 
 
-def test_order_flow_imbalance_snapshots(orderbook_snapshots):
-    ofi = order_flow_imbalance(orderbook_snapshots)
+@pytest.mark.parametrize("func", [order_flow_imbalance, calc_ofi])
+def test_order_flow_imbalance_snapshots(orderbook_snapshots, func):
+    ofi = func(orderbook_snapshots)
     assert list(ofi) == [0, 4, -3, -1]
 
 
@@ -138,8 +141,9 @@ def test_depth_imbalance_snapshots(orderbook_snapshots):
     assert all(abs(a - b) < 1e-9 for a, b in zip(di, expected))
 
 
-def test_order_flow_imbalance_l2(l2_snapshots):
-    ofi = order_flow_imbalance(l2_snapshots, depth=2)
+@pytest.mark.parametrize("func", [order_flow_imbalance, calc_ofi])
+def test_order_flow_imbalance_l2(l2_snapshots, func):
+    ofi = func(l2_snapshots, depth=2)
     assert list(ofi) == [0.0, 13.0, 0.0]
 
 


### PR DESCRIPTION
## Summary
- expose `calc_ofi` wrapper and public `depth_imbalance` delegate
- switch strategies and backtest engine to use new `calc_ofi`
- expand feature tests with deterministic synthetic data for both OFI names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a372475f80832d90022679a27ac54e