### PR TITLE
feat: expose adapter stream capabilities

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -23,6 +23,7 @@ from monitoring.dashboard import router as dashboard_router
 from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
+from ...cli.main import get_adapter_class, get_supported_kinds
 
 # Persistencia
 try:
@@ -78,6 +79,16 @@ async def _metrics_middleware(request: Request, call_next):
 @app.get("/health")
 def health():
     return {"status": "ok", "db": bool(_CAN_PG)}
+
+
+@app.get("/venues/{name}/kinds")
+def venue_kinds(name: str):
+    """Return available streaming kinds for the given venue."""
+
+    cls = get_adapter_class(name)
+    if cls is None:
+        raise HTTPException(status_code=404, detail="venue not found")
+    return {"kinds": get_supported_kinds(cls)}
 
 @app.get("/logs")
 def logs(lines: int = Query(200, ge=1, le=1000)):

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -271,11 +271,31 @@ async function runCli(){
   }
 }
 
+async function loadKinds(){
+  const venue=document.getElementById('dm-venue').value;
+  try{
+    const r=await fetch(api(`/venues/${venue}/kinds`));
+    const data=await r.json();
+    const sel=document.getElementById('dm-kind');
+    sel.innerHTML='';
+    for(const k of data.kinds){
+      const opt=document.createElement('option');
+      opt.value=k;
+      opt.textContent=k;
+      sel.appendChild(opt);
+    }
+  }catch(e){
+    console.error(e);
+  }
+}
+
 document.getElementById('dm-action').addEventListener('change',updateFields);
 document.getElementById('dm-run').addEventListener('click',runData);
 document.getElementById('dm-stop').addEventListener('click',stopData);
 document.getElementById('cli-run').addEventListener('click',runCli);
+document.getElementById('dm-venue').addEventListener('change',loadKinds);
 updateFields();
+loadKinds();
 </script>
 </body>
 </html>

--- a/tests/test_api_venue_kinds.py
+++ b/tests/test_api_venue_kinds.py
@@ -1,0 +1,24 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def get_app():
+    import tradingbot.apps.api.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_venue_kinds_endpoint(monkeypatch):
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+    app = get_app()
+    client = TestClient(app)
+
+    resp = client.get("/venues/binance_spot/kinds", auth=("u", "p"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "trades" in data["kinds"]
+
+    resp = client.get("/venues/unknown/kinds", auth=("u", "p"))
+    assert resp.status_code == 404

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -1,0 +1,14 @@
+import pytest
+
+from tradingbot.cli.main import get_adapter_class, get_supported_kinds
+
+
+def test_get_supported_kinds_binance_spot():
+    cls = get_adapter_class("binance_spot")
+    assert cls is not None
+    kinds = get_supported_kinds(cls)
+    # basic kinds available on most venues
+    assert "trades" in kinds
+    assert "orderbook" in kinds
+    # binance spot does not expose open interest
+    assert "open_interest" not in kinds


### PR DESCRIPTION
## Summary
- add helper to list stream_* methods for adapters
- expose supported kinds via `/venues/{name}/kinds` API
- dynamically populate kind options in data.html UI
- validate ingest kind against adapter capabilities

## Testing
- `pytest tests/test_cli_supported_kinds.py tests/test_api_venue_kinds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1bd09f0832db70c4e3ae4b54787