### PR TITLE
refactor logging utilities

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,29 @@
+# Logging
+
+Los módulos deben obtener un logger mediante `get_logger` para mantener un
+formato consistente en toda la aplicación.
+
+```python
+from tradingbot.utils.logging import get_logger
+
+log = get_logger(__name__)
+```
+
+En las secciones críticas conviene separar el envío de órdenes de la
+persistencia de datos y registrar errores específicos.
+
+```python
+try:
+    res = await adapter.place_order(...)
+except Exception:
+    log.error("Order placement failed")
+
+try:
+    timescale.insert_order(engine, ...)
+except Exception:
+    log.exception("Persist failure: insert_order")
+```
+
+Esto facilita identificar rápidamente el punto exacto del fallo al revisar los
+logs.
+

--- a/src/tradingbot/live/common_exec.py
+++ b/src/tradingbot/live/common_exec.py
@@ -1,9 +1,10 @@
 # src/tradingbot/live/common_exec.py
 from __future__ import annotations
-import logging
 from datetime import datetime, timezone
 
-log = logging.getLogger(__name__)
+from ..utils.logging import get_logger
+
+log = get_logger(__name__)
 
 try:
     from ..storage.timescale import (

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-import logging
 from typing import Dict, Tuple
 
 from .manager import RiskManager
@@ -9,8 +8,9 @@ from .portfolio_guard import PortfolioGuard
 from .daily_guard import DailyGuard
 from .correlation_service import CorrelationService
 from ..storage import timescale
+from ..utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class RiskService:

--- a/src/tradingbot/utils/logging.py
+++ b/src/tradingbot/utils/logging.py
@@ -1,0 +1,27 @@
+"""Common logging utilities.
+
+This module centralises the creation of loggers so all components share the
+same configuration and naming conventions.  Modules should obtain a logger via
+``get_logger(__name__)`` instead of accessing :mod:`logging` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a logger using the project's standard configuration.
+
+    Parameters
+    ----------
+    name:
+        Optional logger name.  When ``None`` the module name of this utility is
+        used.
+    """
+
+    return logging.getLogger(name if name else __name__)
+
+
+__all__ = ["get_logger"]
+


### PR DESCRIPTION
## Summary
- centralize logger creation with new `get_logger` helper
- log specific errors for order placement and persistence
- document logging conventions and add regression test

## Testing
- `pytest tests/test_router_orders.py::test_router_logs_order_error -q`
- `pytest` *(failed: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a39075cdec832dafe36dc967415526