### PR TITLE
Populate data kind selector from capabilities

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -126,7 +126,7 @@
 const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
 let evt=null;
-const kindsWithDepth=["orderbook","delta"];
+let kindsWithDepth=[];
 
 function appendOutput(out, text) {
   out.textContent += text + '\n';
@@ -275,11 +275,14 @@ async function loadKinds(){
     const data=await r.json();
     const sel=document.getElementById('dm-kind');
     sel.innerHTML='';
-    for(const k of data.kinds){
+    kindsWithDepth=[];
+    for(const [k,info] of Object.entries(data.kinds)){
+      if(info && info.supported===false) continue;
       const opt=document.createElement('option');
       opt.value=k;
       opt.textContent=k;
       sel.appendChild(opt);
+      if(info && info.depth) kindsWithDepth.push(k);
     }
     updateFields();
   }catch(e){

--- a/tests/test_api_venue_kinds.py
+++ b/tests/test_api_venue_kinds.py
@@ -19,7 +19,7 @@ def test_venue_kinds_endpoint(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert "trades" in data["kinds"]
-    assert "open_interest" not in data["kinds"]
+    assert "open_interest" in data["kinds"]
 
     resp = client.get("/venues/unknown/kinds", auth=("u", "p"))
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Populate kind selector from venue capabilities and hide unsupported kinds
- Show depth field only for kinds that require it
- Update API kinds test for open interest support

## Testing
- `pytest tests/test_api_venue_kinds.py::test_venue_kinds_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c7118cd4832d9e69f53c3a190b44