### PR TITLE
Add configurable maker/taker fees and adjust calculations

### DIFF
--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -1,7 +1,6 @@
 # src/tradingbot/adapters/binance_futures.py
 from __future__ import annotations
 import asyncio
-import os
 import logging, time, uuid
 from datetime import datetime, timezone
 from typing import AsyncIterator, Optional, Any, Dict
@@ -32,6 +31,8 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         api_secret: Optional[str] = None,
         testnet: bool = True,
         leverage: int = 5,
+        maker_fee_bps: float | None = None,
+        taker_fee_bps: float | None = None,
     ):
         super().__init__()
         if ccxt is None:
@@ -46,7 +47,24 @@ class BinanceFuturesAdapter(ExchangeAdapter):
             "enableRateLimit": True,
             "options": {"defaultType": "future"},
         })
-        self.taker_fee_bps = float(os.getenv("TRADING_TAKER_FEE_BPS_FUT", "5.0"))
+        self.maker_fee_bps = float(
+            maker_fee_bps
+            if maker_fee_bps is not None
+            else (
+                settings.binance_futures_testnet_maker_fee_bps
+                if testnet
+                else settings.binance_futures_maker_fee_bps
+            )
+        )
+        self.taker_fee_bps = float(
+            taker_fee_bps
+            if taker_fee_bps is not None
+            else (
+                settings.binance_futures_testnet_taker_fee_bps
+                if testnet
+                else settings.binance_futures_taker_fee_bps
+            )
+        )
         self.rest.set_sandbox_mode(testnet)
 
         # Advertir si faltan scopes necesarios o sobran permisos

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -1,7 +1,6 @@
 # src/tradingbot/adapters/binance_spot.py
 from __future__ import annotations
 import asyncio
-import os
 import logging, time, uuid
 from datetime import datetime, timezone
 from typing import AsyncIterator, Optional, Any, Dict
@@ -33,6 +32,8 @@ class BinanceSpotAdapter(ExchangeAdapter):
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         testnet: bool = False,
+        maker_fee_bps: float | None = None,
+        taker_fee_bps: float | None = None,
     ):
         super().__init__()
         if ccxt is None:
@@ -47,7 +48,24 @@ class BinanceSpotAdapter(ExchangeAdapter):
             "enableRateLimit": True,
             "options": {"defaultType": "spot"},
         })
-        self.taker_fee_bps = float(os.getenv("TRADING_TAKER_FEE_BPS", "10.0"))
+        self.maker_fee_bps = float(
+            maker_fee_bps
+            if maker_fee_bps is not None
+            else (
+                settings.binance_spot_testnet_maker_fee_bps
+                if testnet
+                else settings.binance_spot_maker_fee_bps
+            )
+        )
+        self.taker_fee_bps = float(
+            taker_fee_bps
+            if taker_fee_bps is not None
+            else (
+                settings.binance_spot_testnet_taker_fee_bps
+                if testnet
+                else settings.binance_spot_taker_fee_bps
+            )
+        )
         self.rest.set_sandbox_mode(testnet)
 
         # Advertir si faltan scopes necesarios o si hay permisos peligrosos

--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -52,6 +52,20 @@ class Settings(BaseSettings):
     binance_futures_leverage: int = 5    # puedes cambiarlo en CLI también
     binance_futures_market: str = "USDT-M"  # informativo
 
+    # Fees (bps) configurable por entorno
+    paper_maker_fee_bps: float = 0.0
+    paper_taker_fee_bps: float | None = None
+
+    binance_spot_maker_fee_bps: float = 0.0
+    binance_spot_taker_fee_bps: float = 10.0
+    binance_spot_testnet_maker_fee_bps: float = 0.0
+    binance_spot_testnet_taker_fee_bps: float = 10.0
+
+    binance_futures_maker_fee_bps: float = 0.0
+    binance_futures_taker_fee_bps: float = 5.0
+    binance_futures_testnet_maker_fee_bps: float = 0.0
+    binance_futures_testnet_taker_fee_bps: float = 5.0
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -8,6 +8,7 @@ import csv
 
 from ..adapters.base import ExchangeAdapter
 from .order_types import Order
