### PR TITLE
feat: add config endpoints and bot lifecycle controls

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -150,7 +150,7 @@
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify({strategy, pairs})
       });
-      await fetch('/config/start', {method:'POST'});
+      await fetch('/bot/start', {method:'POST'});
       document.getElementById('cfg-result').textContent = 'Bot started';
     } catch(err) {
       document.getElementById('cfg-result').textContent = 'Error: ' + err;
@@ -159,7 +159,7 @@
 
   async function stopBot(){
     try {
-      await fetch('/config/stop', {method:'POST'});
+      await fetch('/bot/stop', {method:'POST'});
       document.getElementById('cfg-result').textContent = 'Bot stopped';
     } catch(err) {
       document.getElementById('cfg-result').textContent = 'Error: ' + err;


### PR DESCRIPTION
## Summary
- call `/bot/start` and `/bot/stop` from dashboard buttons
- expose configuration and bot lifecycle endpoints

## Testing
- `pytest tests/test_monitoring_panel.py::test_config_roundtrip tests/test_monitoring_panel.py::test_start_stop -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3edfed4ac832dbe3a27fb0b7656fa