### PR TITLE
Add entrypoint for core services and streamline Docker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,16 @@ del MVP está en [tradebot_mvp.md](tradebot_mvp.md).
    cd TradeBot
    ```
 
-2. **Crear `.env`**
-   Copia el archivo `.env.example` a `.env` y completa las credenciales.
+2. **Levantar los servicios**
    ```bash
-   cp .env.example .env
+   ./entrypoint.sh
+   ```
+   También puedes ejecutar directamente:
+   ```bash
+   docker compose up -d timescaledb api prometheus alertmanager grafana
    ```
 
-3. **Levantar los servicios**
-   ```bash
-   make up
-   ```
-
-4. **Ingerir datos**
+3. **Ingerir datos**
    ```bash
    tradingbot ingest
    ```
@@ -40,12 +38,12 @@ del MVP está en [tradebot_mvp.md](tradebot_mvp.md).
    tradingbot backfill --days 7 --symbols BTC/USDT
    ```
 
-5. **Ejecutar backtesting**
+4. **Ejecutar backtesting**
    ```bash
    tradingbot backtest
    ```
 
-6. **Iniciar dashboards**
+5. **Iniciar dashboards**
    ```bash
    uvicorn tradingbot.apps.api.main:app --reload --port 8000
    ```
@@ -203,16 +201,11 @@ cp .env.example .env   # completa con tus claves
    ```powershell
    pip install "vectorbt>=0.26"
    ```
-5. Copia el archivo de entorno:
+5. Inicia los servicios:
    ```powershell
-   copy .env.example .env
+   docker compose up -d timescaledb api prometheus alertmanager grafana
    ```
-6. (Opcional) Si tienes Docker Desktop, inicia los servicios:
-   ```powershell
-   docker compose up -d
-   ```
-   También puedes ejecutar `make up` desde Git Bash si dispones de `make`.
-7. Ejecuta el bot o la API:
+6. Ejecuta el bot o la API:
    ```powershell
    python -m tradingbot.cli ingest
    python -m tradingbot.cli backtest
@@ -222,22 +215,22 @@ cp .env.example .env   # completa con tus claves
 
 ## Arranque rápido
 
-Inicia y detén los servicios de Docker con el Makefile:
+Inicia y detén los servicios de Docker:
 
 ```bash
-make up    # levanta los servicios en segundo plano
-make logs  # sigue los logs de todos los contenedores
-make down  # detiene y elimina los servicios
+./entrypoint.sh   # levanta los servicios en segundo plano
+docker compose logs -f  # sigue los logs de todos los contenedores
+docker compose down  # detiene y elimina los servicios
 ```
 ## Configuración inicial
 
-1. Copia `.env.example` a `.env` y completa tus claves API (`BINANCE_KEY`,
+1. (Opcional) Copia `.env.example` a `.env` y completa tus claves API (`BINANCE_KEY`,
    `BINANCE_SECRET`, etc.). Para pruebas en modo papel puedes dejar los
    valores vacíos.
-2. (Opcional) Levanta la base de datos y el stack de monitoreo con Docker:
+2. Levanta la base de datos y el stack de monitoreo con Docker:
 
    ```bash
-   make up
+   ./entrypoint.sh
    ```
 
 3. Inicia la API y los dashboards:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       - "9090:9090"
     depends_on:
       - api
-      - alertmanager
 
   alertmanager:
     image: prom/alertmanager:latest
@@ -62,6 +61,8 @@ services:
       - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     ports:
       - "9093:9093"
+    depends_on:
+      - api
 
   grafana:
     image: grafana/grafana:latest
@@ -78,6 +79,7 @@ services:
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
     depends_on:
       - prometheus
+      - alertmanager
 
   questdb:
     image: questdb/questdb:latest

--- a/docs/guia_usuario_completa.md
+++ b/docs/guia_usuario_completa.md
@@ -47,7 +47,7 @@ source venv/bin/activate  # En Windows: venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-5. Copia las variables de ejemplo y completa tus credenciales:
+5. (Opcional) Copia las variables de ejemplo y completa tus credenciales:
 
 ```bash
 cp .env.example .env
@@ -57,10 +57,10 @@ En el archivo `.env` encontrarás espacios para poner tus claves de Binance,
 Bybit u otros exchanges. Si sólo harás pruebas con datos históricos o en modo
 simulación puedes dejarlos vacíos.
 
-6. (Opcional) Levanta la base de datos y el panel de monitoreo con Docker:
+6. Levanta la base de datos y el panel de monitoreo con Docker:
 
 ```bash
-make up
+./entrypoint.sh
 ```
 
 Esto descargará los contenedores y los dejará listos. Más adelante podrás
@@ -286,7 +286,7 @@ subida. Se compra cuando esa probabilidad supera un umbral.
 
 ## 6. Panel web y API
 
-Con los contenedores levantados (`make up`) puedes acceder a:
+Con los contenedores levantados (`./entrypoint.sh`) puedes acceder a:
 
 * **API y panel**: <http://localhost:8000>
 * **Prometheus**: <http://localhost:9090>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,7 +111,7 @@ El repositorio incluye un `docker-compose.yml` que levanta la API junto con
 TimescaleDB, Prometheus y Grafana para visualización.
 
 ```bash
-docker compose up
+./entrypoint.sh
 ```
 
 Una vez levantados los servicios:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+docker compose up -d timescaledb api prometheus alertmanager grafana


### PR DESCRIPTION
## Summary
- add entrypoint.sh to start TimescaleDB, API, Prometheus, Alertmanager and Grafana
- enforce service start order in docker-compose.yml
- update docs to recommend `./entrypoint.sh` as the only step after cloning

## Testing
- `pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68a796e2fb70832d9b7510f840b0ea03