### PR TITLE
Add reduce-only order flag

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -219,6 +219,7 @@ class ExchangeAdapter(ABC):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         """Return provider response (paper/live)."""
 

--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -159,6 +159,7 @@ class BinanceWSAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         """Envía una orden usando el adaptador REST si está disponible."""
 

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -104,6 +104,7 @@ class BinanceSpotAdapter(ExchangeAdapter):
         client_order_id: str | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        reduce_only: bool = False,
     ):
         """
         Envía orden con idempotencia (NEW CLIENT ORDER ID) + retries.

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -175,6 +175,7 @@ class BybitFuturesAdapter(ExchangeAdapter):
         iceberg_qty: float | None = None,
         take_profit: float | None = None,
         stop_loss: float | None = None,
+        reduce_only: bool = False,
         params: dict | None = None,
     ) -> dict:
         params = params or {}
@@ -185,6 +186,7 @@ class BybitFuturesAdapter(ExchangeAdapter):
             iceberg_qty=iceberg_qty,
             take_profit=take_profit,
             stop_loss=stop_loss,
+            reduce_only=reduce_only,
         )
         params.update(extra)
         backoff = 1.0

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -134,8 +134,17 @@ class BybitSpotAdapter(ExchangeAdapter):
         oi = float(item.get("openInterest", 0.0))
         return {"ts": ts, "oi": oi}
 
-    async def place_order(self, symbol: str, side: str, type_: str, qty: float,
-                          price: float | None = None) -> dict:
+    async def place_order(
+        self,
+        symbol: str,
+        side: str,
+        type_: str,
+        qty: float,
+        price: float | None = None,
+        post_only: bool = False,
+        time_in_force: str | None = None,
+        reduce_only: bool = False,
+    ) -> dict:
         return await self.rest.create_order(symbol, type_, side, qty, price)
 
     async def cancel_order(self, order_id: str, symbol: str | None = None) -> dict:

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -116,12 +116,15 @@ class DeribitAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         params = {}
         if post_only:
             params["post_only"] = True
         if time_in_force:
             params["time_in_force"] = time_in_force
+        if reduce_only:
+            params["reduce_only"] = True
         return await self._request(self.rest.create_order, symbol, type_, side, qty, price, params)
 
     async def cancel_order(self, order_id: str) -> dict:

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -174,6 +174,7 @@ class OKXFuturesAdapter(ExchangeAdapter):
         iceberg_qty: float | None = None,
         take_profit: float | None = None,
         stop_loss: float | None = None,
+        reduce_only: bool = False,
         params: dict | None = None,
     ) -> dict:
         params = params or {}
@@ -184,6 +185,7 @@ class OKXFuturesAdapter(ExchangeAdapter):
             iceberg_qty=iceberg_qty,
             take_profit=take_profit,
             stop_loss=stop_loss,
+            reduce_only=reduce_only,
         )
         params.update(extra)
         return await self._request(

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -141,6 +141,7 @@ class OKXSpotAdapter(ExchangeAdapter):
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        reduce_only: bool = False,
         params: dict | None = None,
     ) -> dict:
         params = params or {}
@@ -148,6 +149,8 @@ class OKXSpotAdapter(ExchangeAdapter):
             params["postOnly"] = True
         if time_in_force:
             params["timeInForce"] = time_in_force
+        if reduce_only:
+            params["reduceOnly"] = True
         backoff = 1.0
         while True:
             try:

--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -104,6 +104,7 @@ class BinanceConnector(ExchangeConnector):
         iceberg_qty: float | None = None,
         take_profit: float | None = None,
         stop_loss: float | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         """Submit an order to Binance via CCXT.
 
@@ -119,6 +120,7 @@ class BinanceConnector(ExchangeConnector):
             iceberg_qty=iceberg_qty,
             take_profit=take_profit,
             stop_loss=stop_loss,
