### PR TITLE
Simplify kinds loading in data management UI

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -275,14 +275,13 @@ async function loadKinds(){
     const data=await r.json();
     const sel=document.getElementById('dm-kind');
     sel.innerHTML='';
-    kindsWithDepth=[];
-    for(const [k,info] of Object.entries(data.kinds)){
-      if(info && info.supported===false) continue;
-      const opt=document.createElement('option');
-      opt.value=k;
-      opt.textContent=k;
+    const kinds=data.kinds || [];
+    kindsWithDepth = kinds.filter(k => ['orderbook','delta'].includes(k));
+    for (const k of kinds) {
+      const opt = document.createElement('option');
+      opt.value = k;
+      opt.textContent = k;
       sel.appendChild(opt);
-      if(info && info.depth) kindsWithDepth.push(k);
     }
     updateFields();
   }catch(e){


### PR DESCRIPTION
## Summary
- simplify kind loading on data page by treating API response as array
- compute depth-requiring kinds via direct filter for `orderbook` and `delta`

## Testing
- `pytest tests/test_api_venue_kinds.py::test_venue_kinds_endpoint -q`
- `node <<'NODE'
let kindsWithDepth=[];
const document={
  elements:{'dm-kind':{innerHTML:'',children:[],appendChild(el){this.children.push(el);}}},
  getElementById(id){return this.elements[id];},
  createElement(tag){return {value:'',textContent:'',tagName:tag};}
};
function loadKindsTest(data){
  const sel=document.getElementById('dm-kind');
  sel.innerHTML='';
  const kinds=data.kinds||[];
  kindsWithDepth=kinds.filter(k=>['orderbook','delta'].includes(k));
  for(const k of kinds){
    const opt=document.createElement('option');
    opt.value=k;
    opt.textContent=k;
    sel.appendChild(opt);
  }
}
loadKindsTest({kinds:['trades','orderbook','delta']});
console.log('options:', document.getElementById('dm-kind').children.map(c=>c.value));
console.log('kindsWithDepth:', kindsWithDepth);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a8cffcf600832d91d0ed92e90e3f81