### PR TITLE
Handle Binance open interest stream timeouts

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -190,6 +190,7 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
                 raw = await asyncio.wait_for(messages.__anext__(), timeout=15)
             except asyncio.TimeoutError:
                 log.warning("No message received on %s for 15s", stream)
+                messages = self._ws_messages(url)
                 continue
             except StopAsyncIteration:
                 return


### PR DESCRIPTION
## Summary
- Reinitialize WebSocket message generator in `stream_open_interest` when no data is received to keep stream alive
- Test open interest stream warns on delayed messages and recovers once data arrives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8aaef1fb8832da336216a23707959