### PR TITLE
docs: document extra features and polish dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ gracias al **paper trading** (simulación).
 - **Panel web** con métricas en vivo y un **ejecutor de comandos CLI** que
   permite lanzar cualquier comando desde el navegador.
 
+## Funcionalidades extra
+
+TradeBot incluye una serie de capacidades adicionales más allá del MVP
+original. Entre ellas se destacan las estrategias de arbitraje
+triangular y entre exchanges, señales basadas en microestructura,
+adaptadores para múltiples venues con soporte de testnet, un panel web
+que permite ejecutar comandos de la CLI y una API para control remoto.
+La descripción completa y ejemplos de uso se encuentran en
+[docs/extra_features.md](docs/extra_features.md).
+
 ## Exchanges y pares soportados
 
 - **Exchanges**: [Binance](https://www.binance.com),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,4 +28,6 @@ raíz del repositorio.
 
 Para una explicación detallada de los componentes y su interacción
 consulta [docs/usage.md](usage.md) y los ejemplos de
-[docs/examples.md](examples.md).
+[docs/examples.md](examples.md).  Las funcionalidades adicionales que
+no forman parte del MVP se describen en
+[extra_features.md](extra_features.md).

--- a/docs/blueprint_map.md
+++ b/docs/blueprint_map.md
@@ -13,3 +13,10 @@ Este documento enlaza los puntos del [blueprint inicial](../blueprint_trading_bo
 | **7. Backtesting & simulación** | `backtest/event_engine.py`, `backtesting/engine.py`, `backtesting/vectorbt_wrapper.py` | `backtest`, `backtest-cfg`, `walk-forward`, `paper-run` |
 | **8. Monitoreo & Ops** | `monitoring/panel.py`, `monitoring/metrics.py`, `utils/metrics.py` | `report` |
 
+## Funcionalidades extra
+
+Además de los puntos anteriores, el proyecto incorpora estrategias de
+arbitraje avanzado, señales de microestructura, adaptadores para
+testnets, un panel web con ejecución de comandos y una API de control
+remoto.  La lista completa se describe en
+[extra_features.md](extra_features.md).

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -37,3 +37,7 @@ Job de cron que ejecuta cada minuto:
 ```
 * * * * * cd /ruta/a/TradeBot && /usr/bin/python /ruta/a/poll_perp.py >> /var/log/tradingbot.log 2>&1
 ```
+
+Para conocer características avanzadas como estrategias de arbitraje,
+panel web y API de control, consulta
+[extra_features.md](extra_features.md).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -57,6 +57,9 @@ stats = run_parameter_sweep(bars, ma_signal, {"fast": [5], "slow": [20]})
 print(stats)
 ```
 
+Más ejemplos de estrategias avanzadas y uso del panel web se encuentran
+en [extra_features.md](extra_features.md).
+
 ## Backtest rápido
 ```bash
 python -m tradingbot.cli backtest data/examples/btcusdt_1m.csv \

--- a/docs/extra_features.md
+++ b/docs/extra_features.md
@@ -1,0 +1,83 @@
+# Funcionalidades extra de TradeBot
+
+Este documento resume capacidades que van más allá del MVP inicial.
+Cada una se describe con un detalle técnico breve y un ejemplo de uso
+para que también sea comprensible para quien no tiene experiencia previa.
+
+## Estrategias avanzadas
+
+Además de las estrategias básicas del MVP (momentum, mean reversion y
+breakout), el bot incluye módulos listos para:
+
+- **Arbitraje triangular**: detecta desalineaciones entre tres pares en un
+  mismo exchange y ejecuta las tres patas en una sola operación.
+  ```bash
+  python -m tradingbot.cli tri-arb BTC-ETH-USDT --notional 100
+  ```
+- **Arbitraje entre exchanges / cash-and-carry**: compara precios spot vs
+  futuros o entre venues y abre posiciones opuestas.
+  ```bash
+  python -m tradingbot.cli cross-arb BTC/USDT binance_spot binance_futures \
+      --threshold 0.001 --notional 50
+  ```
+- **Microestructura**: señales basadas en Order Flow Imbalance (OFI),
+  profundidad de libro y desequilibrio de colas para scalping.
+
+Estas estrategias pueden ejecutarse en modo ``paper`` o en cuentas reales.
+
+## Adaptadores y conectores
+
+El proyecto expone adaptadores REST/WebSocket para **Binance**, **Bybit**
+ y **OKX**, con soportes tanto para spot como para futuros y sus testnets.
+La estructura es modular para facilitar la inclusión de nuevos exchanges.
+
+Ejemplo rápido para obtener trades de Bybit:
+```bash
+python -m tradingbot.cli ingest --venue bybit_spot --symbol BTC/USDT
+```
+
+## Monitoreo y panel web
+
+La aplicación FastAPI incluye un **dashboard** en `/` con métricas en
+ tiempo real, PnL, exposición y eventos de riesgo.  También posee un
+ ejecutor de comandos para lanzar cualquier instrucción de la CLI desde el
+ navegador, permitiendo la gestión sin necesidad de terminal.
+
+Ejemplo: ejecutar un backtest desde la interfaz web escribiendo en la caja
+"`backtest data/btc.csv --strategy breakout_atr`".
+
+## Backtesting y análisis
+
+- Motor **vectorizado** basado en `vectorbt` para exploración rápida.
+- Motor **event-driven** que simula profundidad L2, slippage y latencia.
+- Utilidades de **walk-forward** y generación de reportes con métricas
+  como Sharpe, Sortino y drawdown.
+
+## Gestión de riesgo ampliada
+
+- **PortfolioGuard** con límites duros y blandos por símbolo y globales.
+- **DailyGuard** que corta operaciones al exceder pérdidas diarias.
+- **CorrelationService** para limitar exposición en activos altamente
+  correlacionados.
+
+## API y control remoto
+
+El módulo `apps.api` expone endpoints protegidos por autenticación básica
+para consultar órdenes, señales, PnL o pausar el bot.  Ejemplo con `curl`:
+```bash
+curl -u admin:admin http://localhost:8000/risk/halt -X POST -d '{"reason":"manual"}'
+```
+
+## Suite de pruebas
+
+Más de un centenar de pruebas unitarias e integrales verifican la
+integridad de las estrategias, del router de ejecución y de los servicios
+de riesgo y monitoreo.  Se ejecutan con:
+```bash
+pytest
+```
+
+Estas funcionalidades extra amplían considerablemente el alcance del MVP
+original y convierten a TradeBot en una plataforma completa para
+explorar, probar y desplegar estrategias de trading cuantitativo.
+

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -21,3 +21,6 @@ la latencia reportada en las órdenes debe reflejar el incremento.
 
 Ambas pruebas están marcadas con `@pytest.mark.integration` y se ejecutan
 automáticamente en CI mediante `pytest -m integration`.
+
+Para verificar también las funcionalidades extra (arbitrajes, panel web,
+API, etc.) consulta [extra_features.md](extra_features.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -27,3 +27,7 @@ except Exception:
 Esto facilita identificar rápidamente el punto exacto del fallo al revisar los
 logs.
 
+Para una descripción de funcionalidades avanzadas y cómo generan logs
+adicionales (arbitrajes, panel web, API), ver
+[extra_features.md](extra_features.md).
+

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -38,6 +38,9 @@ Available endpoints:
 - `GET /orders` – open orders with id, symbol, side and status.
 - `GET /positions` – open positions by symbol.
 - `GET /kill-switch` – kill switch active flag.
+
+Para un resumen de todas las capacidades adicionales del panel y la API
+consulta [extra_features.md](extra_features.md).
 - `GET /strategies/status` – current strategy states.
 - `POST /strategies/{name}/{status}` – update a strategy state.
 - `GET /summary` – metrics and strategy states combined.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,3 +8,7 @@ Mantener seguras las credenciales es fundamental. Algunas recomendaciones:
 - El gestor sólo registra el identificador de la clave (últimos 4 caracteres) para evitar filtrar información sensible.
 - Revisa periódicamente los registros y rota las claves con regularidad.
 - Nunca compartas claves ni las publiques en repositorios.
+
+Algunas funciones avanzadas (API web, panel de monitoreo, estrategias de
+arbitraje) también requieren considerar permisos y autenticación.
+Consulta [extra_features.md](extra_features.md) para más detalles.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,10 @@ pytest
 ```
 El módulo de análisis ahora forma parte del paquete `tradingbot` y se importa como `tradingbot.analysis`.
 
+Una vez instalado, puedes explorar funciones avanzadas descritas en
+[extra_features.md](extra_features.md), como estrategias de arbitraje y
+el panel web con ejecución de comandos.
+
 ## Descarga de datos
 Puedes descargar históricos de barras, trades o snapshots de libro L2 con
 `bin/download_history.py`.  Los datos se normalizan y pueden guardarse en

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,6 +3,9 @@
 Este proyecto incluye una interfaz de línea de comandos y una API para
 controlar estrategias.  A continuación algunos ejemplos rápidos.
 
+Las funcionalidades adicionales (arbitrajes, panel web con CLI, API de
+control) se documentan en [extra_features.md](extra_features.md).
+
 ## CLI
 
 ```bash

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -38,13 +38,13 @@
     <div class="kv"><div class="k">Último evento riesgo</div><div class="v" id="sum-risk-last">—</div></div>
     <div class="kv"><div class="k">Notional promedio (QUOTE)</div><div class="v" id="sum-avg-notional">—</div></div>
     <div class="kv"><div class="k">Exposición total (Spot)</div><div class="v" id="sum-expo-spot">—</div></div>
-    <div class="kv"><div class="k">Exposición total (Spot)</div><div class="v" id="sum-expo-fut">—</div></div>
+    <div class="kv"><div class="k">Exposición total (Futuros)</div><div class="v" id="sum-expo-fut">—</div></div>
     <div class="kv"><div class="k">UPnL (Spot)</div><div class="v" id="sum-upnl-spot">—</div></div>
     <div class="kv"><div class="k">RPnL (Spot)</div><div class="v" id="sum-rpnl-spot">—</div></div>
     <div class="kv"><div class="k">PnL Neto (Spot)</div><div class="v" id="sum-net-spot">—</div></div>
-    <div class="kv"><div class="k">UPnL (Spot)</div><div class="v" id="sum-upnl-fut">—</div></div>
-    <div class="kv"><div class="k">RPnL (Spot)</div><div class="v" id="sum-rpnl-fut">—</div></div>
-    <div class="kv"><div class="k">PnL Neto (Spot)</div><div class="v" id="sum-net-fut">—</div></div>
+    <div class="kv"><div class="k">UPnL (Futuros)</div><div class="v" id="sum-upnl-fut">—</div></div>
+    <div class="kv"><div class="k">RPnL (Futuros)</div><div class="v" id="sum-rpnl-fut">—</div></div>
+    <div class="kv"><div class="k">PnL Neto (Futuros)</div><div class="v" id="sum-net-fut">—</div></div>
   </div>
 
 
@@ -113,6 +113,28 @@
     </div>
 
     <div class="card" style="margin-top:16px">
+      <h2>Exposición por símbolo (Futuros)</h2>
+      <div class="muted">Último snapshot por símbolo</div>
+      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
+        <table id="tbl-expo-fut">
+          <thead><tr><th>symbol</th><th>position</th><th>px</th><th>notional</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:16px">
+      <h2>PnL por símbolo (Futuros)</h2>
+      <div class="muted">Realizado, no realizado y neto</div>
+      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
+        <table id="tbl-pnl-fut">
+          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:16px">
       <h2>PnL (Spot) – Serie temporal</h2>
       <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
       <div style="padding:10px">
@@ -122,7 +144,7 @@
   </div>
 
   <div class="card" style="margin-top:16px">
-      <h2>PnL (Spot) – Serie temporal</h2>
+      <h2>PnL (Futuros) – Serie temporal</h2>
       <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
     <div style="padding:10px">
       <canvas id="chart-pnl-fut" height="120"></canvas>
@@ -238,6 +260,28 @@ async function refreshExposure(){
   }catch(e){}
 }
 
+async function refreshExposureFut(){
+  try{
+    const r = await fetch(api("/risk/exposure?venue=binance_futures_um_testnet"));
+    const j = await r.json();
+    document.getElementById("sum-expo-fut").textContent = "$ " + fmtUSD(j.total_notional || 0);
+    const tb = document.querySelector("#tbl-expo-fut tbody");
+    if(tb){
+      tb.innerHTML = "";
+      for(const it of (j.items || [])){
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+        <td>${it.symbol}</td>
+        <td class="mono">${fmtNum(it.position, 6)}</td>
+        <td class="mono">${fmtNum(it.price, 2)}</td>
+        <td class="mono">$ ${fmtUSD(it.notional_usd)}</td>
+        `;
+        tb.appendChild(tr);
+      }
+    }
+  }catch(e){}
+}
+
 async function refreshRisk(){
   try{
     const r = await fetch(api("/risk/events?venue=binance_spot_testnet&limit=20"));
@@ -264,6 +308,7 @@ async function refreshRisk(){
       document.getElementById("sum-risk-last").textContent = "—";
     }
   }catch(e){}
+}
 
 async function refreshSpotPnL(){
   try{
@@ -297,15 +342,16 @@ async function refreshFuturePnL(){
     const r = await fetch(api("/pnl/summary?venue=binance_futures_um_testnet"));
     const j = await r.json();
     const t = j.totals || {};
-    document.getElementById("sum-upnl-spot").textContent = "$ " + fmtUSD(t.upnl || 0);
-    document.getElementById("sum-rpnl-spot").textContent = "$ " + fmtUSD(t.rpnl || 0);
-    document.getElementById("sum-net-spot").textContent = "$ " + fmtUSD(t.net_pnl || 0);
+    document.getElementById("sum-upnl-fut").textContent = "$ " + fmtUSD(t.upnl || 0);
+    document.getElementById("sum-rpnl-fut").textContent = "$ " + fmtUSD(t.rpnl || 0);
+    document.getElementById("sum-net-fut").textContent = "$ " + fmtUSD(t.net_pnl || 0);
 
-    const tb = document.querySelector("#tbl-pnl-spot tbody");
-    tb.innerHTML = "";
-    for(const it of (j.items || [])){
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
+    const tb = document.querySelector("#tbl-pnl-fut tbody");
+    if(tb){
+      tb.innerHTML = "";
+      for(const it of (j.items || [])){
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
         <td>${it.symbol}</td>
         <td class="mono">${fmtNum(it.qty,6)}</td>
         <td class="mono">${fmtNum(it.avg_price,2)}</td>
@@ -313,8 +359,9 @@ async function refreshFuturePnL(){
         <td class="mono">$ ${fmtUSD(it.realized_pnl)}</td>
         <td class="mono">$ ${fmtUSD(it.fees_paid)}</td>
         <td class="mono">$ ${fmtUSD(it.total_pnl)}</td>
-      `;
-      tb.appendChild(tr);
+        `;
+        tb.appendChild(tr);
+      }
     }
   }catch(e){}
 }
@@ -400,14 +447,15 @@ async function refreshPnlChart(){
 // boot
 refreshHealth(); refreshSummary(); refreshTables();
 setInterval(refreshExposure, 5000); refreshExposure();
+setInterval(refreshExposureFut, 5000); refreshExposureFut();
 setInterval(refreshRisk, 5000); refreshRisk();
 setInterval(refreshSpotPnL, 5000); refreshSpotPnL();
-setInterval(refreshFutureSpotPnL, 5000); refreshFutureSpotPnL();
+setInterval(refreshFuturePnL, 5000); refreshFuturePnL();
 setInterval(refreshPnlChart, 10000); refreshPnlChart();
 setInterval(refreshPnlChartFut, 10000); refreshPnlChartFut();
-  setInterval(refreshHealth, 5000);
-  setInterval(refreshSummary, 5000);
-  setInterval(refreshTables, 5000);
+setInterval(refreshHealth, 5000);
+setInterval(refreshSummary, 5000);
+setInterval(refreshTables, 5000);
 
   document.getElementById("cli-run").addEventListener("click", runCli);
 

--- a/tradebot_mvp.md
+++ b/tradebot_mvp.md
@@ -151,6 +151,15 @@
 
 ---
 
+## Funcionalidades extra implementadas
+
+El repositorio actual expande este MVP con estrategias de arbitraje
+triangular y cross‑exchange, señales de microestructura como Order Flow
+Imbalance, adaptadores para testnets de Binance, Bybit y OKX, un panel
+web con ejecución de comandos de la CLI y una API de monitoreo/riesgo.
+La descripción detallada y ejemplos de uso están en
+[docs/extra_features.md](docs/extra_features.md).
+
 ## 6) Riesgo, PnL y OCO (implementación de referencia)
 
 ### 6.1 RiskManager


### PR DESCRIPTION
## Summary
- add comprehensive docs on advanced strategies, adapters and monitoring
- link extra feature docs from README, MVP and blueprint
- revamp dashboard to show futures exposure/PnL and run CLI commands

## Testing
- `pytest` *(fails: translate_order_flags() got an unexpected keyword argument 'reduce_only')*

------
https://chatgpt.com/codex/tasks/task_e_68a38c9a7048832d8ffa5335ab549aa5