### PR TITLE
feat: sync UI venue options with CLI adapters

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -42,9 +42,13 @@
       <div id="field-venue">
         <label for="dm-venue">Venue</label>
         <select id="dm-venue">
+          <option value="binance_futures_usdm_testnet">Binance Futures USDM Testnet</option>
           <option value="binance_spot">Binance Spot</option>
-          <option value="binance_futures_um">Binance Futuros</option>
+          <option value="bybit_futures">Bybit Futures</option>
           <option value="bybit_spot">Bybit Spot</option>
+          <option value="deribit">Deribit</option>
+          <option value="deribit_ws">Deribit WS</option>
+          <option value="okx_futures">OKX Futures</option>
           <option value="okx_spot">OKX Spot</option>
         </select>
       </div>

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -67,9 +67,13 @@
       <div>
         <label for="cfg-exchange">Exchange</label>
         <select id="cfg-exchange">
+          <option value="binance_futures_usdm_testnet">Binance Futures USDM Testnet</option>
           <option value="binance_spot">Binance Spot</option>
-          <option value="binance_futures_um">Binance Futuros</option>
+          <option value="bybit_futures">Bybit Futures</option>
           <option value="bybit_spot">Bybit Spot</option>
+          <option value="deribit">Deribit</option>
+          <option value="deribit_ws">Deribit WS</option>
+          <option value="okx_futures">OKX Futures</option>
           <option value="okx_spot">OKX Spot</option>
         </select>
       </div>


### PR DESCRIPTION
## Summary
- update data management and credentials pages to list all available venues from the CLI
- ensure UI venues match tradingbot.cli.main._get_available_venues

## Testing
- `pytest tests/test_smoke.py -q`
- `PYTHONPATH=src python -m tradingbot.cli.main ingest --help`
- `PYTHONPATH=src timeout 5s python -m tradingbot.cli.main ingest --venue binance_spot --symbol BTC/USDT --depth 1 --kind trades --backend csv`


------
https://chatgpt.com/codex/tasks/task_e_68a7e0f74560832dbb46ff496ce9fc30