### PR TITLE
feat: add backend option to ingest CLI

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,7 @@ Recibe datos de mercado en vivo y opcionalmente los almacena.
 - `--depth`: profundidad del libro de órdenes (10).
 - `--kind`: tipo de dato: `trades`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
 - `--persist`: si se indica, guarda los datos en la base de datos.
+- `--backend`: backend de almacenamiento (`timescale` o `csv`).
 
 ## `backfill`
 Descarga datos históricos con límites de velocidad.

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -157,13 +157,15 @@ function updateFields(){
   const hk=document.getElementById('dm-hkind').value;
   document.getElementById('field-hdepth').style.display=hist && hk==='orderbook'?'':'none';
   document.getElementById('field-hlimit').style.display=hist && hk==='trades'?'':'none';
-  document.getElementById('field-backend').style.display=hist?'':'none';
+  const persist=document.getElementById('dm-persist').checked;
+  document.getElementById('field-backend').style.display=(hist || (act==='ingest' && persist))?'':'none';
 }
 
 document.getElementById('dm-source').addEventListener('change',updateFields);
 document.getElementById('dm-hkind').addEventListener('change',updateFields);
 document.getElementById('dm-start').addEventListener('change',updateFields);
 document.getElementById('dm-end').addEventListener('change',updateFields);
+document.getElementById('dm-persist').addEventListener('change',updateFields);
 
 async function runData(){
   if(evt){evt.close();evt=null;}
@@ -179,7 +181,8 @@ async function runData(){
     const depth=document.getElementById('dm-depth').value;
     const kind=document.getElementById('dm-kind').value;
     const persist=document.getElementById('dm-persist').checked;
-    cmd=`ingest --venue ${venue} ${symbols.map(s=>`--symbol ${s}`).join(' ')} --depth ${depth} --kind ${kind}`+(persist?' --persist':'');
+    const backend=document.getElementById('dm-backend').value;
+    cmd=`ingest --venue ${venue} ${symbols.map(s=>`--symbol ${s}`).join(' ')} --depth ${depth} --kind ${kind} --backend ${backend}`+(persist?' --persist':'');
   }else if(act==='backfill'){
     const start=document.getElementById('dm-start').value;
     const end=document.getElementById('dm-end').value;


### PR DESCRIPTION
## Summary
- allow choosing storage backend via `--backend` flag in `ingest`
- document new backend flag
- surface backend selection in data UI and CLI command builder

## Testing
- `pytest tests/test_data_ingestion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7dc4cd78c832daf1958ee1096ec59