### PR TITLE
Add NoTicks alert to detect lack of trades

### DIFF
--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -99,3 +99,12 @@ groups:
         annotations:
           summary: Excessive order slippage
           description: 95th percentile slippage above 10 bps for 5m
+
+      - alert: NoTicks
+        expr: rate(trades_total[30s]) == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: No trades received
+          description: No ticks have been observed in the last 30s


### PR DESCRIPTION
## Summary
- add `NoTicks` Prometheus alert to watch for missing trade events

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a386f1781c832d870a9b8954be13ef