### PR TITLE
feat: switch dashboard to dark theme

### DIFF
--- a/monitoring/static/index.html
+++ b/monitoring/static/index.html
@@ -15,60 +15,59 @@
   </nav>
 
   <section class="section">
-    <div class="columns is-multiline">
-      <div class="column is-one-third">
-        <div id="pnl" class="box" style="height:250px;"></div>
-      </div>
-      <div class="column is-one-third">
-        <div id="slippage" class="box" style="height:250px;"></div>
-      </div>
-      <div class="column is-one-third">
-        <div id="latency" class="box" style="height:250px;"></div>
+    <div class="container">
+      <div class="columns">
+        <div class="column"><div id="pnl" class="box chart-box"></div></div>
+        <div class="column"><div id="slippage" class="box chart-box"></div></div>
+        <div class="column"><div id="latency" class="box chart-box"></div></div>
       </div>
 
-        <div class="column is-half">
-          <div class="box">
-            <h2 class="subtitle">Funding</h2>
-            <p id="funding-value">--</p>
+      <div class="columns is-multiline">
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Funding</h2>
+            <p id="funding-value" class="stat-value">--</p>
           </div>
         </div>
-        <div class="column is-half">
-          <div class="box">
-            <h2 class="subtitle">Open Interest</h2>
-            <p id="open-interest-value">--</p>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Open Interest</h2>
+            <p id="open-interest-value" class="stat-value">--</p>
           </div>
         </div>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Fills</h2>
+            <p id="fills-value" class="stat-value">--</p>
+          </div>
+        </div>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Risk Events</h2>
+            <p id="risk-events-value" class="stat-value">--</p>
+          </div>
+        </div>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Reject Rate</h2>
+            <p id="reject-rate-value" class="stat-value">--</p>
+          </div>
+        </div>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">CPU %</h2>
+            <p id="cpu-value" class="stat-value">--</p>
+          </div>
+        </div>
+        <div class="column is-one-quarter">
+          <div class="box stat-box">
+            <h2 class="subtitle is-6">Memory</h2>
+            <p id="memory-value" class="stat-value">--</p>
+          </div>
+        </div>
+      </div>
 
-        <div class="column is-one-fifth">
-          <div class="box">
-            <h2 class="subtitle">Fills</h2>
-            <p id="fills-value">--</p>
-          </div>
-        </div>
-        <div class="column is-one-fifth">
-          <div class="box">
-            <h2 class="subtitle">Risk Events</h2>
-            <p id="risk-events-value">--</p>
-          </div>
-        </div>
-        <div class="column is-one-fifth">
-          <div class="box">
-            <h2 class="subtitle">Reject Rate</h2>
-            <p id="reject-rate-value">--</p>
-          </div>
-        </div>
-        <div class="column is-one-fifth">
-          <div class="box">
-            <h2 class="subtitle">CPU %</h2>
-            <p id="cpu-value">--</p>
-          </div>
-        </div>
-        <div class="column is-one-fifth">
-          <div class="box">
-            <h2 class="subtitle">Memory</h2>
-            <p id="memory-value">--</p>
-          </div>
-        </div>
+      <div class="columns is-multiline">
 
         <div class="column is-full">
           <h2 class="subtitle">Positions</h2>
@@ -226,6 +225,7 @@
       </div>
 
   </div>
+    </div>
 </section>
 
  <section class="section">
@@ -239,9 +239,10 @@
   const pnlTrace = {x: [], y: [], mode: 'lines', name: 'PnL'};
   const slippageTrace = {x: [], y: [], mode: 'lines', name: 'Slippage'};
   const latencyTrace = {x: [], y: [], mode: 'lines', name: 'Latency'};
-  Plotly.newPlot('pnl', [pnlTrace], {paper_bgcolor:'#ffffff', plot_bgcolor:'#ffffff', font:{color:'#222'}, title:'PnL'});
-  Plotly.newPlot('slippage', [slippageTrace], {paper_bgcolor:'#ffffff', plot_bgcolor:'#ffffff', font:{color:'#222'}, title:'Slippage (bps)'});
-  Plotly.newPlot('latency', [latencyTrace], {paper_bgcolor:'#ffffff', plot_bgcolor:'#ffffff', font:{color:'#222'}, title:'Order Latency (s)'});
+  const plotLayout = {paper_bgcolor:'#2b3848', plot_bgcolor:'#2b3848', font:{color:'#e0e0e0'}};
+  Plotly.newPlot('pnl', [pnlTrace], {...plotLayout, title:'PnL'});
+  Plotly.newPlot('slippage', [slippageTrace], {...plotLayout, title:'Slippage (bps)'});
+  Plotly.newPlot('latency', [latencyTrace], {...plotLayout, title:'Order Latency (s)'});
 
   function formatBytes(bytes){
     if(bytes === undefined) return '--';

--- a/monitoring/static/style.css
+++ b/monitoring/static/style.css
@@ -1,12 +1,12 @@
-/* Light, clean color palette */
+/* Dark professional color palette */
 :root {
-  --color-bg: #f5f5f5;
-  --color-text: #222222;
-  --color-card: #ffffff;
-  --color-primary: #3273dc;
-  --color-success: #48c774;
-  --color-warning: #ffdd57;
-  --color-danger: #f14668;
+  --color-bg: #1e2a38;
+  --color-text: #e0e0e0;
+  --color-card: #2b3848;
+  --color-primary: #209cee;
+  --color-success: #2ecc71;
+  --color-warning: #f1c40f;
+  --color-danger: #e74c3c;
 }
 
 html,
@@ -16,8 +16,8 @@ body {
 }
 
 .navbar {
-  background-color: var(--color-primary);
-  color: #fff;
+  background-color: var(--color-card);
+  color: var(--color-text);
 }
 
 .box {
@@ -28,6 +28,19 @@ body {
 .table {
   background-color: var(--color-card);
   color: var(--color-text);
+}
+
+/* Simple card and chart helpers */
+.chart-box {
+  height: 250px;
+}
+
+.stat-box {
+  text-align: center;
+}
+
+.stat-box .stat-value {
+  font-size: 1.5rem;
 }
 
 /* Status and alert colors */


### PR DESCRIPTION
## Summary
- apply dark color palette and helper classes for dashboard
- restructure dashboard layout with metric cards and container
- match Plotly charts to dark theme

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a47f8a111c832d9e32e1c486960659