### PR TITLE
Replace interval_sec with index price in Binance futures funding stream

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -151,11 +151,12 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
                 continue
             ts_ms = d.get("E") or d.get("T") or 0
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            index_px = float(d.get("i") or 0.0)
             yield {
                 "symbol": symbol,
                 "ts": ts,
                 "rate": float(rate),
-                "interval_sec": int(d.get("i") or 0),
+                "index_px": index_px,
             }
 
     async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -280,6 +280,24 @@ async def test_binance_futures_ws_fetch_ok():
 
 
 @pytest.mark.asyncio
+async def test_binance_futures_ws_stream_funding():
+    ws = BinanceFuturesWSAdapter()
+
+    msg = json.dumps({"data": {"r": "0.01", "i": "100", "E": 0}})
+
+    async def _fake_messages(url):
+        yield msg
+
+    ws._ws_messages = _fake_messages
+    gen = ws.stream_funding("BTC/USDT")
+    funding = await gen.__anext__()
+    await gen.aclose()
+    assert funding["rate"] == 0.01
+    assert funding["index_px"] == 100.0
+    assert "interval_sec" not in funding
+
+
+@pytest.mark.asyncio
 async def test_binance_futures_ws_fetch_error():
     ws = BinanceFuturesWSAdapter()
 


### PR DESCRIPTION
## Summary
- fix Binance futures websocket funding parsing by emitting `index_px` instead of `interval_sec`
- add unit test covering funding stream parsing

## Testing
- `pytest tests/test_adapters.py::test_binance_futures_ws_stream_funding -q`
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a87b65f838832db2ee386d5c2b7030