### PR TITLE
Refactor dashboard sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ La correspondencia entre el blueprint original y los módulos del código se doc
    ```bash
    uvicorn tradingbot.apps.api.main:app --reload --port 8000
    ```
-   Visita `http://localhost:8000/` para la configuración del bot o
-   `http://localhost:8000/monitor` para el panel de monitoreo.
+   Visita `http://localhost:8000/` para gestionar credenciales,
+   `http://localhost:8000/monitor` para monitoreo y
+   `http://localhost:8000/bots` para lanzar bots o usar la CLI.
 
 Al terminar, consulta [docs/blueprint_map.md](docs/blueprint_map.md) para entender la correspondencia entre el blueprint y el código.
 
@@ -71,9 +72,10 @@ gracias al **paper trading** (simulación).
 - Gestión de riesgo y portafolio con límites de exposición y ``kill switch``.
 - Router de ejecución con algoritmos TWAP/VWAP/POV y soporte maker/taker.
 - Backtester vectorizado y motor event‑driven con modelado de slippage.
-- **Panel web** con métricas en vivo y un **ejecutor de comandos CLI** que
-  permite lanzar cualquier comando desde el navegador.  Incluye formularios
-  para configurar exchanges, claves API y estrategias sin usar la terminal.
+- **Panel web** dividido en secciones de credenciales, monitoreo y bots.
+  La sección de bots incorpora un **ejecutor de comandos CLI** para
+  lanzar cualquier comando desde el navegador y formularios para
+  configurar estrategias sin usar la terminal.
 
 ## Funcionalidades extra
 
@@ -187,8 +189,9 @@ make down  # detiene y elimina los servicios
    uvicorn tradingbot.apps.api.main:app --reload --port 8000
    ```
 
-   `http://localhost:8000/` abre el dashboard de configuración y
-   `http://localhost:8000/monitor` el de monitoreo.
+   `http://localhost:8000/` abre el panel de credenciales,
+   `http://localhost:8000/monitor` el de monitoreo y
+   `http://localhost:8000/bots` la gestión de bots.
 
 ## Comandos CLI
 

--- a/docs/blueprint_map.md
+++ b/docs/blueprint_map.md
@@ -11,7 +11,7 @@ Este documento enlaza los puntos del [blueprint inicial](../blueprint_trading_bo
 | **5. Ejecución** | `execution/router.py`, `execution/algos.py`, `execution/order_types.py` | `run-bot --algo`, `run-cross-arb` |
 | **6. Persistencia** | `storage/timescale.py`, `storage/quest.py` | `ingest`, `ingest-historical`, `ingestion-workers`, `report` |
 | **7. Backtesting & simulación** | `backtest/event_engine.py`, `backtesting/engine.py`, `backtesting/vectorbt_wrapper.py` | `backtest`, `backtest-cfg`, `walk-forward`, `paper-run` |
-| **8. Monitoreo & Ops** | `monitoring/metrics.py`, `src/tradingbot/apps/api/static/index.html`, `src/tradingbot/apps/api/static/monitor.html`, `utils/metrics.py` | `report` |
+| **8. Monitoreo & Ops** | `monitoring/metrics.py`, `src/tradingbot/apps/api/static/index.html`, `src/tradingbot/apps/api/static/monitor.html`, `src/tradingbot/apps/api/static/bots.html`, `utils/metrics.py` | `report` |
 
 ## Funcionalidades extra
 

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -316,8 +316,13 @@ def stop_strategy(name: str):
 @app.get("/strategies/status")
 def strategies_status():
     """Return the status of all known strategies."""
+    from ...strategies import STRATEGIES
 
-    return {"strategies": _strategies_state}
+    return {
+        "strategies": {
+            name: _strategies_state.get(name, "stopped") for name in STRATEGIES
+        }
+    }
 
 
 # --- Funding and basis endpoints ------------------------------------------------

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -71,10 +71,12 @@
         <input id="bot-leverage" type="number" step="1"/>
       </div>
       <div>
-        <label><input type="checkbox" id="bot-testnet" checked/> Testnet</label>
-      </div>
-      <div>
-        <label><input type="checkbox" id="bot-dry-run"/> Dry run</label>
+        <label for="bot-env">Entorno</label>
+        <select id="bot-env">
+          <option value="live">Live</option>
+          <option value="paper">Paper trading</option>
+          <option value="testnet" selected>Testnet</option>
+        </select>
       </div>
     </div>
     <button id="bot-start" style="margin-top:10px">Start</button>
@@ -90,6 +92,14 @@
         <tbody></tbody>
       </table>
     </div>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h2>Comandos CLI</h2>
+    <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
+    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
+    <button id="cli-run" style="margin-top:8px">Ejecutar</button>
+    <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
 <script>
@@ -116,8 +126,9 @@ async function startBot(){
   const market = document.getElementById('bot-market').value;
   const trade_qty = document.getElementById('bot-trade-qty').value;
   const leverage = document.getElementById('bot-leverage').value;
-  const testnet = document.getElementById('bot-testnet').checked;
-  const dry_run = document.getElementById('bot-dry-run').checked;
+  const env = document.getElementById('bot-env').value;
+  const testnet = env === 'testnet';
+  const dry_run = env === 'paper';
   const payload = {strategy, pairs, exchange, market, testnet, dry_run};
   if(notional) payload.notional = Number(notional);
   if(trade_qty) payload.trade_qty = Number(trade_qty);
@@ -151,6 +162,19 @@ async function refreshBots(){
   }catch(e){}
 }
 
+async function runCli(){
+  const cmd = document.getElementById('cli-input').value;
+  if(!cmd.trim()) return;
+  try{
+    const r = await fetch(api('/cli/run'), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({command: cmd})});
+    const j = await r.json();
+    const out = (j.stdout||'') + (j.stderr ? '\n'+j.stderr : '');
+    document.getElementById('cli-output').textContent = out;
+  }catch(e){
+    document.getElementById('cli-output').textContent = String(e);
+  }
+}
+
 async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST'}); refreshBots(); }
 async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
 async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
