### PR TITLE
feat(cli): add websocket venue adapters

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,12 +10,26 @@ A continuación se describen los comandos disponibles.
 
 ## `ingest`
 Recibe datos de mercado en vivo y opcionalmente los almacena.
-- `--venue`: intercambio a utilizar (ej. `binance_spot`).
+- `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_ws`, `okx_ws`).
 - `--symbol`: puede repetirse para varios pares (por defecto `BTC/USDT`).
 - `--depth`: profundidad del libro de órdenes (10).
 - `--kind`: tipo de dato: `trades`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
 - `--persist`: si se indica, guarda los datos en la base de datos.
 - `--backend`: backend de almacenamiento (`timescale` o `csv`).
+
+Ejemplos:
+
+```bash
+# Funding rate en Binance Futures
+python -m tradingbot.cli ingest --venue binance_futures_ws --symbol BTC/USDT --kind funding
+
+# Open interest en Bybit
+python -m tradingbot.cli ingest --venue bybit_ws --symbol BTC/USDT --kind open_interest
+
+# Funding y open interest en OKX
+python -m tradingbot.cli ingest --venue okx_ws --symbol BTC/USDT --kind funding
+python -m tradingbot.cli ingest --venue okx_ws --symbol BTC/USDT --kind open_interest
+```
 
 ## `backfill`
 Descarga datos históricos con límites de velocidad.

--- a/src/tradingbot/adapters/__init__.py
+++ b/src/tradingbot/adapters/__init__.py
@@ -3,10 +3,14 @@
 from .base import ExchangeAdapter
 from .binance_spot import BinanceSpotAdapter
 from .binance_futures import BinanceFuturesAdapter
+from .binance_spot_ws import BinanceSpotWSAdapter
+from .binance_futures_ws import BinanceFuturesWSAdapter
 from .bybit_spot import BybitSpotAdapter
 from .bybit_futures import BybitFuturesAdapter
+from .bybit_ws import BybitWSAdapter
 from .okx_spot import OKXSpotAdapter
 from .okx_futures import OKXFuturesAdapter
+from .okx_ws import OKXWSAdapter
 from .deribit import DeribitAdapter
 from .deribit_ws import DeribitWSAdapter
 
@@ -14,10 +18,14 @@ __all__ = [
     "ExchangeAdapter",
     "BinanceSpotAdapter",
     "BinanceFuturesAdapter",
+    "BinanceSpotWSAdapter",
+    "BinanceFuturesWSAdapter",
     "BybitSpotAdapter",
     "BybitFuturesAdapter",
+    "BybitWSAdapter",
     "OKXSpotAdapter",
     "OKXFuturesAdapter",
+    "OKXWSAdapter",
     "DeribitAdapter",
     "DeribitWSAdapter",
 ]

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -34,12 +34,16 @@ from .. import adapters
 from ..adapters import (
     BinanceFuturesAdapter,
     BinanceSpotAdapter,
+    BinanceFuturesWSAdapter,
+    BinanceSpotWSAdapter,
     BybitFuturesAdapter,
     BybitSpotAdapter,
+    BybitWSAdapter,
     DeribitAdapter,
     DeribitWSAdapter,
     OKXFuturesAdapter,
     OKXSpotAdapter,
+    OKXWSAdapter,
 )
 from ..logging_conf import setup_logging
 from tradingbot.analysis.backtest_report import generate_report
@@ -70,10 +74,14 @@ app = typer.Typer(add_completion=False, help="Utilities for running TradingBot")
 _ADAPTER_CLASS_MAP: dict[str, type[adapters.ExchangeAdapter]] = {
     "binance_spot": BinanceSpotAdapter,
     "binance_futures": BinanceFuturesAdapter,
+    "binance_spot_ws": BinanceSpotWSAdapter,
+    "binance_futures_ws": BinanceFuturesWSAdapter,
     "bybit_spot": BybitSpotAdapter,
     "bybit_futures": BybitFuturesAdapter,
+    "bybit_ws": BybitWSAdapter,
     "okx_spot": OKXSpotAdapter,
     "okx_futures": OKXFuturesAdapter,
+    "okx_ws": OKXWSAdapter,
     "deribit": DeribitAdapter,
     "deribit_ws": DeribitWSAdapter,
 }

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -12,3 +12,27 @@ def test_get_supported_kinds_binance_spot():
     assert "orderbook" in kinds
     # binance spot does not expose open interest
     assert "open_interest" not in kinds
+
+
+def test_get_supported_kinds_binance_futures_ws():
+    cls = get_adapter_class("binance_futures_ws")
+    assert cls is not None
+    kinds = get_supported_kinds(cls)
+    assert "funding" in kinds
+    assert "open_interest" in kinds
+
+
+def test_get_supported_kinds_bybit_ws():
+    cls = get_adapter_class("bybit_ws")
+    assert cls is not None
+    kinds = get_supported_kinds(cls)
+    assert "funding" in kinds
+    assert "open_interest" in kinds
+
+
+def test_get_supported_kinds_okx_ws():
+    cls = get_adapter_class("okx_ws")
+    assert cls is not None
+    kinds = get_supported_kinds(cls)
+    assert "funding" in kinds
+    assert "open_interest" in kinds


### PR DESCRIPTION
## Summary
- register websocket adapters for Binance, Bybit and OKX in CLI
- document new websocket venue names with funding/open interest examples
- test supported stream kinds for new websocket adapters

## Testing
- `pytest tests/test_cli_supported_kinds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8035cd548832d806dc82d098ad45c