### PR TITLE
Add comprehensive TradeBot documentation

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,0 +1,52 @@
+# Blueprint de Arquitectura
+
+Este documento describe los componentes principales del bot y cómo se
+comunican. La intención es ofrecer una visión general accesible para
+personas sin experiencia técnica.
+
+## Componentes
+
+### Adaptadores
+Conectores que permiten comunicarse con los intercambios (Binance, Bybit,
+OKX, etc.). Se encuentran en `src/tradingbot/adapters` y se encargan de
+enviar órdenes y recibir información del mercado.
+
+### Ingesta de datos
+Los módulos en `src/tradingbot/data` descargan y almacenan información del
+mercado. El comando [`ingest`](docs/commands.md#ingest) permite recibir
+flujos en vivo y opcionalmente guardarlos en la base de datos.
+
+### Estrategias
+Las reglas de decisión para comprar o vender viven en
+`src/tradingbot/strategies`. Existen estrategias de rompimiento, arbitraje,
+mean reversion y otras. Cada estrategia genera señales que luego se
+transforman en órdenes.
+
+### Ejecución
+El módulo `src/tradingbot/execution` traduce las señales en órdenes reales y
+las envía al intercambio correspondiente mediante un `ExecutionRouter`.
+
+### Gestión de riesgo
+En `src/tradingbot/risk` hay componentes que limitan pérdidas, controlan el
+apalancamiento y aplican otras reglas de seguridad.
+
+### Almacenamiento
+Los datos y las métricas se guardan en TimescaleDB o QuestDB. Las funciones
+se encuentran en `src/tradingbot/storage` y se utilizan tanto para ingestar
+datos como para generar reportes.
+
+### Monitoreo
+La carpeta [`monitoring`](monitoring/) contiene la configuración de Grafana
+y Prometheus. Los dashboards disponibles se describen en
+[docs/dashboards.md](docs/dashboards.md).
+
+## Flujo básico
+
+1. **Ingesta** de datos de mercado.
+2. **Estrategias** generan señales.
+3. **Ejecución** convierte señales en órdenes.
+4. **Gestión de riesgo** supervisa posiciones y límites.
+5. **Monitoreo** muestra el desempeño y el estado del sistema.
+
+Este blueprint sirve como mapa para comprender cómo las piezas encajan entre
+sí dentro de TradeBot.

--- a/MVP.md
+++ b/MVP.md
@@ -1,0 +1,43 @@
+# MVP de TradeBot
+
+El objetivo del MVP es ofrecer un recorrido mínimo para ejecutar una
+estrategia simple con datos reales en modo de prueba.
+
+## Objetivos
+
+1. Descargar y almacenar datos de mercado.
+2. Ejecutar una estrategia en modo "paper" (sin dinero real).
+3. Observar métricas básicas en un dashboard.
+
+## Pasos
+
+### 1. Ingestar datos
+
+```bash
+python -m tradingbot.cli ingest --symbol BTC/USDT --kind trades --persist
+```
+
+Este comando abre un flujo de transacciones del par `BTC/USDT` y lo guarda en
+la base de datos.
+
+### 2. Ejecutar una estrategia en modo paper
+
+```bash
+python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr
+```
+
+El bot aplica la estrategia de rompimiento con ATR sobre el símbolo elegido y
+expone métricas en `http://localhost:8000/metrics`.
+
+### 3. Revisar métricas
+
+Levante el stack de monitoreo:
+
+```bash
+make monitoring-up
+```
+
+Abra Grafana (`http://localhost:3000`) y cargue el dashboard "TradeBot
+Metrics" para ver PnL, latencia y estado de las estrategias.
+
+Con estos pasos se completa el MVP funcional de TradeBot.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# TradeBot
+
+TradeBot es un bot de trading educativo y de código abierto para mercados de
+criptomonedas. El proyecto incluye herramientas para descargar datos,
+realizar backtesting, ejecutar estrategias en modo prueba o con dinero real
+y monitorear el desempeño con tableros de control.
+
+La documentación completa está en la carpeta [`docs`](docs/). Allí se
+explican los conceptos básicos, las estrategias disponibles y todas las
+opciones de la línea de comandos.
+
+## Requisitos mínimos
+
+- Python 3.11
+- Dependencias listadas en `requirements.txt`
+
+## Instalación rápida
+
+```bash
+pip install -e .
+```
+
+## Uso básico
+
+Todos los comandos se ejecutan con `python -m tradingbot.cli` seguido del
+subcomando deseado. Por ejemplo, para ver la ayuda general:
+
+```bash
+python -m tradingbot.cli --help
+```
+
+Para una guía detallada de cada comando, consulte [docs/commands.md](docs/commands.md).
+
+## Recursos
+
+- [Blueprint de arquitectura](BLUEPRINT.md)
+- [MVP: características mínimas](MVP.md)
+- [Glosario de términos](docs/glossary.md)
+- [Estrategias disponibles](docs/strategies.md)
+- [Dashboards de monitoreo](docs/dashboards.md)
+
+## Licencia
+
+Este proyecto se distribuye bajo la licencia MIT.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentación de TradeBot
+
+Esta carpeta contiene material de referencia para entender y usar el bot.
+Si es la primera vez que lo utiliza, comience por revisar el
+[glosario](glossary.md) y luego la [lista de comandos](commands.md).
+
+## Contenido
+
+- [Glosario](glossary.md)
+- [Comandos de la CLI](commands.md)
+- [Estrategias disponibles](strategies.md)
+- [Dashboards de monitoreo](dashboards.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,125 @@
+# Comandos de la CLI
+
+Todos los comandos se ejecutan como:
+
+```bash
+python -m tradingbot.cli <comando> [opciones]
+```
+
+A continuación se describen los comandos disponibles.
+
+## `ingest`
+Recibe datos de mercado en vivo y opcionalmente los almacena.
+- `--venue`: intercambio a utilizar (ej. `binance_spot`).
+- `--symbol`: puede repetirse para varios pares (por defecto `BTC/USDT`).
+- `--depth`: profundidad del libro de órdenes (10).
+- `--kind`: tipo de dato: `trades`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
+- `--persist`: si se indica, guarda los datos en la base de datos.
+
+## `backfill`
+Descarga datos históricos con límites de velocidad.
+- `--days`: número de días hacia atrás (1 por defecto).
+- `--symbols`: lista de símbolos a descargar.
+
+## `ingest-historical`
+Obtiene datos históricos de Kaiko o CoinAPI.
+- `source`: `kaiko` o `coinapi`.
+- `symbol`: par de mercado.
+- `--exchange`: requerido para Kaiko.
+- `--kind`: `trades`, `orderbook`, `open_interest` o `funding`.
+- `--backend`: backend de almacenamiento (por defecto `timescale`).
+- `--limit`: cantidad de registros a traer.
+- `--depth`: profundidad del order book.
+
+## `run-bot`
+Ejecuta el bot en modo en vivo (testnet o real).
+- `--exchange`: nombre del exchange (`binance`).
+- `--market`: `spot` o `futures`.
+- `--symbol`: puede repetirse; símbolo a operar.
+- `--testnet`: usa endpoints de prueba.
+- `--trade-qty`: tamaño de la orden.
+- `--leverage`: apalancamiento para futuros.
+- `--dry-run`: simula órdenes en testnet.
+- `--stop-loss` y `--take-profit`: porcentajes de la estrategia.
+- `--stop-loss-pct` y `--max-drawdown-pct`: límites del gestor de riesgo.
+
+## `paper-run`
+Corre una estrategia en modo paper (sin dinero real) y expone métricas.
+- `--symbol`: par a operar (por defecto `BTC/USDT`).
+- `--strategy`: nombre de la estrategia (`breakout_atr`).
+- `--metrics-port`: puerto para las métricas (8000).
+- `--config`: ruta a un archivo YAML con parámetros opcionales.
+
+## `real-run`
+Ejecuta el bot contra un exchange real.
+- `--exchange`: nombre del exchange.
+- `--market`: `spot` o `futures`.
+- `--symbol`: puede repetirse.
+- `--trade-qty`: tamaño de la orden.
+- `--leverage`: apalancamiento.
+- `--dry-run`: simula órdenes sin enviarlas.
+- `--i-know-what-im-doing`: confirmación necesaria para operar con dinero real.
+
+## `daemon`
+Lanza el demonio principal usando una configuración de Hydra.
+- `config`: ruta al YAML de configuración (por defecto `config/config.yaml`).
+
+## `ingestion-workers`
+Inicia trabajadores de ingesta de funding y open interest definidos en un YAML.
+- `config`: ruta al archivo de configuración.
+- `--backend`: backend de almacenamiento.
+
+## `cfg-validate`
+Valida que un archivo YAML de configuración contenga los campos mínimos
+necesarios para backtesting y walk-forward.
+
+## `backtest`
+Ejecuta un backtest vectorizado desde un archivo CSV.
+- `data`: ruta al CSV.
+- `--symbol`: par a evaluar.
+- `--strategy`: estrategia a utilizar.
+
+## `backtest-cfg`
+Ejecuta un backtest basado en un archivo de configuración Hydra.
+- `config`: archivo YAML con los parámetros.
+
+## `backtest-db`
+Realiza un backtest usando datos almacenados en la base de datos.
+- `--exchange`: nombre del exchange.
+- `--symbol`: par a evaluar.
+- `--strategy`: estrategia.
+- `--start` y `--end`: rango de fechas (YYYY-MM-DD).
+- `--timeframe`: periodo de las velas (`1m`).
+
+## `walk-forward`
+Optimiza una estrategia con técnica walk-forward usando una configuración
+Hydra.
+- `config`: archivo YAML con datos, estrategia y grilla de parámetros.
+
+## `report`
+Muestra un resumen de PnL desde TimescaleDB.
+- `--venue`: nombre del venue (por defecto `binance_spot_testnet`).
+
+## `train-ml`
+Entrena un modelo basado en `MLStrategy` y lo guarda en disco.
+- `data`: CSV con los datos de entrenamiento.
+- `target`: columna objetivo.
+- `output`: archivo donde se almacenará el modelo.
+
+## `tri-arb`
+Ejecuta un arbitraje triangular simple en Binance.
+- `route`: cadena `BASE-MID-QUOTE` que define los tres pares.
+- `--notional`: monto a utilizar en la divisa de salida.
+
+## `cross-arb`
+Arbitraje entre un mercado spot y uno de futuros.
+- `symbol`: par a arbitrar.
+- `spot`: nombre del adaptador spot.
+- `perp`: nombre del adaptador de futuros.
+- `--threshold`: diferencia mínima de precio para actuar.
+- `--notional`: monto por pata.
+
+## `run-cross-arb`
+Versión que utiliza el `ExecutionRouter` para arbitraje spot/perp.
+Acepta los mismos parámetros que `cross-arb`.
+

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,29 @@
+# Dashboards de Monitoreo
+
+TradeBot incluye paneles de Grafana para visualizar el estado del bot y los
+resultados de las operaciones. Los archivos de cada dashboard se encuentran
+en `monitoring/grafana/dashboards`.
+
+## Core Metrics (`core.json`)
+Muestra métricas básicas del proceso:
+- **Trading PnL**: resultado acumulado.
+- **E2E latency (95th)**: latencia extremo a extremo del sistema.
+- **WS failures**: cantidad de fallos en conexiones WebSocket.
+- **Kill switch active**: indicador del interruptor de emergencia.
+- **CPU Usage** y **Memory Usage**: consumo de recursos.
+- **Process Uptime**: tiempo que lleva corriendo el bot.
+
+## PnL & Positions (`pnl_positions.json`)
+Enfocado en resultados y exposición:
+- **Trading PnL**.
+- **Kill switch active**.
+- **Open Positions**: gráfico de posiciones abiertas por símbolo.
+
+## TradeBot Metrics (`tradebot.json`)
+Vista general del desempeño del bot:
+- **API latency (95th)**.
+- **WS failures** por adaptador.
+- **Order fills**: órdenes ejecutadas.
+- **Risk events (5m)**: eventos de riesgo recientes.
+- **E2E latency (95th)**.
+- **Strategy states**: estado reportado por cada estrategia.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,33 @@
+# Glosario
+
+Este glosario explica los términos más comunes utilizados en el proyecto.
+
+### Backfill
+Proceso de descargar datos históricos para llenar vacíos en la base de
+datos. Se realiza con el comando `backfill`.
+
+### Leverage (Apalancamiento)
+Multiplica la exposición de una posición sin necesidad de tener todo el
+capital. Un apalancamiento de 2x permite operar el doble del saldo propio.
+
+### Ingesta
+Acción de recibir datos del mercado en tiempo real y, opcionalmente,
+guardarlos para su posterior análisis.
+
+### PnL
+Ganancia o pérdida neta de una operación o conjunto de operaciones.
+
+### Estrategia
+Conjunto de reglas que determinan cuándo comprar o vender.
+
+### Backtesting
+Simulación de una estrategia usando datos históricos para evaluar su
+rendimiento.
+
+### Walk-forward
+Técnica que repite entrenamientos y pruebas en ventanas de tiempo
+sucesivas para estimar cómo se comportaría una estrategia en el futuro.
+
+### Dashboard
+Tablero de control donde se visualizan métricas de funcionamiento y
+resultados del bot.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,55 @@
+# Estrategias Disponibles
+
+Las estrategias definen cómo se toman decisiones de compra o venta. A
+continuación se presenta un resumen en lenguaje sencillo.
+
+### Breakout con ATR (`breakout_atr`)
+Compra cuando el precio supera el canal superior calculado con el indicador
+ATR y vende cuando cae por debajo del canal inferior.
+
+### Breakout por Volumen (`breakout_vol`)
+Detecta rupturas de precio acompañadas de incrementos de volumen.
+
+### Momentum
+Sigue la tendencia actual: compra si el precio sube de forma sostenida y
+vende cuando la tendencia se revierte.
+
+### Mean Reversion (`mean_reversion`)
+Asume que los precios tienden a volver a un promedio. Compra cuando el
+precio cae por debajo del promedio y vende cuando lo supera.
+
+### Mean Reversion con OFI (`mean_rev_ofi`)
+Variación de mean reversion que utiliza el desequilibrio de flujo de órdenes
+(Order Flow Imbalance) para estimar el regreso al promedio.
+
+### Depth Imbalance (`depth_imbalance`)
+Evalúa el desequilibrio entre órdenes de compra y venta en el libro de
+órdenes para anticipar movimientos.
+
+### Liquidity Events (`liquidity_events`)
+Busca momentos donde la liquidez cambia rápidamente, lo que puede generar
+oportunidades de corto plazo.
+
+### Order Flow (`order_flow`)
+Analiza el flujo de órdenes que llegan al mercado para detectar presiones de
+compra o venta.
+
+### Triple Barrier (`triple_barrier`)
+Define tres barreras (objetivo, stop loss y tiempo) y cierra la posición
+según cuál se alcance primero.
+
+### Cash and Carry (`cash_and_carry`)
+Aprovecha diferencias de precio entre el mercado spot y los futuros para
+capturar rendimientos sin exposición direccional.
+
+### Arbitraje (`arbitrage`)
+Busca beneficios cuando un mismo activo tiene precios distintos en dos
+mercados.
+
+### Arbitraje Triangular (`arbitrage_triangular`)
+Opera tres pares de divisas al mismo tiempo para explotar desequilibrios en
+las tasas de cambio.
+
+### Arbitraje entre Exchanges (`cross_exchange_arbitrage`)
+Compara el precio entre un mercado spot y uno de futuros (perpetuo) y opera
+cuando la diferencia supera un umbral.


### PR DESCRIPTION
## Summary
- Add top-level README, architecture blueprint and MVP guide
- Introduce `docs/` with glossary, CLI command reference, strategies overview and dashboard guide

## Testing
- `pytest tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79cb87d68832dbce9a1d6a672afd9