### PR TITLE
Add metrics summary endpoint

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -33,6 +33,7 @@ credentials via the `API_USER` and `API_PASS` environment variables
 Available endpoints:
 
 - `GET /metrics` – aggregated metrics in JSON format.
+- `GET /metrics/summary` – minimal summary of key metrics.
 - `GET /metrics/prometheus` – Prometheus metrics.
 - `GET /pnl` – current trading PnL.
 - `GET /orders` – open orders with id, symbol, side and status.

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -258,6 +258,13 @@ def metrics() -> dict:
     return metrics_summary()
 
 
+@router.get("/metrics/summary")
+def metrics_summary_route() -> dict:
+    """Expose a minimal summary of key metrics."""
+
+    return metrics_summary()
+
+
 @router.get("/metrics/prometheus")
 def metrics_prometheus() -> Response:
     """Expose Prometheus metrics for scraping."""


### PR DESCRIPTION
## Summary
- expose metrics summary at `/metrics/summary`
- document new endpoint in monitoring docs

## Testing
- `pytest`
- `curl -s -o /tmp/metrics_summary.json -w "%{http_code}" -u admin:admin http://127.0.0.1:8000/metrics/summary`


------
https://chatgpt.com/codex/tasks/task_e_68a4064df6b8832dbe7df6c94e54b702