### PR TITLE
Handle alternate open interest field in Binance futures WS

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -174,7 +174,7 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
         async for raw in self._ws_messages(url):
             msg = json.loads(raw)
             d = msg.get("data") or msg
-            oi = d.get("oi") or d.get("openInterest")
+            oi = d.get("oi") or d.get("openInterest") or d.get("o")
             if oi is None:
                 continue
             ts_ms = d.get("E") or d.get("T") or 0


### PR DESCRIPTION
## Summary
- include "o" field as fallback when parsing open interest in Binance Futures websocket stream

## Testing
- `pytest tests/test_adapters.py::test_binance_futures_rest_fetch -q`
- `PYTHONPATH=src timeout 10s python -m tradingbot.cli.main ingest --venue binance_futures_ws --symbol BTC/USDT --kind open_interest` *(fails: proxy rejected connection: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a88479455c832db31f22a518e2a301