### PR TITLE
Display dynamic kind descriptions in data manager

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -107,7 +107,7 @@
         </select>
       </div>
     </div>
-    <div class="muted" style="margin-top:8px">Los datos se guardan en el backend configurado. Puedes analizarlos en <a href="/stats">Estadísticas</a> u otras herramientas.</div>
+    <p id="kind-desc" class="muted" style="margin-top:8px"></p>
     <button id="dm-run" style="margin-top:10px">Ejecutar</button>
     <button id="dm-stop" style="margin-top:10px;margin-left:8px" disabled>Detener</button>
     <button id="dm-clear" style="margin-top:10px;margin-left:8px">Limpiar</button>
@@ -127,6 +127,15 @@ const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
 let evt=null;
 let kindsWithDepth=[];
+const kindDescriptions={
+  bba:"Mejores posturas bid/ask",
+  delta:"Deltas del libro de órdenes",
+  open_interest:"Interés abierto",
+  orderbook:"Libro de órdenes completo",
+  trades:"Operaciones ejecutadas",
+  funding:"Tasa de financiamiento",
+  ticker:"Precio de ticker"
+};
 
 function appendOutput(out, text) {
   out.textContent += text + '\n';
@@ -163,7 +172,12 @@ document.getElementById('dm-hkind').addEventListener('change',updateFields);
 document.getElementById('dm-start').addEventListener('change',updateFields);
 document.getElementById('dm-end').addEventListener('change',updateFields);
 document.getElementById('dm-persist').addEventListener('change',updateFields);
-document.getElementById('dm-kind').addEventListener('change',updateFields);
+document.getElementById('dm-kind').addEventListener('change', e => {
+  updateFields();
+  const kind=e.target.value;
+  const desc=document.getElementById('kind-desc');
+  desc.textContent=kindDescriptions[kind]||'';
+});
 
 async function runData(){
   if(evt){evt.close();evt=null;}
@@ -284,6 +298,7 @@ async function loadKinds(){
       sel.appendChild(opt);
     }
     updateFields();
+    document.getElementById('kind-desc').textContent = kindDescriptions[sel.value] || '';
   }catch(e){
     console.error(e);
   }


### PR DESCRIPTION
## Summary
- Add `kindDescriptions` mapping to describe each data kind
- Update `dm-kind` change handler to show selected kind description
- Remove hardcoded paragraph and show dynamic text

## Testing
- `pytest` *(fails: process killed due to memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a900516eb0832d8bd92fee35fbe977