### PR TITLE
docs: clarify optional vectorbt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ git clone <repo>
 cd TradeBot
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+# Opcional: habilita el backtester vectorizado
+pip install "vectorbt>=0.26"
 cp .env.example .env   # completa con tus claves
 ```
 ## Arranque rápido

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -96,7 +96,7 @@ Consulta el notebook [docs/notebooks/breakout_atr.ipynb](notebooks/breakout_atr.
 para ver un flujo de trabajo completo de un backtest.
 
 ## Barrido de parámetros con vectorbt
-Se requiere instalar la dependencia opcional `vectorbt`.
+Se requiere instalar la dependencia opcional `vectorbt` (por ejemplo, `pip install "vectorbt>=0.26"`).
 
 ```python
 import numpy as np

--- a/docs/extra_features.md
+++ b/docs/extra_features.md
@@ -55,7 +55,7 @@ Ejemplos:
 
 ## Backtesting y análisis
 
-- Motor **vectorizado** basado en `vectorbt` para exploración rápida.
+- Motor **vectorizado** basado en `vectorbt` para exploración rápida (instalar con `pip install "vectorbt>=0.26"`).
 - Motor **event-driven** que simula profundidad L2, slippage y latencia.
 - Utilidades de **walk-forward** y generación de reportes con métricas
   como Sharpe, Sortino y drawdown.

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,6 @@ httpx>=0.27
 flake8>=7.0
 
 # Backtesting helpers
-vectorbt>=0.26; python_version == "0"  # optional dependency
+# Optional: install vectorbt to enable the vectorized backtester
+# pip install "vectorbt>=0.26"
+


### PR DESCRIPTION
## Summary
- document how to install optional `vectorbt` dependency
- remove fake requirement and update docs to enable vectorized backtester

## Testing
- `pytest tests/test_backtest_engine.py::test_run_vectorbt_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_68a47b09a060832db1816751a46cc414