### PR TITLE
Add backfill progress indicator for data page

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -6,6 +6,10 @@
   <title>DMI - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
+  <style>
+  @keyframes blink{0%,100%{opacity:.2;}50%{opacity:1;}}
+  #dm-working{animation:blink 1s linear infinite;display:none;margin-left:8px;}
+  </style>
 </head>
 <body>
 <header class="center" style="margin-bottom:8px">
@@ -111,6 +115,7 @@
     <button id="dm-run" style="margin-top:10px">Ejecutar</button>
     <button id="dm-stop" style="margin-top:10px;margin-left:8px" disabled>Detener</button>
     <button id="dm-clear" style="margin-top:10px;margin-left:8px">Limpiar</button>
+    <span id="dm-working">Procesando<span id="dm-dots"></span></span>
     <pre id="dm-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
@@ -127,6 +132,21 @@ const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
 let evt=null;
 let kindsWithDepth=[];
+let dotsInterval=null;
+
+function showWorking(){
+  const w=document.getElementById('dm-working');
+  const d=document.getElementById('dm-dots');
+  let c=0;
+  w.style.display='inline';
+  dotsInterval=setInterval(()=>{c=(c+1)%4;d.textContent='.'.repeat(c);},500);
+}
+
+function hideWorking(){
+  const w=document.getElementById('dm-working');
+  w.style.display='none';
+  if(dotsInterval){clearInterval(dotsInterval);dotsInterval=null;}
+}
 
 function appendOutput(out, text) {
   out.textContent += text + '\n';
@@ -227,18 +247,22 @@ async function runData(){
       runBtn.textContent='Ejecutar';
       currentJob=null;
       evt.close();
+      if(act==='backfill') hideWorking();
       appendOutput(out, `Proceso finalizado (código ${e.data}).`);
     });
     evt.onerror=()=>{
       appendOutput(out, '[error de conexión]');
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
+      if(act==='backfill') hideWorking();
     };
+    if(act==='backfill') showWorking();
   }catch(e){
     out.textContent=String(e);
     out.scrollTop = out.scrollHeight;
     runBtn.disabled=false;
     runBtn.textContent='Ejecutar';
+    if(act==='backfill') hideWorking();
   }
 }
 
@@ -251,6 +275,7 @@ async function stopData(){
   runBtn.disabled=false;
   runBtn.textContent='Ejecutar';
   currentJob=null;
+  hideWorking();
 }
 
 async function runCli(){


### PR DESCRIPTION
## Summary
- show blinking backfill progress indicator with animated dots
- hide indicator when backfill finishes or is stopped

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9004e4314832da3e7c290f99a8210