+from ..config import settings
 
 log = logging.getLogger(__name__)
 
@@ -31,11 +32,24 @@ class PaperAdapter(ExchangeAdapter):
     """
     name = "paper"
 
-    def __init__(self, maker_fee_bps: float = 0.0, taker_fee_bps: float | None = None):
+    def __init__(
+        self,
+        maker_fee_bps: float | None = None,
+        taker_fee_bps: float | None = None,
+        fee_bps: float | None = None,
+    ):
         self.state = PaperState()
-        self.maker_fee_bps = float(maker_fee_bps)
+        mf = maker_fee_bps
+        if mf is None:
+            mf = fee_bps if fee_bps is not None else settings.paper_maker_fee_bps
+        self.maker_fee_bps = float(mf)
+        default_taker = (
+            settings.paper_taker_fee_bps
+            if settings.paper_taker_fee_bps is not None
+            else self.maker_fee_bps
+        )
         self.taker_fee_bps = float(
-            taker_fee_bps if taker_fee_bps is not None else maker_fee_bps
+            taker_fee_bps if taker_fee_bps is not None else default_taker
         )
 
     def update_last_price(self, symbol: str, px: float):

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -91,7 +91,9 @@ class ExecutionRouter:
 
             maker = maker_pref
             fee_attr = "maker_fee_bps" if maker else "taker_fee_bps"
-            fee_bps = getattr(adapter, fee_attr, getattr(adapter, "fee_bps", 0.0))
+            fee_bps = float(
+                getattr(adapter, fee_attr, getattr(adapter, "fee_bps", 0.0)) or 0.0
+            )
             fee = price * fee_bps / 10000.0
             latency = getattr(adapter, "latency", 0.0)
             direction = 1 if order.side == "buy" else -1
@@ -211,7 +213,9 @@ class ExecutionRouter:
         res.setdefault("est_slippage_bps", est_slippage)
         res.setdefault("queue_position", queue_pos)
         fee_attr = "maker_fee_bps" if maker else "taker_fee_bps"
-        fee_bps = getattr(adapter, fee_attr, getattr(adapter, "fee_bps", 0.0))
+        fee_bps = float(
+            getattr(adapter, fee_attr, getattr(adapter, "fee_bps", 0.0)) or 0.0
+        )
         res.setdefault("fee_type", "maker" if maker else "taker")
         res.setdefault("fee_bps", fee_bps)
         if res.get("status") == "filled":

--- a/src/tradingbot/risk/pnl.py
+++ b/src/tradingbot/risk/pnl.py
@@ -10,10 +10,10 @@ class Position:
     realized_pnl: float = 0.0   # acumulado (USDT)
     fees_paid: float = 0.0      # acumulado (USDT)
 
-def _fee_usdt(px: float, qty: float, taker_fee_bps: float) -> float:
-    return abs(px * qty) * (taker_fee_bps / 10000.0)
+def _fee_usdt(px: float, qty: float, fee_bps: float) -> float:
+    return abs(px * qty) * (fee_bps / 10000.0)
 
-def apply_fill(pos: Position, side: str, qty: float, px: float, taker_fee_bps: float, venue_type: str) -> Position:
+def apply_fill(pos: Position, side: str, qty: float, px: float, fee_bps: float, venue_type: str) -> Position:
     """
     Actualiza la posición con un fill estimado:
       - SPOT: qty >=0, solo lados buy (incrementa) y sell (reduce). No permitimos qty final <0.
