### PR TITLE
feat: add bybit ws subscriptions

### DIFF
--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -62,11 +62,99 @@ class BybitWSAdapter(ExchangeAdapter):
                 yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str, depth: int = 1) -> AsyncIterator[dict]:
-        """Yield L2 order book snapshots for ``symbol``."""
+        """Yield normalised L2 order book snapshots for ``symbol``.
+
+        Bybit's ``orderbook.{depth}`` channel first sends a full snapshot and
+        subsequently publishes incremental updates.  We apply those deltas
+        locally to maintain the book and emit the reconstructed snapshot each
+        time an update is received.
+        """
 
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.{depth}.{sym}"]}
+        bids: dict[float, float] = {}
+        asks: dict[float, float] = {}
+
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            data = msg.get("data") or {}
+            if not data:
+                continue
+
+            side_updates = {
+                "b": bids,
+                "a": asks,
+            }
+
+            if msg.get("type") == "snapshot":
+                for side_key, book in side_updates.items():
+                    updates = data.get(side_key, [])
+                    book.clear()
+                    for p, q, *_ in updates:
+                        book[float(p)] = float(q)
+            elif msg.get("type") == "delta":
+                for side_key, book in side_updates.items():
+                    for p, q, *_ in data.get(side_key, []):
+                        price = float(p)
+                        qty = float(q)
+                        if qty == 0:
+                            book.pop(price, None)
+                        else:
+                            book[price] = qty
+            else:
+                # subscription acknowledgements or unknown messages
+                continue
+
+            ts_ms = int(data.get("ts", 0))
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+
+            bids_sorted = sorted(bids.items(), key=lambda x: -x[0])[:depth]
+            asks_sorted = sorted(asks.items(), key=lambda x: x[0])[:depth]
+            bids_list = [[p, q] for p, q in bids_sorted]
+            asks_list = [[p, q] for p, q in asks_sorted]
+
+            self.state.order_book[symbol] = {"bids": bids_list, "asks": asks_list}
+            yield self.normalize_order_book(symbol, ts, bids_list, asks_list)
+
+    stream_orderbook = stream_order_book
+
+    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
+        """Stream best bid/ask updates for ``symbol`` using the ticker feed."""
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"tickers.{sym}"]}
+        async for raw in self._ws_messages(url, json.dumps(sub)):
+            msg = json.loads(raw)
+            for d in msg.get("data", []) or []:
+                bid_px = d.get("bid1Price")
+                ask_px = d.get("ask1Price")
+                if bid_px is None and ask_px is None:
+                    continue
+                ts_ms = int(d.get("ts", 0))
+                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                yield {
+                    "symbol": symbol,
+                    "ts": ts,
+                    "bid_px": float(bid_px) if bid_px is not None else None,
+                    "bid_qty": float(d.get("bid1Size", 0.0)),
+                    "ask_px": float(ask_px) if ask_px is not None else None,
+                    "ask_qty": float(d.get("ask1Size", 0.0)),
+                }
+
+    async def stream_book_delta(self, symbol: str, depth: int = 1) -> AsyncIterator[dict]:
+        """Stream order book deltas for ``symbol``.
+
+        The ``orderbook`` channel itself provides incremental updates.  We
+        subscribe separately and emit the changed levels directly without
+        reconstructing the full book.
+        """
+
+        url = self.ws_public_url
+        sym = self.normalize_symbol(symbol)
+        sub = {"op": "subscribe", "args": [f"orderbook.{depth}.{sym}"]}
+
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             data = msg.get("data") or {}
@@ -76,53 +164,13 @@ class BybitWSAdapter(ExchangeAdapter):
             asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
             ts_ms = int(data.get("ts", 0))
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
-            self.state.order_book[symbol] = {"bids": bids, "asks": asks}
-            yield self.normalize_order_book(symbol, ts, bids, asks)
-
-    stream_orderbook = stream_order_book
-
-    async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
-        """Stream best bid/ask updates for ``symbol``."""
-
-        async for ob in self.stream_order_book(symbol, depth=1):
-            bid_px = ob.get("bid_px", [])
-            ask_px = ob.get("ask_px", [])
-            bid_qty = ob.get("bid_qty", [])
-            ask_qty = ob.get("ask_qty", [])
             yield {
                 "symbol": symbol,
-                "ts": ob.get("ts"),
-                "bid_px": bid_px[0] if bid_px else None,
-                "bid_qty": bid_qty[0] if bid_qty else 0.0,
-                "ask_px": ask_px[0] if ask_px else None,
-                "ask_qty": ask_qty[0] if ask_qty else 0.0,
-            }
-
-    async def stream_book_delta(self, symbol: str, depth: int = 1) -> AsyncIterator[dict]:
-        """Stream order book deltas compared to the previous snapshot."""
-
-        prev: dict | None = None
-        async for ob in self.stream_order_book(symbol, depth):
-            curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
-            curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
-            if prev is None:
-                delta_bids = curr_bids
-                delta_asks = curr_asks
-            else:
-                prev_bids = dict(zip(prev.get("bid_px", []), prev.get("bid_qty", [])))
-                prev_asks = dict(zip(prev.get("ask_px", []), prev.get("ask_qty", [])))
-                delta_bids = [[p, q] for p, q in curr_bids if prev_bids.get(p) != q]
-                delta_bids += [[p, 0.0] for p in prev_bids.keys() - {p for p, _ in curr_bids}]
-                delta_asks = [[p, q] for p, q in curr_asks if prev_asks.get(p) != q]
-                delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
-            prev = ob
-            yield {
-                "symbol": symbol,
-                "ts": ob.get("ts"),
-                "bid_px": [p for p, _ in delta_bids],
-                "bid_qty": [q for _, q in delta_bids],
-                "ask_px": [p for p, _ in delta_asks],
-                "ask_qty": [q for _, q in delta_asks],
+                "ts": ts,
+                "bid_px": [p for p, _ in bids],
+                "bid_qty": [q for _, q in bids],
+                "ask_px": [p for p, _ in asks],
+                "ask_qty": [q for _, q in asks],
             }
 
     async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
@@ -133,6 +181,8 @@ class BybitWSAdapter(ExchangeAdapter):
         sub = {"op": "subscribe", "args": [f"fundingRate.{sym}"]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
+            if msg.get("op") == "subscribe" and not msg.get("success", True):
+                raise NotImplementedError("fundingRate stream not supported")
             for d in msg.get("data", []) or []:
                 rate = d.get("fundingRate") or d.get("rate")
                 if rate is None:
@@ -155,6 +205,8 @@ class BybitWSAdapter(ExchangeAdapter):
         sub = {"op": "subscribe", "args": [f"openInterest.{sym}"]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
+            if msg.get("op") == "subscribe" and not msg.get("success", True):
+                raise NotImplementedError("openInterest stream not supported")
             for d in msg.get("data", []) or []:
                 oi = d.get("openInterest") or d.get("oi")
                 if oi is None:


### PR DESCRIPTION
## Summary
- reconstruct order book snapshots and emit deltas from Bybit WS
- stream best bid/ask quotes via `tickers.{symbol}`
- raise errors when funding rate or open interest streams unsupported

## Testing
- `pytest` *(killed: collected 278 items / 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a9005a4b2c832d8c835de58e4705f1