### PR TITLE
feat: revamp dashboard with tailwind layout

### DIFF
--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -5,79 +5,123 @@ router = APIRouter()
 
 _HTML = """
 <!DOCTYPE html>
-<html>
+<html lang="en" class="dark">
 <head>
-    <meta charset="utf-8" />
-    <title>TradeBot Dashboard</title>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TradeBot Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = {darkMode: 'class'};</script>
+  <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 </head>
-<body>
-<h1>TradeBot Metrics Dashboard</h1>
-<div id="pnl" style="width:100%;height:300px;"></div>
-<div id="slippage" style="width:100%;height:300px;"></div>
-<div id="latency" style="width:100%;height:300px;"></div>
-<h2>Strategies</h2>
-<table id="strategies" border="1" cellspacing="0" cellpadding="5">
-  <thead><tr><th>Name</th><th>Status</th><th>Actions</th></tr></thead>
-  <tbody id="strategy-body"></tbody>
-</table>
-<script>
-const pnlTrace = {x: [], y: [], mode: 'lines', name: 'PnL'};
-const slippageTrace = {x: [], y: [], mode: 'lines', name: 'Slippage'};
-const latencyTrace = {x: [], y: [], mode: 'lines', name: 'Order Latency'};
+<body class="bg-gray-900 text-gray-100 h-screen flex flex-col">
+  <header class="flex items-center justify-between bg-gray-800 p-4 shadow">
+    <h1 class="text-xl font-bold">TradeBot Dashboard</h1>
+    <button id="menu-btn" class="md:hidden">☰</button>
+  </header>
+  <div class="flex flex-1 overflow-hidden">
+    <aside id="side-menu" class="bg-gray-800 w-64 p-4 space-y-2 hidden md:block">
+      <nav class="space-y-2">
+        <a href="#metrics" class="block p-2 rounded hover:bg-gray-700">Metrics</a>
+        <a href="#configuration" class="block p-2 rounded hover:bg-gray-700">Configuration</a>
+        <a href="#logs" class="block p-2 rounded hover:bg-gray-700">Logs</a>
+      </nav>
+    </aside>
+    <main class="flex-1 overflow-y-auto p-4 space-y-8">
+      <section id="metrics">
+        <h2 class="text-lg font-semibold mb-4">Metrics</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div id="pnl" class="bg-gray-800 rounded p-2 h-64"></div>
+          <div id="slippage" class="bg-gray-800 rounded p-2 h-64"></div>
+          <div id="latency" class="bg-gray-800 rounded p-2 h-64"></div>
+        </div>
+      </section>
+      <section id="configuration">
+        <h2 class="text-lg font-semibold mb-4">Strategies</h2>
+        <div class="bg-gray-800 rounded p-4 overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead class="bg-gray-700">
+              <tr><th class="p-2 text-left">Name</th><th class="p-2 text-left">Status</th><th class="p-2 text-left">Actions</th></tr>
+            </thead>
+            <tbody id="strategy-body"></tbody>
+          </table>
+        </div>
+      </section>
+      <section id="logs">
+        <h2 class="text-lg font-semibold mb-4">Logs</h2>
+        <pre id="log-output" class="bg-gray-800 rounded p-4 h-64 overflow-y-auto text-xs"></pre>
+      </section>
+    </main>
+  </div>
+  <script>
+  const menuBtn = document.getElementById('menu-btn');
+  const sideMenu = document.getElementById('side-menu');
+  menuBtn?.addEventListener('click', () => sideMenu.classList.toggle('hidden'));
 
-Plotly.newPlot('pnl', [pnlTrace], {title: 'PnL'});
-Plotly.newPlot('slippage', [slippageTrace], {title: 'Slippage (bps)'});
-Plotly.newPlot('latency', [latencyTrace], {title: 'Order Latency (s)'});
+  const pnlTrace = {x: [], y: [], mode: 'lines', name: 'PnL'};
+  const slippageTrace = {x: [], y: [], mode: 'lines', name: 'Slippage'};
+  const latencyTrace = {x: [], y: [], mode: 'lines', name: 'Order Latency'};
 
-async function updateMetrics(){
-  try {
-    const now = new Date();
-    const pnl = await fetch('/metrics/pnl').then(r => r.json());
-    const slip = await fetch('/metrics/slippage').then(r => r.json());
-    const lat = await fetch('/metrics/latency').then(r => r.json());
+  Plotly.newPlot('pnl', [pnlTrace], {title:'PnL', paper_bgcolor:'#1f2937', plot_bgcolor:'#1f2937', font:{color:'#e5e7eb'}});
+  Plotly.newPlot('slippage', [slippageTrace], {title:'Slippage (bps)', paper_bgcolor:'#1f2937', plot_bgcolor:'#1f2937', font:{color:'#e5e7eb'}});
+  Plotly.newPlot('latency', [latencyTrace], {title:'Order Latency (s)', paper_bgcolor:'#1f2937', plot_bgcolor:'#1f2937', font:{color:'#e5e7eb'}});
 
-    pnlTrace.x.push(now);
-    pnlTrace.y.push(pnl.pnl || 0);
-    slippageTrace.x.push(now);
-    slippageTrace.y.push(slip.avg_slippage_bps || 0);
-    latencyTrace.x.push(now);
-    latencyTrace.y.push(lat.avg_order_latency_seconds || 0);
-
-    Plotly.update('pnl', {x: [pnlTrace.x], y: [pnlTrace.y]});
-    Plotly.update('slippage', {x: [slippageTrace.x], y: [slippageTrace.y]});
-    Plotly.update('latency', {x: [latencyTrace.x], y: [latencyTrace.y]});
-  } catch(err) {
-    console.error('Error fetching metrics', err);
-  }
-}
-
-async function updateStrategies(){
-  try {
-    const data = await fetch('/strategies/status').then(r => r.json());
-    const tbody = document.getElementById('strategy-body');
-    tbody.innerHTML = '';
-    for (const [name, status] of Object.entries(data.strategies || {})) {
-      const row = document.createElement('tr');
-      row.innerHTML = `<td>${name}</td><td>${status}</td>` +
-        `<td><button onclick="controlStrategy('${name}','disable')">Pause</button>` +
-        `<button onclick="controlStrategy('${name}','enable')">Resume</button></td>`;
-      tbody.appendChild(row);
+  async function updateMetrics(){
+    try {
+      const now = new Date();
+      const pnl = await fetch('/metrics/pnl').then(r => r.json());
+      const slip = await fetch('/metrics/slippage').then(r => r.json());
+      const lat = await fetch('/metrics/latency').then(r => r.json());
+      pnlTrace.x.push(now);
+      pnlTrace.y.push(pnl.pnl || 0);
+      slippageTrace.x.push(now);
+      slippageTrace.y.push(slip.avg_slippage_bps || 0);
+      latencyTrace.x.push(now);
+      latencyTrace.y.push(lat.avg_order_latency_seconds || 0);
+      Plotly.update('pnl', {x:[pnlTrace.x], y:[pnlTrace.y]});
+      Plotly.update('slippage', {x:[slippageTrace.x], y:[slippageTrace.y]});
+      Plotly.update('latency', {x:[latencyTrace.x], y:[latencyTrace.y]});
+    } catch(err) {
+      console.error('Error fetching metrics', err);
     }
-  } catch(err) {
-    console.error('Error fetching strategies', err);
   }
-}
 
-async function controlStrategy(name, action){
-  await fetch(`/strategies/${name}/${action}`, {method: 'POST'});
+  async function updateStrategies(){
+    try {
+      const data = await fetch('/strategies/status').then(r => r.json());
+      const tbody = document.getElementById('strategy-body');
+      tbody.innerHTML = '';
+      for (const [name, status] of Object.entries(data.strategies || {})) {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td class="p-2">${name}</td><td class="p-2">${status}</td>` +
+          `<td class="p-2"><button class="bg-red-600 px-2 py-1 rounded mr-2" onclick="controlStrategy('${name}','disable')">Pause</button>` +
+          `<button class="bg-green-600 px-2 py-1 rounded" onclick="controlStrategy('${name}','enable')">Resume</button></td>`;
+        tbody.appendChild(row);
+      }
+    } catch(err) {
+      console.error('Error fetching strategies', err);
+    }
+  }
+
+  async function controlStrategy(name, action){
+    await fetch(`/strategies/${name}/${action}`, {method: 'POST'});
+    updateStrategies();
+  }
+
+  async function updateLogs(){
+    try {
+      const logs = await fetch('/logs').then(r => r.text());
+      document.getElementById('log-output').textContent = logs;
+    } catch(err) {
+      console.error('Error fetching logs', err);
+    }
+  }
+
+  setInterval(() => {updateMetrics(); updateStrategies(); updateLogs();}, 5000);
+  updateMetrics();
   updateStrategies();
-}
-
-setInterval(() => {updateMetrics(); updateStrategies();}, 5000);
-updateMetrics();
-updateStrategies();
-</script>
+  updateLogs();
+  </script>
 </body>
 </html>
 """
@@ -87,3 +131,4 @@ updateStrategies();
 async def dashboard() -> HTMLResponse:
     """Serve the Plotly dashboard with live metrics and controls."""
     return HTMLResponse(content=_HTML)
+


### PR DESCRIPTION
## Summary
- rebuild dashboard to use Tailwind CSS with dark theme
- add responsive top bar, side navigation, metric cards, strategy table, and log panel

## Testing
- `pytest` *(fails: translate_order_flags() got an unexpected keyword argument 'time_in_force')*

------
https://chatgpt.com/codex/tasks/task_e_68a3e2de9a1c832d9938de2d5631b43f