### PR TITLE
Add Dockerfile for API service and update compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src
+ENV PYTHONPATH=/app/src
+
+CMD ["uvicorn", "tradingbot.apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       - timescaledb
 
   api:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     command: uvicorn tradingbot.apps.api.main:app --host 0.0.0.0 --port 8000
     volumes:
       - ./src:/app/src


### PR DESCRIPTION
## Summary
- add Dockerfile based on python 3.11-slim to run API via uvicorn
- update docker-compose.yml to build from new Dockerfile

## Testing
- `pip install -r requirements.txt`
- `pytest` *(killed: out of memory?)*


------
https://chatgpt.com/codex/tasks/task_e_68a5fe1a6fa4832da90984a48ef01917