### PR TITLE
Expose configuration endpoint and support reduce-only order flag

### DIFF
--- a/src/tradingbot/execution/venue_adapter.py
+++ b/src/tradingbot/execution/venue_adapter.py
@@ -19,6 +19,9 @@ Currently the translator understands the following flags:
     Prices for one-cancels-the-other (OCO) orders.  Exchanges use different
     names for these fields (``tpPrice``/``stopPrice`` on Binance vs
     ``takeProfit``/``stopLoss`` on Bybit/OKX).
+``reduce_only``
+    Ensure an order only decreases an existing position.  Typically maps to a
+    ``reduceOnly`` parameter on derivative venues.
 """
 from __future__ import annotations
 
@@ -33,6 +36,7 @@ def translate_order_flags(
     iceberg_qty: Optional[float] = None,
     take_profit: Optional[float] = None,
     stop_loss: Optional[float] = None,
+    reduce_only: bool = False,
 ) -> Dict[str, Any]:
     """Translate generic order flags into venue specific ``params``.
 
@@ -51,6 +55,10 @@ def translate_order_flags(
     take_profit, stop_loss:
         Optional prices for OCO style orders.  If only one of them is provided
         a simple TP or SL order is produced.
+    reduce_only:
+        For derivative venues this flag ensures the order only reduces an
+        existing position.  Many venues share the same ``reduceOnly`` parameter
+        name.
 
     Returns
     -------
@@ -73,6 +81,8 @@ def translate_order_flags(
             params["tpPrice"] = float(take_profit)
         if stop_loss is not None:
             params["stopPrice"] = float(stop_loss)
+        if reduce_only:
+            params["reduceOnly"] = True
         return params
 
     # Bybit / OKX ---------------------------------------------------------
@@ -87,6 +97,8 @@ def translate_order_flags(
             params["takeProfit"] = float(take_profit)
         if stop_loss is not None:
             params["stopLoss"] = float(stop_loss)
+        if reduce_only:
+            params["reduceOnly"] = True
         return params
 
     # Fallback for other venues ------------------------------------------
@@ -100,6 +112,8 @@ def translate_order_flags(
         params["takeProfit"] = float(take_profit)
     if stop_loss is not None:
         params["stopLoss"] = float(stop_loss)
+    if reduce_only:
+        params["reduceOnly"] = True
     return params
 
 


### PR DESCRIPTION
## Summary
- persist monitoring configuration and provide `/config` GET/POST endpoints with validation
- add `reduce_only` handling to `translate_order_flags`

## Testing
- `pytest tests/test_monitoring_panel.py::test_config_roundtrip -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa42a554832d825f6f64ca4f31d2