### PR TITLE
Handle Binance open interest stream timeouts

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -225,6 +225,9 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
                     raise NotImplementedError(
                         "openInterest channel unavailable on Binance"
                     )
+                messages = self._ws_messages(url)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30)
                 continue
             except StopAsyncIteration:
                 return


### PR DESCRIPTION
## Summary
- Recreate open interest websocket stream on timeout and apply exponential backoff

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92dcfec50832d9ba2d40638064b6e