### PR TITLE
Toggle depth field based on selected data kind

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -141,11 +141,14 @@
 const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
 let evt=null;
+const kindsWithDepth=["orderbook","delta"];
 
 function updateFields(){
   const act=document.getElementById('dm-action').value;
+  const kind=document.getElementById('dm-kind').value;
+  const showDepth=act==='ingest' && kindsWithDepth.includes(kind);
   document.getElementById('field-venue').style.display=act==='ingest'?'':'none';
-  document.getElementById('field-depth').style.display=act==='ingest'?'':'none';
+  document.getElementById('field-depth').style.display=showDepth?'':'none';
   document.getElementById('field-kind').style.display=act==='ingest'?'':'none';
   document.getElementById('field-persist').style.display=act==='ingest'?'':'none';
   const start=document.getElementById('dm-start').value;
@@ -170,6 +173,7 @@ document.getElementById('dm-hkind').addEventListener('change',updateFields);
 document.getElementById('dm-start').addEventListener('change',updateFields);
 document.getElementById('dm-end').addEventListener('change',updateFields);
 document.getElementById('dm-persist').addEventListener('change',updateFields);
+document.getElementById('dm-kind').addEventListener('change',updateFields);
 
 async function runData(){
   if(evt){evt.close();evt=null;}
@@ -284,6 +288,7 @@ async function loadKinds(){
       opt.textContent=k;
       sel.appendChild(opt);
     }
+    updateFields();
   }catch(e){
     console.error(e);
   }


### PR DESCRIPTION
## Summary
- Only show depth input for orderbook or delta kinds
- Refresh depth visibility when kind or venue changes

## Testing
- ⚠️ `pytest -q` (killed: container limit)
- ✅ `pytest tests/test_api_venue_kinds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f7b62d1c832da029d0116f159aff