### PR TITLE
feat: extract dashboard styles

### DIFF
--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -4,33 +4,7 @@
   <meta charset="utf-8"/>
   <title>TradingBot Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
-    h1, h2 { margin: 0.2rem 0; }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
-    table { width:100%; border-collapse: collapse; font-size: 14px; }
-    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
-    th { background:#0f1622; position: sticky; top:0; }
-    .muted { color:#94a3b8; }
-    .badge { display:inline-block; padding:2px 8px; border-radius: 999px; border:1px solid #334155; font-size:12px; }
-    .buy { color:#10b981; }
-    .sell { color:#f43f5e; }
-    .ok { color:#22c55e }
-    .warn { color:#f59e0b }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-    .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
-    .kv .k { font-size:12px; color:#94a3b8 }
-    .kv .v { font-size:18px; margin-top:4px }
-    button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
-    button:hover { background:#1d4ed8; }
-    textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
-    label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
-    nav { margin-bottom:20px; }
-    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
-    nav a:hover { text-decoration:underline; }
-    </style>
+  <link rel="stylesheet" href="/static/styles.css"/>
   </head>
   <body>
   <nav>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -1,0 +1,25 @@
+    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
+    h1, h2 { margin: 0.2rem 0; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
+    table { width:100%; border-collapse: collapse; font-size: 14px; }
+    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
+    th { background:#0f1622; position: sticky; top:0; }
+    .muted { color:#94a3b8; }
+    .badge { display:inline-block; padding:2px 8px; border-radius: 999px; border:1px solid #334155; font-size:12px; }
+    .buy { color:#10b981; }
+    .sell { color:#f43f5e; }
+    .ok { color:#22c55e }
+    .warn { color:#f59e0b }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
+    .kv .k { font-size:12px; color:#94a3b8 }
+    .kv .v { font-size:18px; margin-top:4px }
+    button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
+    button:hover { background:#1d4ed8; }
+    textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
+    label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
+    nav { margin-bottom:20px; }
+    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
+    nav a:hover { text-decoration:underline; }


### PR DESCRIPTION
## Summary
- move dashboard inline styles to new styles.css and link it in the head
- keep CLI controls intact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a448371c832d8f9f583a4404f66d