### PR TITLE
Add order rejection rate alert and metrics

### DIFF
--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -64,6 +64,16 @@ groups:
           summary: Risk management events detected
           description: Risk events occurred in the last 5m
 
+      - alert: HighOrderRejectRate
+        # Trigger when more than 5% of orders are rejected
+        expr: increase(order_rejects_total[5m]) / increase(order_sent_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High order rejection rate
+          description: Order rejection rate exceeded 5% in the last 5m
+
       - alert: KillSwitchActive
         expr: kill_switch_active > 0
         for: 1m

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -14,6 +14,8 @@ from tradingbot.utils.metrics import (
     SLIPPAGE,
     RISK_EVENTS,
     ORDER_LATENCY,
+    ORDER_SENT,
+    ORDER_REJECTS,
     MAKER_TAKER_RATIO,
     KILL_SWITCH_ACTIVE,
     WS_FAILURES,
@@ -172,6 +174,10 @@ def metrics_summary() -> dict:
     avg_market_latency = _avg_market_latency()
     avg_e2e = _avg_e2e_latency()
 
+    orders_sent = ORDER_SENT._value.get()
+    order_rejects = ORDER_REJECTS._value.get()
+    reject_rate = order_rejects / orders_sent if orders_sent else 0.0
+
     # Compute average maker/taker ratio across venues
     ratio_samples = [
         sample.value
@@ -236,6 +242,9 @@ def metrics_summary() -> dict:
         "disconnects": SYSTEM_DISCONNECTS._value.get(),
         "fills": fill_total,
         "risk_events": risk_total,
+        "orders_sent": orders_sent,
+        "order_rejects": order_rejects,
+        "order_reject_rate": reject_rate,
         "kill_switch_active": KILL_SWITCH_ACTIVE._value.get(),
         "avg_slippage_bps": avg_slippage,
         "avg_market_latency_seconds": avg_market_latency,

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -35,6 +35,17 @@ FILL_COUNT = Counter(
     ["symbol", "side"],
 )
 
+# Order flow counters
+ORDER_SENT = Counter(
+    "order_sent_total",
+    "Total orders sent",
+)
+
+ORDER_REJECTS = Counter(
+    "order_rejects_total",
+    "Total order rejections",
+)
+
 # Slippage observed in order execution (basis points)
 SLIPPAGE = Histogram(
     "order_slippage_bps",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,10 @@
-from tradingbot.utils.metrics import FILL_COUNT, SLIPPAGE, RISK_EVENTS
+from tradingbot.utils.metrics import (
+    FILL_COUNT,
+    SLIPPAGE,
+    RISK_EVENTS,
+    ORDER_SENT,
+    ORDER_REJECTS,
+)
 
 
 def test_fill_slippage_risk_metrics():
@@ -6,6 +12,8 @@ def test_fill_slippage_risk_metrics():
     FILL_COUNT.clear()
     SLIPPAGE.clear()
     RISK_EVENTS.clear()
+    ORDER_SENT._value.set(0)
+    ORDER_REJECTS._value.set(0)
 
     FILL_COUNT.labels(symbol="BTCUSDT", side="buy").inc()
     samples = list(FILL_COUNT.collect())[0].samples
@@ -23,3 +31,13 @@ def test_fill_slippage_risk_metrics():
     samples = list(RISK_EVENTS.collect())[0].samples
     risk_sample = [s for s in samples if s.name == "risk_events_total" and s.labels["event_type"] == "limit_breach"][0]
     assert risk_sample.value == 1.0
+
+    ORDER_SENT.inc()
+    sent_samples = list(ORDER_SENT.collect())[0].samples
+    sent_sample = [s for s in sent_samples if s.name == "order_sent_total"][0]
+    assert sent_sample.value == 1.0
+
+    ORDER_REJECTS.inc()
+    rej_samples = list(ORDER_REJECTS.collect())[0].samples
+    rej_sample = [s for s in rej_samples if s.name == "order_rejects_total"][0]
+    assert rej_sample.value == 1.0

--- a/tests/test_monitoring_alerts.py
+++ b/tests/test_monitoring_alerts.py
@@ -18,6 +18,7 @@ def test_alerts_and_metrics_definitions():
     assert "RiskEvents" in rule_names
     assert "KillSwitchActive" in rule_names
     assert "WebsocketDisconnects" in rule_names
+    assert "HighOrderRejectRate" in rule_names
 
     assert "order_book_min_depth" in rule_names["LowOrderBookDepth"]["expr"]
     assert "ws_reconnections_total" in rule_names["WebsocketReconnections"]["expr"]
@@ -25,6 +26,8 @@ def test_alerts_and_metrics_definitions():
     assert "risk_events_total" in rule_names["RiskEvents"]["expr"]
     assert "kill_switch_active" in rule_names["KillSwitchActive"]["expr"]
     assert "ws_failures_total" in rule_names["WebsocketDisconnects"]["expr"]
+    assert "order_rejects_total" in rule_names["HighOrderRejectRate"]["expr"]
+    assert "order_sent_total" in rule_names["HighOrderRejectRate"]["expr"]
 
     ORDER_BOOK_MIN_DEPTH.clear()
     WS_RECONNECTS.clear()


### PR DESCRIPTION
## Summary
- alert on elevated order rejection rate over last 5 minutes
- track total orders sent and rejected, exposing rejection rate in metrics summary
- test coverage for new metrics and alert

## Testing
- `pytest tests/test_metrics.py tests/test_monitoring_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a386f20178832d86eae2a9746e3a5d