### PR TITLE
fix: handle backfill indicator

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -142,6 +142,16 @@ const kindDescriptions={
   ticker:"Precio de ticker"
 };
 
+function showWorking() {
+  const span = document.getElementById('dm-working');
+  if (span) span.style.display = 'inline';
+}
+
+function hideWorking() {
+  const span = document.getElementById('dm-working');
+  if (span) span.style.display = 'none';
+}
+
 function appendOutput(out, text) {
   out.textContent += text + '\n';
   requestAnimationFrame(() => out.scrollTop = out.scrollHeight);
@@ -246,14 +256,14 @@ async function runData(){
       runBtn.textContent='Ejecutar';
       currentJob=null;
       evt.close();
-      if(act==='backfill') hideWorking();
+        hideWorking();
       appendOutput(out, `Proceso finalizado (código ${e.data}).`);
     });
     evt.onerror=()=>{
       appendOutput(out, '[error de conexión]');
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
-      if(act==='backfill') hideWorking();
+      hideWorking();
     };
     if(act==='backfill') showWorking();
   }catch(e){
@@ -261,7 +271,7 @@ async function runData(){
     out.scrollTop = out.scrollHeight;
     runBtn.disabled=false;
     runBtn.textContent='Ejecutar';
-    if(act==='backfill') hideWorking();
+    hideWorking();
   }
 }
 


### PR DESCRIPTION
## Summary
- define showWorking/hideWorking helpers for data backfill UI
- ensure progress indicator is hidden after backfill completes or errors

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a911ecb1c0832db0e8bb86551047a6