### PR TITLE
Disable Binance Futures testnet by default and document env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ python -m tradingbot.cli --help
 
 Para una guía detallada de cada comando, consulte [docs/commands.md](docs/commands.md).
 
+## Variables de entorno
+
+De forma predeterminada, Binance Futures opera contra el entorno real. Para
+volver a utilizar la testnet es necesario indicar explícitamente:
+
+```bash
+export BINANCE_FUTURES_TESTNET=true
+```
+
+Si esta variable no está definida o se establece en `false`, el bot usará el
+entorno real de Binance Futures.
+
 ## Recursos
 
 - [Blueprint de arquitectura](BLUEPRINT.md)

--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     # Binance Futures (USDT-M) - TESTNET
     binance_futures_api_key: str | None = None
     binance_futures_api_secret: str | None = None
-    binance_futures_testnet: bool = True
+    binance_futures_testnet: bool = False
     binance_futures_leverage: int = 5    # puedes cambiarlo en CLI también
     binance_futures_market: str = "USDT-M"  # informativo
 


### PR DESCRIPTION
## Summary
- default `binance_futures_testnet` to `False`
- document how to re-enable Binance Futures testnet via `BINANCE_FUTURES_TESTNET`

## Testing
- `pytest tests/test_execution_flags.py tests/test_binance_futures_ws_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8c62f3b0c832db81c83649c535e3a