### PR TITLE
Remove open interest from Binance Futures WS supported kinds

### DIFF
--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -12,7 +12,7 @@ connecting to test environments.
 | binance_spot | trades, orderbook, bba, delta |
 | binance_futures | trades, orderbook, bba, delta, funding, open_interest |
 | binance_spot_ws | trades, trades_multi, orderbook, bba, delta |
-| binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding, open_interest |
+| binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding |
 | bybit_spot | trades, orderbook, bba, delta |
 | bybit_futures | trades, orderbook, bba, delta, funding, open_interest |
 | bybit_futures_ws | trades, orderbook, bba, delta, funding, open_interest |

--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -28,6 +28,14 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
     Permite operar tanto en mainnet como en testnet.
     """
     name = "binance_futures_ws"
+    supported_kinds = {
+        "bba",
+        "delta",
+        "funding",
+        "orderbook",
+        "trades",
+        "trades_multi",
+    }
 
     def __init__(
         self,

--- a/tests/test_api_venue_kinds.py
+++ b/tests/test_api_venue_kinds.py
@@ -15,7 +15,7 @@ def test_venue_kinds_endpoint(monkeypatch):
     app = get_app()
     client = TestClient(app)
 
-    resp = client.get("/venues/binance_spot/kinds", auth=("u", "p"))
+    resp = client.get("/venues/binance_futures/kinds", auth=("u", "p"))
     assert resp.status_code == 200
     data = resp.json()
     assert "trades" in data["kinds"]

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -25,7 +25,6 @@ EXPECTED_KINDS = {
         "bba",
         "delta",
         "funding",
-        "open_interest",
     },
     "bybit_spot": {
         "trades",


### PR DESCRIPTION
## Summary
- declare supported_kinds on BinanceFuturesWSAdapter without open_interest
- document updated supported kinds list
- adjust CLI and API tests to match

## Testing
- `pytest tests/test_cli_supported_kinds.py -q`
- `pytest tests/test_api_venue_kinds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a942d223dc832d9f8a115f95e8d535