### PR TITLE
feat: allow YAML-configured strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ python -m tradingbot.cli <comando> [opciones]
 | `ingest` | Stream de order book a la base de datos | `python -m tradingbot.cli ingest --venue binance_spot --symbol BTC/USDT --depth 20` |
 | `ingest-historical` | Descarga histórica desde Kaiko o CoinAPI | `python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades` |
 | `run-bot` | Ejecuta el bot en vivo o testnet | `python -m tradingbot.cli run-bot --exchange binance --symbol BTC/USDT` |
-| `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr` |
+| `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr --config params.yaml` |
 | `daemon` | Levanta el daemon de trading mediante Hydra | `python -m tradingbot.cli daemon config/config.yaml` |
 | `ingestion-workers` | Workers de funding y open interest | `python -m tradingbot.cli ingestion-workers` |
 | `backtest` | Backtest vectorizado desde CSV | `python -m tradingbot.cli backtest data/ohlcv.csv` |
@@ -188,6 +188,9 @@ python -m tradingbot.cli <comando> [opciones]
 
 La salida de cada comando aparecerá tanto en la terminal como en la consola
 del panel web.
+
+Las estrategias que lo permitan aceptan parámetros externos a través de un
+archivo YAML pasado con el flag `--config`.
 
 ## Ejecutar pruebas
 

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -333,13 +333,21 @@ def paper_run(
     symbol: str = typer.Option("BTC/USDT", "--symbol", help="Trading symbol"),
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
+    config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
     setup_logging()
     from ..live.runner_paper import run_paper
 
-    asyncio.run(run_paper(symbol=symbol, strategy_name=strategy, metrics_port=metrics_port))
+    asyncio.run(
+        run_paper(
+            symbol=symbol,
+            strategy_name=strategy,
+            config_path=config,
+            metrics_port=metrics_port,
+        )
+    )
 
 
 @app.command("real-run")

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -93,6 +93,8 @@ async def run_live_binance(
     daily_max_loss_usdt: float = 100.0,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
+    *,
+    config_path: str | None = None,
 ):
     """
     Pipeline en vivo:
@@ -101,7 +103,7 @@ async def run_live_binance(
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
     risk_core = RiskManager(max_pos=1.0)
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -31,6 +31,7 @@ async def run_paper(
     symbol: str = "BTC/USDT",
     strategy_name: str = "breakout_atr",
     *,
+    config_path: str | None = None,
     metrics_port: int = 8000,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
@@ -46,7 +47,7 @@ async def run_paper(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    strat = strat_cls()
+    strat = strat_cls(config_path=config_path) if config_path else strat_cls()
 
     server = await _start_metrics(metrics_port)
 

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -87,6 +87,7 @@ async def _run_symbol(
     daily_max_loss_usdt: float,
     daily_max_drawdown_pct: float,
     max_consecutive_losses: int,
+    config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     api_key, api_secret = _get_keys(exchange)
@@ -96,7 +97,7 @@ async def _run_symbol(
     ws = ws_cls()
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     risk = RiskManager(max_pos=1.0)
     guard = PortfolioGuard(
         GuardConfig(
@@ -180,6 +181,7 @@ async def run_live_real(
     daily_max_loss_usdt: float = 100.0,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
+    config_path: str | None = None,
 ) -> None:
     """Run a simple live loop on a real crypto exchange."""
 
@@ -209,6 +211,7 @@ async def run_live_real(
             daily_max_loss_usdt,
             daily_max_drawdown_pct,
             max_consecutive_losses,
+            config_path=config_path,
         )
         for c in cfgs
     ]

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -44,7 +44,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
                       dry_run: bool, total_cap_usdt: float, per_symbol_cap_usdt: float,
                       soft_cap_pct: float, soft_cap_grace_sec: int,
                       daily_max_loss_usdt: float, daily_max_drawdown_pct: float,
-                      max_consecutive_losses: int) -> None:
+                      max_consecutive_losses: int, config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     ws_kwargs: Dict[str, Any] = {}
     exec_kwargs: Dict[str, Any] = {}
@@ -64,7 +64,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         except TypeError:
             exec_adapter = exec_cls()
     agg = BarAggregator()
-    strat = BreakoutATR()
+    strat = BreakoutATR(config_path=config_path)
     risk = RiskManager(max_pos=1.0)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
@@ -133,6 +133,8 @@ async def run_live_testnet(
     daily_max_loss_usdt: float = 100.0,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
+    *,
+    config_path: str | None = None,
 ) -> None:
     """Run a simple live loop on a crypto exchange testnet."""
     if (exchange, market) not in ADAPTERS:
@@ -142,7 +144,8 @@ async def run_live_testnet(
     tasks = [
         _run_symbol(exchange, market, c, leverage, dry_run, total_cap_usdt,
                     per_symbol_cap_usdt, soft_cap_pct, soft_cap_grace_sec,
-                    daily_max_loss_usdt, daily_max_drawdown_pct, max_consecutive_losses)
+                    daily_max_loss_usdt, daily_max_drawdown_pct,
+                    max_consecutive_losses, config_path=config_path)
         for c in cfgs
     ]
     await asyncio.gather(*tasks)

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 import time
+
+import yaml
 
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
@@ -17,6 +20,29 @@ class Strategy(ABC):
     @abstractmethod
     def on_bar(self, bar: dict[str, Any]) -> Signal | None:
         ...
+
+
+def load_params(path: str | None) -> dict[str, Any]:
+    """Load strategy parameters from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        Location of a YAML file containing a mapping of parameter names to
+        values. If ``None`` or empty, an empty dict is returned. The function
+        raises :class:`FileNotFoundError` when the path does not exist and
+        :class:`ValueError` if the YAML payload is not a mapping.
+    """
+
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(path)
+    data = yaml.safe_load(p.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError("config file must define a mapping of parameters")
+    return data
 
 
 def record_signal_metrics(fn):
@@ -59,4 +85,4 @@ def record_signal_metrics(fn):
     return wrapper
 
 
-__all__ = ["Signal", "Strategy", "record_signal_metrics"]
+__all__ = ["Signal", "Strategy", "load_params", "record_signal_metrics"]

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -1,14 +1,23 @@
 import pandas as pd
-from .base import Strategy, Signal, record_signal_metrics
+
+from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import keltner_channels
 
 class BreakoutATR(Strategy):
     name = "breakout_atr"
 
-    def __init__(self, ema_n: int = 20, atr_n: int = 14, mult: float = 1.5):
-        self.ema_n = ema_n
-        self.atr_n = atr_n
-        self.mult = mult
+    def __init__(
+        self,
+        ema_n: int = 20,
+        atr_n: int = 14,
+        mult: float = 1.5,
+        *,
+        config_path: str | None = None,
+    ):
+        params = load_params(config_path)
+        self.ema_n = int(params.get("ema_n", ema_n))
+        self.atr_n = int(params.get("atr_n", atr_n))
+        self.mult = float(params.get("mult", mult))
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from .base import Strategy, Signal, record_signal_metrics
+from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import calc_ofi, returns
 
 
@@ -32,11 +32,14 @@ class MeanRevOFI(Strategy):
         zscore_threshold: float = 1.0,
         vol_window: int = 20,
         vol_threshold: float = 0.01,
+        *,
+        config_path: str | None = None,
     ) -> None:
-        self.ofi_window = ofi_window
-        self.zscore_threshold = zscore_threshold
-        self.vol_window = vol_window
-        self.vol_threshold = vol_threshold
+        params = load_params(config_path)
+        self.ofi_window = int(params.get("ofi_window", ofi_window))
+        self.zscore_threshold = float(params.get("zscore_threshold", zscore_threshold))
+        self.vol_window = int(params.get("vol_window", vol_window))
+        self.vol_threshold = float(params.get("vol_threshold", vol_threshold))
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:


### PR DESCRIPTION
## Summary
- add helper to load YAML strategy parameters
- support `config_path` in BreakoutATR and MeanRevOFI
- wire config option through runners, CLI and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a378b4a95c832d825688c1b28aa892