### PR TITLE
Apply TimescaleDB schema during startup

### DIFF
--- a/bin/start_stack.sh
+++ b/bin/start_stack.sh
@@ -3,3 +3,11 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
 cd "$SCRIPT_DIR/.."
 docker compose up -d
+
+# Wait for TimescaleDB to be ready
+until pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Apply database schema
+PGPASSWORD=postgres psql -h localhost -U postgres -d trading -f sql/schema_timescale.sql

--- a/bin/start_timescale.sh
+++ b/bin/start_timescale.sh
@@ -3,3 +3,11 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
 cd "$SCRIPT_DIR/.."
 docker compose -f sql/docker-compose.timescale.yml up -d
+
+# Wait for TimescaleDB to be ready
+until pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Apply database schema
+PGPASSWORD=postgres psql -h localhost -U postgres -d trading -f sql/schema_timescale.sql


### PR DESCRIPTION
## Summary
- Apply TimescaleDB schema after bringing up database-only stack
- Ensure full stack startup applies TimescaleDB schema so market tables exist for backfill

## Testing
- `PGPASSWORD=postgres psql -h localhost -U postgres -d trading -f sql/schema_timescale.sql` *(fails: connection refused)*
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a757de780c832d956127b82e1d6df6