### PR TITLE
feat: support explicit backfill ranges

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,6 +20,8 @@ Recibe datos de mercado en vivo y opcionalmente los almacena.
 Descarga datos históricos con límites de velocidad.
 - `--days`: número de días hacia atrás (1 por defecto).
 - `--symbols`: lista de símbolos a descargar.
+- `--start`: fecha inicial en formato ISO.
+- `--end`: fecha final en formato ISO.
 
 ## `ingest-historical`
 Obtiene datos históricos de Kaiko o CoinAPI.

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -27,3 +27,14 @@ Vista general del desempeño del bot:
 - **Risk events (5m)**: eventos de riesgo recientes.
 - **E2E latency (95th)**.
 - **Strategy states**: estado reportado por cada estrategia.
+
+## Carga de datos históricos
+Para completar los paneles con datos antiguos se puede usar el comando
+`backfill` indicando un rango explícito:
+
+```bash
+python -m tradingbot.cli backfill --symbols BTC/USDT \
+    --start 2023-01-01T00:00:00Z --end 2023-01-02T00:00:00Z
+```
+
+Las opciones `--start` y `--end` aceptan fechas en formato ISO.


### PR DESCRIPTION
## Summary
- allow backfill to accept explicit start/end datetimes
- expose new --start/--end options in the CLI and docs
- test overlapping backfill range to avoid duplicates

## Testing
- `PG_TEST=1 pytest tests/test_backfill_persistence.py -q` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68a7b4d026e4832d9a0f1e67e9429c28