### PR TITLE
Resolve CLI venues to adapter classes directly

### DIFF
--- a/tests/test_cli_venues.py
+++ b/tests/test_cli_venues.py
@@ -1,0 +1,9 @@
+import pytest
+
+from tradingbot.cli import main
+
+
+def test_cli_venues_resolve_classes():
+    for venue in main._AVAILABLE_VENUES:
+        cls = main._get_adapter_cls(venue)
+        assert getattr(cls, "name") == venue


### PR DESCRIPTION
## Summary
- map venue names to adapter classes instead of deriving class names
- use mapping in CLI ingest command
- test that each CLI venue resolves to its adapter class

## Testing
- `pytest tests/test_cli_venues.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e8d33c58832d96547ba6677aed2b