### PR TITLE
Refactor dashboard into monitoring, bots, and stats tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+src/tradingbot/apps/api/static/logo.png

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1,6 +1,6 @@
 # src/tradingbot/apps/api/main.py
 from fastapi import FastAPI, Query, HTTPException, Depends, status, Response
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
@@ -145,14 +145,19 @@ def index():
     except Exception:
         return {"message": "Sube el dashboard en /static/index.html"}
 
-# Servir monitor.html en "/monitor"
-@app.get("/monitor")
-def monitor_page():
+# Servir stats.html en "/stats"
+@app.get("/stats")
+def stats_page():
     try:
-        html = (_static_dir / "monitor.html").read_text(encoding="utf-8")
+        html = (_static_dir / "stats.html").read_text(encoding="utf-8")
         return Response(content=html, media_type="text/html")
     except Exception:
-        return {"message": "Sube el dashboard en /static/monitor.html"}
+        return {"message": "Sube el dashboard en /static/stats.html"}
+
+# Compatibilidad: redirige "/monitor" a "/stats"
+@app.get("/monitor")
+def monitor_redirect():
+    return RedirectResponse("/stats")
 
 @app.get("/risk/exposure")
 def risk_exposure(venue: str = "binance_spot_testnet"):

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -14,11 +14,13 @@
     th { background:#0f1622; position: sticky; top:0; }
     .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
     .muted { color:#94a3b8; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
     button:hover { background:#1d4ed8; }
     input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
     label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
     nav { margin-bottom:20px; }
+    nav img { height:40px; vertical-align:middle; margin-right:15px; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }
     pre { background:#0f1622; padding:10px; border-radius:8px; overflow:auto; }
@@ -26,9 +28,10 @@
 </head>
 <body>
   <nav>
-    <a href="/">Configuración</a>
-    <a href="/monitor">Monitoreo</a>
+    <img src="/static/logo.png" alt="DMI Bot Trading"/>
+    <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
+    <a href="/stats">Estadísticas operativas</a>
   </nav>
   <h1>Bots</h1>
 
@@ -97,9 +100,18 @@
   <div class="card" style="margin-top:16px">
     <h2>Comandos CLI</h2>
     <div class="muted">Ejecuta cualquier comando de <code>tradingbot.cli</code></div>
-    <textarea id="cli-input" rows="2" placeholder="--help"></textarea>
+    <input id="cli-input" class="mono" placeholder="--help"/>
     <button id="cli-run" style="margin-top:8px">Ejecutar</button>
     <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h2>Gestión de riesgo</h2>
+    <div class="muted">Consultar exposiciones y eventos o ejecutar acciones</div>
+    <button id="risk-refresh">Consultar</button>
+    <button id="risk-halt">Halt</button>
+    <button id="risk-reset">Reset</button>
+    <pre id="risk-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
 <script>
@@ -180,11 +192,45 @@ async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'PO
 async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
 async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
 
+async function refreshRisk(){
+  try{
+    const ex = await fetch(api('/risk/exposure'));
+    const exj = await ex.json();
+    const ev = await fetch(api('/risk/events?limit=20'));
+    const evj = await ev.json();
+    document.getElementById('risk-output').textContent = JSON.stringify({exposure: exj, events: evj.items||evj.events||[]}, null,2);
+  }catch(e){
+    document.getElementById('risk-output').textContent = String(e);
+  }
+}
+
+async function haltRisk(){
+  try{
+    await fetch(api('/risk/halt'), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({reason:'dashboard'})});
+    refreshRisk();
+  }catch(e){
+    document.getElementById('risk-output').textContent = String(e);
+  }
+}
+
+async function resetRisk(){
+  try{
+    await fetch(api('/risk/reset'), {method:'POST'});
+    refreshRisk();
+  }catch(e){
+    document.getElementById('risk-output').textContent = String(e);
+  }
+}
+
 document.getElementById('bot-start').addEventListener('click', startBot);
 loadStrategies();
 refreshBots();
 setInterval(refreshBots,5000);
 document.getElementById('cli-run').addEventListener('click', runCli);
+document.getElementById('risk-refresh').addEventListener('click', refreshRisk);
+document.getElementById('risk-halt').addEventListener('click', haltRisk);
+document.getElementById('risk-reset').addEventListener('click', resetRisk);
+refreshRisk();
 </script>
 </body>
 </html>

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -2,18 +2,25 @@
 <html lang="es">
 <head>
   <meta charset="utf-8"/>
-  <title>TradingBot Dashboard</title>
+  <title>Monitoreo - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
   <nav>
-    <a href="/">Configuración</a>
-    <a href="/monitor">Monitoreo</a>
+    <img src="/static/logo.png" alt="DMI Bot Trading"/>
+    <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
+    <a href="/stats">Estadísticas operativas</a>
   </nav>
-  <h1>TradingBot Dashboard</h1>
+  <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
+  <div class="grid4" style="margin:14px 0 20px">
+    <div class="kv"><div class="k">Reject Rate</div><div class="v" id="m-reject">—</div></div>
+    <div class="kv"><div class="k">CPU %</div><div class="v" id="m-cpu">—</div></div>
+    <div class="kv"><div class="k">Mem (MB)</div><div class="v" id="m-mem">—</div></div>
+    <div class="kv"><div class="k">Uptime (s)</div><div class="v" id="m-uptime">—</div></div>
+  </div>
 
   <div class="card" style="margin-top:16px">
     <h2>Credenciales</h2>
@@ -55,6 +62,17 @@ async function refreshHealth(){
   }
 }
 
+async function refreshMetrics(){
+  try{
+    const r = await fetch(api('/metrics'));
+    const j = await r.json();
+    document.getElementById('m-reject').textContent = ((j.order_reject_rate||0)*100).toFixed(2)+'%';
+    document.getElementById('m-cpu').textContent = (j.cpu_percent||0).toFixed(1);
+    document.getElementById('m-mem').textContent = ((j.memory_bytes||0)/1048576).toFixed(1);
+    document.getElementById('m-uptime').textContent = (j.process_uptime_seconds||0).toFixed(0);
+  }catch(e){}
+}
+
 async function saveConfig(){
   const ex = document.getElementById('cfg-exchange').value;
   const key = document.getElementById('cfg-key').value.trim();
@@ -76,6 +94,8 @@ async function saveConfig(){
 
 refreshHealth();
 setInterval(refreshHealth, 5000);
+refreshMetrics();
+setInterval(refreshMetrics, 5000);
 
 document.getElementById('cfg-save').addEventListener('click', saveConfig);
 </script>

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
   <meta charset="utf-8"/>
-  <title>Monitoreo - TradingBot</title>
+  <title>Estadísticas - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <style>
     body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
@@ -17,18 +17,21 @@
     .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
     .kv .k { font-size:12px; color:#94a3b8 }
     .kv .v { font-size:18px; margin-top:4px }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     nav { margin-bottom:20px; }
+    nav img { height:40px; vertical-align:middle; margin-right:15px; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }
   </style>
 </head>
 <body>
   <nav>
-    <a href="/">Configuración</a>
-    <a href="/monitor">Monitoreo</a>
+    <img src="/static/logo.png" alt="DMI Bot Trading"/>
+    <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
+    <a href="/stats">Estadísticas operativas</a>
   </nav>
-  <h1>Monitoreo</h1>
+  <h1>Estadísticas operativas</h1>
   <div class="grid3" style="margin:14px 0 20px">
     <div class="kv"><div class="k">PnL</div><div class="v" id="m-pnl">—</div></div>
     <div class="kv"><div class="k">Fills</div><div class="v" id="m-fills">—</div></div>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -13,6 +13,7 @@
     .warn { color:#f59e0b }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
     .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
     .kv .k { font-size:12px; color:#94a3b8 }
     .kv .v { font-size:18px; margin-top:4px }
@@ -21,5 +22,6 @@
     textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
     label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
     nav { margin-bottom:20px; }
+    nav img { height:40px; vertical-align:middle; margin-right:15px; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }


### PR DESCRIPTION
## Summary
- add DMI Bot Trading logo and unified navigation across dashboard
- implement Monitoreo tab with credential registration, health check, and process metrics
- enhance Bots tab with fixed CLI input and risk management controls
- rename Monitor page to Stats and expose PnL charts, positions and logs
- remove committed logo image and ignore binary/assets in .gitignore

## Testing
- `pytest -q` (killed)


------
https://chatgpt.com/codex/tasks/task_e_68a4bc4ebb14832dbb5cabab59f2c0d0