### PR TITLE
Document adapter modules and venues

### DIFF
--- a/docs/venues.md
+++ b/docs/venues.md
@@ -1,0 +1,20 @@
+# Supported venues
+
+The following table lists the available venue identifiers, the market type they
+target and the primary connection method used by each adapter.
+
+| Venue | Market type | Connection method |
+| ----- | ----------- | ----------------- |
+| binance_spot | Spot | REST |
+| binance_spot_ws | Spot | WebSocket |
+| binance_futures | Futures (USD-M) | REST |
+| binance_futures_ws | Futures (USD-M) | WebSocket |
+| bybit_spot | Spot | REST |
+| bybit_futures | Futures | REST |
+| bybit_ws | Futures | WebSocket |
+| okx_spot | Spot | REST |
+| okx_futures | Futures | REST |
+| okx_futures_ws | Futures | WebSocket |
+| deribit | Perpetual futures | REST |
+| deribit_ws | Perpetual futures | WebSocket |
+

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -1,12 +1,8 @@
 # src/tradingbot/adapters/bybit_ws.py
-"""Lightweight websocket adapter for Bybit perpetual futures.
+"""WebSocket adapter for Bybit USDT perpetual futures.
 
-Based on the `binance_spot_ws` implementation, this adapter focuses on
-streaming trades and L2 order book snapshots while delegating optional REST
-queries for funding, basis and open interest to an injected REST adapter.
-
-Only the public websocket is used; ping/pong handling and reconnect backoff
-are provided by :func:`ExchangeAdapter._ws_messages` from the base class.
+Streams trades and L2 order book snapshots and can leverage a REST client for
+auxiliary data such as funding and open interest.
 """
 
 from __future__ import annotations

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -1,3 +1,5 @@
+"""REST adapter for Deribit perpetual futures."""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -1,3 +1,5 @@
+"""WebSocket adapter for streaming markets from Deribit."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary
- add module-level descriptions to Deribit and Bybit websocket adapters
- document available trading venues and their connection methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8da287140832d979db87a4a44d506