### PR TITLE
Standardize futures venue names across adapters, CLI and docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,7 @@ A continuación se describen los comandos disponibles.
 
 ## `ingest`
 Recibe datos de mercado en vivo y opcionalmente los almacena.
-- `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_ws`, `okx_futures_ws`).
+- `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_futures_ws`, `okx_futures_ws`). Los nombres siguen el patrón `<exchange>_<market>` para REST y `<exchange>_<market>_ws` para WebSocket; se añade `_testnet` automáticamente cuando se usa el entorno de prueba.
 - `--symbol`: puede repetirse para varios pares (por defecto `BTC/USDT`).
 - `--depth`: profundidad del libro de órdenes (10).
 - `--kind`: tipo de dato: `trades`, `trades_multi`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
@@ -24,7 +24,7 @@ Ejemplos:
 python -m tradingbot.cli ingest --venue binance_futures_ws --symbol BTC/USDT --kind funding
 
 # Open interest en Bybit
-python -m tradingbot.cli ingest --venue bybit_ws --symbol BTC/USDT --kind open_interest
+python -m tradingbot.cli ingest --venue bybit_futures_ws --symbol BTC/USDT --kind open_interest
 
 # Funding y open interest en OKX
 python -m tradingbot.cli ingest --venue okx_futures_ws --symbol BTC/USDT --kind funding

--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -2,7 +2,10 @@
 
 The CLI exposes different market data streams depending on the selected
 exchange adapter.  The table below lists the available ``kind`` values for
-each venue as detected by :func:`get_supported_kinds`.
+each venue as detected by :func:`get_supported_kinds`. Venue names follow the
+pattern ``<exchange>_<market>`` for REST adapters and ``<exchange>_<market>_ws``
+for WebSocket adapters; the suffix ``_testnet`` is appended automatically when
+connecting to test environments.
 
 | Exchange | Supported kinds |
 | -------- | --------------- |
@@ -12,12 +15,12 @@ each venue as detected by :func:`get_supported_kinds`.
 | binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding, open_interest |
 | bybit_spot | trades, orderbook, bba, delta, funding, open_interest |
 | bybit_futures | trades, orderbook, bba, delta, funding, open_interest |
-| bybit_ws | trades, orderbook, bba, delta, funding, open_interest |
+| bybit_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
 | okx_spot | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
-| deribit | trades, funding, open_interest |
-| deribit_ws | trades, orderbook, bba, delta, funding, open_interest |
+| deribit_futures | trades, funding, open_interest |
+| deribit_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
 
 This reference aims to keep the UI and CLI documentation aligned with the
 actual capabilities of each adapter.

--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -23,7 +23,7 @@ from ..utils.secrets import validate_scopes
 log = logging.getLogger(__name__)
 
 class BinanceFuturesAdapter(ExchangeAdapter):
-    name = "binance_futures_usdm_testnet"
+    name = "binance_futures"
 
     def __init__(
         self,
@@ -76,14 +76,14 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         # Cache de metadatos/filters
         self.meta = ExchangeMeta.binanceusdm_testnet(
             api_key or settings.binance_futures_api_key,
-            api_secret or settings.binance_futures_api_secret
+            api_secret or settings.binance_futures_api_secret,
         )
         try:
             self.meta.load_markets()
         except Exception as e:
             log.warning("load_markets falló: %s", e)
 
-        self.name = "binance_futures_usdm_testnet" if testnet else "binance_futures_usdm"
+        self.name = "binance_futures_testnet" if testnet else "binance_futures"
 
         try:
             self._configure_lock = asyncio.Lock()

--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -21,7 +21,7 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
     WS de Binance USDⓈ-M Futures (UM) para datos de mercado.
     Permite operar tanto en mainnet como en testnet.
     """
-    name = "binance_futures_um_testnet_ws"
+    name = "binance_futures_ws"
 
     def __init__(
         self,
@@ -42,6 +42,7 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
         self.rest = rest
         self._api_key = api_key
         self._api_secret = api_secret
+        self.name = "binance_futures_ws_testnet" if testnet else "binance_futures_ws"
 
     def _ensure_rest(self):
         if self.rest is None:

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -29,7 +29,7 @@ class BybitWSAdapter(ExchangeAdapter):
     basis and open interest retrieval via an optional REST client.
     """
 
-    name = "bybit_ws"
+    name = "bybit_futures_ws"
 
     def __init__(self, ws_base: str | None = None, rest: ExchangeAdapter | None = None, testnet: bool = False):
         super().__init__()
@@ -42,7 +42,7 @@ class BybitWSAdapter(ExchangeAdapter):
                 else "wss://stream.bybit.com/v5/public/linear"
             )
         self.rest = rest