@@ -160,6 +184,7 @@ document.getElementById('bot-start').addEventListener('click', startBot);
 loadStrategies();
 refreshBots();
 setInterval(refreshBots,5000);
+document.getElementById('cli-run').addEventListener('click', runCli);
 </script>
 </body>
 </html>

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -5,8 +5,8 @@
   <title>TradingBot Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
-  </head>
-  <body>
+</head>
+<body>
   <nav>
     <a href="/">Configuración</a>
     <a href="/monitor">Monitoreo</a>
@@ -16,8 +16,7 @@
   <div class="muted" id="health">Comprobando estado…</div>
 
   <div class="card" style="margin-top:16px">
-    <h2>Configuración</h2>
-    <div class="muted">Selecciona exchange, claves y estrategia sin usar la CLI</div>
+    <h2>Credenciales</h2>
     <div class="grid3" style="margin-top:10px">
       <div>
         <label for="cfg-exchange">Exchange</label>
@@ -36,521 +35,49 @@
         <label for="cfg-secret">API Secret</label>
         <input id="cfg-secret" type="password" placeholder="secreto"/>
       </div>
-      <div>
-        <label for="cfg-strategy">Estrategia</label>
-        <select id="cfg-strategy">
-          <option value="breakout_atr">Breakout ATR</option>
-          <option value="breakout_vol">Breakout Vol</option>
-          <option value="momentum">Momentum</option>
-          <option value="mean_reversion">Mean Reversion</option>
-          <option value="triangular_arb">Tri-Arb</option>
-          <option value="cash_and_carry">Cash &amp; Carry</option>
-          <option value="order_flow">Order Flow</option>
-          <option value="depth_imbalance">Depth Imbalance</option>
-          <option value="liquidity_events">Liquidity Events</option>
-          <option value="triple_barrier">Triple Barrier</option>
-          <option value="ml">ML Strategy</option>
-          <option value="mean_rev_ofi">Mean Rev OFI</option>
-        </select>
-      </div>
-      <div>
-        <label for="cfg-notional">Notional (USDT)</label>
-        <input id="cfg-notional" type="number" step="0.01" placeholder="100"/>
-      </div>
-      <div>
-        <label for="cfg-threshold">Umbral</label>
-        <input id="cfg-threshold" type="number" step="0.0001" placeholder="0.001"/>
-      </div>
     </div>
