### PR TITLE
feat: add consistent dashboard color palette

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -4,16 +4,8 @@
   <meta charset="utf-8" />
   <title>TradeBot Dashboard</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  <link rel="stylesheet" href="style.css">
   <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-  <style>
-    html, body {
-      background-color: #1e1e2f;
-      color: #fff;
-    }
-    .box {
-      background-color: #2a2a40;
-    }
-  </style>
 </head>
 <body>
   <nav class="navbar is-dark" role="navigation">

--- a/monitoring/static/style.css
+++ b/monitoring/static/style.css
@@ -1,0 +1,57 @@
+/* Global color palette */
+:root {
+  --color-dark-blue: #001f3f;
+  --color-black: #000000;
+  --color-white: #ffffff;
+  --color-yellow: #ffd60a;
+  --color-green: #2ecc71;
+  --color-red: #e3342f;
+}
+
+html,
+body {
+  background-color: var(--color-dark-blue);
+  color: var(--color-white);
+}
+
+.box {
+  background-color: var(--color-black);
+}
+
+/* Status and alert colors */
+.status-warning {
+  color: var(--color-yellow);
+}
+
+.status-success {
+  color: var(--color-green);
+}
+
+.status-danger {
+  color: var(--color-red);
+}
+
+/* Override Bulma button colors for better contrast */
+.button.is-success {
+  background-color: var(--color-green);
+  color: var(--color-black);
+}
+
+.button.is-warning {
+  background-color: var(--color-yellow);
+  color: var(--color-black);
+}
+
+.button.is-danger {
+  background-color: var(--color-red);
+  color: var(--color-white);
+}
+
+.navbar.is-dark {
+  background-color: var(--color-black);
+}
+
+.table.is-dark {
+  background-color: var(--color-black);
+  color: var(--color-white);
+}


### PR DESCRIPTION
## Summary
- introduce style.css with dark blue and black base palette and status highlight colors
- link monitoring dashboard to new stylesheet and remove inline styles

## Testing
- `pytest` *(fails: translate_order_flags() got an unexpected keyword argument 'kw')*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa46feb4832db37c1a8963fdeb3e