### PR TITLE
docs: add mainnet usage example

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,16 @@ python -m tradingbot.cli ingest --venue okx_ws --symbol BTC/USDT --kind open_int
 python -m tradingbot.cli ingest --venue binance_spot_ws --symbol BTC/USDT --symbol ETH/USDT --kind trades_multi
 ```
 
+### Uso en mainnet
+
+Por defecto, los conectores de Binance Futures usan el entorno de prueba. Para
+conectarse a la red principal se debe deshabilitar el modo testnet mediante la
+variable de entorno `BINANCE_FUTURES_TESTNET`:
+
+```bash
+BINANCE_FUTURES_TESTNET=false python -m tradingbot.cli ingest --venue binance_futures_ws --symbol BTC/USDT --kind funding
+```
+
 ## `backfill`
 Descarga datos históricos con límites de velocidad.
 - `--days`: número de días hacia atrás (1 por defecto).


### PR DESCRIPTION
## Summary
- document how to run ingestion against Binance Futures mainnet by disabling testnet

## Testing
- `pytest tests/test_cli_supported_kinds.py -q` *(fails: AssertionError: assert 'open_interest' not in ['bba', 'delta', 'funding', 'open_interest', 'orderbook', 'trades'])*
- `pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c6388384832dbfb8392a0f8f417e