-    <button id="cfg-save" style="margin-top:10px">Guardar configuración</button>
+    <button id="cfg-save" style="margin-top:10px">Guardar credenciales</button>
     <pre id="cfg-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
-  <div class="grid3" style="margin:14px 0 20px">
-    <div class="kv"><div class="k">Señales (últimas)</div><div class="v" id="sum-count">—</div></div>
-    <div class="kv"><div class="k">Edge promedio</div><div class="v" id="sum-avg-edge">—</div></div>
-    <div class="kv"><div class="k">Último evento riesgo</div><div class="v" id="sum-risk-last">—</div></div>
-    <div class="kv"><div class="k">Notional promedio (QUOTE)</div><div class="v" id="sum-avg-notional">—</div></div>
-    <div class="kv"><div class="k">Exposición total (Spot)</div><div class="v" id="sum-expo-spot">—</div></div>
-    <div class="kv"><div class="k">Exposición total (Futuros)</div><div class="v" id="sum-expo-fut">—</div></div>
-    <div class="kv"><div class="k">UPnL (Spot)</div><div class="v" id="sum-upnl-spot">—</div></div>
-    <div class="kv"><div class="k">RPnL (Spot)</div><div class="v" id="sum-rpnl-spot">—</div></div>
-    <div class="kv"><div class="k">PnL Neto (Spot)</div><div class="v" id="sum-net-spot">—</div></div>
-    <div class="kv"><div class="k">UPnL (Futuros)</div><div class="v" id="sum-upnl-fut">—</div></div>
-    <div class="kv"><div class="k">RPnL (Futuros)</div><div class="v" id="sum-rpnl-fut">—</div></div>
-    <div class="kv"><div class="k">PnL Neto (Futuros)</div><div class="v" id="sum-net-fut">—</div></div>
-  </div>
-
-
-  <div class="row">
-    <div class="card">
-      <h2>Señales Triangulares</h2>
-      <div class="muted">Auto‑refresh 5s</div>
-      <div style="overflow:auto; max-height: 60vh; margin-top:10px">
-        <table id="tbl-signals">
-          <thead>
-            <tr>
-              <th>ts</th><th>paridad</th><th>dir</th><th>edge</th><th>notional</th><th>bq</th><th>mq</th><th>mb</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card">
-      <h2>Historial de Órdenes</h2>
-      <div class="muted">Auto‑refresh 5s</div>
-      <input id="order-search" placeholder="buscar…" style="margin-top:8px"/>
-      <div style="overflow:auto; max-height: 60vh; margin-top:10px">
-        <table id="tbl-orders">
-          <thead>
-            <tr>
-              <th>ts</th><th>strategy</th><th>symbol</th><th>side</th><th>qty</th><th>px</th><th>status</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>Eventos de riesgo (Spot)</h2>
-      <div class="muted">Últimos 20</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-risk-events">
-          <thead><tr><th>ts</th><th>kind</th><th>symbol</th><th>message</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>Exposición por símbolo (Spot)</h2>
-      <div class="muted">Último snapshot por símbolo</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-expo-spot">
-          <thead><tr><th>symbol</th><th>position</th><th>px</th><th>notional</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>PnL por símbolo (Spot)</h2>
-      <div class="muted">Realizado, no realizado y neto</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-pnl-spot">
-          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>Exposición por símbolo (Futuros)</h2>
-      <div class="muted">Último snapshot por símbolo</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-expo-fut">
-          <thead><tr><th>symbol</th><th>position</th><th>px</th><th>notional</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>PnL por símbolo (Futuros)</h2>
-      <div class="muted">Realizado, no realizado y neto</div>
-      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
-        <table id="tbl-pnl-fut">
-          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="card" style="margin-top:16px">
-      <h2>PnL (Spot) – Serie temporal</h2>
-      <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
-      <div style="padding:10px">
-        <canvas id="chart-pnl-spot" height="120"></canvas>
-      </div>
-    </div>
-  </div>
-
-  <div class="card" style="margin-top:16px">
-      <h2>PnL (Futuros) – Serie temporal</h2>
-      <div class="muted">UPnL, RPnL y Neto (últimas 6h, 1m)</div>
-    <div style="padding:10px">
-      <canvas id="chart-pnl-fut" height="120"></canvas>
-    </div>
-  </div>
-  <div class="card" style="margin-top:16px">
-    <h2>Logs</h2>
-    <div class="muted">Auto‑refresh 5s</div>
-    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
-  </div>
-  <div class="card" style="margin-top:16px">
-    <h2>Comandos CLI</h2>
-    <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
-    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
-    <button id="cli-run" style="margin-top:8px">Ejecutar</button>
-    <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
-</div>
 <script>
 const api = (path) => `${location.origin}${path}`;
