### PR TITLE
feat: auto-scroll output panel

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -127,6 +127,11 @@ let currentJob=null;
 let evt=null;
 const kindsWithDepth=["orderbook","delta"];
 
+function appendOutput(out, text) {
+  out.textContent += text + '\n';
+  requestAnimationFrame(() => out.scrollTop = out.scrollHeight);
+}
+
 function updateFields(){
   const act=document.getElementById('dm-action').value;
   const kind=document.getElementById('dm-kind').value;
@@ -214,22 +219,17 @@ async function runData(){
     currentJob=j.id;
     document.getElementById('dm-stop').disabled=false;
     evt=new EventSource(api(`/cli/stream/${j.id}`));
-    evt.onmessage = (e) => {
-      out.textContent += e.data + '\n';
-      out.scrollTop = out.scrollHeight;
-    };
+    evt.onmessage = (e) => appendOutput(out, e.data);
     evt.addEventListener('end',(e)=>{
       document.getElementById('dm-stop').disabled=true;
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
       currentJob=null;
       evt.close();
-      out.textContent+=`Proceso finalizado (código ${e.data}).\n`;
-      out.scrollTop = out.scrollHeight;
+      appendOutput(out, `Proceso finalizado (código ${e.data}).`);
     });
     evt.onerror=()=>{
-      out.textContent+='[error de conexión]\n';
-      out.scrollTop = out.scrollHeight;
+      appendOutput(out, '[error de conexión]');
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
     };


### PR DESCRIPTION
## Summary
- add helper to append output and auto-scroll
- use helper for job stream events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a888821580832d857cc788628191dd