### PR TITLE
feat: expose strategy schema and dynamic config form

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -157,12 +157,7 @@
                 <input id="cfg-notional" class="input" type="number" min="0" step="any" placeholder="1000" />
               </div>
             </div>
-            <div class="field">
-              <label class="label has-text-light">Params (JSON)</label>
-              <div class="control">
-                <textarea id="cfg-params" class="textarea" placeholder='{"atr_period":14}'></textarea>
-              </div>
-            </div>
+            <div id="cfg-params-container"></div>
             <div class="field">
               <div class="control">
                 <button type="submit" class="button is-info is-fullwidth">Save</button>
@@ -263,6 +258,46 @@
         opt.textContent = name;
         select.appendChild(opt);
       }
+      select.addEventListener('change', () => loadStrategySchema(select.value));
+    } catch(err){ console.error(err); }
+  }
+
+  async function loadStrategySchema(name, values={}){
+    const container = document.getElementById('cfg-params-container');
+    container.innerHTML = '';
+    if(!name) return;
+    try {
+      const res = await fetch(`/strategies/${name}/schema`).then(r => r.json());
+      for(const param of res.params || []){
+        const field = document.createElement('div');
+        field.className = 'field';
+        const label = document.createElement('label');
+        label.className = 'label has-text-light';
+        label.textContent = param.name;
+        const control = document.createElement('div');
+        control.className = 'control';
+        let input;
+        if(param.type.includes('bool')){
+          input = document.createElement('input');
+          input.type = 'checkbox';
+          input.className = 'checkbox';
+          input.checked = (values[param.name] ?? param.default) || false;
+        } else {
+          input = document.createElement('input');
+          input.className = 'input';
+          input.value = values[param.name] ?? param.default ?? '';
+          if(param.type.includes('int')){ input.type = 'number'; input.step = '1'; }
+          else if(param.type.includes('float')){ input.type = 'number'; input.step = 'any'; }
+          else { input.type = 'text'; }
+        }
+        input.id = `param-${param.name}`;
+        input.dataset.param = param.name;
+        input.dataset.type = param.type;
+        control.appendChild(input);
+        field.appendChild(label);
+        field.appendChild(control);
+        container.appendChild(field);
+      }
     } catch(err){ console.error(err); }
   }
 
@@ -273,13 +308,13 @@
       document.getElementById('cfg-strategy').value = cfg.strategy || '';
       document.getElementById('cfg-pairs').value = (cfg.pairs || []).join(',');
       document.getElementById('cfg-notional').value = cfg.notional ?? '';
-      document.getElementById('cfg-params').value = JSON.stringify(cfg.params || {}, null, 2);
       document.getElementById('cfg-exchange').value = cfg.exchange || 'binance';
       document.getElementById('cfg-market').value = cfg.market || 'spot';
       document.getElementById('cfg-trade-qty').value = cfg.trade_qty ?? '';
       document.getElementById('cfg-leverage').value = cfg.leverage ?? '';
       document.getElementById('cfg-testnet').checked = cfg.testnet ?? true;
       document.getElementById('cfg-dry-run').checked = cfg.dry_run ?? false;
+      await loadStrategySchema(cfg.strategy || '', cfg.params || {});
     } catch(err){ console.error(err); }
   }
 
@@ -301,14 +336,24 @@
     if(tradeQtyVal){ payload.trade_qty = parseFloat(tradeQtyVal); }
     if(leverageVal){ payload.leverage = parseInt(leverageVal); }
     if(notionalVal){ payload.notional = parseFloat(notionalVal); }
-    const paramsText = document.getElementById('cfg-params').value.trim();
-    if(paramsText){
-      try { payload.params = JSON.parse(paramsText); }
-      catch(err){
-        document.getElementById('cfg-result').textContent = 'Invalid params JSON';
-        throw err;
+    const paramInputs = document.querySelectorAll('#cfg-params-container [data-param]');
+    const params = {};
+    for(const input of paramInputs){
+      const type = input.dataset.type || '';
+      const name = input.dataset.param;
+      let value;
+      if(type.includes('bool')){
+        value = input.checked;
+      } else {
+        const v = input.value;
+        if(v === '') continue;
+        if(type.includes('int')) value = parseInt(v);
+        else if(type.includes('float')) value = parseFloat(v);
+        else value = v;
       }
+      params[name] = value;
     }
+    if(Object.keys(params).length) payload.params = params;
     try {
       const res = await fetch('/config', {
         method:'POST',


### PR DESCRIPTION
## Summary
- add `/strategies/{name}/schema` endpoint that inspects strategy class parameters
- render strategy parameter fields dynamically in dashboard and build config params object

## Testing
- `pytest tests/test_monitoring_panel.py tests/test_monitoring_strategies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40c4c16f4832d92438002b73fbe42