### PR TITLE
feat: normalize deribit symbols

### DIFF
--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -14,16 +14,50 @@ except Exception:  # pragma: no cover
 
 from .base import ExchangeAdapter
 from ..config import settings
-from ..core.symbols import normalize
+from ..core.symbols import normalize as _core_normalize
 from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
+
+
+try:  # pragma: no cover - provide fallback when ccxt missing
+    from ccxt.base.errors import BadSymbol
+except Exception:  # pragma: no cover
+    class BadSymbol(Exception):
+        """Fallback ``BadSymbol`` when ccxt isn't available."""
+        pass
 
 
 class DeribitAdapter(ExchangeAdapter):
     """Adapter simple para Deribit (perpetuos)."""
 
     name = "deribit_futures"
+
+    # Deribit únicamente lista perpetuos de BTC y ETH.  Este mapa traduce
+    # símbolos genéricos (``ETHUSDT``) al identificador oficial del venue
+    # (``ETH-PERPETUAL``).  Las claves se almacenan ya normalizadas mediante
+    # :func:`tradingbot.core.symbols.normalize` para aceptar múltiples
+    # variantes de entrada ("ETH/USDT", "eth-perp", etc.).
+    _SYMBOL_MAP = {
+        "BTCUSDT": "BTC-PERPETUAL",
+        "BTCUSD": "BTC-PERPETUAL",
+        "BTCPERP": "BTC-PERPETUAL",
+        "BTCPERPETUAL": "BTC-PERPETUAL",
+        "ETHUSDT": "ETH-PERPETUAL",
+        "ETHUSD": "ETH-PERPETUAL",
+        "ETHPERP": "ETH-PERPETUAL",
+        "ETHPERPETUAL": "ETH-PERPETUAL",
+    }
+
+    @classmethod
+    def normalize(cls, symbol: str) -> str:
+        """Return Deribit instrument name for ``symbol`` or raise ``BadSymbol``."""
+
+        sym = _core_normalize(symbol)
+        mapped = cls._SYMBOL_MAP.get(sym)
+        if mapped is None:
+            raise BadSymbol(symbol)
+        return mapped
 
     def __init__(
         self,
@@ -48,16 +82,17 @@ class DeribitAdapter(ExchangeAdapter):
         self.name = "deribit_futures_testnet" if testnet else "deribit_futures"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
+        sym = self.normalize(symbol)
         while True:  # poll trades vía REST; Deribit no posee WS en este adaptador
-            data = await self._request(self.rest.fetch_trades, symbol, limit=1)
+            data = await self._request(self.rest.fetch_trades, sym, limit=1)
             for t in data:
                 price = float(t.get("price", 0.0))
                 qty = float(t.get("amount") or t.get("size") or 0.0)
                 ts_ms = int(t.get("timestamp") or 0)
                 ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
                 side = t.get("side") or t.get("direction")
-                self.state.last_px[symbol] = price
-                yield self.normalize_trade(symbol, ts, price, qty, side)
+                self.state.last_px[sym] = price
+                yield self.normalize_trade(sym, ts, price, qty, side)
             await asyncio.sleep(1)
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:  # pragma: no cover - not supported
@@ -72,21 +107,23 @@ class DeribitAdapter(ExchangeAdapter):
     async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
         """Poll funding rate updates via REST."""
 
+        sym = self.normalize(symbol)
         while True:
-            data = await self.fetch_funding(symbol)
-            yield {"symbol": symbol, **data}
+            data = await self.fetch_funding(sym)
+            yield {"symbol": sym, **data}
             await asyncio.sleep(60)
 
     async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
         """Poll open interest updates via REST."""
 
+        sym = self.normalize(symbol)
         while True:
-            data = await self.fetch_oi(symbol)
-            yield {"symbol": symbol, **data}
+            data = await self.fetch_oi(sym)
+            yield {"symbol": sym, **data}
             await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
-        sym = normalize(symbol)
+        sym = self.normalize(symbol)
         method = (
             getattr(self.rest, "public_get_get_funding_rate", None)
             or getattr(self.rest, "fetchFundingRate", None)
@@ -102,7 +139,7 @@ class DeribitAdapter(ExchangeAdapter):
         return {"ts": ts_dt, "rate": rate}
 
     async def fetch_basis(self, symbol: str):
-        sym = normalize(symbol)
+        sym = self.normalize(symbol)
         method = getattr(self.rest, "public_get_ticker", None) or getattr(self.rest, "fetchTicker", None)
         if method is None:
             raise NotImplementedError("Basis not supported")
@@ -117,7 +154,7 @@ class DeribitAdapter(ExchangeAdapter):
         return {"ts": ts_dt, "basis": basis}
 
     async def fetch_oi(self, symbol: str):
-        sym = normalize(symbol)
+        sym = self.normalize(symbol)
         method = (
             getattr(self.rest, "public_get_get_open_interest", None)
             or getattr(self.rest, "fetchOpenInterest", None)
@@ -145,6 +182,7 @@ class DeribitAdapter(ExchangeAdapter):
         time_in_force: str | None = None,
         reduce_only: bool = False,
     ) -> dict:
+        sym = self.normalize(symbol)
         params = {}
         if post_only:
             params["post_only"] = True
@@ -152,7 +190,7 @@ class DeribitAdapter(ExchangeAdapter):
             params["time_in_force"] = time_in_force
         if reduce_only:
             params["reduce_only"] = True
-        return await self._request(self.rest.create_order, symbol, type_, side, qty, price, params)
+        return await self._request(self.rest.create_order, sym, type_, side, qty, price, params)
 
     async def cancel_order(self, order_id: str) -> dict:
         return await self._request(self.rest.cancel_order, order_id)


### PR DESCRIPTION
## Summary
- map common symbols like BTCUSDT/ETHUSDT to Deribit PERPETUAL names
- validate symbols before REST requests and use normalized names throughout

## Testing
- `pytest tests/test_adapters.py::test_deribit_fetch_methods -q`
- `pytest tests/test_deribit_connector.py::test_rest_normalization_deribit -q`
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_to_rest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9005d37b8832da6a81f16adc11f97