### PR TITLE
Add web form for editing bot configuration

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -50,23 +50,42 @@
       <div class="column is-one-third">
         <h2 class="subtitle has-text-light">Bot Config</h2>
         <div class="box">
-          <div class="field">
-            <label class="label has-text-light">Strategy</label>
-            <div class="control">
-              <div class="select is-fullwidth">
-                <select id="cfg-strategy">
-                  <option value="breakout_atr">Breakout ATR</option>
-                  <option value="momentum">Momentum</option>
-                </select>
+          <form id="config-form" onsubmit="saveConfig(event)">
+            <div class="field">
+              <label class="label has-text-light">Strategy</label>
+              <div class="control">
+                <div class="select is-fullwidth">
+                  <select id="cfg-strategy">
+                    <option value="breakout_atr">Breakout ATR</option>
+                    <option value="momentum">Momentum</option>
+                  </select>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="field">
-            <label class="label has-text-light">Pairs (comma separated)</label>
-            <div class="control">
-              <input id="cfg-pairs" class="input" placeholder="BTCUSDT,ETHUSDT" />
+            <div class="field">
+              <label class="label has-text-light">Pairs (comma separated)</label>
+              <div class="control">
+                <input id="cfg-pairs" class="input" placeholder="BTCUSDT,ETHUSDT" />
+              </div>
             </div>
-          </div>
+            <div class="field">
+              <label class="label has-text-light">Notional</label>
+              <div class="control">
+                <input id="cfg-notional" class="input" type="number" min="0" step="any" placeholder="1000" />
+              </div>
+            </div>
+            <div class="field">
+              <label class="label has-text-light">Params (JSON)</label>
+              <div class="control">
+                <textarea id="cfg-params" class="textarea" placeholder='{"atr_period":14}'></textarea>
+              </div>
+            </div>
+            <div class="field">
+              <div class="control">
+                <button type="submit" class="button is-info is-fullwidth">Save</button>
+              </div>
+            </div>
+          </form>
           <div class="field is-grouped">
             <div class="control is-expanded">
               <button id="btn-start" class="button is-success is-fullwidth" onclick="startBot()">Start</button>
@@ -132,18 +151,55 @@
     updateStrategies();
   }
 
-  async function startBot(){
+  async function loadConfig(){
+    try {
+      const res = await fetch('/config').then(r => r.json());
+      const cfg = res.config || {};
+      document.getElementById('cfg-strategy').value = cfg.strategy || '';
+      document.getElementById('cfg-pairs').value = (cfg.pairs || []).join(',');
+      document.getElementById('cfg-notional').value = cfg.notional ?? '';
+      document.getElementById('cfg-params').value = JSON.stringify(cfg.params || {}, null, 2);
+    } catch(err){ console.error(err); }
+  }
+
+  async function saveConfig(ev){
+    if(ev) ev.preventDefault();
     const strategy = document.getElementById('cfg-strategy').value;
     const pairs = document.getElementById('cfg-pairs').value
       .split(',')
       .map(p => p.trim())
       .filter(Boolean);
+    const notionalVal = document.getElementById('cfg-notional').value;
+    const payload = {strategy, pairs};
+    if(notionalVal){ payload.notional = parseFloat(notionalVal); }
+    const paramsText = document.getElementById('cfg-params').value.trim();
+    if(paramsText){
+      try { payload.params = JSON.parse(paramsText); }
+      catch(err){
+        document.getElementById('cfg-result').textContent = 'Invalid params JSON';
+        throw err;
+      }
+    }
     try {
-      await fetch('/config', {
+      const res = await fetch('/config', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({strategy, pairs})
+        body: JSON.stringify(payload)
       });
+      if(res.ok){
+        document.getElementById('cfg-result').textContent = 'Config saved';
+      } else {
+        const err = await res.json();
+        document.getElementById('cfg-result').textContent = 'Error: ' + (err.detail || res.status);
+      }
+    } catch(err){
+      document.getElementById('cfg-result').textContent = 'Error: ' + err;
+    }
+  }
+
+  async function startBot(){
+    try {
+      await saveConfig();
       const res = await fetch('/bot/start', {method:'POST'});
       if(res.ok){
         document.getElementById('cfg-result').textContent = 'Bot started';
@@ -153,7 +209,7 @@
         document.getElementById('cfg-result').textContent = 'Error: ' + (err.detail || res.status);
       }
     } catch(err) {
-      document.getElementById('cfg-result').textContent = 'Error: ' + err;
+      if(err) console.error(err);
     }
     updateStrategies();
   }
@@ -176,6 +232,7 @@
 
   updateMetrics();
   updateStrategies();
+  loadConfig();
   setInterval(()=>{updateMetrics(); updateStrategies();},5000);
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add HTML form to edit strategy, pairs, notional and params
- load existing config on page init and save via /config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40052ea64832d8ab2dd890ca9dd5a