### PR TITLE
Ensure Timescale schema exists before backfill

### DIFF
--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -45,6 +45,7 @@ async def backfill(days: int, symbols: Sequence[str]) -> None:
     delay = getattr(ex, "rateLimit", 1000) / 1000
 
     client = AsyncTimescaleClient()
+    await client.ensure_schema()
     client.register_table("market.bars", INSERT_BAR_SQL)
     client.register_table("market.trades", INSERT_TRADE_SQL)
 

--- a/src/tradingbot/storage/async_timescale.py
+++ b/src/tradingbot/storage/async_timescale.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from prometheus_client import Histogram
@@ -71,6 +72,29 @@ class AsyncTimescaleClient:
         self._closed = False
 
         self._insert_sql: dict[str, str] = insert_sql.copy() if insert_sql else {}
+
+    # ------------------------------------------------------------------
+    # Schema management
+    async def ensure_schema(self, path: str | Path | None = None) -> None:
+        """Apply database schema to ensure required tables exist.
+
+        Parameters
+        ----------
+        path:
+            Optional path to a SQL file containing ``CREATE TABLE`` statements.
+            If omitted, ``db/schema.sql`` from the repository root is used.  The
+            statements must be separated by semicolons.
+        """
+
+        if path is None:
+            path = Path(__file__).resolve().parents[3] / "db" / "schema.sql"
+        schema_sql = Path(path).read_text()
+        engine = await self.connect()
+        async with engine.begin() as conn:
+            for stmt in schema_sql.split(";"):
+                s = stmt.strip()
+                if s:
+                    await conn.execute(text(s))
 
     # ------------------------------------------------------------------
     # Connection management


### PR DESCRIPTION
## Summary
- add an `ensure_schema` helper to AsyncTimescaleClient to apply `db/schema.sql`
- ensure backfill job calls `ensure_schema` so tables exist before writing

## Testing
- `pytest -q` *(killed: OOM?)*

------
https://chatgpt.com/codex/tasks/task_e_68a760aea160832db6024ae0922607de