### PR TITLE
Rename OKX WS adapter to okx_futures_ws

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,7 @@ A continuación se describen los comandos disponibles.
 
 ## `ingest`
 Recibe datos de mercado en vivo y opcionalmente los almacena.
-- `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_ws`, `okx_ws`).
+- `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_ws`, `okx_futures_ws`).
 - `--symbol`: puede repetirse para varios pares (por defecto `BTC/USDT`).
 - `--depth`: profundidad del libro de órdenes (10).
 - `--kind`: tipo de dato: `trades`, `trades_multi`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
@@ -27,8 +27,8 @@ python -m tradingbot.cli ingest --venue binance_futures_ws --symbol BTC/USDT --k
 python -m tradingbot.cli ingest --venue bybit_ws --symbol BTC/USDT --kind open_interest
 
 # Funding y open interest en OKX
-python -m tradingbot.cli ingest --venue okx_ws --symbol BTC/USDT --kind funding
-python -m tradingbot.cli ingest --venue okx_ws --symbol BTC/USDT --kind open_interest
+python -m tradingbot.cli ingest --venue okx_futures_ws --symbol BTC/USDT --kind funding
+python -m tradingbot.cli ingest --venue okx_futures_ws --symbol BTC/USDT --kind open_interest
 
 # Trades de múltiples símbolos
 python -m tradingbot.cli ingest --venue binance_spot_ws --symbol BTC/USDT --symbol ETH/USDT --kind trades_multi

--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -15,7 +15,7 @@ each venue as detected by :func:`get_supported_kinds`.
 | bybit_ws | trades, orderbook, bba, delta, funding, open_interest |
 | okx_spot | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures | trades, orderbook, bba, delta, funding, open_interest |
-| okx_ws | trades, orderbook, bba, delta, funding, open_interest |
+| okx_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
 | deribit | trades, funding, open_interest |
 | deribit_ws | trades, orderbook, bba, delta, funding, open_interest |
 

--- a/src/tradingbot/adapters/okx_ws.py
+++ b/src/tradingbot/adapters/okx_ws.py
@@ -20,9 +20,9 @@ log = logging.getLogger(__name__)
 
 
 class OKXWSAdapter(ExchangeAdapter):
-    """Lightweight OKX websocket adapter."""
+    """Lightweight OKX futures websocket adapter."""
 
-    name = "okx_ws"
+    name = "okx_futures_ws"
 
     def __init__(self, ws_base: str | None = None, rest: ExchangeAdapter | None = None, testnet: bool = False):
         super().__init__()
@@ -35,7 +35,7 @@ class OKXWSAdapter(ExchangeAdapter):
                 else "wss://ws.okx.com:8443/ws/v5/public"
             )
         self.rest = rest
-        self.name = "okx_ws_testnet" if testnet else "okx_ws"
+        self.name = "okx_futures_ws_testnet" if testnet else "okx_futures_ws"
 
     # ------------------------------------------------------------------
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -84,7 +84,7 @@ _ADAPTER_CLASS_MAP: dict[str, type[adapters.ExchangeAdapter]] = {
     "bybit_ws": BybitWSAdapter,
     "okx_spot": OKXSpotAdapter,
     "okx_futures": OKXFuturesAdapter,
-    "okx_ws": OKXWSAdapter,
+    "okx_futures_ws": OKXWSAdapter,
     "deribit": DeribitAdapter,
     "deribit_ws": DeribitWSAdapter,
 }

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -69,7 +69,7 @@ EXPECTED_KINDS = {
         "funding",
         "open_interest",
     },
-    "okx_ws": {
+    "okx_futures_ws": {
         "trades",
         "orderbook",
         "bba",


### PR DESCRIPTION
## Summary
- rename OKX websocket adapter key to `okx_futures_ws`
- update CLI mapping, docs and tests to the new name

## Testing
- `pytest tests/test_cli_supported_kinds.py tests/test_okx_ws_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8d007b258832db461f77d84f2837a