### PR TITLE
Refine dashboard metrics and restore arbitrage strategy

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -19,16 +19,16 @@
     button:hover { background:#1d4ed8; }
     input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
     label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
-    nav { margin-bottom:20px; }
-    nav img { height:40px; vertical-align:middle; margin-right:15px; }
+    nav { margin-bottom:20px; text-align:center; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }
+    .logo { height:80px; display:block; margin:0 auto 20px; }
     pre { background:#0f1622; padding:10px; border-radius:8px; overflow:auto; }
   </style>
 </head>
 <body>
+  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo"/>
   <nav>
-    <img src="/static/logo.png" alt="DMI Bot Trading"/>
     <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
     <a href="/stats">Estadísticas operativas</a>

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -7,19 +7,20 @@
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
+  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo"/>
   <nav>
-    <img src="/static/logo.png" alt="DMI Bot Trading"/>
     <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
     <a href="/stats">Estadísticas operativas</a>
   </nav>
   <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
-  <div class="grid4" style="margin:14px 0 20px">
+  <div class="grid5" style="margin:14px 0 20px">
     <div class="kv"><div class="k">Reject Rate</div><div class="v" id="m-reject">—</div></div>
     <div class="kv"><div class="k">CPU %</div><div class="v" id="m-cpu">—</div></div>
     <div class="kv"><div class="k">Mem (MB)</div><div class="v" id="m-mem">—</div></div>
     <div class="kv"><div class="k">Uptime (s)</div><div class="v" id="m-uptime">—</div></div>
+    <div class="kv"><div class="k">Latencia (s)</div><div class="v" id="m-latency">—</div></div>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -47,6 +48,11 @@
     <pre id="cfg-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+  <div class="card" style="margin-top:16px">
+    <h2>Logs</h2>
+    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
+  </div>
+
 <script>
 const api = (path) => `${location.origin}${path}`;
 
@@ -70,6 +76,11 @@ async function refreshMetrics(){
     document.getElementById('m-cpu').textContent = (j.cpu_percent||0).toFixed(1);
     document.getElementById('m-mem').textContent = ((j.memory_bytes||0)/1048576).toFixed(1);
     document.getElementById('m-uptime').textContent = (j.process_uptime_seconds||0).toFixed(0);
+    try{
+      const l = await fetch(api('/metrics/latency'));
+      const lj = await l.json();
+      document.getElementById('m-latency').textContent = (lj.avg_order_latency_seconds||0).toFixed(3);
+    }catch(e){}
   }catch(e){}
 }
 
@@ -96,6 +107,16 @@ refreshHealth();
 setInterval(refreshHealth, 5000);
 refreshMetrics();
 setInterval(refreshMetrics, 5000);
+
+async function refreshLogs(){
+  try{
+    const r=await fetch(api('/logs?lines=200'));
+    const j=await r.json();
+    document.getElementById('logs').textContent=(j.items||[]).join('\n');
+  }catch(e){}
+}
+refreshLogs();
+setInterval(refreshLogs,5000);
 
 document.getElementById('cfg-save').addEventListener('click', saveConfig);
 </script>

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -18,15 +18,15 @@
     .kv .k { font-size:12px; color:#94a3b8 }
     .kv .v { font-size:18px; margin-top:4px }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    nav { margin-bottom:20px; }
-    nav img { height:40px; vertical-align:middle; margin-right:15px; }
+    nav { margin-bottom:20px; text-align:center; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }
+    .logo { height:80px; display:block; margin:0 auto 20px; }
   </style>
 </head>
 <body>
+  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo"/>
   <nav>
-    <img src="/static/logo.png" alt="DMI Bot Trading"/>
     <a href="/">Monitoreo</a>
     <a href="/bots">Bots</a>
     <a href="/stats">Estadísticas operativas</a>
@@ -36,9 +36,6 @@
     <div class="kv"><div class="k">PnL</div><div class="v" id="m-pnl">—</div></div>
     <div class="kv"><div class="k">Fills</div><div class="v" id="m-fills">—</div></div>
     <div class="kv"><div class="k">Risk Events</div><div class="v" id="m-risk">—</div></div>
-    <div class="kv"><div class="k">Reject Rate</div><div class="v" id="m-reject">—</div></div>
-    <div class="kv"><div class="k">CPU %</div><div class="v" id="m-cpu">—</div></div>
-    <div class="kv"><div class="k">Mem (MB)</div><div class="v" id="m-mem">—</div></div>
   </div>
   <div class="card">
     <h2>PnL Spot (6h)</h2>
@@ -48,6 +45,27 @@
     <h2>PnL Futuros (6h)</h2>
     <canvas id="chart-pnl-fut" height="120"></canvas>
   </div>
+  <div class="card" style="margin-top:16px">
+      <h2>PnL por símbolo (Spot)</h2>
+      <div class="muted">Realizado, no realizado y neto</div>
+      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
+        <table id="tbl-pnl-spot">
+          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:16px">
+      <h2>PnL por símbolo (Futuros)</h2>
+      <div class="muted">Realizado, no realizado y neto</div>
+      <div style="overflow:auto; max-height: 40vh; margin-top:10px">
+        <table id="tbl-pnl-fut">
+          <thead><tr><th>symbol</th><th>qty</th><th>avg</th><th>UPnL</th><th>RPnL</th><th>fees</th><th>net</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
   <div class="card" style="margin-top:20px">
     <h2>Posiciones</h2>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
@@ -57,10 +75,6 @@
       </table>
     </div>
   </div>
-  <div class="card" style="margin-top:20px">
-    <h2>Logs</h2>
-    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
-  </div>
 <script>
 async function refreshMetrics(){
   try{
@@ -69,9 +83,6 @@ async function refreshMetrics(){
     document.getElementById('m-pnl').textContent = (j.pnl||0).toFixed(2);
     document.getElementById('m-fills').textContent = j.fills||0;
     document.getElementById('m-risk').textContent = j.risk_events||0;
-    document.getElementById('m-reject').textContent = ((j.order_reject_rate||0)*100).toFixed(2)+'%';
-    document.getElementById('m-cpu').textContent = (j.cpu_percent||0).toFixed(1);
-    document.getElementById('m-mem').textContent = ((j.memory_bytes||0)/1048576).toFixed(1);
   }catch(e){}
 }
 async function refreshPositions(){
@@ -109,23 +120,44 @@ async function refreshPnlFut(){
     buildPnlChart(document.getElementById('chart-pnl-fut').getContext('2d'),labels,upnl,rpnl,net);
   }catch(e){}
 }
-async function refreshLogs(){
+async function refreshPnlSummarySpot(){
   try{
-    const r=await fetch('/logs?lines=200');
+    const r=await fetch('/pnl/summary?venue=binance_spot_testnet');
     const j=await r.json();
-    document.getElementById('logs').textContent=(j.items||[]).join('\n');
+    const body=document.querySelector('#tbl-pnl-spot tbody');
+    body.innerHTML='';
+    (j.items||[]).forEach(it=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${it.symbol}</td><td>${Number(it.qty).toFixed(4)}</td><td>${Number(it.avg_price).toFixed(4)}</td><td>${Number(it.upnl||0).toFixed(2)}</td><td>${Number(it.realized_pnl||0).toFixed(2)}</td><td>${Number(it.fees_paid||0).toFixed(2)}</td><td>${Number(it.total_pnl||0).toFixed(2)}</td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
+async function refreshPnlSummaryFut(){
+  try{
+    const r=await fetch('/pnl/summary?venue=binance_futures_um_testnet');
+    const j=await r.json();
+    const body=document.querySelector('#tbl-pnl-fut tbody');
+    body.innerHTML='';
+    (j.items||[]).forEach(it=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${it.symbol}</td><td>${Number(it.qty).toFixed(4)}</td><td>${Number(it.avg_price).toFixed(4)}</td><td>${Number(it.upnl||0).toFixed(2)}</td><td>${Number(it.realized_pnl||0).toFixed(2)}</td><td>${Number(it.fees_paid||0).toFixed(2)}</td><td>${Number(it.total_pnl||0).toFixed(2)}</td>`;
+      body.appendChild(tr);
+    });
   }catch(e){}
 }
 refreshMetrics();
 refreshPositions();
 refreshPnlSpot();
 refreshPnlFut();
-refreshLogs();
+refreshPnlSummarySpot();
+refreshPnlSummaryFut();
 setInterval(refreshMetrics,5000);
 setInterval(refreshPositions,5000);
 setInterval(refreshPnlSpot,10000);
 setInterval(refreshPnlFut,10000);
-setInterval(refreshLogs,5000);
+setInterval(refreshPnlSummarySpot,10000);
+setInterval(refreshPnlSummaryFut,10000);
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </body>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -14,6 +14,7 @@
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
     .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+    .grid5 { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
     .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
     .kv .k { font-size:12px; color:#94a3b8 }
     .kv .v { font-size:18px; margin-top:4px }
@@ -21,7 +22,7 @@
     button:hover { background:#1d4ed8; }
     textarea, input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
     label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
-    nav { margin-bottom:20px; }
-    nav img { height:40px; vertical-align:middle; margin-right:15px; }
+    nav { margin-bottom:20px; text-align:center; }
     nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
     nav a:hover { text-decoration:underline; }
+    .logo { height:80px; display:block; margin:0 auto 20px; }

--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -1,6 +1,38 @@
-"""Simple spread based arbitrage strategy."""
+"""Simple spread based arbitrage strategy.
+
+This module exposes a minimal ``Strategy`` subclass so the arbitrage
+implementation becomes available in the dashboard's strategy selector.  The
+runtime strategy is intentionally simplistic – it merely checks the spread
+between two assets and never issues live orders – but it allows operators to
+experiment and extend it further.
+"""
+
+from typing import Any
 
 import pandas as pd
+
+from .base import Strategy, Signal
+
+
+class Arbitrage(Strategy):
+    """Placeholder arbitrage strategy used for live experimentation."""
+
+    name = "arbitrage"
+
+    def __init__(self, **_: Any) -> None:
+        """Accept arbitrary parameters for future extensions."""
+
+        # No configuration required for the placeholder implementation.
+
+    def on_bar(self, bar: dict[str, Any]) -> Signal | None:  # pragma: no cover -
+        """Inspect ``bar`` data and return ``Signal`` if conditions met.
+
+        The current implementation does not produce trading signals. It serves
+        as a stub so the arbitrage strategy appears in the UI.  Users can
+        replace this with a real implementation later on.
+        """
+
+        return Signal("flat", 0.0)
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
@@ -42,5 +74,5 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     return df[["signal", "position", "stop_loss", "take_profit", "fee", "slippage"]]
 
 
-__all__ = ["generate_signals"]
+__all__ = ["Arbitrage", "generate_signals"]
 


### PR DESCRIPTION
## Summary
- Add placeholder `arbitrage` strategy so it appears in the bot manager
- Split dashboard: monitoring now focuses on API health, operational stats focus on trading data
- Center and enlarge logo across pages and introduce per-symbol PnL tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cecba0cc832d83e7020c8b9fc1b7