### PR TITLE
Downgrade scope validation log to debug

### DIFF
--- a/src/tradingbot/utils/secrets.py
+++ b/src/tradingbot/utils/secrets.py
@@ -69,7 +69,7 @@ def validate_scopes(
     try:
         has_perm = getattr(exchange, "has", {}).get("fetchPermissions")
         if not has_perm:
-            log.warning("exchange %s no soporta fetch_permissions", getattr(exchange, "id", ""))
+            log.debug("fetch_permissions no soportado para %s", getattr(exchange, "id", ""))
             return
         perms = exchange.fetch_permissions()
     except Exception as e:  # pragma: no cover - depende del exchange


### PR DESCRIPTION
## Summary
- Lower log level when exchange lacks fetch_permissions support to avoid warnings

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f279cc98832d8a8f04fd3b644ff9