### PR TITLE
feat: auto register strategies

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -55,10 +55,7 @@
               <label class="label has-text-light">Strategy</label>
               <div class="control">
                 <div class="select is-fullwidth">
-                  <select id="cfg-strategy">
-                    <option value="breakout_atr">Breakout ATR</option>
-                    <option value="momentum">Momentum</option>
-                  </select>
+                  <select id="cfg-strategy"></select>
                 </div>
               </div>
             </div>
@@ -148,6 +145,20 @@
     updateStrategies();
   }
 
+  async function loadStrategies(){
+    try {
+      const data = await fetch('/strategies').then(r => r.json());
+      const select = document.getElementById('cfg-strategy');
+      select.innerHTML = '';
+      for (const name of data.strategies || []){
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        select.appendChild(opt);
+      }
+    } catch(err){ console.error(err); }
+  }
+
   async function loadConfig(){
     try {
       const res = await fetch('/config').then(r => r.json());
@@ -229,7 +240,7 @@
 
   updateMetrics();
   updateStrategies();
-  loadConfig();
+  loadStrategies().then(loadConfig);
   setInterval(()=>{updateMetrics(); updateStrategies();},5000);
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Auto-discover strategy modules on startup and expose names via `/strategies`
- Fetch strategies on dashboard load and populate strategy selector dynamically

## Testing
- `pytest tests/test_monitoring_strategies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4064f8d80832d9328852446832970