### PR TITLE
feat: load strategy params from YAML configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ consola del panel web.
 python -m tradingbot.cli <comando> [opciones]
 ```
 
+Los runners (`run-bot`, `real-run`, `paper-run`) aceptan una opción
+`--config` para cargar parámetros de la estrategia desde un archivo YAML.
+
 | Comando | Descripción | Ejemplo |
 |---------|-------------|---------|
 | `ingest` | Stream de order book a la base de datos | `python -m tradingbot.cli ingest BTC/USDT --depth 20` |
 | `ingest-historical` | Descarga histórica desde Kaiko o CoinAPI | `python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades` |
-| `run-bot` | Ejecuta el bot en vivo o testnet | `python -m tradingbot.cli run-bot --exchange binance --symbol BTC/USDT` |
-| `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr` |
+| `run-bot` | Ejecuta el bot en vivo o testnet | `python -m tradingbot.cli run-bot --exchange binance --symbol BTC/USDT --config cfg/estrategia.yaml` |
+| `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr --config cfg/estrategia.yaml` |
 | `daemon` | Levanta el daemon de trading mediante Hydra | `python -m tradingbot.cli daemon config/config.yaml` |
 | `ingestion-workers` | Workers de funding y open interest | `python -m tradingbot.cli ingestion-workers` |
 | `backtest` | Backtest vectorizado desde CSV | `python -m tradingbot.cli backtest data/ohlcv.csv` |

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -199,6 +199,7 @@ def run_bot(
     trade_qty: float = typer.Option(0.001, help="Order size"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
+    config: str | None = typer.Option(None, "--config", help="YAML with strategy parameters"),
 ) -> None:
     """Run the live trading bot with configurable exchange and symbols."""
 
@@ -214,12 +215,13 @@ def run_bot(
                 trade_qty=trade_qty,
                 leverage=leverage,
                 dry_run=dry_run,
+                config_path=config,
             )
         )
     else:
         from ..live.runner import run_live_binance
 
-        asyncio.run(run_live_binance(symbol=symbols[0]))
+        asyncio.run(run_live_binance(symbol=symbols[0], config_path=config))
 
 
 @app.command("paper-run")
@@ -227,13 +229,21 @@ def paper_run(
     symbol: str = typer.Option("BTC/USDT", "--symbol", help="Trading symbol"),
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
+    config: str | None = typer.Option(None, "--config", help="YAML with strategy parameters"),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
     setup_logging()
     from ..live.runner_paper import run_paper
 
-    asyncio.run(run_paper(symbol=symbol, strategy_name=strategy, metrics_port=metrics_port))
+    asyncio.run(
+        run_paper(
+            symbol=symbol,
+            strategy_name=strategy,
+            metrics_port=metrics_port,
+            config=config,
+        )
+    )
 
 
 @app.command("real-run")
@@ -249,6 +259,7 @@ def real_run(
         "--i-know-what-im-doing",
         help="Acknowledge that this will trade on a real exchange",
     ),
+    config: str | None = typer.Option(None, "--config", help="YAML with strategy parameters"),
 ) -> None:
     """Run the live trading bot on real exchange endpoints."""
 
@@ -266,6 +277,7 @@ def real_run(
             trade_qty=trade_qty,
             leverage=leverage,
             dry_run=dry_run,
+            config_path=config,
             i_know_what_im_doing=i_know_what_im_doing,
         )
     )

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -86,6 +86,7 @@ async def run_live_binance(
     symbol: str = "BTC/USDT",
     fee_bps: float = 1.5,
     persist_pg: bool = False,
+    config_path: str | None = None,
     total_cap_usdt: float = 1000.0,
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
@@ -101,7 +102,7 @@ async def run_live_binance(
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
     risk_core = RiskManager(max_pos=1.0)
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -32,6 +32,7 @@ async def run_paper(
     strategy_name: str = "breakout_atr",
     *,
     metrics_port: int = 8000,
+    config: str | None = None,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
 
@@ -46,7 +47,10 @@ async def run_paper(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    strat = strat_cls()
+    if config:
+        strat = strat_cls(config_path=config)
+    else:
+        strat = strat_cls()
 
     server = await _start_metrics(metrics_port)
 

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -87,6 +87,7 @@ async def _run_symbol(
     daily_max_loss_usdt: float,
     daily_max_drawdown_pct: float,
     max_consecutive_losses: int,
+    config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     api_key, api_secret = _get_keys(exchange)
@@ -96,7 +97,7 @@ async def _run_symbol(
     ws = ws_cls()
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     risk = RiskManager(max_pos=1.0)
     guard = PortfolioGuard(
         GuardConfig(
@@ -171,6 +172,7 @@ async def run_live_real(
     trade_qty: float = 0.001,
     leverage: int = 1,
     dry_run: bool = False,
+    config_path: str | None = None,
     *,
     i_know_what_im_doing: bool,
     total_cap_usdt: float = 1000.0,
@@ -209,6 +211,7 @@ async def run_live_real(
             daily_max_loss_usdt,
             daily_max_drawdown_pct,
             max_consecutive_losses,
+            config_path=config_path,
         )
         for c in cfgs
     ]

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -44,7 +44,8 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
                       dry_run: bool, total_cap_usdt: float, per_symbol_cap_usdt: float,
                       soft_cap_pct: float, soft_cap_grace_sec: int,
                       daily_max_loss_usdt: float, daily_max_drawdown_pct: float,
-                      max_consecutive_losses: int) -> None:
+                      max_consecutive_losses: int,
+                      config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     ws_kwargs: Dict[str, Any] = {}
     exec_kwargs: Dict[str, Any] = {}
@@ -64,7 +65,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         except TypeError:
             exec_adapter = exec_cls()
     agg = BarAggregator()
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     risk = RiskManager(max_pos=1.0)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
@@ -126,6 +127,7 @@ async def run_live_testnet(
     trade_qty: float = 0.001,
     leverage: int = 1,
     dry_run: bool = False,
+    config_path: str | None = None,
     total_cap_usdt: float = 1000.0,
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
@@ -142,7 +144,8 @@ async def run_live_testnet(
     tasks = [
         _run_symbol(exchange, market, c, leverage, dry_run, total_cap_usdt,
                     per_symbol_cap_usdt, soft_cap_pct, soft_cap_grace_sec,
-                    daily_max_loss_usdt, daily_max_drawdown_pct, max_consecutive_losses)
+                    daily_max_loss_usdt, daily_max_drawdown_pct, max_consecutive_losses,
+                    config_path=config_path)
         for c in cfgs
     ]
     await asyncio.gather(*tasks)

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 import time
+
+import yaml
 
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
@@ -59,4 +62,28 @@ def record_signal_metrics(fn):
     return wrapper
 
 
-__all__ = ["Signal", "Strategy", "record_signal_metrics"]
+def load_params(path: str) -> dict[str, Any]:
+    """Load strategy parameters from a YAML file.
+
+    Parameters
+    ----------
+    path : str
+        Path to a YAML file containing a mapping of parameter names to
+        values.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary with parameters. Returns an empty dict if the file is not
+        found or cannot be parsed.
+    """
+
+    try:
+        with Path(path).open("r") as fh:
+            data = yaml.safe_load(fh) or {}
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+__all__ = ["Signal", "Strategy", "record_signal_metrics", "load_params"]

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -1,11 +1,22 @@
 import pandas as pd
-from .base import Strategy, Signal, record_signal_metrics
+from .base import Strategy, Signal, record_signal_metrics, load_params
 from ..data.features import keltner_channels
 
 class BreakoutATR(Strategy):
     name = "breakout_atr"
 
-    def __init__(self, ema_n: int = 20, atr_n: int = 14, mult: float = 1.5):
+    def __init__(
+        self,
+        ema_n: int = 20,
+        atr_n: int = 14,
+        mult: float = 1.5,
+        config_path: str | None = None,
+    ) -> None:
+        if config_path:
+            params = load_params(config_path)
+            ema_n = params.get("ema_n", ema_n)
+            atr_n = params.get("atr_n", atr_n)
+            mult = params.get("mult", mult)
         self.ema_n = ema_n
         self.atr_n = atr_n
         self.mult = mult

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from .base import Strategy, Signal, record_signal_metrics
+from .base import Strategy, Signal, record_signal_metrics, load_params
 from ..data.features import order_flow_imbalance, returns
 
 
@@ -32,7 +32,14 @@ class MeanRevOFI(Strategy):
         zscore_threshold: float = 1.0,
         vol_window: int = 20,
         vol_threshold: float = 0.01,
+        config_path: str | None = None,
     ) -> None:
+        if config_path:
+            params = load_params(config_path)
+            ofi_window = params.get("ofi_window", ofi_window)
+            zscore_threshold = params.get("zscore_threshold", zscore_threshold)
+            vol_window = params.get("vol_window", vol_window)
+            vol_threshold = params.get("vol_threshold", vol_threshold)
         self.ofi_window = ofi_window
         self.zscore_threshold = zscore_threshold
         self.vol_window = vol_window

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -3,6 +3,7 @@ import yaml
 from tradingbot.strategies.breakout_atr import BreakoutATR
 from tradingbot.strategies.order_flow import OrderFlow
 from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
+from tradingbot.strategies.breakout_atr import BreakoutATR
 from hypothesis import given, strategies as st
 
 
@@ -63,6 +64,15 @@ vol_threshold: 1.0
 
     sig_buy = strat.on_bar({"window": df_buy})
     assert sig_buy.side == "buy"
+
+
+def test_breakout_atr_config(tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("ema_n: 5\natr_n: 5\nmult: 2.0\n")
+    strat = BreakoutATR(config_path=str(cfg))
+    assert strat.ema_n == 5
+    assert strat.atr_n == 5
+    assert strat.mult == 2.0
 
 
 @given(start=st.floats(1, 10), inc=st.floats(0.1, 5))


### PR DESCRIPTION
## Summary
- add `load_params` helper to read strategy settings from YAML files
- allow BreakoutATR and MeanRevOFI to load parameters from optional `config_path`
- pass `--config` through live runners and document usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37468c684832d91c27d95516738fc