### PR TITLE
Show backfill status in UI

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -177,17 +177,24 @@ async function runData(){
     if(kind==='orderbook') cmd+=` --depth ${depth}`;
     if(kind==='trades') cmd+=` --limit ${limit}`;
   }
-  document.getElementById('dm-output').textContent='';
+  const out=document.getElementById('dm-output');
+  out.textContent='Iniciando...\n';
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});
     const j=await r.json();
     currentJob=j.id;
     document.getElementById('dm-stop').disabled=false;
     evt=new EventSource(api(`/cli/stream/${j.id}`));
-    evt.onmessage=(e)=>{document.getElementById('dm-output').textContent+=e.data+'\n';};
-    evt.addEventListener('end',()=>{document.getElementById('dm-stop').disabled=true; currentJob=null; evt.close();});
+    evt.onmessage=(e)=>{out.textContent+=e.data+'\n';};
+    evt.addEventListener('end',(e)=>{
+      document.getElementById('dm-stop').disabled=true;
+      currentJob=null;
+      evt.close();
+      out.textContent+=`Proceso finalizado (código ${e.data}).\n`;
+    });
+    evt.onerror=()=>{out.textContent+='[error de conexión]\n';};
   }catch(e){
-    document.getElementById('dm-output').textContent=String(e);
+    out.textContent=String(e);
   }
 }
 


### PR DESCRIPTION
## Summary
- display start and completion messages for data management commands so users know when a backfill is running
- report exit code and connection errors in the data page output

## Testing
- `pytest` *(fails: KeyboardInterrupt during dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e0f5478832da9a75f8a0ab28b63