### PR TITLE
feat: expand dashboard metrics and unify styling

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -4,27 +4,7 @@
   <meta charset="utf-8"/>
   <title>Bots - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
-    h1, h2 { margin: 0.2rem 0; }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
-    table { width:100%; border-collapse: collapse; font-size: 14px; }
-    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
-    th { background:#0f1622; position: sticky; top:0; }
-    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-    .muted { color:#94a3b8; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    button { background:#2563eb; color:#fff; border:none; padding:8px 12px; border-radius:6px; cursor:pointer; }
-    button:hover { background:#1d4ed8; }
-    input, select { width:100%; background:#0f1622; border:1px solid #1f2937; border-radius:8px; color:#e8eef5; padding:8px; font-family:inherit; }
-    label { font-size:12px; color:#94a3b8; display:block; margin-top:8px; margin-bottom:4px; }
-    nav { margin-bottom:20px; text-align:center; }
-    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
-    nav a:hover { text-decoration:underline; }
-    .logo { height:80px; display:block; margin:0 auto 20px; }
-    pre { background:#0f1622; padding:10px; border-radius:8px; overflow:auto; }
-  </style>
+  <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
 <header class="center" style="margin-bottom:8px">
@@ -125,7 +105,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Estrategia</th><th>Pares</th><th>Estado</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Estrategia</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Error</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -262,13 +242,28 @@ async function refreshBots(){
     const body = document.querySelector('#tbl-bots tbody');
     body.innerHTML='';
     (j.bots||[]).forEach(b=>{
-      const tr=document.createElement('tr');
+      const stats=b.stats||{};
       const pairs=(b.config?.pairs||[]).join(',');
+      const tr=document.createElement('tr');
       tr.innerHTML=`<td>${b.pid}</td><td>${b.config?.strategy||''}</td><td>${pairs}</td><td>${b.status}</td>
+      <td>${stats.orders_sent||0}/${stats.fills||0}</td>
+      <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
+      <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>
+      <td>${(stats.fees_usd||0).toFixed(2)}</td>
+      <td>${(stats.slippage_bps||0).toFixed(2)}</td>
+      <td>${((stats.hit_rate||0)*100).toFixed(1)}%</td>
+      <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
+      <td>${(stats.inventory||0).toFixed(4)}</td>
+      <td>${(stats.leverage||0).toFixed(2)}</td>
+      <td>${stats.risk_triggers||0}</td>
+      <td>${b.last_error||''}</td>
       <td>
-        <button onclick="stopBot(${b.pid})">Stop</button>
         <button onclick="pauseBot(${b.pid})">Pause</button>
         <button onclick="resumeBot(${b.pid})">Resume</button>
+        <button class='warn' onclick="haltBot(${b.pid})">Halt</button>
+        <button class='danger' onclick="flattenBot(${b.pid})">Flatten</button>
+        <button onclick="reloadBot(${b.pid})">Reload</button>
+        <button onclick="stopBot(${b.pid})">Stop</button>
         <button onclick="deleteBot(${b.pid})">Delete</button>
       </td>`;
       body.appendChild(tr);
@@ -293,6 +288,9 @@ async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST
 async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
 async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
 async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
+async function haltBot(pid){ await fetch(api(`/bots/${pid}/halt`), {method:'POST'}); refreshBots(); }
+async function flattenBot(pid){ await fetch(api(`/bots/${pid}/flatten`), {method:'POST'}); refreshBots(); }
+async function reloadBot(pid){ await fetch(api(`/bots/${pid}/reload`), {method:'POST'}); refreshBots(); }
 
 async function refreshRisk(){
   try{

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -17,12 +17,37 @@
 </header>
   <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
-  <div class="grid5" style="margin:14px 0 20px">
+  <div class="grid5" style="margin:14px 0 10px">
     <div class="kv"><div class="k">Reject Rate</div><div class="v" id="m-reject">—</div></div>
+    <div class="kv"><div class="k">Latency p90 (s)</div><div class="v" id="m-lat90">—</div></div>
+    <div class="kv"><div class="k">Latency p99 (s)</div><div class="v" id="m-lat99">—</div></div>
+    <div class="kv"><div class="k">WS Uptime %</div><div class="v" id="m-ws-up">—</div></div>
+    <div class="kv"><div class="k">Reconex/hr</div><div class="v" id="m-ws-rec">—</div></div>
+  </div>
+  <div class="grid5" style="margin:0 0 10px">
+    <div class="kv"><div class="k">Book Lag (ms)</div><div class="v" id="m-book-lag">—</div></div>
     <div class="kv"><div class="k">CPU %</div><div class="v" id="m-cpu">—</div></div>
     <div class="kv"><div class="k">Mem (MB)</div><div class="v" id="m-mem">—</div></div>
+    <div class="kv"><div class="k">FDs</div><div class="v" id="m-fds">—</div></div>
     <div class="kv"><div class="k">Uptime (s)</div><div class="v" id="m-uptime">—</div></div>
-    <div class="kv"><div class="k">Latencia (s)</div><div class="v" id="m-latency">—</div></div>
+  </div>
+  <div class="grid5" style="margin:0 0 10px">
+    <div class="kv"><div class="k">Ingest rate</div><div class="v" id="m-ingest">—</div></div>
+    <div class="kv"><div class="k">Persist backlog</div><div class="v" id="m-backlog">—</div></div>
+    <div class="kv"><div class="k">HTTP 4xx</div><div class="v" id="m-err-4xx">—</div></div>
+    <div class="kv"><div class="k">HTTP 5xx</div><div class="v" id="m-err-5xx">—</div></div>
+    <div class="kv"><div class="k">Timeouts</div><div class="v" id="m-err-timeout">—</div></div>
+  </div>
+  <div class="grid4" style="margin:0 0 10px">
+    <div class="kv"><div class="k">Throttling</div><div class="v" id="m-err-throttle">—</div></div>
+    <div class="kv"><div class="k">Auth Errors</div><div class="v" id="m-err-auth">—</div></div>
+    <div class="kv"><div class="k">Spread</div><div class="v" id="m-spread">—</div></div>
+    <div class="kv"><div class="k">Depth</div><div class="v" id="m-depth">—</div></div>
+  </div>
+  <div class="grid4" style="margin:0 0 20px">
+    <div class="kv"><div class="k">Funding</div><div class="v" id="m-funding-now">—</div></div>
+    <div class="kv"><div class="k">Próx Funding</div><div class="v" id="m-funding-next">—</div></div>
+    <div class="kv"><div class="k">Basis</div><div class="v" id="m-basis">—</div></div>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -52,7 +77,7 @@
 
   <div class="card" style="margin-top:16px">
     <h2>Logs</h2>
-    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh; background:#0f1622; padding:10px"></pre>
+    <pre id="logs" class="mono" style="overflow:auto; max-height:60vh"></pre>
   </div>
 
 <script>
@@ -75,14 +100,43 @@ async function refreshMetrics(){
     const r = await fetch(api('/metrics'));
     const j = await r.json();
     document.getElementById('m-reject').textContent = ((j.order_reject_rate||0)*100).toFixed(2)+'%';
+    document.getElementById('m-ws-up').textContent = ((j.ws_uptime||0)*100).toFixed(2)+'%';
+    document.getElementById('m-ws-rec').textContent = (j.ws_reconnections_per_hour||0).toFixed(2);
+    document.getElementById('m-book-lag').textContent = (j.book_lag_ms||0).toFixed(1);
     document.getElementById('m-cpu').textContent = (j.cpu_percent||0).toFixed(1);
     document.getElementById('m-mem').textContent = ((j.memory_bytes||0)/1048576).toFixed(1);
+    document.getElementById('m-fds').textContent = j.fd_count||0;
     document.getElementById('m-uptime').textContent = (j.process_uptime_seconds||0).toFixed(0);
+    document.getElementById('m-ingest').textContent = (j.ingest_rate||0).toFixed(1);
+    document.getElementById('m-backlog').textContent = j.persist_backlog||0;
+    document.getElementById('m-err-4xx').textContent = j.errors_4xx||0;
+    document.getElementById('m-err-5xx').textContent = j.errors_5xx||0;
+    document.getElementById('m-err-timeout').textContent = j.errors_timeout||0;
+    document.getElementById('m-err-throttle').textContent = j.errors_throttling||0;
+    document.getElementById('m-err-auth').textContent = j.errors_auth||0;
     try{
       const l = await fetch(api('/metrics/latency'));
       const lj = await l.json();
-      document.getElementById('m-latency').textContent = (lj.avg_order_latency_seconds||0).toFixed(3);
+      document.getElementById('m-lat90').textContent = (lj.p90||0).toFixed(3);
+      document.getElementById('m-lat99').textContent = (lj.p99||0).toFixed(3);
     }catch(e){}
+  }catch(e){}
+}
+
+async function refreshMarket(){
+  try{
+    const r = await fetch(api('/metrics/market'));
+    const j = await r.json();
+    document.getElementById('m-spread').textContent = (j.spread||0).toFixed(4);
+    document.getElementById('m-depth').textContent = (j.depth||0).toFixed(0);
+    document.getElementById('m-funding-now').textContent = (j.funding_current||0).toFixed(4);
+    document.getElementById('m-funding-next').textContent = (j.funding_next||0).toFixed(4);
+    document.getElementById('m-basis').textContent = (j.basis||0).toFixed(4);
+    if(j.basis_alert){
+      document.getElementById('m-basis').classList.add('warn');
+    }else{
+      document.getElementById('m-basis').classList.remove('warn');
+    }
   }catch(e){}
 }
 
@@ -109,6 +163,8 @@ refreshHealth();
 setInterval(refreshHealth, 5000);
 refreshMetrics();
 setInterval(refreshMetrics, 5000);
+refreshMarket();
+setInterval(refreshMarket, 5000);
 
 async function refreshLogs(){
   try{

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -4,25 +4,7 @@
   <meta charset="utf-8"/>
   <title>Estadísticas - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
-    body { font-family: system-ui, Arial, sans-serif; margin: 20px; background:#0b0f14; color:#e8eef5; }
-    h1, h2 { margin: 0.2rem 0; }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-    .card { background:#121826; border:1px solid #1f2937; border-radius:12px; padding:14px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); }
-    table { width:100%; border-collapse: collapse; font-size: 14px; }
-    th, td { border-bottom: 1px solid #1f2937; padding: 8px 6px; text-align: left; }
-    th { background:#0f1622; position: sticky; top:0; }
-    .muted { color:#94a3b8; }
-    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-    .kv { background:#0f1622; border:1px solid #1f2937; border-radius:10px; padding:10px; }
-    .kv .k { font-size:12px; color:#94a3b8 }
-    .kv .v { font-size:18px; margin-top:4px }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    nav { margin-bottom:20px; text-align:center; }
-    nav a { color:#e8eef5; margin-right:15px; text-decoration:none; }
-    nav a:hover { text-decoration:underline; }
-    .logo { height:80px; display:block; margin:0 auto 20px; }
-  </style>
+  <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
 <header class="center" style="margin-bottom:8px">
@@ -35,9 +17,31 @@
 </header>
 
   <h1>Estadísticas operativas</h1>
-  <div class="grid3" style="margin:14px 0 20px">
-    <div class="kv"><div class="k">PnL</div><div class="v" id="m-pnl">—</div></div>
-    <div class="kv"><div class="k">Fills</div><div class="v" id="m-fills">—</div></div>
+  <div class="grid5" style="margin:14px 0 10px">
+    <div class="kv"><div class="k">PnL bruto</div><div class="v" id="m-pnl-gross">—</div></div>
+    <div class="kv"><div class="k">PnL neto</div><div class="v" id="m-pnl-net">—</div></div>
+    <div class="kv"><div class="k">Fees</div><div class="v" id="m-fees">—</div></div>
+    <div class="kv"><div class="k">Funding</div><div class="v" id="m-funding">—</div></div>
+    <div class="kv"><div class="k">Borrow</div><div class="v" id="m-borrow">—</div></div>
+  </div>
+  <div class="grid5" style="margin:0 0 10px">
+    <div class="kv"><div class="k">Sharpe</div><div class="v" id="m-sharpe">—</div></div>
+    <div class="kv"><div class="k">Sortino</div><div class="v" id="m-sortino">—</div></div>
+    <div class="kv"><div class="k">Calmar</div><div class="v" id="m-calmar">—</div></div>
+    <div class="kv"><div class="k">Max DD</div><div class="v" id="m-maxdd">—</div></div>
+    <div class="kv"><div class="k">TUW</div><div class="v" id="m-tuw">—</div></div>
+  </div>
+  <div class="grid5" style="margin:0 0 10px">
+    <div class="kv"><div class="k">Hit Rate</div><div class="v" id="m-hit">—</div></div>
+    <div class="kv"><div class="k">Expectancy</div><div class="v" id="m-expectancy">—</div></div>
+    <div class="kv"><div class="k">Payoff</div><div class="v" id="m-payoff">—</div></div>
+    <div class="kv"><div class="k">Trades/día</div><div class="v" id="m-trades-day">—</div></div>
+    <div class="kv"><div class="k">Notional medio</div><div class="v" id="m-notional">—</div></div>
+  </div>
+  <div class="grid4" style="margin:0 0 20px">
+    <div class="kv"><div class="k">DSR</div><div class="v" id="m-dsr">—</div></div>
+    <div class="kv"><div class="k">Alpha vol</div><div class="v" id="m-alpha-vol">—</div></div>
+    <div class="kv"><div class="k">Benchmark</div><div class="v" id="m-benchmark">—</div></div>
     <div class="kv"><div class="k">Risk Events</div><div class="v" id="m-risk">—</div></div>
   </div>
   <div class="card">
@@ -101,13 +105,59 @@
       </table>
     </div>
   </div>
+  <div class="card" style="margin-top:16px">
+    <h2>Ejecución (microestructura)</h2>
+    <div class="muted">Implementation shortfall, slippage y fill ratio</div>
+    <div style="overflow:auto; max-height:40vh; margin-top:10px">
+      <table id="tbl-exec">
+        <thead><tr><th>symbol</th><th>IS</th><th>slippage</th><th>fill_ratio</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <div class="card" style="margin-top:16px">
+    <h2>Calidad de señales</h2>
+    <div class="muted">Precision/Recall y AUC</div>
+    <div style="overflow:auto; max-height:40vh; margin-top:10px">
+      <table id="tbl-signals">
+        <thead><tr><th>signal</th><th>precision</th><th>recall</th><th>AUC</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <div class="card" style="margin-top:16px">
+    <h2>Riesgo</h2>
+    <div class="muted">Activaciones de guardas y correlaciones</div>
+    <div style="overflow:auto; max-height:40vh; margin-top:10px">
+      <table id="tbl-risk-events">
+        <thead><tr><th>tipo</th><th>count</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
 <script>
 async function refreshMetrics(){
   try{
     const r = await fetch('/metrics');
     const j = await r.json();
-    document.getElementById('m-pnl').textContent = (j.pnl||0).toFixed(2);
-    document.getElementById('m-fills').textContent = j.fills||0;
+    document.getElementById('m-pnl-gross').textContent = (j.pnl_gross||0).toFixed(2);
+    document.getElementById('m-pnl-net').textContent = (j.pnl_net||0).toFixed(2);
+    document.getElementById('m-fees').textContent = (j.fees||0).toFixed(2);
+    document.getElementById('m-funding').textContent = (j.funding||0).toFixed(2);
+    document.getElementById('m-borrow').textContent = (j.borrow||0).toFixed(2);
+    document.getElementById('m-sharpe').textContent = (j.sharpe||0).toFixed(2);
+    document.getElementById('m-sortino').textContent = (j.sortino||0).toFixed(2);
+    document.getElementById('m-calmar').textContent = (j.calmar||0).toFixed(2);
+    document.getElementById('m-maxdd').textContent = (j.max_drawdown||0).toFixed(2);
+    document.getElementById('m-tuw').textContent = (j.time_under_water||0).toFixed(2);
+    document.getElementById('m-hit').textContent = ((j.hit_rate||0)*100).toFixed(1)+'%';
+    document.getElementById('m-expectancy').textContent = (j.expectancy||0).toFixed(2);
+    document.getElementById('m-payoff').textContent = (j.payoff_ratio||0).toFixed(2);
+    document.getElementById('m-trades-day').textContent = (j.trades_per_day||0).toFixed(2);
+    document.getElementById('m-notional').textContent = (j.avg_notional||0).toFixed(2);
+    document.getElementById('m-dsr').textContent = (j.dsr||0).toFixed(2);
+    document.getElementById('m-alpha-vol').textContent = (j.alpha_vol||0).toFixed(2);
+    document.getElementById('m-benchmark').textContent = (j.benchmark||0).toFixed(2);
     document.getElementById('m-risk').textContent = j.risk_events||0;
   }catch(e){}
 }
@@ -194,6 +244,45 @@ async function refreshFillsSummary(){
     }
   }catch(e){}
 }
+async function refreshExecution(){
+  try{
+    const r=await fetch('/metrics/execution');
+    const j=await r.json();
+    const body=document.querySelector('#tbl-exec tbody');
+    body.innerHTML='';
+    (j.items||[]).forEach(it=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${it.symbol}</td><td>${(it.is||0).toFixed(2)}</td><td>${(it.slippage||0).toFixed(2)}</td><td>${(it.fill_ratio||0).toFixed(2)}</td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
+async function refreshSignals(){
+  try{
+    const r=await fetch('/metrics/signals');
+    const j=await r.json();
+    const body=document.querySelector('#tbl-signals tbody');
+    body.innerHTML='';
+    (j.items||[]).forEach(it=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${it.name}</td><td>${(it.precision||0).toFixed(2)}</td><td>${(it.recall||0).toFixed(2)}</td><td>${(it.auc||0).toFixed(2)}</td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
+async function refreshRiskStats(){
+  try{
+    const r=await fetch('/metrics/risk');
+    const j=await r.json();
+    const body=document.querySelector('#tbl-risk-events tbody');
+    body.innerHTML='';
+    Object.entries(j.triggers||{}).forEach(([k,v])=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${k}</td><td>${v}</td>`;
+      body.appendChild(tr);
+    });
+  }catch(e){}
+}
 function applyFilters(){
   currentSymbol=document.getElementById('fl-symbol').value.trim();
   refreshPnlSpot();
@@ -201,6 +290,9 @@ function applyFilters(){
   refreshPnlSummarySpot();
   refreshPnlSummaryFut();
   refreshFillsSummary();
+  refreshExecution();
+  refreshSignals();
+  refreshRiskStats();
 }
 refreshMetrics();
 refreshPositions();
@@ -209,6 +301,9 @@ refreshPnlFut();
 refreshPnlSummarySpot();
 refreshPnlSummaryFut();
 refreshFillsSummary();
+refreshExecution();
+refreshSignals();
+refreshRiskStats();
 setInterval(refreshMetrics,5000);
 setInterval(refreshPositions,5000);
 setInterval(refreshPnlSpot,10000);
@@ -216,6 +311,9 @@ setInterval(refreshPnlFut,10000);
 setInterval(refreshPnlSummarySpot,10000);
 setInterval(refreshPnlSummaryFut,10000);
 setInterval(refreshFillsSummary,10000);
+setInterval(refreshExecution,10000);
+setInterval(refreshSignals,10000);
+setInterval(refreshRiskStats,10000);
 document.getElementById('fl-apply').addEventListener('click',applyFilters);
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -150,3 +150,11 @@ button.ghost{
 /* ====== Helpers ====== */
 .row{ display:grid; grid-template-columns: 1fr 1fr; gap:16px }
 .center{ text-align:center }
+
+/* formateo de bloques preformateados */
+pre{
+  background:#0f1622;
+  padding:10px;
+  border-radius:8px;
+  overflow:auto;
+}


### PR DESCRIPTION
## Summary
- apply shared styles.css to bots and stats pages
- expand monitoring dashboard with extensive system and market metrics
- add execution, signal quality and risk stats sections

## Testing
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a502466260832d857e164af05065b3