### PR TITLE
feat(dashboards): add filtering variables

### DIFF
--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -4,6 +4,18 @@ TradeBot incluye paneles de Grafana para visualizar el estado del bot y los
 resultados de las operaciones. Los archivos de cada dashboard se encuentran
 en `monitoring/grafana/dashboards`.
 
+## Variables de consulta
+Para los paneles que acceden a datos de mercado desde PostgreSQL se añadieron
+variables que permiten filtrar las consultas:
+
+- **$symbol**: símbolo o par de trading a visualizar.
+- **$start**: timestamp inicial del rango a consultar.
+- **$end**: timestamp final del rango.
+
+Estas variables pueden emplearse en las cláusulas `WHERE` de las consultas a
+`market.bars` o `market.trades` para limitar los resultados por símbolo y
+periodo.
+
 ## Core Metrics (`core.json`)
 Muestra métricas básicas del proceso:
 - **Trading PnL**: resultado acumulado.

--- a/monitoring/grafana/dashboards/core.json
+++ b/monitoring/grafana/dashboards/core.json
@@ -6,7 +6,7 @@
   "title": "Core Metrics",
   "uid": "core",
   "schemaVersion": 16,
-  "version": 1,
+  "version": 2,
   "panels": [
     {
       "type": "stat",
@@ -99,5 +99,41 @@
       "id": 7,
       "gridPos": {"x": 16, "y": 16, "w": 8, "h": 8}
     }
-  ]
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "symbol",
+        "label": "Symbol",
+        "type": "query",
+        "datasource": "Postgres",
+        "refresh": 1,
+        "query": "SELECT DISTINCT symbol FROM market.trades ORDER BY 1",
+        "current": {
+          "text": "BTCUSD",
+          "value": "BTCUSD"
+        }
+      },
+      {
+        "name": "start",
+        "label": "Start time",
+        "type": "textbox",
+        "query": "now() - interval '1 hour'",
+        "current": {
+          "text": "now() - interval '1 hour'",
+          "value": "now() - interval '1 hour'"
+        }
+      },
+      {
+        "name": "end",
+        "label": "End time",
+        "type": "textbox",
+        "query": "now()",
+        "current": {
+          "text": "now()",
+          "value": "now()"
+        }
+      }
+    ]
+  }
 }

--- a/monitoring/grafana/dashboards/pnl_positions.json
+++ b/monitoring/grafana/dashboards/pnl_positions.json
@@ -4,7 +4,7 @@
   "title": "PnL & Positions",
   "uid": "pnlpos",
   "schemaVersion": 16,
-  "version": 1,
+  "version": 2,
   "panels": [
     {
       "type": "stat",
@@ -36,5 +36,41 @@
       "id": 3,
       "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8}
     }
-  ]
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "symbol",
+        "label": "Symbol",
+        "type": "query",
+        "datasource": "Postgres",
+        "refresh": 1,
+        "query": "SELECT DISTINCT symbol FROM market.trades ORDER BY 1",
+        "current": {
+          "text": "BTCUSD",
+          "value": "BTCUSD"
+        }
+      },
+      {
+        "name": "start",
+        "label": "Start time",
+        "type": "textbox",
+        "query": "now() - interval '1 hour'",
+        "current": {
+          "text": "now() - interval '1 hour'",
+          "value": "now() - interval '1 hour'"
+        }
+      },
+      {
+        "name": "end",
+        "label": "End time",
+        "type": "textbox",
+        "query": "now()",
+        "current": {
+          "text": "now()",
+          "value": "now()"
+        }
+      }
+    ]
+  }
 }

--- a/monitoring/grafana/dashboards/tradebot.json
+++ b/monitoring/grafana/dashboards/tradebot.json
@@ -123,10 +123,59 @@
       ],
       "datasource": "Prometheus",
       "id": 10
+    },
+    {
+      "type": "graph",
+      "title": "Trades per minute",
+      "datasource": "Postgres",
+      "targets": [
+        {
+          "refId": "A",
+          "format": "time_series",
+          "rawSql": "SELECT time_bucket('1 minute', ts) AS time, count(*) AS trades FROM market.trades WHERE symbol = '$symbol' AND ts BETWEEN '$start' AND '$end' GROUP BY time ORDER BY time"
+        }
+      ],
+      "id": 11
     }
   ],
+  "templating": {
+    "list": [
+      {
+        "name": "symbol",
+        "label": "Symbol",
+        "type": "query",
+        "datasource": "Postgres",
+        "refresh": 1,
+        "query": "SELECT DISTINCT symbol FROM market.trades ORDER BY 1",
+        "current": {
+          "text": "BTCUSD",
+          "value": "BTCUSD"
+        }
+      },
+      {
+        "name": "start",
+        "label": "Start time",
+        "type": "textbox",
+        "query": "now() - interval '1 hour'",
+        "current": {
+          "text": "now() - interval '1 hour'",
+          "value": "now() - interval '1 hour'"
+        }
+      },
+      {
+        "name": "end",
+        "label": "End time",
+        "type": "textbox",
+        "query": "now()",
+        "current": {
+          "text": "now()",
+          "value": "now()"
+        }
+      }
+    ]
+  },
   "schemaVersion": 16,
   "title": "TradeBot Metrics",
   "uid": "tradebot",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
## Summary
- add $symbol, $start and $end templating variables to Grafana dashboards
- query market.trades with the new variables for trade metrics
- document dashboard variables and usage

## Testing
- `pytest` *(killed: killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b4d323a8832dbc20cddb1a3e20ec