### PR TITLE
Handle unsupported spot metrics

### DIFF
--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -9,14 +9,14 @@ connecting to test environments.
 
 | Exchange | Supported kinds |
 | -------- | --------------- |
-| binance_spot | trades, orderbook, bba, delta, funding, open_interest |
+| binance_spot | trades, orderbook, bba, delta |
 | binance_futures | trades, orderbook, bba, delta, funding, open_interest |
 | binance_spot_ws | trades, trades_multi, orderbook, bba, delta |
 | binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding, open_interest |
-| bybit_spot | trades, orderbook, bba, delta, funding, open_interest |
+| bybit_spot | trades, orderbook, bba, delta |
 | bybit_futures | trades, orderbook, bba, delta, funding, open_interest |
 | bybit_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
-| okx_spot | trades, orderbook, bba, delta, funding, open_interest |
+| okx_spot | trades, orderbook, bba, delta |
 | okx_futures | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
 | deribit_futures | trades, funding, open_interest |

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -101,6 +101,9 @@ class BybitSpotAdapter(ExchangeAdapter):
 
     async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
         """Poll funding rate updates for ``symbol`` via REST."""
+        sym = normalize(symbol)
+        if ":" not in symbol and "-" not in sym:
+            raise NotImplementedError("Funding stream is not available for spot symbols")
 
         while True:
             data = await self.fetch_funding(symbol)
@@ -109,6 +112,9 @@ class BybitSpotAdapter(ExchangeAdapter):
 
     async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
         """Poll open interest updates for ``symbol`` via REST."""
+        sym = normalize(symbol)
+        if ":" not in symbol and "-" not in sym:
+            raise NotImplementedError("Open interest stream is not available for spot symbols")
 
         while True:
             data = await self.fetch_oi(symbol)

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -141,6 +141,10 @@ def get_supported_kinds(adapter_cls: type[adapters.ExchangeAdapter]) -> list[str
         elif kind == "book_delta":
             kind = "delta"
         kinds.add(kind)
+    name = getattr(adapter_cls, "name", "")
+    if "futures" not in name:
+        kinds.discard("funding")
+        kinds.discard("open_interest")
     return sorted(kinds)
 
 

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -8,8 +8,6 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
-        "funding",
-        "open_interest",
     },
     "binance_futures": {
         "trades",
@@ -34,8 +32,6 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
-        "funding",
-        "open_interest",
     },
     "bybit_futures": {
         "trades",
@@ -58,8 +54,6 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
-        "funding",
-        "open_interest",
     },
     "okx_futures": {
         "trades",


### PR DESCRIPTION
## Summary
- raise NotImplementedError for funding and open interest streams when used with spot symbols on Bybit
- filter funding and open interest from supported kinds for non-futures adapters
- update documentation and tests to reflect reduced spot capabilities

## Testing
- `pytest -q`
- `pytest tests/test_cli_supported_kinds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9005bf034832daf39054b12cdd9c2