### PR TITLE
feat: add testnet toggle for Binance spot WS

### DIFF
--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -15,15 +15,30 @@ def _stream_name(symbol: str, channel: str = "trade") -> str:
 
 class BinanceSpotWSAdapter(ExchangeAdapter):
     """
-    WS de Binance Spot **TESTNET** para trades.
+    WS de Binance Spot para trades.
+    Usa el entorno de *testnet* si ``testnet=True``.
     """
-    name = "binance_spot_testnet_ws"
+    name = "binance_spot_ws"
 
-    def __init__(self, ws_base: str | None = None, rest: ExchangeAdapter | None = None):
+    def __init__(
+        self,
+        ws_base: str | None = None,
+        rest: ExchangeAdapter | None = None,
+        testnet: bool = False,
+    ):
         super().__init__()
-        # Spot testnet: wss://testnet.binance.vision/stream?streams=
-        self.ws_base = ws_base or "wss://testnet.binance.vision/stream?streams="
         self.rest = rest
+        self.testnet = testnet
+
+        default_ws_base = (
+            "wss://testnet.binance.vision/stream?streams="
+            if testnet
+            else "wss://stream.binance.com:9443/stream?streams="
+        )
+        self.ws_base = ws_base or default_ws_base
+
+        if testnet:
+            self.name = "binance_spot_testnet_ws"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _stream_name(normalize(symbol))


### PR DESCRIPTION
## Summary
- add testnet parameter to BinanceSpotWSAdapter and default to mainnet URL
- set adapter name and websocket base according to testnet selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c6364128832db793b4344bf5680f