### PR TITLE
feat: add bot management tab and API

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -15,6 +15,9 @@ Open <http://localhost:8000/> to access a lightweight React dashboard. The
 SPA connects to the `/ws/summary` WebSocket for real‑time metrics, PnL and
 risk updates.
 
+The dashboard includes a **Bots** tab where strategies can be launched or
+stopped visually without typing CLI commands.
+
 If the trading API is hosted on another URL, set `API_URL` before launching
 the panel so risk endpoints can be polled correctly:
 

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -551,4 +551,5 @@ async def run_cli(cmd: CLICommand) -> dict:
 
 
 static_dir = Path(__file__).parent / "static"
+static_dir.mkdir(exist_ok=True)
 app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <title>Bots - TradingBot</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <link rel="stylesheet" href="/static/styles.css"/>
+</head>
+<body>
+  <nav>
+    <a href="/">Configuración</a>
+    <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
+  </nav>
+  <h1>Bots</h1>
+
+  <div class="card">
+    <h2>Nuevo bot</h2>
+    <div class="grid3" style="margin-top:10px">
+      <div>
+        <label for="bot-strategy">Estrategia</label>
+        <select id="bot-strategy"></select>
+      </div>
+      <div>
+        <label for="bot-pairs">Pares (coma)</label>
+        <input id="bot-pairs" placeholder="BTC/USDT,ETH/USDT"/>
+      </div>
+      <div>
+        <label for="bot-notional">Notional (USDT)</label>
+        <input id="bot-notional" type="number" step="0.01"/>
+      </div>
+      <div>
+        <label for="bot-exchange">Exchange</label>
+        <select id="bot-exchange">
+          <option value="binance">Binance</option>
+          <option value="bybit">Bybit</option>
+          <option value="okx">OKX</option>
+        </select>
+      </div>
+      <div>
+        <label for="bot-market">Mercado</label>
+        <select id="bot-market">
+          <option value="spot">Spot</option>
+          <option value="futures">Futuros</option>
+        </select>
+      </div>
+      <div>
+        <label for="bot-trade-qty">Trade qty</label>
+        <input id="bot-trade-qty" type="number" step="0.0001"/>
+      </div>
+      <div>
+        <label for="bot-leverage">Leverage</label>
+        <input id="bot-leverage" type="number" step="1"/>
+      </div>
+      <div>
+        <label><input type="checkbox" id="bot-testnet" checked/> Testnet</label>
+      </div>
+      <div>
+        <label><input type="checkbox" id="bot-dry-run"/> Dry run</label>
+      </div>
+    </div>
+    <button id="bot-start" style="margin-top:10px">Start</button>
+    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h2>Bots activos</h2>
+    <div class="muted">Auto-refresh 5s</div>
+    <div style="overflow:auto; max-height:60vh; margin-top:10px">
+      <table id="tbl-bots">
+        <thead><tr><th>PID</th><th>Estrategia</th><th>Pares</th><th>Estado</th><th>Acciones</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h2>Comandos CLI</h2>
+    <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
+    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
+    <button id="cli-run" style="margin-top:8px">Ejecutar</button>
+    <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+<script>
+const api = (path) => `${location.origin}${path}`;
+
+async function loadStrategies(){
+  try{
+    const r = await fetch(api('/strategies/status'));
+    const j = await r.json();
+    const sel = document.getElementById('bot-strategy');
+    sel.innerHTML='';
+    Object.keys(j.strategies || {}).forEach(s=>{
+      const o=document.createElement('option');
+      o.value=s; o.textContent=s; sel.appendChild(o);
+    });
+  }catch(e){}
+}
+
+async function runCli(){
+  const cmd = document.getElementById('cli-input').value;
+  if(!cmd.trim()) return;
+  try{
+    const r = await fetch(api('/cli/run'), {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({command: cmd})
+    });
+    const j = await r.json();
+    const out = (j.stdout || '') + (j.stderr ? '\n'+j.stderr : '');
+    document.getElementById('cli-output').textContent = out;
+  }catch(e){
+    document.getElementById('cli-output').textContent = String(e);
+  }
+}
+
+async function startBot(){
+  const strategy = document.getElementById('bot-strategy').value;
+  const pairs = document.getElementById('bot-pairs').value.split(',').map(s=>s.trim()).filter(Boolean);
+  const notional = document.getElementById('bot-notional').value;
+  const exchange = document.getElementById('bot-exchange').value;
+  const market = document.getElementById('bot-market').value;
+  const trade_qty = document.getElementById('bot-trade-qty').value;
+  const leverage = document.getElementById('bot-leverage').value;
+  const testnet = document.getElementById('bot-testnet').checked;
+  const dry_run = document.getElementById('bot-dry-run').checked;
+  const payload = {strategy, pairs, exchange, market, testnet, dry_run};
+  if(notional) payload.notional = Number(notional);
+  if(trade_qty) payload.trade_qty = Number(trade_qty);
+  if(leverage) payload.leverage = Number(leverage);
+  try{
+    const r = await fetch(api('/bots'), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
+    const j = await r.json();
+    document.getElementById('bot-output').textContent = JSON.stringify(j,null,2);
+    refreshBots();
+  }catch(e){ document.getElementById('bot-output').textContent = String(e); }
+}
+
+async function refreshBots(){
+  try{
+    const r = await fetch(api('/bots'));
+    const j = await r.json();
+    const body = document.querySelector('#tbl-bots tbody');
+    body.innerHTML='';
+    (j.bots||[]).forEach(b=>{
+      const tr=document.createElement('tr');
+      const pairs=(b.config?.pairs||[]).join(',');
+      tr.innerHTML=`<td>${b.pid}</td><td>${b.config?.strategy||''}</td><td>${pairs}</td><td>${b.status}</td>
+      <td>
+        <button onclick="stopBot(${b.pid})">Stop</button>
+        <button onclick="pauseBot(${b.pid})">Pause</button>
+        <button onclick="resumeBot(${b.pid})">Resume</button>
+        <button onclick="deleteBot(${b.pid})">Delete</button>
+      </td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
+
+async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST'}); refreshBots(); }
+async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
+async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
+async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
+
+document.getElementById('bot-start').addEventListener('click', startBot);
+document.getElementById('cli-run').addEventListener('click', runCli);
+loadStrategies();
+refreshBots();
+setInterval(refreshBots,5000);
+</script>
+</body>
+</html>
+

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -4,45 +4,20 @@
   <meta charset="utf-8"/>
   <title>TradingBot Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
-    h1, h2 { margin: 0.2rem 0; }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
-    table { width:100%; border-collapse: collapse; font-size: 14px; }
-    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
-    th { background:#0f1622; position: sticky; top:0; }
-    .muted { color:#94a3b8; }
-    .badge { display:inline-block; padding:2px 8px; border-radius: 999px; border:1px solid #334155; font-size:12px; }
-    .buy { color:#10b981; }
-    .sell { color:#f43f5e; }
-    .ok { color:#22c55e }
-    .warn { color:#f59e0b }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-    .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
-    .kv .k { font-size:12px; color:#94a3b8 }
-    .kv .v { font-size:18px; margin-top:4px }
-    button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
-    button:hover { background:#1d4ed8; }
-    textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
-    label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
-    nav { margin-bottom:20px; }
-    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
-    nav a:hover { text-decoration:underline; }
-    </style>
+  <link rel="stylesheet" href="/static/styles.css"/>
   </head>
   <body>
   <nav>
     <a href="/">Configuración</a>
     <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
   </nav>
   <h1>TradingBot Dashboard</h1>
   <div class="muted" id="health">Comprobando estado…</div>
 
   <div class="card" style="margin-top:16px">
     <h2>Configuración</h2>
-    <div class="muted">Selecciona exchange, claves y estrategia sin usar la CLI</div>
+    <div class="muted">Configura las credenciales del exchange sin usar la CLI</div>
     <div class="grid3" style="margin-top:10px">
       <div>
         <label for="cfg-exchange">Exchange</label>
@@ -60,31 +35,6 @@
       <div>
         <label for="cfg-secret">API Secret</label>
         <input id="cfg-secret" type="password" placeholder="secreto"/>
-      </div>
-      <div>
-        <label for="cfg-strategy">Estrategia</label>
-        <select id="cfg-strategy">
-          <option value="breakout_atr">Breakout ATR</option>
-          <option value="breakout_vol">Breakout Vol</option>
-          <option value="momentum">Momentum</option>
-          <option value="mean_reversion">Mean Reversion</option>
-          <option value="triangular_arb">Tri-Arb</option>
-          <option value="cash_and_carry">Cash &amp; Carry</option>
-          <option value="order_flow">Order Flow</option>
-          <option value="depth_imbalance">Depth Imbalance</option>
-          <option value="liquidity_events">Liquidity Events</option>
-          <option value="triple_barrier">Triple Barrier</option>
-          <option value="ml">ML Strategy</option>
-          <option value="mean_rev_ofi">Mean Rev OFI</option>
-        </select>
-      </div>
-      <div>
-        <label for="cfg-notional">Notional (USDT)</label>
-        <input id="cfg-notional" type="number" step="0.01" placeholder="100"/>
-      </div>
-      <div>
-        <label for="cfg-threshold">Umbral</label>
-        <input id="cfg-threshold" type="number" step="0.0001" placeholder="0.001"/>
       </div>
     </div>
     <button id="cfg-save" style="margin-top:10px">Guardar configuración</button>
@@ -162,17 +112,6 @@
     </div>
 
     <div class="card" style="margin-top:16px">
-      <h2>PnL por símbolo (Spot)</h2>
-      <div class="muted">Realizado, no realizado y neto</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-pnl-spot">
-          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
       <h2>Exposición por símbolo (Futuros)</h2>
       <div class="muted">Último snapshot por símbolo</div>
       <div style="overflow:auto; max-height: 40vh; margin-top:10px">
@@ -182,50 +121,17 @@
         </table>
       </div>
     </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>PnL por símbolo (Futuros)</h2>
-      <div class="muted">Realizado, no realizado y neto</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-pnl-fut">
-          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>PnL (Spot) – Serie temporal</h2>
-      <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
-      <div style="padding:10px">
-        <canvas id="chart-pnl-spot" height="120"></canvas>
-      </div>
     </div>
   </div>
 
-  <div class="card" style="margin-top:16px">
-      <h2>PnL (Futuros) – Serie temporal</h2>
-      <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
-    <div style="padding:10px">
-      <canvas id="chart-pnl-fut" height="120"></canvas>
-    </div>
-  </div>
   <div class="card" style="margin-top:16px">
     <h2>Logs</h2>
     <div class="muted">Auto‑refresh 5s</div>
     <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
   </div>
-  <div class="card" style="margin-top:16px">
-    <h2>Comandos CLI</h2>
-    <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
-    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
-    <button id="cli-run" style="margin-top:8px">Ejecutar</button>
-    <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
 </div>
 <script>
 const api = (path) => `${location.origin}${path}`;
-let pnlChart;
 let orderQuery = "";
 
 function fmtEdge(x){ if(x==null) return "—"; return (x*100).toFixed(3)+"%"; }
@@ -381,61 +287,7 @@ async function refreshRisk(){
   }catch(e){}
 }
 
-async function refreshSpotPnL(){
-  try{
-    const r = await fetch(api("/pnl/summary?venue=binance_spot_testnet"));
-    const j = await r.json();
-    const t = j.totals || {};
-    document.getElementById("sum-upnl-spot").textContent = "$ " + fmtUSD(t.upnl || 0);
-    document.getElementById("sum-rpnl-spot").textContent = "$ " + fmtUSD(t.rpnl || 0);
-    document.getElementById("sum-net-spot").textContent = "$ " + fmtUSD(t.net_pnl || 0);
 
-    const tb = document.querySelector("#tbl-pnl-spot tbody");
-    tb.innerHTML = "";
-    for(const it of (j.items || [])){
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.qty,6)}</td>
-        <td class="mono">${fmtNum(it.avg_price,2)}</td>
-        <td class="mono">$ ${fmtUSD(it.upnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.realized_pnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.fees_paid)}</td>
-        <td class="mono">$ ${fmtUSD(it.total_pnl)}</td>
-      `;
-      tb.appendChild(tr);
-    }
-  }catch(e){}
-}
-
-async function refreshFuturePnL(){
-  try{
-    const r = await fetch(api("/pnl/summary?venue=binance_futures_um_testnet"));
-    const j = await r.json();
-    const t = j.totals || {};
-    document.getElementById("sum-upnl-fut").textContent = "$ " + fmtUSD(t.upnl || 0);
-    document.getElementById("sum-rpnl-fut").textContent = "$ " + fmtUSD(t.rpnl || 0);
-    document.getElementById("sum-net-fut").textContent = "$ " + fmtUSD(t.net_pnl || 0);
-
-    const tb = document.querySelector("#tbl-pnl-fut tbody");
-    if(tb){
-      tb.innerHTML = "";
-      for(const it of (j.items || [])){
-        const tr = document.createElement("tr");
-        tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.qty,6)}</td>
-        <td class="mono">${fmtNum(it.avg_price,2)}</td>
-        <td class="mono">$ ${fmtUSD(it.upnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.realized_pnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.fees_paid)}</td>
-        <td class="mono">$ ${fmtUSD(it.total_pnl)}</td>
-        `;
-        tb.appendChild(tr);
-      }
-    }
-  }catch(e){}
-}
 
 async function refreshLogs(){
   try{
@@ -446,92 +298,13 @@ async function refreshLogs(){
   }catch(e){}
 }
 
-function buildPnlChart(ctx, labels, upnl, rpnl, net){
-  if(pnlChart){ pnlChart.destroy(); }
-  pnlChart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: labels,
-      datasets: [
-        { label: 'UPnL', data: upnl },
-        { label: 'RPnL', data: rpnl },
-        { label: 'Neto', data: net }
-      ]
-    },
-    options: {
-      responsive: true,
-      animation: false,
-      interaction: { mode: 'index', intersect: false },
-      scales: {
-        x: { ticks: { maxRotation: 0 }, grid: { display: false } },
-        y: { beginAtZero: false }
-      },
-      plugins: {
-        legend: { position: 'top' },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => `${ctx.dataset.label}: $ ${Number(ctx.parsed.y).toLocaleString(undefined,{maximumFractionDigits:2})}`
-          }
-        }
-      }
-    }
-  });
-}
 
-async function refreshPnlChart(){
-  try{
-    // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
-    const r = await fetch(api("/pnl/timeseries?venue=binance_spot_testnet&bucket=1%20minute&hours=6"));
-    const j = await r.json();
-    const pts = j.points || [];
-    const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
-    const upnl = pts.map(p => p.upnl || 0);
-    const rpnl = pts.map(p => p.rpnl || 0);
-    const net  = pts.map(p => p.net || 0);
-    const ctx = document.getElementById("chart-pnl-spot").getContext("2d");
-    buildPnlChart(ctx, labels, upnl, rpnl, net);
-  }catch(e){}
-}
 
-async function refreshPnlChartFut(){
-    try{
-      // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
-      const r = await fetch(api("/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6"));
-      const j = await r.json();
-      const pts = j.points || [];
-      const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
-      const upnl = pts.map(p => p.upnl || 0);
-      const rpnl = pts.map(p => p.rpnl || 0);
-      const net  = pts.map(p => p.net || 0);
-      const ctx = document.getElementById("chart-pnl-fut").getContext("2d");
-      buildPnlChart(ctx, labels, upnl, rpnl, net);
-    }catch(e){}
-  }
-
-  async function runCli(){
-    const cmd = document.getElementById("cli-input").value;
-    if(!cmd.trim()) return;
-    try{
-      const r = await fetch(api("/cli/run"), {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({command: cmd})
-      });
-      const j = await r.json();
-      const out = (j.stdout || "") + (j.stderr ? "\n"+j.stderr : "");
-      document.getElementById("cli-output").textContent = out;
-    }catch(e){
-      document.getElementById("cli-output").textContent = String(e);
-    }
-  }
 
   async function saveConfig(){
     const ex = document.getElementById("cfg-exchange").value;
     const key = document.getElementById("cfg-key").value.trim();
     const sec = document.getElementById("cfg-secret").value.trim();
-    const strat = document.getElementById("cfg-strategy").value;
-    const notional = document.getElementById("cfg-notional").value;
-    const threshold = document.getElementById("cfg-threshold").value;
     let output = "";
     if(key && sec){
       try{
@@ -544,17 +317,7 @@ async function refreshPnlChartFut(){
         output += (j.stdout||"") + (j.stderr?"\n"+j.stderr:"");
       }catch(e){ output += String(e); }
     }
-    const params = {};
-    if(notional) params.notional = Number(notional);
-    if(threshold) params.threshold = Number(threshold);
-    try{
-      await fetch(api(`/strategies/${strat}/params`), {
-        method:"POST",
-        headers:{"Content-Type":"application/json"},
-        body: JSON.stringify(params)
-      });
-      if(!output) output = "Configuración guardada";
-    }catch(e){ output += `\n${e}`; }
+    if(!output) output = "Configuración guardada";
     document.getElementById("cfg-output").textContent = output;
   }
 // boot
@@ -562,20 +325,14 @@ refreshHealth(); refreshSummary(); refreshTables();
 setInterval(refreshExposure, 5000); refreshExposure();
 setInterval(refreshExposureFut, 5000); refreshExposureFut();
 setInterval(refreshRisk, 5000); refreshRisk();
-setInterval(refreshSpotPnL, 5000); refreshSpotPnL();
-setInterval(refreshFuturePnL, 5000); refreshFuturePnL();
 setInterval(refreshLogs, 5000); refreshLogs();
-setInterval(refreshPnlChart, 10000); refreshPnlChart();
-setInterval(refreshPnlChartFut, 10000); refreshPnlChartFut();
 setInterval(refreshHealth, 5000);
 setInterval(refreshSummary, 5000);
 setInterval(refreshTables, 5000);
 
-  document.getElementById("cli-run").addEventListener("click", runCli);
   document.getElementById("cfg-save").addEventListener("click", saveConfig);
   document.getElementById("order-search").addEventListener("input", (e)=>{ orderQuery = e.target.value; refreshOrders(); });
 
   </script>
 </body>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </html>

--- a/src/tradingbot/apps/api/static/monitor.html
+++ b/src/tradingbot/apps/api/static/monitor.html
@@ -4,28 +4,13 @@
   <meta charset="utf-8"/>
   <title>Monitoreo - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
-    h1, h2 { margin: 0.2rem 0; }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
-    table { width:100%; border-collapse: collapse; font-size: 14px; }
-    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
-    th { background:#0f1622; position: sticky; top:0; }
-    .muted { color:#94a3b8; }
-    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-    .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
-    .kv .k { font-size:12px; color:#94a3b8 }
-    .kv .v { font-size:18px; margin-top:4px }
-    nav { margin-bottom:20px; }
-    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
-    nav a:hover { text-decoration:underline; }
-  </style>
+  <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
   <nav>
     <a href="/">Configuración</a>
     <a href="/monitor">Monitoreo</a>
+    <a href="/bots">Bots</a>
   </nav>
   <h1>Monitoreo</h1>
   <div class="grid3" style="margin:14px 0 20px">
@@ -38,7 +23,11 @@
   </div>
   <div class="card">
     <h2>PnL Spot (6h)</h2>
-    <canvas id="chart-pnl" height="120"></canvas>
+    <canvas id="chart-pnl-spot" height="120"></canvas>
+  </div>
+  <div class="card" style="margin-top:20px">
+    <h2>PnL Futuros (6h)</h2>
+    <canvas id="chart-pnl-fut" height="120"></canvas>
   </div>
   <div class="card" style="margin-top:20px">
     <h2>Posiciones</h2>
@@ -79,19 +68,29 @@ async function refreshPositions(){
 function buildPnlChart(ctx, labels, upnl, rpnl, net){
   new Chart(ctx,{type:'line',data:{labels,datasets:[{label:'UPnL',data:upnl,borderColor:'#10b981'},{label:'RPnL',data:rpnl,borderColor:'#3b82f6'},{label:'Net',data:net,borderColor:'#f59e0b'}]},options:{responsive:true,animation:false,interaction:{mode:'index',intersect:false},scales:{x:{grid:{display:false}},y:{beginAtZero:false}}}});
 }
-async function refreshPnlChart(){
+async function refreshPnlChartSpot(){
   try{
     const r=await fetch('/pnl/timeseries?venue=binance_spot_testnet&bucket=1%20minute&hours=6');
     const j=await r.json();
     const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
     const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
-    buildPnlChart(document.getElementById('chart-pnl').getContext('2d'),labels,upnl,rpnl,net);
+    buildPnlChart(document.getElementById('chart-pnl-spot').getContext('2d'),labels,upnl,rpnl,net);
   }catch(e){}
 }
-refreshMetrics(); refreshPositions(); refreshPnlChart();
+async function refreshPnlChartFut(){
+  try{
+    const r=await fetch('/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6');
+    const j=await r.json();
+    const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
+    const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
+    buildPnlChart(document.getElementById('chart-pnl-fut').getContext('2d'),labels,upnl,rpnl,net);
+  }catch(e){}
+}
+refreshMetrics(); refreshPositions(); refreshPnlChartSpot(); refreshPnlChartFut();
 setInterval(refreshMetrics,5000);
 setInterval(refreshPositions,5000);
-setInterval(refreshPnlChart,10000);
+setInterval(refreshPnlChartSpot,10000);
+setInterval(refreshPnlChartFut,10000);
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </body>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -1,0 +1,26 @@
+body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
+h1, h2 { margin: 0.2rem 0; }
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow:0 4px 12px rgba(0,0,0,0.25); }
+table { width:100%; border-collapse: collapse; font-size: 14px; }
+th, td { border-bottom:1px solid #1f2937; padding:8px 6px; text-align:left; }
+th { background:#0f1622; position:sticky; top:0; }
+.muted { color:#94a3b8; }
+.badge { display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid #334155; font-size:12px; }
+.buy { color:#10b981; }
+.sell { color:#f43f5e; }
+.ok { color:#22c55e; }
+.warn { color:#f59e0b; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.grid3 { display:grid; grid-template-columns:repeat(3, 1fr); gap:12px; }
+.kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
+.kv .k { font-size:12px; color:#94a3b8; }
+.kv .v { font-size:18px; margin-top:4px; }
+button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
+button:hover { background:#1d4ed8; }
+textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
+label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
+nav { margin-bottom:20px; }
+nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
+nav a:hover { text-decoration:underline; }
+pre { background:#0f1622; padding:10px; border-radius:8px; overflow:auto; }

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -1,0 +1,56 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from tradingbot.apps.api.main import app
+
+
+def test_bot_endpoints(monkeypatch):
+    client = TestClient(app)
+
+    class DummyProc:
+        def __init__(self, pid: int):
+            self.pid = pid
+            self.returncode = None
+
+        async def wait(self):
+            self.returncode = 0
+
+        def terminate(self):
+            self.returncode = 0
+
+        def send_signal(self, sig):
+            return None
+
+    procs: list[DummyProc] = []
+
+    async def fake_exec(*args, **kwargs):
+        proc = DummyProc(100 + len(procs))
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    payload = {
+        "strategy": "dummy",
+        "pairs": ["BTC/USDT"],
+        "exchange": "binance",
+        "market": "spot",
+        "trade_qty": 1.0,
+        "leverage": 1,
+        "testnet": True,
+        "dry_run": False,
+    }
+
+    resp = client.post("/bots", json=payload, auth=("admin", "admin"))
+    assert resp.status_code == 200
+    pid = resp.json()["pid"]
+
+    lst = client.get("/bots", auth=("admin", "admin"))
+    assert lst.status_code == 200
+    assert any(b["pid"] == pid for b in lst.json()["bots"])
+
+    assert client.post(f"/bots/{pid}/pause", auth=("admin", "admin")).status_code == 200
+    assert client.post(f"/bots/{pid}/resume", auth=("admin", "admin")).status_code == 200
+    assert client.post(f"/bots/{pid}/stop", auth=("admin", "admin")).status_code == 200
+    assert client.delete(f"/bots/{pid}", auth=("admin", "admin")).status_code == 200
+


### PR DESCRIPTION
## Summary
- add REST endpoints to start, stop, pause and list bot processes
- expose new Bots dashboard to launch and control strategies
- document bot panel and ensure monitoring panel serves static files
- reorganize dashboard sections and extract shared styles

## Testing
- `pytest -q tests/test_api_bots.py tests/test_monitoring_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49a7e1420832db195672093f8a9bd