### PR TITLE
Use explicit adapter mapping and add venue loading tests

### DIFF
--- a/tests/test_cli_venues.py
+++ b/tests/test_cli_venues.py
@@ -1,0 +1,18 @@
+import inspect
+
+import pytest
+
+from tradingbot.adapters.base import ExchangeAdapter
+from tradingbot.cli.main import _AVAILABLE_VENUES, get_adapter_class
+
+
+@pytest.mark.parametrize("venue", sorted(_AVAILABLE_VENUES))
+def test_each_venue_loads_class(venue):
+    cls = get_adapter_class(venue)
+    assert cls is not None
+    sig = inspect.signature(cls)
+    kwargs = {}
+    if "testnet" in sig.parameters:
+        kwargs["testnet"] = True
+    adapter = cls(**kwargs)
+    assert isinstance(adapter, ExchangeAdapter)


### PR DESCRIPTION
## Summary
- Map venue names to adapter classes in `cli.main` instead of deriving names by capitalization
- Use the mapping for CLI adapter lookups, including ingestion workers
- Test that every listed venue resolves to its adapter class without errors

## Testing
- `pytest tests/test_cli_venues.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ebc3cdb0832da17ddc79845a46cc