### PR TITLE
Refine data kind descriptions and styling

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -9,6 +9,7 @@
   <style>
   @keyframes blink{0%,100%{opacity:.2;}50%{opacity:1;}}
   #dm-working{animation:blink 1s linear infinite;display:none;margin-left:8px;}
+  .dm-kind-desc {color: #0d6efd;font-weight: 500;display: block;margin-top: 8px;}
   </style>
 </head>
 <body>
@@ -111,7 +112,7 @@
         </select>
       </div>
     </div>
-    <p id="kind-desc" class="muted" style="margin-top:8px"></p>
+    <p id="dm-kind-desc" class="dm-kind-desc"></p>
     <button id="dm-run" style="margin-top:10px">Ejecutar</button>
     <button id="dm-stop" style="margin-top:10px;margin-left:8px" disabled>Detener</button>
     <button id="dm-clear" style="margin-top:10px;margin-left:8px">Limpiar</button>
@@ -133,13 +134,12 @@ let currentJob=null;
 let evt=null;
 let kindsWithDepth=[];
 const kindDescriptions={
-  bba:"Mejores posturas bid/ask",
-  delta:"Deltas del libro de órdenes",
-  open_interest:"Interés abierto",
-  orderbook:"Libro de órdenes completo",
-  trades:"Operaciones ejecutadas",
-  funding:"Tasa de financiamiento",
-  ticker:"Precio de ticker"
+  bba:"BBA (Best Bid & Ask): muestra las mejores posturas de compra (bid) y venta (ask) en el libro de órdenes.",
+  open_interest:"Open interest: cantidad total de contratos abiertos (posiciones vigentes) en un mercado de derivados.",
+  funding:"Funding (tasa de financiamiento): pagos periódicos entre compradores y vendedores de perpetuos para alinear el precio con el spot.",
+  trades:"Trades: cada transacción ejecutada (precio, cantidad y lado).",
+  orderbook:"Order book: niveles completos de posturas de compra y venta hasta la profundidad solicitada.",
+  delta:"Book delta: cambios recientes en las mejores posturas de compra y venta."
 };
 
 function appendOutput(out, text) {
@@ -180,7 +180,7 @@ document.getElementById('dm-persist').addEventListener('change',updateFields);
 document.getElementById('dm-kind').addEventListener('change', e => {
   updateFields();
   const kind=e.target.value;
-  const desc=document.getElementById('kind-desc');
+  const desc=document.getElementById('dm-kind-desc');
   desc.textContent=kindDescriptions[kind]||'';
 });
 
@@ -308,7 +308,7 @@ async function loadKinds(){
       sel.appendChild(opt);
     }
     updateFields();
-    document.getElementById('kind-desc').textContent = kindDescriptions[sel.value] || '';
+    document.getElementById('dm-kind-desc').textContent = kindDescriptions[sel.value] || '';
   }catch(e){
     console.error(e);
   }


### PR DESCRIPTION
## Summary
- add `.dm-kind-desc` style for data type descriptions
- expand `kindDescriptions` with clearer explanations
- apply new class to description element and update references

## Testing
- `pytest` *(killed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a912154840832d93c0192d04d0a9e4