### PR TITLE
Include monitoring package in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src
-ENV PYTHONPATH=/app/src
+# Include monitoring package so API can import monitoring.* modules
+COPY monitoring/ ./monitoring
+# Ensure both src and project root are on PYTHONPATH
+ENV PYTHONPATH=/app/src:/app
 
 CMD ["uvicorn", "tradingbot.apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     command: uvicorn tradingbot.apps.api.main:app --host 0.0.0.0 --port 8000
     volumes:
       - ./src:/app/src
+      - ./monitoring:/app/monitoring
     environment:
       - SENTRY_ENABLED=${SENTRY_ENABLED:-false}
       - SENTRY_DSN=${SENTRY_DSN:-}


### PR DESCRIPTION
## Summary
- copy monitoring package into Docker image and add it to PYTHONPATH
- mount monitoring folder in docker-compose so API can import monitoring modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a65acee118832d896b7789291a7281