### PR TITLE
Verify adapter open interest capability

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -181,6 +181,9 @@ def ingest(
 
                 tasks.append(asyncio.create_task(_f(sym)))
             elif kind in ("oi", "open_interest"):
+                if not hasattr(adapter, "stream_open_interest"):
+                    raise typer.BadParameter("adapter does not support open_interest")
+
                 async def _oi(symbol: str) -> None:
                     async for d in adapter.stream_open_interest(symbol):
                         typer.echo(str(d))


### PR DESCRIPTION
## Summary
- prevent open-interest ingestion when adapter lacks `stream_open_interest`

## Testing
- `pytest` *(killed: container ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e0fb5a18832daf8a7f86b407bb6f