-        self.name = "bybit_ws_testnet" if testnet else "bybit_ws"
+        self.name = "bybit_futures_ws_testnet" if testnet else "bybit_futures_ws"
 
     # ------------------------------------------------------------------
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 class DeribitAdapter(ExchangeAdapter):
     """Adapter simple para Deribit (perpetuos)."""
 
-    name = "deribit"
+    name = "deribit_futures"
 
     def __init__(
         self,
@@ -43,7 +43,7 @@ class DeribitAdapter(ExchangeAdapter):
         })
         self.rest.set_sandbox_mode(testnet)
         validate_scopes(self.rest, log)
-        self.name = "deribit_testnet" if testnet else "deribit"
+        self.name = "deribit_futures_testnet" if testnet else "deribit_futures"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         while True:  # poll trades vía REST; Deribit no posee WS en este adaptador

--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class DeribitWSAdapter(ExchangeAdapter):
     """Websocket wrapper delegando a :class:`DeribitAdapter` para REST."""
 
-    name = "deribit_ws"
+    name = "deribit_futures_ws"
 
     def __init__(self, rest: DeribitAdapter | None = None, testnet: bool = False):
         super().__init__()
@@ -23,6 +23,7 @@ class DeribitWSAdapter(ExchangeAdapter):
         self.ws_url = (
             "wss://test.deribit.com/ws/api/v2" if testnet else "wss://www.deribit.com/ws/api/v2"
         )
+        self.name = "deribit_futures_ws_testnet" if testnet else "deribit_futures_ws"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         """Stream trades from Deribit public websocket."""

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -40,7 +40,7 @@
         </select>
       </div>
       <div id="field-venue">
-        <label for="dm-venue">Venue</label>
+        <label for="dm-venue">Venue (e.g. binance_futures_ws)</label>
         <select id="dm-venue"></select>
       </div>
       <div id="field-symbols">
@@ -293,6 +293,7 @@ async function loadVenues(){
   try{
     const r=await fetch(api('/venues'));
     const venues=await r.json();
+    venues.sort();
     const sel=document.getElementById('dm-venue');
     sel.innerHTML='';
     for(const v of venues){

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -67,12 +67,12 @@
       <div>
         <label for="cfg-exchange">Exchange</label>
         <select id="cfg-exchange">
-          <option value="binance_futures_usdm_testnet">Binance Futures USDM Testnet</option>
+          <option value="binance_futures_testnet">Binance Futures Testnet</option>
           <option value="binance_spot">Binance Spot</option>
           <option value="bybit_futures">Bybit Futures</option>
           <option value="bybit_spot">Bybit Spot</option>
-          <option value="deribit">Deribit</option>
-          <option value="deribit_ws">Deribit WS</option>
+          <option value="deribit_futures">Deribit Futures</option>
+          <option value="deribit_futures_ws">Deribit Futures WS</option>
           <option value="okx_futures">OKX Futures</option>
           <option value="okx_spot">OKX Spot</option>
         </select>

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -81,12 +81,12 @@ _ADAPTER_CLASS_MAP: dict[str, type[adapters.ExchangeAdapter]] = {
     "binance_futures_ws": BinanceFuturesWSAdapter,
     "bybit_spot": BybitSpotAdapter,
     "bybit_futures": BybitFuturesAdapter,
-    "bybit_ws": BybitWSAdapter,
+    "bybit_futures_ws": BybitWSAdapter,
     "okx_spot": OKXSpotAdapter,
     "okx_futures": OKXFuturesAdapter,
     "okx_futures_ws": OKXWSAdapter,
-    "deribit": DeribitAdapter,
-    "deribit_ws": DeribitWSAdapter,
+    "deribit_futures": DeribitAdapter,
+    "deribit_futures_ws": DeribitWSAdapter,
 }
 
 

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -45,7 +45,7 @@ EXPECTED_KINDS = {
         "funding",
         "open_interest",
     },
-    "bybit_ws": {
+    "bybit_futures_ws": {
         "trades",
         "orderbook",
         "bba",
@@ -77,8 +77,8 @@ EXPECTED_KINDS = {
         "funding",
         "open_interest",
     },
-    "deribit": {"trades", "funding", "open_interest"},
-    "deribit_ws": {
+    "deribit_futures": {"trades", "funding", "open_interest"},
+    "deribit_futures_ws": {
         "trades",
         "orderbook",
         "bba",


### PR DESCRIPTION
## Summary
- normalize futures adapter `name` attributes and handle `_testnet` suffix dynamically
- align CLI venue mapping and API UI with standardized spot/futures and WS naming
- document updated venue names and supported stream kinds

## Testing
- `pytest tests/test_cli_supported_kinds.py`
- `pytest tests/test_cli_venues.py`
- `pytest tests/test_bybit_ws_adapter.py tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_to_rest`


------
https://chatgpt.com/codex/tasks/task_e_68a8da23ee00832da3308fe8d7751e16