@@ -23,7 +23,7 @@ def apply_fill(pos: Position, side: str, qty: float, px: float, taker_fee_bps: f
     q = float(qty)
     px = float(px)
     side = side.lower()
-    fee = _fee_usdt(px, q, taker_fee_bps)
+    fee = _fee_usdt(px, q, fee_bps)
 
     if venue_type == "spot":
       # Representamos spot como qty>=0 siempre

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -358,8 +358,8 @@ def rebuild_positions_from_fills(engine, venue: str) -> dict:
 
     from ..risk.pnl import Position, apply_fill
     out: dict[str, Position] = {}
-    # Asumimos taker fee bps aproximadas; si tus fills traen fee_usdt real, lo sumaremos aparte
-    taker_bps_guess = 2.0 if "futures" in venue else 7.5
+    # Asumimos fee bps aproximadas; si tus fills traen fee_usdt real, lo sumaremos aparte
+    fee_bps_guess = 2.0 if "futures" in venue else 7.5
     for r in rows:
         sym = r["symbol"]
         if sym not in out:
@@ -368,7 +368,7 @@ def rebuild_positions_from_fills(engine, venue: str) -> dict:
         px = float(r["price"])
         q = float(r["qty"])
         side = (r["side"] or "buy").lower()
-        p = apply_fill(p, side, q, px, taker_bps_guess, venue_type=("futures" if "futures" in venue else "spot"))
+        p = apply_fill(p, side, q, px, fee_bps_guess, venue_type=("futures" if "futures" in venue else "spot"))
         # ajusta fees si viene real
         fee = r["fee_usdt"]
         if fee is not None:

--- a/tests/test_execution_router_extra.py
+++ b/tests/test_execution_router_extra.py
@@ -50,3 +50,27 @@ async def test_execute_persists_fee_type(monkeypatch):
     await router.execute(order)
     assert captured["notes"]["fee_type"] == "taker"
     assert captured["notes"]["fee_bps"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_execute_persists_maker_fee(monkeypatch):
+    captured = {}
+
+    def fake_insert_order(engine, **kwargs):
+        nonlocal captured
+        captured = kwargs
+
+    monkeypatch.setattr(timescale, "insert_order", fake_insert_order)
+    adapter = DummyAdapter(maker_fee_bps=1.5)
+    router = ExecutionRouter(adapter, storage_engine="eng")
+    order = Order(
+        symbol="X",
+        side="buy",
+        type_="limit",
+        qty=1.0,
+        price=1.0,
+        post_only=True,
+    )
+    await router.execute(order)
+    assert captured["notes"]["fee_type"] == "maker"
+    assert captured["notes"]["fee_bps"] == 1.5

--- a/tests/test_execution_router_slippage.py
+++ b/tests/test_execution_router_slippage.py
@@ -64,6 +64,17 @@ async def test_router_selects_lowest_cost_venue_maker():
 
 
 @pytest.mark.asyncio
+async def test_execute_reports_fee_info():
+    ob = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(100.0, 1.0)]}}
+    adapter = MockAdapter("a", order_book=ob, taker_fee_bps=12.0)
+    router = ExecutionRouter(adapter)
+    order = Order(symbol="XYZ", side="buy", type_="market", qty=1.0)
+    res = await router.execute(order)
+    assert res["fee_type"] == "taker"
+    assert res["fee_bps"] == 12.0
+
+
+@pytest.mark.asyncio
 async def test_router_records_slippage_metric():
     SLIPPAGE.clear()
     ob = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(100.0, 1.0)]}}

--- a/tradebot_mvp.md
+++ b/tradebot_mvp.md
@@ -177,7 +177,7 @@
 
 ### 6.5 PnL y posiciones
 
-- `apply_fill(pos, side, qty, px, taker_fee_bps, venue_type)` → actualiza `avg_price`, `qty`, `realized_pnl`, `fees_paid`
+- `apply_fill(pos, side, qty, px, fee_bps, venue_type)` → actualiza `avg_price`, `qty`, `realized_pnl`, `fees_paid`
 - `mark_to_market(pos, mark_px)` → `UPnL` intradía
 
 ---


### PR DESCRIPTION
## Summary
- add maker/taker fee configuration to settings
- wire fee parameters through Binance adapters and paper trading
- update router and PnL helpers to use fee_bps
- test custom maker/taker fee scenarios

## Testing
- `pytest tests/test_execution_router_slippage.py tests/test_execution_router_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68a39076f77c832d8ad308a3f7bdd678