### PR TITLE
docs: expand usage and CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ del MVP está en [tradebot_mvp.md](tradebot_mvp.md).
    tradingbot ingest
    ```
 
+   (Opcional) para completar históricos:
+   ```bash
+   tradingbot backfill --days 7 --symbols BTC/USDT
+   ```
+
 5. **Ejecutar backtesting**
    ```bash
    tradingbot backtest
@@ -80,16 +85,6 @@ gracias al **paper trading** (simulación).
   La sección de bots incorpora un **ejecutor de comandos CLI** para
   lanzar cualquier comando desde el navegador y formularios para
   configurar estrategias sin usar la terminal.
-
-## Funcionalidades extra
-
-TradeBot incluye una serie de capacidades adicionales más allá del MVP
-original. Entre ellas se destacan las estrategias de arbitraje
-triangular y entre exchanges, señales basadas en microestructura,
-adaptadores para múltiples venues con soporte de testnet, un panel web
-que permite ejecutar comandos de la CLI y una API para control remoto.
-La descripción completa y ejemplos de uso se encuentran en
-[docs/extra_features.md](docs/extra_features.md).
 
 ## Funcionalidades extra
 
@@ -230,8 +225,10 @@ python -m tradingbot.cli <comando> [opciones]
 | `ingest` | Stream de order book a la base de datos | `python -m tradingbot.cli ingest --venue binance_spot --symbol BTC/USDT --depth 20` |
 | `ingest-historical` | Descarga histórica desde Kaiko o CoinAPI | `python -m tradingbot.cli ingest-historical kaiko BTC/USDT --kind trades` |
 | `run-bot` | Ejecuta el bot en vivo o testnet | `python -m tradingbot.cli run-bot --exchange binance --symbol BTC/USDT` |
+| `real-run` | Opera en el exchange real (requiere `--i-know-what-im-doing`) | `python -m tradingbot.cli real-run --exchange binance --symbol BTC/USDT --i-know-what-im-doing` |
 | `paper-run` | Ejecuta una estrategia en modo simulación | `python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr --config params.yaml` |
 | `daemon` | Levanta el daemon de trading mediante Hydra | `python -m tradingbot.cli daemon config/config.yaml` |
+| `backfill` | Backfill de OHLCV y trades con rate limit | `python -m tradingbot.cli backfill --days 7 --symbols BTC/USDT ETH/USDT` |
 | `ingestion-workers` | Workers de funding y open interest | `python -m tradingbot.cli ingestion-workers` |
 | `backtest` | Backtest vectorizado desde CSV | `python -m tradingbot.cli backtest data/ohlcv.csv` |
 | `backtest-cfg` | Backtest desde un YAML de configuración | `python -m tradingbot.cli backtest-cfg data/examples/backtest.yaml` |

--- a/blueprint_trading_bot.md
+++ b/blueprint_trading_bot.md
@@ -10,10 +10,12 @@ señales y ejecuta operaciones en los exchanges soportados.
   vía WebSocket.
 - **Histórico**: descargas REST de OHLCV, trades y snapshots de libro.
 - **Adaptadores**: módulos por exchange que normalizan símbolos y datos.
+- **Backfill**: comando dedicado para completar históricos en bloque.
 
 _Ejemplo:_
 ```bash
 python -m tradingbot.cli ingest --venue binance_spot --symbol BTC/USDT --depth 20
+python -m tradingbot.cli backfill --days 7 --symbols BTC/USDT
 ```
 
 ## 2. Generación de features
@@ -64,6 +66,7 @@ Router multi‑exchange con algoritmos **TWAP**, **VWAP** y **POV**.  Soporta
 _Ejemplo:_
 ```bash
 python -m tradingbot.cli run-bot --exchange binance --symbol ETH/USDT --algo twap
+python -m tradingbot.cli real-run --exchange binance --symbol ETH/USDT --i-know-what-im-doing
 ```
 
 ## 6. Persistencia

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,10 @@ Los módulos se comunican mediante un bus de eventos (`bus.py`) lo
 que permite desacoplar la generación de señales de la ejecución y
 el almacenamiento.
 
