### PR TITLE
feat: add bot management tab and API

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -15,6 +15,9 @@ Open <http://localhost:8000/> to access a lightweight React dashboard. The
 SPA connects to the `/ws/summary` WebSocket for real‑time metrics, PnL and
 risk updates.
 
+The dashboard includes a **Bots** tab where strategies can be launched or
+stopped visually without typing CLI commands.
+
 If the trading API is hosted on another URL, set `API_URL` before launching
 the panel so risk endpoints can be polled correctly:
 

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -551,4 +551,5 @@ async def run_cli(cmd: CLICommand) -> dict:
 
 
 static_dir = Path(__file__).parent / "static"
+static_dir.mkdir(exist_ok=True)
 app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -10,6 +10,8 @@ import secrets
 import subprocess
 import sys
 import shlex
+import asyncio
+import signal
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 
@@ -401,4 +403,135 @@ def run_cli(req: CLIRequest):
         }
     except Exception as exc:  # pragma: no cover - subprocess failures
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# --- Bot lifecycle --------------------------------------------------------------
+
+
+class BotConfig(BaseModel):
+    """Configuration for launching a trading bot."""
+
+    strategy: str
+    pairs: list[str] | None = None
+    notional: float | None = None
+    exchange: str | None = None
+    market: str | None = None
+    trade_qty: float | None = None
+    leverage: int | None = None
+    testnet: bool | None = None
+    dry_run: bool | None = None
+
+
+_BOTS: dict[int, dict] = {}
+
+
+def _build_bot_args(cfg: BotConfig) -> list[str]:
+    args = [
+        sys.executable,
+        "-m",
+        "tradingbot.cli",
+        "run-bot",
+        "--strategy",
+        cfg.strategy,
+    ]
+    for pair in cfg.pairs or []:
+        args.extend(["--symbol", pair])
+    if cfg.notional is not None:
+        args.extend(["--notional", str(cfg.notional)])
+    if cfg.exchange:
+        args.extend(["--exchange", cfg.exchange])
+    if cfg.market:
+        args.extend(["--market", cfg.market])
+    if cfg.trade_qty is not None:
+        args.extend(["--trade-qty", str(cfg.trade_qty)])
+    if cfg.leverage is not None:
+        args.extend(["--leverage", str(cfg.leverage)])
+    if cfg.testnet is not None:
+        args.append("--testnet" if cfg.testnet else "--no-testnet")
+    if cfg.dry_run is not None:
+        args.append("--dry-run" if cfg.dry_run else "--no-dry-run")
+    return args
+
+
+@app.post("/bots")
+async def start_bot(cfg: BotConfig):
+    """Launch a bot process using the provided configuration."""
+
+    args = _build_bot_args(cfg)
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _BOTS[proc.pid] = {"process": proc, "config": cfg.dict()}
+    return {"pid": proc.pid, "status": "started"}
+
+
+@app.get("/bots")
+def list_bots():
+    """Return information about running bot processes."""
+
+    items = []
+    for pid, info in _BOTS.items():
+        proc = info["process"]
+        status = "running" if proc.returncode is None else f"stopped:{proc.returncode}"
+        items.append({"pid": pid, "status": status, "config": info["config"]})
+    return {"bots": items}
+
+
+@app.post("/bots/{pid}/stop")
+async def stop_bot(pid: int):
+    """Terminate a running bot process."""
+
+    info = _BOTS.get(pid)
+    if not info:
+        raise HTTPException(status_code=404, detail="bot not found")
+    proc: asyncio.subprocess.Process = info["process"]
+    if proc.returncode is not None:
+        raise HTTPException(status_code=400, detail="bot not running")
+    proc.terminate()
+    await proc.wait()
+    return {"pid": pid, "status": "stopped", "returncode": proc.returncode}
+
+
+@app.post("/bots/{pid}/pause")
+def pause_bot(pid: int):
+    """Send SIGSTOP to a running bot process."""
+
+    info = _BOTS.get(pid)
+    if not info:
+        raise HTTPException(status_code=404, detail="bot not found")
+    proc: asyncio.subprocess.Process = info["process"]
+    if proc.returncode is not None:
+        raise HTTPException(status_code=400, detail="bot not running")
+    proc.send_signal(signal.SIGSTOP)
+    return {"pid": pid, "status": "paused"}
+
+
+@app.post("/bots/{pid}/resume")
+def resume_bot(pid: int):
+    """Send SIGCONT to resume a paused bot."""
+
+    info = _BOTS.get(pid)
+    if not info:
+        raise HTTPException(status_code=404, detail="bot not found")
+    proc: asyncio.subprocess.Process = info["process"]
+    if proc.returncode is not None:
+        raise HTTPException(status_code=400, detail="bot not running")
+    proc.send_signal(signal.SIGCONT)
+    return {"pid": pid, "status": "running"}
+
+
+@app.delete("/bots/{pid}")
+async def delete_bot(pid: int):
+    """Remove process information and terminate if still running."""
+
+    info = _BOTS.pop(pid, None)
+    if not info:
+        raise HTTPException(status_code=404, detail="bot not found")
+    proc: asyncio.subprocess.Process = info["process"]
+    if proc.returncode is None:
+        proc.terminate()
+        await proc.wait()
+    return {"pid": pid, "status": "deleted", "returncode": proc.returncode}
 

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <title>Bots - TradingBot</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
+    h1, h2 { margin: 0.2rem 0; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
+    table { width:100%; border-collapse: collapse; font-size: 14px; }
+    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
+    th { background:#0f1622; position: sticky; top:0; }
+    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    .muted { color:#94a3b8; }
+    button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
+    button:hover { background:#1d4ed8; }
+    input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
+    label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
+    nav { margin-bottom:20px; }
+    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
+    nav a:hover { text-decoration:underline; }
+    pre { background:#0f1622; padding:10px; border-radius:8px; overflow:auto; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="/">Configuración</a>
+    <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
+  </nav>
+  <h1>Bots</h1>
+
+  <div class="card">
+    <h2>Nuevo bot</h2>
+    <div class="grid3" style="margin-top:10px">
+      <div>
+        <label for="bot-strategy">Estrategia</label>
+        <select id="bot-strategy"></select>
+      </div>
+      <div>
+        <label for="bot-pairs">Pares (coma)</label>
+        <input id="bot-pairs" placeholder="BTC/USDT,ETH/USDT"/>
+      </div>
+      <div>
+        <label for="bot-notional">Notional (USDT)</label>
+        <input id="bot-notional" type="number" step="0.01"/>
+      </div>
+      <div>
+        <label for="bot-exchange">Exchange</label>
+        <select id="bot-exchange">
+          <option value="binance">Binance</option>
+          <option value="bybit">Bybit</option>
+          <option value="okx">OKX</option>
+        </select>
+      </div>
+      <div>
+        <label for="bot-market">Mercado</label>
+        <select id="bot-market">
+          <option value="spot">Spot</option>
+          <option value="futures">Futuros</option>
+        </select>
+      </div>
+      <div>
+        <label for="bot-trade-qty">Trade qty</label>
+        <input id="bot-trade-qty" type="number" step="0.0001"/>
+      </div>
+      <div>
+        <label for="bot-leverage">Leverage</label>
+        <input id="bot-leverage" type="number" step="1"/>
+      </div>
+      <div>
+        <label><input type="checkbox" id="bot-testnet" checked/> Testnet</label>
+      </div>
+      <div>
+        <label><input type="checkbox" id="bot-dry-run"/> Dry run</label>
+      </div>
+    </div>
+    <button id="bot-start" style="margin-top:10px">Start</button>
+    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h2>Bots activos</h2>
+    <div class="muted">Auto-refresh 5s</div>
+    <div style="overflow:auto; max-height:60vh; margin-top:10px">
+      <table id="tbl-bots">
+        <thead><tr><th>PID</th><th>Estrategia</th><th>Pares</th><th>Estado</th><th>Acciones</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+<script>
+const api = (path) => `${location.origin}${path}`;
+
+async function loadStrategies(){
+  try{
+    const r = await fetch(api('/strategies/status'));
+    const j = await r.json();
+    const sel = document.getElementById('bot-strategy');
+    sel.innerHTML='';
+    Object.keys(j.strategies || {}).forEach(s=>{
+      const o=document.createElement('option');
+      o.value=s; o.textContent=s; sel.appendChild(o);
+    });
+  }catch(e){}
+}
+
+async function startBot(){
+  const strategy = document.getElementById('bot-strategy').value;
+  const pairs = document.getElementById('bot-pairs').value.split(',').map(s=>s.trim()).filter(Boolean);
+  const notional = document.getElementById('bot-notional').value;
+  const exchange = document.getElementById('bot-exchange').value;
+  const market = document.getElementById('bot-market').value;
+  const trade_qty = document.getElementById('bot-trade-qty').value;
+  const leverage = document.getElementById('bot-leverage').value;
+  const testnet = document.getElementById('bot-testnet').checked;
+  const dry_run = document.getElementById('bot-dry-run').checked;
+  const payload = {strategy, pairs, exchange, market, testnet, dry_run};
+  if(notional) payload.notional = Number(notional);
+  if(trade_qty) payload.trade_qty = Number(trade_qty);
+  if(leverage) payload.leverage = Number(leverage);
+  try{
+    const r = await fetch(api('/bots'), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
+    const j = await r.json();
+    document.getElementById('bot-output').textContent = JSON.stringify(j,null,2);
+    refreshBots();
+  }catch(e){ document.getElementById('bot-output').textContent = String(e); }
+}
+
+async function refreshBots(){
+  try{
+    const r = await fetch(api('/bots'));
+    const j = await r.json();
+    const body = document.querySelector('#tbl-bots tbody');
+    body.innerHTML='';
+    (j.bots||[]).forEach(b=>{
+      const tr=document.createElement('tr');
+      const pairs=(b.config?.pairs||[]).join(',');
+      tr.innerHTML=`<td>${b.pid}</td><td>${b.config?.strategy||''}</td><td>${pairs}</td><td>${b.status}</td>
+      <td>
+        <button onclick="stopBot(${b.pid})">Stop</button>
+        <button onclick="pauseBot(${b.pid})">Pause</button>
+        <button onclick="resumeBot(${b.pid})">Resume</button>
+        <button onclick="deleteBot(${b.pid})">Delete</button>
+      </td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
+
+async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST'}); refreshBots(); }
+async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
+async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
+async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
+
+document.getElementById('bot-start').addEventListener('click', startBot);
+loadStrategies();
+refreshBots();
+setInterval(refreshBots,5000);
+</script>
+</body>
+</html>
+

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -36,6 +36,7 @@
   <nav>
     <a href="/">Configuración</a>
     <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
   </nav>
   <h1>TradingBot Dashboard</h1>
   <div class="muted" id="health">Comprobando estado…</div>

--- a/src/tradingbot/apps/api/static/monitor.html
+++ b/src/tradingbot/apps/api/static/monitor.html
@@ -26,6 +26,7 @@
   <nav>
     <a href="/">Configuración</a>
     <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
   </nav>
   <h1>Monitoreo</h1>
   <div class="grid3" style="margin:14px 0 20px">

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -1,0 +1,56 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from tradingbot.apps.api.main import app
+
+
+def test_bot_endpoints(monkeypatch):
+    client = TestClient(app)
+
+    class DummyProc:
+        def __init__(self, pid: int):
+            self.pid = pid
+            self.returncode = None
+
+        async def wait(self):
+            self.returncode = 0
+
+        def terminate(self):
+            self.returncode = 0
+
+        def send_signal(self, sig):
+            return None
+
+    procs: list[DummyProc] = []
+
+    async def fake_exec(*args, **kwargs):
+        proc = DummyProc(100 + len(procs))
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    payload = {
+        "strategy": "dummy",
+        "pairs": ["BTC/USDT"],
+        "exchange": "binance",
+        "market": "spot",
+        "trade_qty": 1.0,
+        "leverage": 1,
+        "testnet": True,
+        "dry_run": False,
+    }
+
+    resp = client.post("/bots", json=payload, auth=("admin", "admin"))
+    assert resp.status_code == 200
+    pid = resp.json()["pid"]
+
+    lst = client.get("/bots", auth=("admin", "admin"))
+    assert lst.status_code == 200
+    assert any(b["pid"] == pid for b in lst.json()["bots"])
+
+    assert client.post(f"/bots/{pid}/pause", auth=("admin", "admin")).status_code == 200
+    assert client.post(f"/bots/{pid}/resume", auth=("admin", "admin")).status_code == 200
+    assert client.post(f"/bots/{pid}/stop", auth=("admin", "admin")).status_code == 200
+    assert client.delete(f"/bots/{pid}", auth=("admin", "admin")).status_code == 200
+


### PR DESCRIPTION
## Summary
- add REST endpoints to start, stop, pause and list bot processes
- expose new Bots dashboard to launch and control strategies
- document bot panel and ensure monitoring panel serves static files

## Testing
- `pytest -q tests/test_api_bots.py tests/test_monitoring_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49a7e1420832db195672093f8a9bd