### PR TITLE
feat: expose strategy schema and dynamic params form

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -113,12 +113,7 @@
                 <input id="cfg-notional" class="input" type="number" min="0" step="any" placeholder="1000" />
               </div>
             </div>
-            <div class="field">
-              <label class="label has-text-light">Params (JSON)</label>
-              <div class="control">
-                <textarea id="cfg-params" class="textarea" placeholder='{"atr_period":14}'></textarea>
-              </div>
-            </div>
+            <div id="param-fields"></div>
             <div class="field">
               <div class="control">
                 <button type="submit" class="button is-info is-fullwidth">Save</button>
@@ -147,6 +142,30 @@
   Plotly.newPlot('pnl', [pnlTrace], {paper_bgcolor:'#2a2a40', plot_bgcolor:'#2a2a40', font:{color:'#fff'}, title:'PnL'});
   Plotly.newPlot('slippage', [slippageTrace], {paper_bgcolor:'#2a2a40', plot_bgcolor:'#2a2a40', font:{color:'#fff'}, title:'Slippage (bps)'});
   Plotly.newPlot('latency', [latencyTrace], {paper_bgcolor:'#2a2a40', plot_bgcolor:'#2a2a40', font:{color:'#fff'}, title:'Order Latency (s)'});
+  let currentSchema = [];
+
+  async function loadSchema(strategy, existingParams={}){
+    if(!strategy) return;
+    try {
+      const data = await fetch(`/strategies/${strategy}/schema`).then(r => r.json());
+      currentSchema = data.params || [];
+      const container = document.getElementById('param-fields');
+      container.innerHTML = '';
+      for(const p of currentSchema){
+        const field = document.createElement('div');
+        field.className = 'field';
+        const label = `<label class="label has-text-light">${p.name}</label>`;
+        const value = existingParams[p.name] ?? p.default ?? '';
+        if(p.type === 'bool'){
+          field.innerHTML = `${label}<div class="control"><input type="checkbox" id="param-${p.name}" ${value ? 'checked' : ''}></div>`;
+        } else {
+          const typeAttr = (p.type === 'int' || p.type === 'float') ? 'number' : 'text';
+          field.innerHTML = `${label}<div class="control"><input class="input" id="param-${p.name}" type="${typeAttr}" ${p.type === 'float' ? 'step="any"' : ''} value="${value}"></div>`;
+        }
+        container.appendChild(field);
+      }
+    } catch(err){ console.error(err); }
+  }
 
   function formatBytes(bytes){
     if(bytes === undefined) return '--';
@@ -215,7 +234,7 @@
       document.getElementById('cfg-strategy').value = cfg.strategy || '';
       document.getElementById('cfg-pairs').value = (cfg.pairs || []).join(',');
       document.getElementById('cfg-notional').value = cfg.notional ?? '';
-      document.getElementById('cfg-params').value = JSON.stringify(cfg.params || {}, null, 2);
+      await loadSchema(cfg.strategy || document.getElementById('cfg-strategy').value, cfg.params || {});
     } catch(err){ console.error(err); }
   }
 
@@ -229,13 +248,27 @@
     const notionalVal = document.getElementById('cfg-notional').value;
     const payload = {strategy, pairs};
     if(notionalVal){ payload.notional = parseFloat(notionalVal); }
-    const paramsText = document.getElementById('cfg-params').value.trim();
-    if(paramsText){
-      try { payload.params = JSON.parse(paramsText); }
-      catch(err){
-        document.getElementById('cfg-result').textContent = 'Invalid params JSON';
-        throw err;
+    if(currentSchema.length){
+      const params = {};
+      for(const p of currentSchema){
+        const el = document.getElementById(`param-${p.name}`);
+        if(!el) continue;
+        let val;
+        if(p.type === 'bool'){
+          val = el.checked;
+        } else if(p.type === 'int'){
+          val = parseInt(el.value);
+          if(isNaN(val)) continue;
+        } else if(p.type === 'float'){
+          val = parseFloat(el.value);
+          if(isNaN(val)) continue;
+        } else {
+          val = el.value;
+          if(val === '') continue;
+        }
+        params[p.name] = val;
       }
+      if(Object.keys(params).length) payload.params = params;
     }
     try {
       const res = await fetch('/config', {
@@ -290,6 +323,7 @@
   updateMetrics();
   updateStrategies();
   loadConfig();
+  document.getElementById('cfg-strategy').addEventListener('change', ev => loadSchema(ev.target.value));
   setInterval(()=>{updateMetrics(); updateStrategies();},5000);
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add `/strategies/{name}/schema` endpoint to inspect strategy constructor parameters
- render dynamic parameter fields on dashboard and build params object on save

## Testing
- `pytest` (partial: 6 passed, 3 skipped)


------
https://chatgpt.com/codex/tasks/task_e_68a409437ad4832d905635c6bba83305