### PR TITLE
Expose Binance spot open interest capability

### DIFF
--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -261,7 +261,7 @@ class BinanceSpotAdapter(ExchangeAdapter):
             await asyncio.sleep(60)
 
     async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
-        """Poll open interest updates via REST."""
+        """Poll open interest for ``symbol`` using the futures REST API."""
 
         while True:
             data = await self.fetch_oi(symbol)

--- a/tests/test_api_venue_kinds.py
+++ b/tests/test_api_venue_kinds.py
@@ -19,7 +19,7 @@ def test_venue_kinds_endpoint(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert "trades" in data["kinds"]
-    assert "open_interest" not in data["kinds"]
+    assert "open_interest" in data["kinds"]
 
     resp = client.get("/venues/unknown/kinds", auth=("u", "p"))
     assert resp.status_code == 404

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -10,8 +10,8 @@ def test_get_supported_kinds_binance_spot():
     # basic kinds available on most venues
     assert "trades" in kinds
     assert "orderbook" in kinds
-    # binance spot does not expose open interest
-    assert "open_interest" not in kinds
+    # binance spot exposes open interest via the futures API
+    assert "open_interest" in kinds
 
 
 def test_get_supported_kinds_binance_futures_ws():


### PR DESCRIPTION
## Summary
- clarify stream_open_interest docstring for Binance spot adapter
- expect open_interest support in CLI/API kind listings

## Testing
- `pytest` *(fails: process killed)*
- `pytest tests/test_cli_supported_kinds.py tests/test_api_venue_kinds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c7106a74832dbd31d18b307c9696