-let pnlChart;
-let orderQuery = "";
-
-function fmtEdge(x){ if(x==null) return "—"; return (x*100).toFixed(3)+"%"; }
-function fmtNum(x, d=6){ if(x==null) return "—"; const n=Number(x); return isFinite(n)? n.toFixed(d): x; }
-function fmtUSD(x){ if(x==null) return "—"; const n=Number(x); if(!isFinite(n)) return x; return n.toLocaleString(undefined,{maximumFractionDigits:2}); }
 
 async function refreshHealth(){
   try {
-    const r = await fetch(api("/health"));
+    const r = await fetch(api('/health'));
     const j = await r.json();
-    const s = j.status === "ok" ? `<span class="ok">OK</span>` : `<span class="warn">WARN</span>`;
-    const db = j.db ? `<span class="ok">DB</span>` : `<span class="warn">no DB</span>`;
-    document.getElementById("health").innerHTML = `Estado: ${s} · ${db}`;
-  } catch (e) {
-    document.getElementById("health").innerHTML = `<span class="warn">Sin conexión</span>`;
+    const s = j.status === 'ok' ? '<span class="ok">OK</span>' : '<span class="warn">WARN</span>';
+    const db = j.db ? '<span class="ok">DB</span>' : '<span class="warn">no DB</span>';
+    document.getElementById('health').innerHTML = `Estado: ${s} · ${db}`;
+  } catch(e){
+    document.getElementById('health').innerHTML = '<span class="warn">Sin conexión</span>';
   }
 }
 