+            reduce_only=reduce_only,
         )
 
         data = await self._rest_call(

--- a/src/tradingbot/connectors/bybit.py
+++ b/src/tradingbot/connectors/bybit.py
@@ -93,6 +93,7 @@ class BybitConnector(ExchangeConnector):
         iceberg_qty: float | None = None,
         take_profit: float | None = None,
         stop_loss: float | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         """Submit an order through the CCXT Bybit client."""
 
@@ -103,6 +104,7 @@ class BybitConnector(ExchangeConnector):
             iceberg_qty=iceberg_qty,
             take_profit=take_profit,
             stop_loss=stop_loss,
+            reduce_only=reduce_only,
         )
 
         data = await self._rest_call(

--- a/src/tradingbot/connectors/okx.py
+++ b/src/tradingbot/connectors/okx.py
@@ -92,6 +92,7 @@ class OKXConnector(ExchangeConnector):
         iceberg_qty: float | None = None,
         take_profit: float | None = None,
         stop_loss: float | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         """Place an order via the underlying CCXT client.
 
@@ -107,6 +108,7 @@ class OKXConnector(ExchangeConnector):
             iceberg_qty=iceberg_qty,
             take_profit=take_profit,
             stop_loss=stop_loss,
+            reduce_only=reduce_only,
         )
 
         data = await self._rest_call(

--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -10,3 +10,4 @@ class Order:
     post_only: bool = False
     time_in_force: str | None = None
     iceberg_qty: float | None = None
+    reduce_only: bool = False

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -159,6 +159,7 @@ class PaperAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
+        reduce_only: bool = False,
     ) -> dict:
         order_id = self._next_order_id()
         last = self.state.last_px.get(symbol)

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -197,6 +197,7 @@ class ExecutionRouter:
             price=order.price,
             post_only=order.post_only,
             time_in_force=order.time_in_force,
+            reduce_only=order.reduce_only,
         )
         if order.iceberg_qty is not None:
             sig = inspect.signature(adapter.place_order)
@@ -238,7 +239,11 @@ class ExecutionRouter:
                         px=res.get("price"),
                         status=res.get("status", "unknown"),
                         ext_order_id=res.get("order_id"),
-                        notes={"fee_type": "maker" if maker else "taker", "fee_bps": fee_bps},
+                        notes={
+                            "fee_type": "maker" if maker else "taker",
+                            "fee_bps": fee_bps,
+                            "reduce_only": order.reduce_only,
+                        },
                     )
                 except Exception:  # pragma: no cover - logging only
                     log.exception("Persist failure: insert_order")

--- a/src/tradingbot/live/common_exec.py
+++ b/src/tradingbot/live/common_exec.py
@@ -74,7 +74,8 @@ def persist_after_order(
 
     # 1) Orden
     try:
-        notes = resp if isinstance(resp, dict) else {}
+        notes = resp.copy() if isinstance(resp, dict) else {}
+        notes["reduce_only"] = bool(reduce_only)
         insert_order(
             engine,
             strategy=strategy,
@@ -84,8 +85,8 @@ def persist_after_order(
             type_=type_,
             qty=float(qty),
             px=None,
-            status=(resp.get("status", "sent") if isinstance(notes, dict) else "sent"),
-            ext_order_id=(notes.get("ext_order_id") if isinstance(notes, dict) else None),
+            status=(resp.get("status", "sent") if isinstance(resp, dict) else "sent"),
+            ext_order_id=(resp.get("ext_order_id") if isinstance(resp, dict) else None),
             notes=notes,
         )
     except Exception:

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -489,7 +489,13 @@ class TradeBotDaemon:
         if price is not None and not self.risk.check_limits(price):
             log.warning("risk_halt", extra={"price": price})
             return
-        order = Order(symbol=symbol, side="buy" if delta > 0 else "sell", type_="market", qty=abs(delta))
+        order = Order(
+            symbol=symbol,
+            side="buy" if delta > 0 else "sell",
+            type_="market",
+            qty=abs(delta),
+            reduce_only=getattr(signal, "reduce_only", False),
+        )
         res = await self.router.execute(order)
         venue = res.get("venue")
         await self.bus.publish("fill", {"symbol": symbol, "side": order.side, "qty": order.qty, "venue": venue, **res})

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -82,7 +82,13 @@ async def run_paper(
             if not allowed or abs(delta) <= 0:
                 continue
             side = "buy" if delta > 0 else "sell"
-            order = Order(symbol=symbol, side=side, type_="market", qty=abs(delta))
+            order = Order(
+                symbol=symbol,
+                side=side,
+                type_="market",
+                qty=abs(delta),
+                reduce_only=signal.reduce_only,
+            )
             await router.execute(order)
             risk.on_fill(symbol, side, abs(delta), venue="paper")
     finally:

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -13,6 +13,7 @@ from ..storage import timescale
 class Signal:
     side: str  # 'buy' | 'sell' | 'flat'
     strength: float = 1.0
+    reduce_only: bool = False
 
 class Strategy(ABC):
     name: str

--- a/tests/test_execution_router_extra.py
+++ b/tests/test_execution_router_extra.py
@@ -74,3 +74,19 @@ async def test_execute_persists_maker_fee(monkeypatch):
     await router.execute(order)
     assert captured["notes"]["fee_type"] == "maker"
     assert captured["notes"]["fee_bps"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_execute_persists_reduce_only(monkeypatch):
+    captured = {}
+
+    def fake_insert_order(engine, **kwargs):
+        nonlocal captured
+        captured = kwargs
+
+    monkeypatch.setattr(timescale, "insert_order", fake_insert_order)
+    adapter = DummyAdapter()
+    router = ExecutionRouter(adapter, storage_engine="eng")
+    order = Order(symbol="X", side="buy", type_="market", qty=1.0, reduce_only=True)
+    await router.execute(order)
+    assert captured["notes"]["reduce_only"] is True

--- a/tests/test_router_orders.py
+++ b/tests/test_router_orders.py
@@ -47,6 +47,7 @@ async def test_best_venue_selection():
         {"type_": "limit", "price": 100.0, "time_in_force": "IOC"},
         {"type_": "limit", "price": 100.0, "time_in_force": "FOK"},
         {"type_": "limit", "price": 100.0, "iceberg_qty": 0.1},
+        {"type_": "market", "reduce_only": True},
     ],
 )
 async def test_order_type_support(kwargs):


### PR DESCRIPTION
## Summary
- allow strategies to specify reduce-only orders via `Signal` and forward the flag through the routing stack
- propagate `reduce_only` to exchange adapters and persist it in Timescale notes
- exercise reduce-only handling with new unit tests

## Testing
- `pytest tests/test_router_orders.py tests/test_execution_router_extra.py tests/test_execution.py tests/test_execution_router_slippage.py`


------
https://chatgpt.com/codex/tasks/task_e_68a398219608832d97c80eea201df1ee