### PR TITLE
Add additional market data streams to adapters

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -31,3 +31,19 @@ sucesivas para estimar cómo se comportaría una estrategia en el futuro.
 ### Dashboard
 Tablero de control donde se visualizan métricas de funcionamiento y
 resultados del bot.
+
+### Best Bid/Ask (BBA)
+La mejor oferta de compra y venta disponible en el libro de órdenes. Se usa
+para conocer rápidamente el spread vigente.
+
+### Book Delta
+Actualización incremental del libro de órdenes que sólo incluye los niveles
+que cambiaron respecto a la instantánea previa.
+
+### Funding Rate
+Interés periódico que pagan o cobran las posiciones en swaps perpetuos para
+mantener el precio del contrato cercano al spot.
+
+### Open Interest (OI)
+Cantidad total de contratos abiertos en un mercado de derivados. Sirve como
+indicador del interés y liquidez en ese instrumento.

--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -235,6 +235,57 @@ class BinanceFuturesAdapter(ExchangeAdapter):
             yield self.normalize_order_book(symbol, ts, bids, asks)
             await asyncio.sleep(1)
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental order book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)
         method = getattr(self.rest, "fetchFundingRate", None)

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -217,6 +217,57 @@ class BinanceSpotAdapter(ExchangeAdapter):
             yield self.normalize_order_book(symbol, ts, bids, asks)
             await asyncio.sleep(1)
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental order book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
     async def fetch_funding(self, symbol: str):
         """Return current funding rate for ``symbol``.
 

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -91,6 +91,57 @@ class BybitFuturesAdapter(ExchangeAdapter):
     # Backwards compatible alias
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental order book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)
         method = getattr(self.rest, "fetchFundingRate", None)

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -1,6 +1,7 @@
 # src/tradingbot/adapters/bybit_spot.py
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -62,6 +63,57 @@ class BybitSpotAdapter(ExchangeAdapter):
             yield self.normalize_order_book(symbol, ts, bids, asks)
 
     stream_orderbook = stream_order_book
+
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates for ``symbol`` via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates for ``symbol`` via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -58,6 +58,28 @@ class DeribitAdapter(ExchangeAdapter):
                 yield self.normalize_trade(symbol, ts, price, qty, side)
             await asyncio.sleep(1)
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
+        raise NotImplementedError("BBA stream not supported")
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:  # pragma: no cover - not supported
+        raise NotImplementedError("Order book delta stream not supported")
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)
         method = (

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -1,6 +1,7 @@
 # src/tradingbot/adapters/okx_futures.py
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -88,6 +89,57 @@ class OKXFuturesAdapter(ExchangeAdapter):
                 yield self.normalize_order_book(symbol, ts, bids, asks)
 
     stream_orderbook = stream_order_book
+
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental order book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -64,6 +64,57 @@ class OKXSpotAdapter(ExchangeAdapter):
 
     stream_orderbook = stream_order_book
 
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Emit best bid/ask quotes for ``symbol``."""
+
+        async for ob in self.stream_order_book(symbol):
+            bid = ob.get("bid_px", [None])[0]
+            ask = ob.get("ask_px", [None])[0]
+            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+
+    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+        """Yield incremental order book updates for ``symbol``."""
+
+        prev: dict | None = None
+        async for ob in self.stream_order_book(symbol):
+            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
+            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
+            if prev is None:
+                delta_bids = curr_bids
+                delta_asks = curr_asks
+            else:
+                pb = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
+                pa = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
+                delta_bids = [[p, q] for p, q in curr_bids if pb.get(p) != q]
+                delta_bids += [[p, 0.0] for p in pb.keys() - {p for p, _ in curr_bids}]
+                delta_asks = [[p, q] for p, q in curr_asks if pa.get(p) != q]
+                delta_asks += [[p, 0.0] for p in pa.keys() - {p for p, _ in curr_asks}]
+            prev = ob
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": [p for p, _ in delta_bids],
+                "bid_qty": [q for _, q in delta_bids],
+                "ask_px": [p for p, _ in delta_asks],
+                "ask_qty": [q for _, q in delta_asks],
+            }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll funding rate updates via REST."""
+
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        """Poll open interest updates via REST."""
+
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
     async def fetch_funding(self, symbol: str):
         sym = normalize(symbol)
         method = getattr(self.rest, "fetchFundingRate", None)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -182,6 +182,18 @@ async def test_binance_spot_rest_streams():
     assert book["bid_px"][0] == 1.0
     assert book["bid_qty"][0] == 2.0
 
+    gen3 = adapter.stream_bba("BTC/USDT")
+    bba = await gen3.__anext__()
+    await gen3.aclose()
+    assert bba["bid"] == 1.0
+    assert bba["ask"] == 3.0
+
+    gen4 = adapter.stream_book_delta("BTC/USDT")
+    delta = await gen4.__anext__()
+    await gen4.aclose()
+    assert delta["bid_px"][0] == 1.0
+    assert delta["ask_px"][0] == 3.0
+
 
 @pytest.mark.asyncio
 async def test_binance_futures_rest_fetch():
@@ -197,6 +209,16 @@ async def test_binance_futures_rest_fetch():
     assert isinstance(basis["ts"], datetime)
     assert oi["oi"] == 100.0
     assert oi["ts"] == datetime.fromtimestamp(1, tz=timezone.utc)
+
+    sf_gen = adapter.stream_funding("BTC/USDT")
+    sf = await sf_gen.__anext__()
+    await sf_gen.aclose()
+    assert sf["rate"] == 0.01
+
+    oi_gen = adapter.stream_open_interest("BTC/USDT")
+    soi = await oi_gen.__anext__()
+    await oi_gen.aclose()
+    assert soi["oi"] == 100.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend REST/WebSocket adapters with stream_bba, stream_book_delta, stream_funding and stream_open_interest where supported
- document BBA, book deltas, funding rate and open interest in glossary
- cover new streams in adapter tests

## Testing
- `pytest tests/test_adapters.py::test_binance_spot_rest_streams tests/test_adapters.py::test_binance_futures_rest_fetch -q`


------
https://chatgpt.com/codex/tasks/task_e_68a803660a14832da95617c145f9a811