### PR TITLE
Fix Bybit order book channels to v5

### DIFF
--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -72,14 +72,20 @@ class BybitWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
-        sub = {"op": "subscribe", "args": [f"orderbook.{depth}.{sym}"]}
+        # Bybit v5 supports only ``orderbook.50`` and ``orderbook.200`` topics.
+        sub_depth = 50 if depth <= 50 else 200
+        sub = {"op": "subscribe", "args": [f"orderbook.{sub_depth}.{sym}"]}
         bids: dict[float, float] = {}
         asks: dict[float, float] = {}
 
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
-            data = msg.get("data") or {}
-            if not data:
+            data_raw = msg.get("data") or {}
+            if isinstance(data_raw, list):
+                data = data_raw[0] if data_raw else {}
+            else:
+                data = data_raw
+            if not data or msg.get("type") not in {"snapshot", "delta"}:
                 continue
 
             side_updates = {
@@ -102,11 +108,7 @@ class BybitWSAdapter(ExchangeAdapter):
                             book.pop(price, None)
                         else:
                             book[price] = qty
-            else:
-                # subscription acknowledgements or unknown messages
-                continue
-
-            ts_ms = int(data.get("ts", 0))
+            ts_ms = int(msg.get("ts") or data.get("ts", 0))
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
 
             bids_sorted = sorted(bids.items(), key=lambda x: -x[0])[:depth]
@@ -153,16 +155,21 @@ class BybitWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
-        sub = {"op": "subscribe", "args": [f"orderbook.{depth}.{sym}"]}
+        sub_depth = 50 if depth <= 50 else 200
+        sub = {"op": "subscribe", "args": [f"orderbook.{sub_depth}.{sym}"]}
 
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
-            data = msg.get("data") or {}
-            if not data:
+            data_raw = msg.get("data") or {}
+            if isinstance(data_raw, list):
+                data = data_raw[0] if data_raw else {}
+            else:
+                data = data_raw
+            if not data or msg.get("type") not in {"snapshot", "delta"}:
                 continue
             bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
             asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
-            ts_ms = int(data.get("ts", 0))
+            ts_ms = int(msg.get("ts") or data.get("ts", 0))
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
             yield {
                 "symbol": symbol,

--- a/tests/test_bybit_ws_streams.py
+++ b/tests/test_bybit_ws_streams.py
@@ -1,0 +1,35 @@
+import asyncio
+import os
+import pytest
+
+from tradingbot.adapters.bybit_ws import BybitWSAdapter
+
+
+requires_net = pytest.mark.skipif(
+    not os.getenv("BYBIT_WS_TEST"), reason="requires network access to Bybit"
+)
+
+
+@requires_net
+@pytest.mark.asyncio
+async def test_stream_order_book_snapshot():
+    adapter = BybitWSAdapter(testnet=True)
+    stream = adapter.stream_order_book("BTC/USDT", depth=1)
+    try:
+        book = await asyncio.wait_for(stream.__anext__(), timeout=20)
+    finally:
+        await stream.aclose()
+    assert book["bids"] and book["asks"]
+
+
+@requires_net
+@pytest.mark.asyncio
+async def test_stream_book_delta_update():
+    adapter = BybitWSAdapter(testnet=True)
+    stream = adapter.stream_book_delta("BTC/USDT", depth=1)
+    try:
+        delta = await asyncio.wait_for(stream.__anext__(), timeout=20)
+    finally:
+        await stream.aclose()
+    # Ensure keys exist; lists may be empty if no changes but message arrives
+    assert "bid_px" in delta and "ask_px" in delta


### PR DESCRIPTION
## Summary
- Subscribe to Bybit v5 `orderbook.50/200` channels and handle snapshot/delta messages
- Parse order book snapshot and delta events into normalized levels
- Add optional integration tests for order book and delta streams

## Testing
- `pytest tests/test_bybit_ws_streams.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a94d14a49c832d8b130553bfb9991f