### PR TITLE
Drop funding & open interest from Bybit futures WS

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,14 +17,17 @@ Recibe datos de mercado en vivo y opcionalmente los almacena.
 - `--persist`: si se indica, guarda los datos en la base de datos.
 - `--backend`: backend de almacenamiento (`timescale` o `csv`).
 
+Nota: Bybit no provee streams de `funding` ni `open_interest` vía WebSocket;
+para esos datos utilice el adaptador REST (`bybit_futures`).
+
 Ejemplos:
 
 ```bash
 # Funding rate en Binance Futures
 python -m tradingbot.cli ingest --venue binance_futures_ws --symbol BTC/USDT --kind funding
 
-# Open interest en Bybit
-python -m tradingbot.cli ingest --venue bybit_futures_ws --symbol BTC/USDT --kind open_interest
+# Open interest en Bybit (usar REST)
+python -m tradingbot.cli ingest --venue bybit_futures --symbol BTC/USDT --kind open_interest
 
 # Funding y open interest en OKX
 python -m tradingbot.cli ingest --venue okx_futures_ws --symbol BTC/USDT --kind funding

--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -15,7 +15,7 @@ connecting to test environments.
 | binance_futures_ws | trades, trades_multi, orderbook, bba, delta, funding |
 | bybit_spot | trades, orderbook, bba, delta |
 | bybit_futures | trades, orderbook, bba, delta, funding, open_interest |
-| bybit_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
+| bybit_futures_ws | trades, orderbook, bba, delta |
 | okx_spot | trades, orderbook, bba, delta |
 | okx_futures | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
@@ -23,5 +23,7 @@ connecting to test environments.
 | deribit_futures_ws | trades, orderbook, bba, delta |
 
 This reference aims to keep the UI and CLI documentation aligned with the
-actual capabilities of each adapter.
+actual capabilities of each adapter. Bybit's public websocket omits funding
+and open interest streams; use the REST adapter (``bybit_futures``) for those
+data types.
 

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -26,6 +26,11 @@ class BybitWSAdapter(ExchangeAdapter):
     """
 
     name = "bybit_futures_ws"
+    # Bybit's public websocket does not expose funding or open interest
+    # channels (the server responds with ``error:handler not found``).  Only
+    # native streams are advertised here; users should rely on the REST
+    # adapter for those additional kinds.
+    supported_kinds = {"trades", "orderbook", "bba", "delta"}
 
     def __init__(self, ws_base: str | None = None, rest: ExchangeAdapter | None = None, testnet: bool = False):
         super().__init__()

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -45,8 +45,6 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
-        "funding",
-        "open_interest",
     },
     "okx_spot": {
         "trades",


### PR DESCRIPTION
## Summary
- stop advertising funding and open interest streams for `bybit_futures_ws`
- document that Bybit WS lacks these feeds and suggest using `bybit_futures` REST
- adjust CLI docs and tests to reflect supported kinds

## Testing
- `pytest tests/test_cli_supported_kinds.py tests/test_bybit_ws_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a94d13b60c832d9a7bf6b4c0e59fed