+La capa de CLI (`cli/main.py`) expone comandos como `ingest`, `backfill`,
+`run-bot`, `real-run`, `paper-run` o `backtest` para interactuar con estas
+piezas de forma sencilla.
+
 La carpeta `sql/` contiene los esquemas de base de datos y ejemplos
 de `docker-compose` para levantar servicios individuales. El stack
 completo de demostración se levanta con `docker-compose.yml` en la

--- a/docs/blueprint_map.md
+++ b/docs/blueprint_map.md
@@ -4,9 +4,9 @@ Este documento enlaza los puntos del [blueprint inicial](../blueprint_trading_bo
 
 | Punto del blueprint | Módulos / archivos relevantes | Comandos de CLI |
 |---------------------|-------------------------------|-----------------|
-| **1. Ingesta de datos** | `adapters/`, `data/ingestion.py`, `workers/` | `python -m tradingbot.cli ingest`, `python -m tradingbot.cli ingest-historical`, `python -m tradingbot.cli ingestion-workers` |
+| **1. Ingesta de datos** | `adapters/`, `data/ingestion.py`, `workers/` | `python -m tradingbot.cli ingest`, `python -m tradingbot.cli backfill`, `python -m tradingbot.cli ingest-historical`, `python -m tradingbot.cli ingestion-workers` |
 | **2. Feature engineering** | `data/features.py`, `data/basis.py`, `data/open_interest.py` | – |
-| **3. Señal / estrategia** | `strategies/`, `live/runner*.py` – estrategias: `momentum`, `mean_reversion`, `breakout_atr`, `breakout_vol`, `order_flow`, `mean_rev_ofi`, `depth_imbalance`, `liquidity_events`, `cash_and_carry`, `cross_exchange_arbitrage`, `triangular_arb`, `arbitrage`, `triple_barrier` | `run-bot`, `paper-run`, `tri-arb`, `cross-arb`, `run-cross-arb` |
+| **3. Señal / estrategia** | `strategies/`, `live/runner*.py` – estrategias: `momentum`, `mean_reversion`, `breakout_atr`, `breakout_vol`, `order_flow`, `mean_rev_ofi`, `depth_imbalance`, `liquidity_events`, `cash_and_carry`, `cross_exchange_arbitrage`, `triangular_arb`, `arbitrage`, `triple_barrier` | `run-bot`, `real-run`, `paper-run`, `tri-arb`, `cross-arb`, `run-cross-arb` |
 | **4. Gestión de cartera y riesgo** | `risk/manager.py`, `risk/portfolio_guard.py`, `risk/daily_guard.py` | `run-bot`, `daemon` |
 | **5. Ejecución** | `execution/router.py`, `execution/algos.py`, `execution/order_types.py` | `run-bot --algo`, `run-cross-arb` |
 | **6. Persistencia** | `storage/timescale.py`, `storage/quest.py` | `ingest`, `ingest-historical`, `ingestion-workers`, `report` |

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -38,6 +38,13 @@ Job de cron que ejecuta cada minuto:
 * * * * * cd /ruta/a/TradeBot && /usr/bin/python /ruta/a/poll_perp.py >> /var/log/tradingbot.log 2>&1
 ```
 
+También puedes iniciar el daemon directamente desde la CLI
+apuntando a un archivo de configuración de Hydra:
+
+```bash
+python -m tradingbot.cli daemon config/config.yaml
+```
+
 Para conocer características avanzadas como estrategias de arbitraje,
 panel web y API de control, consulta
 [extra_features.md](extra_features.md).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,6 +3,7 @@
 ## Ingesta de datos
 ```bash
 python -m tradingbot.cli ingest --symbol BTC/USDT
+python -m tradingbot.cli backfill --days 7 --symbols BTC/USDT
 ```
 
 ### Ingesta histórica
@@ -17,6 +18,7 @@ python -m tradingbot.cli ingest-historical coinapi BTC/USD --kind orderbook --de
 ```bash
 python -m tradingbot.cli run-bot --exchange binance --market spot --symbol BTC/USDT
 python -m tradingbot.cli run-bot --exchange binance --market futures --symbol BTC/USDT --leverage 5
+python -m tradingbot.cli real-run --exchange binance --symbol BTC/USDT --i-know-what-im-doing
 ```
 
 ## Backfill y backtesting vectorizado

--- a/docs/extra_features.md
+++ b/docs/extra_features.md
@@ -24,6 +24,8 @@ breakout), el bot incluye módulos listos para:
   profundidad de libro y desequilibrio de colas para scalping.
 
 Estas estrategias pueden ejecutarse en modo ``paper`` o en cuentas reales.
+Para habilitar trading en producción utiliza el comando `real-run` y
+confirma con la opción `--i-know-what-im-doing`.
 
 ## Adaptadores y conectores
 
@@ -34,6 +36,13 @@ La estructura es modular para facilitar la inclusión de nuevos exchanges.
 Ejemplo rápido para obtener trades de Bybit:
 ```bash
 python -m tradingbot.cli ingest --venue bybit_spot --symbol BTC/USDT
+```
+
+Para completar históricos existe el comando **backfill**, que descarga
+OHLCV y trades en bloque respetando los límites de cada API:
+
+```bash
+python -m tradingbot.cli backfill --days 30 --symbols BTC/USDT ETH/USDT
 ```
 
 ## Monitoreo y panel web

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -13,6 +13,9 @@ aproximadamente `2.85` unidades, calculado como la diferencia entre el precio
 de cierre final y el precio promedio de la orden ejecutada. Cualquier intento de
 exceder el límite de riesgo es rechazado.
 
+Los datos de prueba pueden obtenerse con `ingest-historical` o de forma más
+rápida con el comando `backfill`.
+
 ## Prueba de estrés de latencia y spreads
 
 El segundo escenario ejecuta el mismo flujo bajo un `StressConfig` que duplica la

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -27,6 +27,10 @@ except Exception:
 Esto facilita identificar rápidamente el punto exacto del fallo al revisar los
 logs.
 
+Todos los comandos de la CLI (`ingest`, `backfill`, `run-bot`, `real-run`, etc.)
+utilizan esta configuración de logging, por lo que los mensajes seguirán el
+mismo formato tanto en modo papel como en ejecución real.
+
 Para una descripción de funcionalidades avanzadas y cómo generan logs
 adicionales (arbitrajes, panel web, API), ver
 [extra_features.md](extra_features.md).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -3,6 +3,10 @@
 This project ships a minimal monitoring stack to track bot health and
 trading performance.
 
+Puedes obtener un resumen rápido de PnL desde la terminal con
+`python -m tradingbot.cli report` siempre que la base de datos esté
+disponible.
+
 ## FastAPI panel
 
 Run the monitoring panel with:

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,9 @@ Mantener seguras las credenciales es fundamental. Algunas recomendaciones:
 - Revisa periódicamente los registros y rota las claves con regularidad.
 - Nunca compartas claves ni las publiques en repositorios.
 
+El comando `real-run` exige el flag `--i-know-what-im-doing` como medida de
+protección para evitar operar por accidente con fondos reales.
+
 Algunas funciones avanzadas (API web, panel de monitoreo, estrategias de
-arbitraje) también requieren considerar permisos y autenticación.
-Consulta [extra_features.md](extra_features.md) para más detalles.
+arbitraje) también requieren considerar permisos y autenticación. Consulta
+[extra_features.md](extra_features.md) para más detalles.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,6 +36,12 @@ archivos CSV dentro de `db/` o directamente en TimescaleDB/QuestDB:
 
 La persistencia se realiza mediante utilidades de `tradingbot.data.ingestion`.
 
+También puedes completar históricos desde la CLI usando:
+
+```bash
+python -m tradingbot.cli backfill --days 30 --symbols BTC/USDT ETH/USDT
+```
+
 ### Claves de API para conectores externos
 
 Algunos proveedores como Kaiko y CoinAPI requieren claves de autenticación.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,9 @@ control) se documentan en [extra_features.md](extra_features.md).
 
 ```bash
 python -m tradingbot.cli ingest --symbol BTC/USDT
+python -m tradingbot.cli backfill --days 7 --symbols BTC/USDT
 python -m tradingbot.cli run-bot --symbol BTC/USDT
+python -m tradingbot.cli real-run --exchange binance --symbol BTC/USDT --i-know-what-im-doing
 python -m tradingbot.cli backtest data/btcusdt_1m.csv --symbol BTC/USDT --strategy breakout_atr
 python -m tradingbot.cli paper-run --strategy breakout_atr --symbol BTC/USDT
 python -m tradingbot.cli backtest-cfg src/tradingbot/config/config.yaml

--- a/tradebot_mvp.md
+++ b/tradebot_mvp.md
@@ -346,11 +346,11 @@ monitoring:
 
 | Punto del blueprint | Módulos / archivos                                                                     | Comandos CLI                                                    |
 | ------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **1. Ingesta**      | `adapters/`, `data/ingestion.py`, `workers/`                                           | `ingest`, `ingest-historical`, `ingestion-workers`              |
+| **1. Ingesta**      | `adapters/`, `data/ingestion.py`, `workers/`                                           | `ingest`, `backfill`, `ingest-historical`, `ingestion-workers`  |
 | **2. Features**     | `data/features.py`, `data/basis.py`, `data/open_interest.py`                           | –                                                               |
-| **3. Estrategias**  | `strategies/`, `live/runner*.py`                                                       | `run-bot`, `paper-run`, `tri-arb`, `cross-arb`, `run-cross-arb` |
-| **4. Riesgo**       | `risk/manager.py`, `risk/portfolio_guard.py`, `risk/daily_guard.py`                    | `run-bot`, `daemon`                                             |
-| **5. Ejecución**    | `execution/router.py`, `execution/algos.py`, `execution/order_types.py`                | `run-bot --algo`, `run-cross-arb`                               |
+| **3. Estrategias**  | `strategies/`, `live/runner*.py`                                                       | `run-bot`, `real-run`, `paper-run`, `tri-arb`, `cross-arb`, `run-cross-arb` |
+| **4. Riesgo**       | `risk/manager.py`, `risk/portfolio_guard.py`, `risk/daily_guard.py`                    | `run-bot`, `real-run`, `daemon`                                |
+| **5. Ejecución**    | `execution/router.py`, `execution/algos.py`, `execution/order_types.py`                | `run-bot --algo`, `real-run --algo`, `run-cross-arb`            |
 | **6. Persistencia** | `storage/timescale.py`, `storage/quest.py`                                             | `ingest*`, `report`                                             |
 | **7. Backtesting**  | `backtest/event_engine.py`, `backtesting/engine.py`, `backtesting/vectorbt_wrapper.py` | `backtest*`, `walk-forward`, `paper-run`                        |
 | **8. Monitoreo**    | `monitoring/metrics.py`, `src/tradingbot/apps/api/static/index.html`, `src/tradingbot/apps/api/static/monitor.html`, `utils/metrics.py` | `report`                                                        |
@@ -430,7 +430,10 @@ monitoring:
 python -m src.tradingbot.cli ingest --venue binance --symbols BTCUSDT,ETHUSDT --persist
 
 # Backfill histórico 7 días
-python -m src.tradingbot.cli ingest-historical --venue binance --symbols BTCUSDT --days 7
+python -m src.tradingbot.cli backfill --days 7 --symbols BTC/USDT
+
+# Ingesta histórica con Kaiko
+python -m src.tradingbot.cli ingest-historical kaiko BTC-USDT --exchange binance --kind trades
 
 # Backtest estrategia Breakout ATR
 python -m src.tradingbot.cli backtest --strategy breakout_atr --config config/default.yaml
@@ -440,6 +443,9 @@ python -m src.tradingbot.cli paper-run --strategy breakout_atr --symbols BTCUSDT
 
 # Testnet multi‑símbolo (futuros)
 python -m src.tradingbot.cli testnet-run --venue binance_futures --symbols BTCUSDT,ETHUSDT --algo twap --oco
+
+# Operación real (requiere confirmación)
+python -m src.tradingbot.cli real-run --exchange binance --symbol BTC/USDT --i-know-what-im-doing
 ```
 
 ### Anexo B) Esquema SQL (borrador Timescale)


### PR DESCRIPTION
## Summary
- document backfill and real-run commands across README, blueprint, and MVP
- update docs/ folder with detailed installation, usage examples, and monitoring notes
- clarify security and logging guidance for real trading

## Testing
- `PYTHONPATH=src:. pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a517069a74832d930ee7be8f5b1dc2