### PR TITLE
feat: expose aggregated metrics endpoint

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -32,8 +32,8 @@ credentials via the `API_USER` and `API_PASS` environment variables
 
 Available endpoints:
 
-- `GET /metrics` – Prometheus metrics.
-- `GET /metrics/summary` – compact JSON snapshot of key metrics.
+- `GET /metrics` – aggregated metrics in JSON format.
+- `GET /metrics/prometheus` – Prometheus metrics.
 - `GET /pnl` – current trading PnL.
 - `GET /orders` – open orders with id, symbol, side and status.
 - `GET /positions` – open positions by symbol.
@@ -65,9 +65,7 @@ uvicorn tradingbot.apps.api.main:app --reload
 
 The dashboard polls the following endpoints every few seconds:
 
-- `GET /metrics/pnl`
-- `GET /metrics/slippage`
-- `GET /metrics/latency`
+- `GET /metrics`
 - `GET /strategies/status`
 
 When the pause/resume buttons are used the dashboard sends POST requests to

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,7 @@ perpetuo utilizando los adapters indicados. El umbral de premium se controla con
 ``--threshold`` y ``--notional`` establece el tamaño por pata.
 
 `paper-run` permite ejecutar cualquier estrategia en modo papel y expone las
-métricas de Prometheus en `http://localhost:8000/metrics`.
+métricas de Prometheus en `http://localhost:8000/metrics/prometheus`.
 
 ```bash
 python -m tradingbot.cli paper-run --strategy breakout_atr --symbol BTC/USDT
@@ -114,7 +114,7 @@ docker compose up
 
 Una vez levantados los servicios:
 
-* API y dashboard estático: <http://localhost:8000> (`/metrics` expone métricas de Prometheus)
+* API y dashboard estático: <http://localhost:8000> (`/metrics` devuelve métricas agregadas, Prometheus en `/metrics/prometheus`)
 * Prometheus: <http://localhost:9090>
 * Grafana: <http://localhost:3000> (usuario `admin`, contraseña `admin`)
 
@@ -184,8 +184,9 @@ print(study.best_params)
 
 ## Interfaz mínima de monitoreo
 
-`monitoring/panel.py` levanta una aplicación FastAPI que expone las métricas en
-`/metrics` y el estado de las estrategias en `/strategies/status`.  Al montar el
-directorio estático se incluye un `index.html` sencillo que consulta ambos
-endpoints para mostrar un resumen rápido.
+`monitoring/panel.py` levanta una aplicación FastAPI que expone métricas
+agregadas en `/metrics` (Prometheus en `/metrics/prometheus`) y el estado de las
+estrategias en `/strategies/status`.  Al montar el directorio estático se incluye
+un `index.html` sencillo que consulta ambos endpoints para mostrar un resumen
+rápido.
 

--- a/monitoring/dashboard.py
+++ b/monitoring/dashboard.py
@@ -69,15 +69,13 @@ _HTML = """
   async function updateMetrics(){
     try {
       const now = new Date();
-      const pnl = await fetch('/metrics/pnl').then(r => r.json());
-      const slip = await fetch('/metrics/slippage').then(r => r.json());
-      const lat = await fetch('/metrics/latency').then(r => r.json());
+      const metrics = await fetch('/metrics').then(r => r.json());
       pnlTrace.x.push(now);
-      pnlTrace.y.push(pnl.pnl || 0);
+      pnlTrace.y.push(metrics.pnl || 0);
       slippageTrace.x.push(now);
-      slippageTrace.y.push(slip.avg_slippage_bps || 0);
+      slippageTrace.y.push(metrics.avg_slippage_bps || 0);
       latencyTrace.x.push(now);
-      latencyTrace.y.push(lat.avg_order_latency_seconds || 0);
+      latencyTrace.y.push(metrics.avg_order_latency_seconds || 0);
       Plotly.update('pnl', {x:[pnlTrace.x], y:[pnlTrace.y]});
       Plotly.update('slippage', {x:[slippageTrace.x], y:[slippageTrace.y]});
       Plotly.update('latency', {x:[latencyTrace.x], y:[latencyTrace.y]});

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -140,14 +140,6 @@ def _avg_e2e_latency() -> float:
     return e2e_sum / e2e_count if e2e_count else 0.0
 
 
-@router.get("/metrics")
-def metrics() -> Response:
-    """Expose Prometheus metrics."""
-    update_process_metrics()
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-
-@router.get("/metrics/summary")
 def metrics_summary() -> dict:
     """Return a minimal summary of key metrics."""
 
@@ -257,6 +249,20 @@ def metrics_summary() -> dict:
         "memory_bytes": PROCESS_MEMORY._value.get(),
         "process_uptime_seconds": PROCESS_UPTIME._value.get(),
     }
+
+
+@router.get("/metrics")
+def metrics() -> dict:
+    """Expose aggregated metrics in JSON format."""
+
+    return metrics_summary()
+
+
+@router.get("/metrics/prometheus")
+def metrics_prometheus() -> Response:
+    """Expose Prometheus metrics for scraping."""
+    update_process_metrics()
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 @router.get("/metrics/pnl")

--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -93,18 +93,15 @@
   async function updateMetrics(){
     try {
       const now = new Date();
-      const pnl = await fetch('/metrics/pnl').then(r => r.json());
-      const slip = await fetch('/metrics/slippage').then(r => r.json());
-      const lat = await fetch('/metrics/latency').then(r => r.json());
-      const summary = await fetch('/metrics/summary').then(r => r.json());
-      pnlTrace.x.push(now); pnlTrace.y.push(pnl.pnl || 0);
-      slippageTrace.x.push(now); slippageTrace.y.push(slip.avg_slippage_bps || 0);
-      latencyTrace.x.push(now); latencyTrace.y.push(lat.avg_order_latency_seconds || 0);
+      const metrics = await fetch('/metrics').then(r => r.json());
+      pnlTrace.x.push(now); pnlTrace.y.push(metrics.pnl || 0);
+      slippageTrace.x.push(now); slippageTrace.y.push(metrics.avg_slippage_bps || 0);
+      latencyTrace.x.push(now); latencyTrace.y.push(metrics.avg_order_latency_seconds || 0);
       Plotly.update('pnl', {x: [pnlTrace.x], y: [pnlTrace.y]});
       Plotly.update('slippage', {x: [slippageTrace.x], y: [slippageTrace.y]});
       Plotly.update('latency', {x: [latencyTrace.x], y: [latencyTrace.y]});
-      const funding = Object.values(summary.funding_rates || {})[0];
-      const oi = Object.values(summary.open_interest || {})[0];
+      const funding = Object.values(metrics.funding_rates || {})[0];
+      const oi = Object.values(metrics.open_interest || {})[0];
       document.getElementById('funding-value').textContent = funding ?? '--';
       document.getElementById('open-interest-value').textContent = oi ?? '--';
     } catch(err){ console.error(err); }

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1,8 +1,7 @@
 # src/tradingbot/apps/api/main.py
-from fastapi import FastAPI, Query, Response, HTTPException, Depends, status
+from fastapi import FastAPI, Query, HTTPException, Depends, status, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from pathlib import Path
 import time
 from starlette.requests import Request
@@ -14,7 +13,6 @@ import shlex
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 
-from monitoring.metrics import metrics_summary as _metrics_summary
 from monitoring.metrics import router as metrics_router
 from monitoring.dashboard import router as dashboard_router
 
@@ -76,18 +74,6 @@ async def _metrics_middleware(request: Request, call_next):
 @app.get("/health")
 def health():
     return {"status": "ok", "db": bool(_CAN_PG)}
-
-
-@app.get("/metrics")
-def metrics():
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
-
-
-@app.get("/metrics/summary")
-def metrics_summary():
-    """Expose a summarized view of key metrics."""
-    return _metrics_summary()
-
 
 @app.get("/logs")
 def logs(lines: int = Query(200, ge=1, le=1000)):

--- a/src/tradingbot/apps/status.py
+++ b/src/tradingbot/apps/status.py
@@ -53,7 +53,6 @@ def _counter_value(counter) -> float:
     return 0.0
 
 
-@app.get("/metrics/summary")
 def metrics_summary() -> dict:
     """Return a minimal summary of key metrics."""
     return {
@@ -63,6 +62,12 @@ def metrics_summary() -> dict:
 
 
 @app.get("/metrics")
-def metrics() -> Response:
+def metrics() -> dict:
+    """Expose aggregated metrics in JSON format."""
+    return metrics_summary()
+
+
+@app.get("/metrics/prometheus")
+def metrics_prometheus() -> Response:
     """Expose Prometheus metrics for scraping."""
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,7 +18,8 @@ def test_metrics_endpoint_exposed():
     client = _client()
     resp = client.get("/metrics")
     assert resp.status_code == 200
-    assert "python_info" in resp.text
+    data = resp.json()
+    assert "pnl" in data
 
 
 def test_cli_endpoint_runs_help():


### PR DESCRIPTION
## Summary
- serve aggregated JSON metrics at `/metrics` and move Prometheus scraping to `/metrics/prometheus`
- dashboard uses consolidated metrics endpoint for charts and stats
- document new metrics endpoints and update test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4005a691c832d87f6ab3c9e4457e8