### PR TITLE
Add Start/Stop controls to monitoring dashboard

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -77,10 +77,10 @@
           </div>
           <div class="field is-grouped">
             <div class="control is-expanded">
-              <button class="button is-success is-fullwidth" onclick="startBot()">Start</button>
+              <button id="btn-start" class="button is-success is-fullwidth" onclick="startBot()">Start</button>
             </div>
             <div class="control is-expanded">
-              <button class="button is-danger is-fullwidth" onclick="stopBot()">Stop</button>
+              <button id="btn-stop" class="button is-danger is-fullwidth" onclick="stopBot()">Stop</button>
             </div>
           </div>
           <p id="cfg-result" class="has-text-light"></p>
@@ -130,6 +130,8 @@
           `<button class="button is-small is-warning" onclick="controlStrategy('${name}','disable')">Stop</button></td>`;
         tbody.appendChild(tr);
       }
+      const isRunning = Object.values(data.strategies || {}).some(s => s === 'running');
+      document.getElementById('btn-start').disabled = isRunning;
     } catch(err){ console.error(err); }
   }
 
@@ -150,20 +152,34 @@
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify({strategy, pairs})
       });
-      await fetch('/bot/start', {method:'POST'});
-      document.getElementById('cfg-result').textContent = 'Bot started';
+      const res = await fetch('/bot/start', {method:'POST'});
+      if(res.ok){
+        document.getElementById('cfg-result').textContent = 'Bot started';
+        document.getElementById('btn-start').disabled = true;
+      } else {
+        const err = await res.json();
+        document.getElementById('cfg-result').textContent = 'Error: ' + (err.detail || res.status);
+      }
     } catch(err) {
       document.getElementById('cfg-result').textContent = 'Error: ' + err;
     }
+    updateStrategies();
   }
 
   async function stopBot(){
     try {
-      await fetch('/bot/stop', {method:'POST'});
-      document.getElementById('cfg-result').textContent = 'Bot stopped';
+      const res = await fetch('/bot/stop', {method:'POST'});
+      if(res.ok){
+        document.getElementById('cfg-result').textContent = 'Bot stopped';
+        document.getElementById('btn-start').disabled = false;
+      } else {
+        const err = await res.json();
+        document.getElementById('cfg-result').textContent = 'Error: ' + (err.detail || res.status);
+      }
     } catch(err) {
       document.getElementById('cfg-result').textContent = 'Error: ' + err;
     }
+    updateStrategies();
   }
 
   updateMetrics();


### PR DESCRIPTION
## Summary
- add dedicated Start and Stop buttons for bot control
- fetch `/bot/start` and `/bot/stop` with success/error feedback
- disable Start button when a strategy is already running

## Testing
- ⚠️ `pytest` *(killed: container OOM after partial run)*
- ✅ `pytest tests/test_monitoring_panel.py::test_start_stop`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa441c78832d93c91dbb55309b82