### PR TITLE
Expose logs and order history endpoints with dashboard updates

### DIFF
--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -109,8 +109,9 @@
     </div>
 
     <div class="card">
-      <h2>Órdenes</h2>
+      <h2>Historial de Órdenes</h2>
       <div class="muted">Auto‑refresh 5s</div>
+      <input id="order-search" placeholder="buscar…" style="margin-top:8px"/>
       <div style="overflow:auto; max-height: 60vh; margin-top:10px">
         <table id="tbl-orders">
           <thead>
@@ -195,6 +196,11 @@
     </div>
   </div>
   <div class="card" style="margin-top:16px">
+    <h2>Logs</h2>
+    <div class="muted">Auto‑refresh 5s</div>
+    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
+  </div>
+  <div class="card" style="margin-top:16px">
     <h2>Comandos CLI</h2>
     <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
     <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
@@ -205,6 +211,7 @@
 <script>
 const api = (path) => `${location.origin}${path}`;
 let pnlChart;
+let orderQuery = "";
 
 function fmtEdge(x){ if(x==null) return "—"; return (x*100).toFixed(3)+"%"; }
 function fmtNum(x, d=6){ if(x==null) return "—"; const n=Number(x); return isFinite(n)? n.toFixed(d): x; }
@@ -271,17 +278,22 @@ function renderOrders(items){
   }
 }
 
+async function refreshOrders(){
+  try{
+    const q = orderQuery ? `&search=${encodeURIComponent(orderQuery)}` : "";
+    const r = await fetch(api(`/orders/history?limit=120${q}`));
+    const j = await r.json();
+    renderOrders(j.items || []);
+  }catch(e){}
+}
+
 async function refreshTables(){
   try {
     const r1 = await fetch(api("/tri/signals?limit=100"));
     const j1 = await r1.json();
     renderSignals(j1.items || []);
   } catch(e){}
-  try {
-    const r2 = await fetch(api("/orders?limit=120"));
-    const j2 = await r2.json();
-    renderOrders(j2.items || []);
-  } catch(e){}
+  refreshOrders();
 }
 
 async function refreshExposure(){
@@ -410,6 +422,15 @@ async function refreshFuturePnL(){
   }catch(e){}
 }
 
+async function refreshLogs(){
+  try{
+    const r = await fetch(api("/logs?lines=200"));
+    const j = await r.json();
+    const pre = document.getElementById("logs");
+    pre.textContent = (j.items || []).join("\n");
+  }catch(e){}
+}
+
 function buildPnlChart(ctx, labels, upnl, rpnl, net){
   if(pnlChart){ pnlChart.destroy(); }
   pnlChart = new Chart(ctx, {
@@ -528,6 +549,7 @@ setInterval(refreshExposureFut, 5000); refreshExposureFut();
 setInterval(refreshRisk, 5000); refreshRisk();
 setInterval(refreshSpotPnL, 5000); refreshSpotPnL();
 setInterval(refreshFuturePnL, 5000); refreshFuturePnL();
+setInterval(refreshLogs, 5000); refreshLogs();
 setInterval(refreshPnlChart, 10000); refreshPnlChart();
 setInterval(refreshPnlChartFut, 10000); refreshPnlChartFut();
 setInterval(refreshHealth, 5000);
@@ -536,6 +558,7 @@ setInterval(refreshTables, 5000);
 
   document.getElementById("cli-run").addEventListener("click", runCli);
   document.getElementById("cfg-save").addEventListener("click", saveConfig);
+  document.getElementById("order-search").addEventListener("input", (e)=>{ orderQuery = e.target.value; refreshOrders(); });
 
   </script>
 </body>

--- a/tests/test_api_logs_orders_history.py
+++ b/tests/test_api_logs_orders_history.py
@@ -1,0 +1,55 @@
+import importlib
+from pathlib import Path
+
+import importlib
+from fastapi.testclient import TestClient
+
+
+def reload_app():
+    import tradingbot.apps.api.main as main
+    importlib.reload(main)
+    return main
+
+
+def test_logs_endpoint(monkeypatch, tmp_path):
+    log_file = tmp_path / "app.log"
+    log_file.write_text("line1\nline2\n")
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+    main = reload_app()
+    main.settings.log_file = str(log_file)
+    client = TestClient(main.app)
+    resp = client.get("/logs", auth=("u", "p"))
+    assert resp.status_code == 200
+    assert "line1" in resp.json()["items"][0]
+
+
+def test_orders_history(monkeypatch):
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+    main = reload_app()
+    client = TestClient(main.app)
+
+    called = {}
+
+    def fake_select(engine, limit=100, search=None, symbol=None, status=None):
+        called.update(dict(limit=limit, search=search, symbol=symbol, status=status))
+        return [
+            {
+                "ts": "2024-01-01T00:00:00Z",
+                "strategy": "s",
+                "symbol": "BTCUSDT",
+                "side": "buy",
+                "qty": 1,
+                "px": 1,
+                "status": "FILLED",
+            }
+        ]
+
+    monkeypatch.setattr(main, "_CAN_PG", True)
+    monkeypatch.setattr(main, "select_order_history", fake_select)
+
+    resp = client.get("/orders/history?search=BTC", auth=("u", "p"))
+    assert resp.status_code == 200
+    assert called["search"] == "BTC"
+    assert resp.json()["items"][0]["symbol"] == "BTCUSDT"


### PR DESCRIPTION
## Summary
- add `/logs` endpoint serving recent log lines
- add `/orders/history` endpoint with optional search filters
- show log output and searchable order history on dashboard

## Testing
- `python -m pytest tests/test_api_auth.py tests/test_api_logs_orders_history.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3fa483e88832d9910c2a04b86f2ae