### PR TITLE
Toggle leverage field on futures market

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -34,7 +34,9 @@
         <input id="bot-pairs" placeholder="BTC/USDT,ETH/USDT"/>
       </div>
       <div>
-        <label for="bot-notional">Notional (USDT)</label>
+        <label for="bot-notional">Notional (USDT)
+          <span class="help-icon" title="Monto en USDT por operación">?</span>
+        </label>
         <input id="bot-notional" type="number" step="0.01"/>
       </div>
       <div id="field-exchange">
@@ -53,7 +55,9 @@
         </select>
       </div>
       <div id="field-trade-qty">
-        <label for="bot-trade-qty">Trade qty</label>
+        <label for="bot-trade-qty">Trade qty
+          <span class="help-icon" title="Cantidad fija de unidades base por operación">?</span>
+        </label>
         <input id="bot-trade-qty" type="number" step="0.0001"/>
       </div>
       <div id="field-leverage">
@@ -89,7 +93,9 @@
         <input id="bot-stop-loss-pct" type="number" step="0.0001" required/>
       </div>
       <div>
-        <label for="bot-max-drawdown-pct">Max drawdown %</label>
+        <label for="bot-max-drawdown-pct">Max drawdown %
+          <span class="help-icon" title="Pérdida máxima permitida antes de detener el bot">?</span>
+        </label>
         <input id="bot-max-drawdown-pct" type="number" step="0.0001" required/>
       </div>
       <div>
@@ -180,16 +186,25 @@ const api = (path) => `${location.origin}${path}`;
     }catch(e){}
   }
 
+  function updateMarketFields(){
+    const market=document.getElementById('bot-market').value;
+    const strat=document.getElementById('bot-strategy').value;
+    const cross=strat==='cross_arbitrage';
+    const lev=document.getElementById('field-leverage');
+    lev.style.display = (!cross && market==='futures') ? '' : 'none';
+  }
+
   async function updateForm(){
     const strat=document.getElementById('bot-strategy').value;
     const cross=strat==='cross_arbitrage';
-    ['field-exchange','field-market','field-trade-qty','field-leverage'].forEach(id=>{
+    ['field-exchange','field-market','field-trade-qty'].forEach(id=>{
       document.getElementById(id).style.display = cross ? 'none' : '';
     });
     ['field-spot','field-perp','field-threshold'].forEach(id=>{
       document.getElementById(id).style.display = cross ? '' : 'none';
     });
     await loadStrategyParams(strat);
+    updateMarketFields();
   }
 
 async function startBot(){
@@ -329,7 +344,9 @@ async function resetRisk(){
 
 document.getElementById('bot-start').addEventListener('click', startBot);
 document.getElementById('bot-strategy').addEventListener('change', updateForm);
+document.getElementById('bot-market').addEventListener('change', updateMarketFields);
 loadStrategies();
+updateMarketFields();
 refreshBots();
 setInterval(refreshBots,5000);
 document.getElementById('cli-run').addEventListener('click', runCli);

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -185,6 +185,19 @@ button.ghost{
 .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace }
 
 /* ====== Helpers ====== */
+.help-icon{
+  display:inline-block;
+  width:14px;
+  height:14px;
+  line-height:12px;
+  text-align:center;
+  border:1px solid var(--muted);
+  border-radius:50%;
+  margin-left:4px;
+  cursor:help;
+  font-size:10px;
+  color:var(--muted);
+}
 .row{ display:grid; grid-template-columns: 1fr 1fr; gap:16px }
 .center{ text-align:center }
 


### PR DESCRIPTION
## Summary
- Add contextual hover help for Notional, Trade qty and Max drawdown
- Hide leverage input when Spot market is selected and show it for Futures

## Testing
- `pytest` *(6 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a530edf7b0832da9536870f7c780a8