### PR TITLE
Expose accurate adapter stream kinds

### DIFF
--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -1,0 +1,24 @@
+# Supported stream kinds by exchange
+
+The CLI exposes different market data streams depending on the selected
+exchange adapter.  The table below lists the available ``kind`` values for
+each venue as detected by :func:`get_supported_kinds`.
+
+| Exchange | Supported kinds |
+| -------- | --------------- |
+| binance_spot | trades, orderbook, bba, delta, funding, open_interest |
+| binance_futures | trades, orderbook, bba, delta, funding, open_interest |
+| binance_spot_ws | trades, trades_multi, orderbook, bba, delta |
+| binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding, open_interest |
+| bybit_spot | trades, orderbook, bba, delta, funding, open_interest |
+| bybit_futures | trades, orderbook, bba, delta, funding, open_interest |
+| bybit_ws | trades, orderbook, bba, delta, funding, open_interest |
+| okx_spot | trades, orderbook, bba, delta, funding, open_interest |
+| okx_futures | trades, orderbook, bba, delta, funding, open_interest |
+| okx_ws | trades, orderbook, bba, delta, funding, open_interest |
+| deribit | trades, funding, open_interest |
+| deribit_ws | trades, orderbook, bba, delta, funding, open_interest |
+
+This reference aims to keep the UI and CLI documentation aligned with the
+actual capabilities of each adapter.
+

--- a/src/tradingbot/adapters/binance_spot_ws.py
+++ b/src/tradingbot/adapters/binance_spot_ws.py
@@ -136,6 +136,12 @@ class BinanceSpotWSAdapter(ExchangeAdapter):
                 "ask_qty": [q for _, q in delta_asks],
             }
 
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
+        raise NotImplementedError("Funding stream not supported for Spot WS")
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
+        raise NotImplementedError("Open interest stream not supported for Spot WS")
+
     async def fetch_funding(self, symbol: str):
         if self.rest:
             return await self.rest.fetch_funding(symbol)

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -58,6 +58,9 @@ class DeribitAdapter(ExchangeAdapter):
                 yield self.normalize_trade(symbol, ts, price, qty, side)
             await asyncio.sleep(1)
 
+    async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
+        raise NotImplementedError("Order book stream not supported")
+
     async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
         raise NotImplementedError("BBA stream not supported")
 

--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -117,6 +118,18 @@ class DeribitWSAdapter(ExchangeAdapter):
                 "ask_px": [p for p, _ in delta_asks],
                 "ask_qty": [q for _, q in delta_asks],
             }
+
+    async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
+        while True:
+            data = await self.fetch_funding(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
+
+    async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
+        while True:
+            data = await self.fetch_oi(symbol)
+            yield {"symbol": symbol, **data}
+            await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
         if self.rest:

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -3,36 +3,97 @@ import pytest
 from tradingbot.cli.main import get_adapter_class, get_supported_kinds
 
 
-def test_get_supported_kinds_binance_spot():
-    cls = get_adapter_class("binance_spot")
+EXPECTED_KINDS = {
+    "binance_spot": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "binance_futures": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "binance_spot_ws": {"trades", "trades_multi", "orderbook", "bba", "delta"},
+    "binance_futures_ws": {
+        "trades",
+        "trades_multi",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "bybit_spot": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "bybit_futures": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "bybit_ws": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "okx_spot": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "okx_futures": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "okx_ws": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+    "deribit": {"trades", "funding", "open_interest"},
+    "deribit_ws": {
+        "trades",
+        "orderbook",
+        "bba",
+        "delta",
+        "funding",
+        "open_interest",
+    },
+}
+
+
+@pytest.mark.parametrize("name,expected", EXPECTED_KINDS.items())
+def test_get_supported_kinds(name: str, expected: set[str]) -> None:
+    cls = get_adapter_class(name)
     assert cls is not None
-    kinds = get_supported_kinds(cls)
-    # basic kinds available on most venues
-    assert "trades" in kinds
-    assert "orderbook" in kinds
-    # binance spot does not expose open interest
-    assert "open_interest" not in kinds
+    kinds = set(get_supported_kinds(cls))
+    assert kinds == expected
 
-
-def test_get_supported_kinds_binance_futures_ws():
-    cls = get_adapter_class("binance_futures_ws")
-    assert cls is not None
-    kinds = get_supported_kinds(cls)
-    assert "funding" in kinds
-    assert "open_interest" in kinds
-
-
-def test_get_supported_kinds_bybit_ws():
-    cls = get_adapter_class("bybit_ws")
-    assert cls is not None
-    kinds = get_supported_kinds(cls)
-    assert "funding" in kinds
-    assert "open_interest" in kinds
-
-
-def test_get_supported_kinds_okx_ws():
-    cls = get_adapter_class("okx_ws")
-    assert cls is not None
-    kinds = get_supported_kinds(cls)
-    assert "funding" in kinds
-    assert "open_interest" in kinds


### PR DESCRIPTION
## Summary
- ignore NotImplemented stream stubs when listing supported kinds
- add missing stream_* methods across adapters
- test supported kinds for all adapters and document them

## Testing
- `pytest tests/test_cli_supported_kinds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c70ff1dc832db6213cf0016c05a7