-async function refreshSummary(){
-  try {
-    const r = await fetch(api("/tri/summary?limit=200"));
-    const j = await r.json();
-    const s = j.summary || {};
-    document.getElementById("sum-count").textContent = s.count ?? "0";
-    document.getElementById("sum-avg-edge").textContent = fmtEdge(s.avg_edge);
-    document.getElementById("sum-avg-notional").textContent = fmtNum(s.avg_notional, 2);
-  } catch(e){}
-}
-
-function renderSignals(items){
-  const tb = document.querySelector("#tbl-signals tbody");
-  tb.innerHTML = "";
-  for(const r of items){
-    const tr = document.createElement("tr");
-    tr.innerHTML = `
-      <td class="mono">${r.ts?.replace('T',' ').replace('Z','')}</td>
-      <td>${r.base}/${r.mid}/${r.quote}</td>
-      <td><span class="badge">${r.direction}</span></td>
-      <td>${fmtEdge(r.edge)}</td>
-      <td class="mono">${fmtNum(r.notional_quote,2)}</td>
-      <td class="mono">${fmtNum(r.bq,2)}</td>
-      <td class="mono">${fmtNum(r.mq,2)}</td>
-      <td class="mono">${fmtNum(r.mb,6)}</td>
-    `;
-    tb.appendChild(tr);
-  }
-}
-
-function renderOrders(items){
-  const tb = document.querySelector("#tbl-orders tbody");
-  tb.innerHTML = "";
-  for(const r of items){
-    const tr = document.createElement("tr");
-    const sideCls = (r.side||"").toLowerCase()==="buy" ? "buy" : "sell";
-    tr.innerHTML = `
-      <td class="mono">${r.ts?.replace('T',' ').replace('Z','')}</td>
-      <td>${r.strategy}</td>
-      <td class="mono">${r.symbol}</td>
-      <td class="${sideCls}">${r.side}</td>
-      <td class="mono">${fmtNum(r.qty,6)}</td>
-      <td class="mono">${fmtNum(r.px,4)}</td>
-      <td>${r.status}</td>
-    `;
-    tb.appendChild(tr);
-  }
-}
-
-async function refreshOrders(){
-  try{
-    const q = orderQuery ? `&search=${encodeURIComponent(orderQuery)}` : "";
-    const r = await fetch(api(`/orders/history?limit=120${q}`));
-    const j = await r.json();
-    renderOrders(j.items || []);
-  }catch(e){}
-}
-
-async function refreshTables(){
-  try {
-    const r1 = await fetch(api("/tri/signals?limit=100"));
-    const j1 = await r1.json();
-    renderSignals(j1.items || []);
-  } catch(e){}
-  refreshOrders();
-}
-
-async function refreshExposure(){
-  try{
-    const r = await fetch(api("/risk/exposure?venue=binance_spot_testnet"));
-    const j = await r.json();
-    document.getElementById("sum-expo-spot").textContent = "$ " + fmtUSD(j.total_notional || 0);
-    const tb = document.querySelector("#tbl-expo-spot tbody");
-    tb.innerHTML = "";
-    for(const it of (j.items || [])){
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.position, 6)}</td>
-        <td class="mono">${fmtNum(it.price, 2)}</td>
-        <td class="mono">$ ${fmtUSD(it.notional_usd)}</td>
-      `;
-      tb.appendChild(tr);
-    }
-  }catch(e){}
-}
-
-async function refreshExposureFut(){
-  try{
-    const r = await fetch(api("/risk/exposure?venue=binance_futures_um_testnet"));
-    const j = await r.json();
-    document.getElementById("sum-expo-fut").textContent = "$ " + fmtUSD(j.total_notional || 0);
-    const tb = document.querySelector("#tbl-expo-fut tbody");
-    if(tb){
-      tb.innerHTML = "";
-      for(const it of (j.items || [])){
-        const tr = document.createElement("tr");
-        tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.position, 6)}</td>
-        <td class="mono">${fmtNum(it.price, 2)}</td>
-        <td class="mono">$ ${fmtUSD(it.notional_usd)}</td>
-        `;
-        tb.appendChild(tr);
-      }
-    }
-  }catch(e){}
-}
-
-async function refreshRisk(){
-  try{
-    const r = await fetch(api("/risk/events?venue=binance_spot_testnet&limit=20"));
-    const j = await r.json();
-    const items = j.items || [];
-    const tb = document.querySelector("#tbl-risk-events tbody");
-    tb.innerHTML = "";
-    for(const it of items){
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td class="mono">${(it.ts||"").replace('T',' ').replace('Z','')}</td>
-        <td>${it.kind}</td>
-        <td>${it.symbol}</td>
-        <td>${it.message}</td>
-      `;
-      tb.appendChild(tr);
-    }
-    // banner “último evento”
-    if(items.length){
-      const last = items[0];
-      const label = `[${last.kind}] ${last.symbol} – ${last.message}`;
-      document.getElementById("sum-risk-last").textContent = label;
-    } else {
-      document.getElementById("sum-risk-last").textContent = "—";
-    }
-  }catch(e){}
-}
-
-async function refreshSpotPnL(){
-  try{
-    const r = await fetch(api("/pnl/summary?venue=binance_spot_testnet"));
-    const j = await r.json();
-    const t = j.totals || {};
-    document.getElementById("sum-upnl-spot").textContent = "$ " + fmtUSD(t.upnl || 0);
-    document.getElementById("sum-rpnl-spot").textContent = "$ " + fmtUSD(t.rpnl || 0);
-    document.getElementById("sum-net-spot").textContent = "$ " + fmtUSD(t.net_pnl || 0);
-
-    const tb = document.querySelector("#tbl-pnl-spot tbody");
-    tb.innerHTML = "";
-    for(const it of (j.items || [])){
-      const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.qty,6)}</td>
-        <td class="mono">${fmtNum(it.avg_price,2)}</td>
-        <td class="mono">$ ${fmtUSD(it.upnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.realized_pnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.fees_paid)}</td>
-        <td class="mono">$ ${fmtUSD(it.total_pnl)}</td>
-      `;
-      tb.appendChild(tr);
-    }
-  }catch(e){}
-}
-
-async function refreshFuturePnL(){
-  try{
-    const r = await fetch(api("/pnl/summary?venue=binance_futures_um_testnet"));
-    const j = await r.json();
-    const t = j.totals || {};
-    document.getElementById("sum-upnl-fut").textContent = "$ " + fmtUSD(t.upnl || 0);
-    document.getElementById("sum-rpnl-fut").textContent = "$ " + fmtUSD(t.rpnl || 0);
-    document.getElementById("sum-net-fut").textContent = "$ " + fmtUSD(t.net_pnl || 0);
-
-    const tb = document.querySelector("#tbl-pnl-fut tbody");
-    if(tb){
-      tb.innerHTML = "";
-      for(const it of (j.items || [])){
-        const tr = document.createElement("tr");
-        tr.innerHTML = `
-        <td>${it.symbol}</td>
-        <td class="mono">${fmtNum(it.qty,6)}</td>
-        <td class="mono">${fmtNum(it.avg_price,2)}</td>
-        <td class="mono">$ ${fmtUSD(it.upnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.realized_pnl)}</td>
-        <td class="mono">$ ${fmtUSD(it.fees_paid)}</td>
-        <td class="mono">$ ${fmtUSD(it.total_pnl)}</td>
-        `;
-        tb.appendChild(tr);
-      }
-    }
-  }catch(e){}
-}
-
-async function refreshLogs(){
-  try{
-    const r = await fetch(api("/logs?lines=200"));
-    const j = await r.json();
-    const pre = document.getElementById("logs");
-    pre.textContent = (j.items || []).join("\n");
-  }catch(e){}
-}
-
-function buildPnlChart(ctx, labels, upnl, rpnl, net){
-  if(pnlChart){ pnlChart.destroy(); }
-  pnlChart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: labels,
-      datasets: [
-        { label: 'UPnL', data: upnl },
-        { label: 'RPnL', data: rpnl },
-        { label: 'Neto', data: net }
-      ]
-    },
-    options: {
-      responsive: true,
-      animation: false,
-      interaction: { mode: 'index', intersect: false },
-      scales: {
-        x: { ticks: { maxRotation: 0 }, grid: { display: false } },
-        y: { beginAtZero: false }
-      },
-      plugins: {
-        legend: { position: 'top' },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => `${ctx.dataset.label}: $ ${Number(ctx.parsed.y).toLocaleString(undefined,{maximumFractionDigits:2})}`
-          }
-        }
-      }
-    }
-  });
-}
-
-async function refreshPnlChart(){
-  try{
-    // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
-    const r = await fetch(api("/pnl/timeseries?venue=binance_spot_testnet&bucket=1%20minute&hours=6"));
-    const j = await r.json();
-    const pts = j.points || [];
-    const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
-    const upnl = pts.map(p => p.upnl || 0);
-    const rpnl = pts.map(p => p.rpnl || 0);
-    const net  = pts.map(p => p.net || 0);
-    const ctx = document.getElementById("chart-pnl-spot").getContext("2d");
-    buildPnlChart(ctx, labels, upnl, rpnl, net);
-  }catch(e){}
-}
-
-async function refreshPnlChartFut(){
+async function saveConfig(){
+  const ex = document.getElementById('cfg-exchange').value;
+  const key = document.getElementById('cfg-key').value.trim();
+  const sec = document.getElementById('cfg-secret').value.trim();
+  let output = '';
+  if(key && sec){
     try{
-      // Spot, agregando todos los símbolos (symbol omitido), bucket 1m, 6h
-      const r = await fetch(api("/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6"));
-      const j = await r.json();
-      const pts = j.points || [];
-      const labels = pts.map(p => (p.ts||'').replace('T',' ').replace('Z',''));
-      const upnl = pts.map(p => p.upnl || 0);
-      const rpnl = pts.map(p => p.rpnl || 0);
-      const net  = pts.map(p => p.net || 0);
-      const ctx = document.getElementById("chart-pnl-fut").getContext("2d");
-      buildPnlChart(ctx, labels, upnl, rpnl, net);
-    }catch(e){}
-  }
-
-  async function runCli(){
-    const cmd = document.getElementById("cli-input").value;
-    if(!cmd.trim()) return;
-    try{
-      const r = await fetch(api("/cli/run"), {
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({command: cmd})
+      const r = await fetch(api('/cli/run'), {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({command: `secrets set ${ex} ${key} ${sec}`})
       });
       const j = await r.json();
-      const out = (j.stdout || "") + (j.stderr ? "\n"+j.stderr : "");
-      document.getElementById("cli-output").textContent = out;
-    }catch(e){
-      document.getElementById("cli-output").textContent = String(e);
-    }
+      output = (j.stdout||'') + (j.stderr ? '\n'+j.stderr : '');
+    }catch(e){ output = String(e); }
   }
+  document.getElementById('cfg-output').textContent = output || 'Credenciales guardadas';
+}
 
-  async function saveConfig(){
-    const ex = document.getElementById("cfg-exchange").value;
-    const key = document.getElementById("cfg-key").value.trim();
-    const sec = document.getElementById("cfg-secret").value.trim();
-    const strat = document.getElementById("cfg-strategy").value;
-    const notional = document.getElementById("cfg-notional").value;
-    const threshold = document.getElementById("cfg-threshold").value;
-    let output = "";
-    if(key && sec){
-      try{
-        const r = await fetch(api("/cli/run"), {
-          method:"POST",
-          headers:{"Content-Type":"application/json"},
-          body: JSON.stringify({command: `secrets set ${ex} ${key} ${sec}`})
-        });
-        const j = await r.json();
-        output += (j.stdout||"") + (j.stderr?"\n"+j.stderr:"");
-      }catch(e){ output += String(e); }
-    }
-    const params = {};
-    if(notional) params.notional = Number(notional);
-    if(threshold) params.threshold = Number(threshold);
-    try{
-      await fetch(api(`/strategies/${strat}/params`), {
-        method:"POST",
-        headers:{"Content-Type":"application/json"},
-        body: JSON.stringify(params)
-      });
-      if(!output) output = "Configuración guardada";
-    }catch(e){ output += `\n${e}`; }
-    document.getElementById("cfg-output").textContent = output;
-  }
-// boot
-refreshHealth(); refreshSummary(); refreshTables();
-setInterval(refreshExposure, 5000); refreshExposure();
-setInterval(refreshExposureFut, 5000); refreshExposureFut();
-setInterval(refreshRisk, 5000); refreshRisk();
-setInterval(refreshSpotPnL, 5000); refreshSpotPnL();
-setInterval(refreshFuturePnL, 5000); refreshFuturePnL();
-setInterval(refreshLogs, 5000); refreshLogs();
-setInterval(refreshPnlChart, 10000); refreshPnlChart();
-setInterval(refreshPnlChartFut, 10000); refreshPnlChartFut();
+refreshHealth();
 setInterval(refreshHealth, 5000);
-setInterval(refreshSummary, 5000);
-setInterval(refreshTables, 5000);
 
-  document.getElementById("cli-run").addEventListener("click", runCli);
-  document.getElementById("cfg-save").addEventListener("click", saveConfig);
-  document.getElementById("order-search").addEventListener("input", (e)=>{ orderQuery = e.target.value; refreshOrders(); });
-
-  </script>
+document.getElementById('cfg-save').addEventListener('click', saveConfig);
+</script>
 </body>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </html>

--- a/src/tradingbot/apps/api/static/monitor.html
+++ b/src/tradingbot/apps/api/static/monitor.html
@@ -39,7 +39,11 @@
   </div>
   <div class="card">
     <h2>PnL Spot (6h)</h2>
-    <canvas id="chart-pnl" height="120"></canvas>
+    <canvas id="chart-pnl-spot" height="120"></canvas>
+  </div>
+  <div class="card" style="margin-top:20px">
+    <h2>PnL Futuros (6h)</h2>
+    <canvas id="chart-pnl-fut" height="120"></canvas>
   </div>
   <div class="card" style="margin-top:20px">
     <h2>Posiciones</h2>
@@ -49,6 +53,10 @@
         <tbody></tbody>
       </table>
     </div>
+  </div>
+  <div class="card" style="margin-top:20px">
+    <h2>Logs</h2>
+    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
   </div>
 <script>
 async function refreshMetrics(){
@@ -80,19 +88,41 @@ async function refreshPositions(){
 function buildPnlChart(ctx, labels, upnl, rpnl, net){
   new Chart(ctx,{type:'line',data:{labels,datasets:[{label:'UPnL',data:upnl,borderColor:'#10b981'},{label:'RPnL',data:rpnl,borderColor:'#3b82f6'},{label:'Net',data:net,borderColor:'#f59e0b'}]},options:{responsive:true,animation:false,interaction:{mode:'index',intersect:false},scales:{x:{grid:{display:false}},y:{beginAtZero:false}}}});
 }
-async function refreshPnlChart(){
+async function refreshPnlSpot(){
   try{
     const r=await fetch('/pnl/timeseries?venue=binance_spot_testnet&bucket=1%20minute&hours=6');
     const j=await r.json();
     const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
     const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
-    buildPnlChart(document.getElementById('chart-pnl').getContext('2d'),labels,upnl,rpnl,net);
+    buildPnlChart(document.getElementById('chart-pnl-spot').getContext('2d'),labels,upnl,rpnl,net);
   }catch(e){}
 }
-refreshMetrics(); refreshPositions(); refreshPnlChart();
+async function refreshPnlFut(){
+  try{
+    const r=await fetch('/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6');
+    const j=await r.json();
+    const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
+    const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
+    buildPnlChart(document.getElementById('chart-pnl-fut').getContext('2d'),labels,upnl,rpnl,net);
+  }catch(e){}
+}
+async function refreshLogs(){
+  try{
+    const r=await fetch('/logs?lines=200');
+    const j=await r.json();
+    document.getElementById('logs').textContent=(j.items||[]).join('\n');
+  }catch(e){}
+}
+refreshMetrics();
+refreshPositions();
+refreshPnlSpot();
+refreshPnlFut();
+refreshLogs();
 setInterval(refreshMetrics,5000);
 setInterval(refreshPositions,5000);
-setInterval(refreshPnlChart,10000);
+setInterval(refreshPnlSpot,10000);
+setInterval(refreshPnlFut,10000);
+setInterval(refreshLogs,5000);
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </body>

--- a/tradebot_mvp.md
+++ b/tradebot_mvp.md
@@ -91,7 +91,7 @@
 ### 2.8 Monitoreo & Ops
 
 - **Prometheus** exporters: `ws_uptime`, `ingest_rate`, `route_latency`, `order_reject_rate`, `pnl_realized/unrealized`
-- **Dashboards FastAPI**: vista de configuración y panel de monitoreo con salud WS, posiciones, PnL intradía y alertas
+- **Dashboards FastAPI**: vistas separadas para credenciales, monitoreo y bots (con CLI)
 - **Alertas**: falta de ticks, DD intradía, tasa de rechazos
 
 ---
@@ -155,8 +155,9 @@
 
 El repositorio actual expande este MVP con estrategias de arbitraje
 triangular y cross‑exchange, señales de microestructura como Order Flow
-Imbalance, adaptadores para testnets de Binance, Bybit y OKX, un panel
-web con ejecución de comandos de la CLI y una API de monitoreo/riesgo.
+Imbalance, adaptadores para testnets de Binance, Bybit y OKX y un panel
+web con secciones de monitoreo y gestión de bots que permite ejecutar
+comandos de la CLI.
 La descripción detallada y ejemplos de uso están en
 [docs/extra_features.md](docs/extra_features.md).
 
@@ -261,7 +262,7 @@ La descripción detallada y ejemplos de uso están en
 ## 10) Monitoreo y panel
 
 - **Exporters Prometheus**: `ws_uptime`, `ingest_rate`, `route_latency`, `order_reject_rate`, `pnl_realized`, `pnl_unrealized`
-- **Dashboards FastAPI**: endpoints REST y vistas web para configuración, salud WS, posiciones/órdenes activas, PnL intradía, alertas y logs
+- **Dashboards FastAPI**: endpoints REST y vistas web para credenciales, monitoreo y bots/CLI
 - **Alertas**: faltas de ticks (>30s), DD intradía, rechazos de órdenes
 
 ---


### PR DESCRIPTION
## Summary
- reorganize API dashboard: dedicated pages for credentials, monitoring and bot control
- move CLI runner to bots page and unify PnL charts under monitoring
- document new layout in README, blueprint map and MVP

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4af89665c832d967ef625bb49d0a6