### PR TITLE
Fix Bybit BBA stream parsing

### DIFF
--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -127,21 +127,21 @@ class BybitWSAdapter(ExchangeAdapter):
         sub = {"op": "subscribe", "args": [f"tickers.{sym}"]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
-            for d in msg.get("data", []) or []:
-                bid_px = d.get("bid1Price")
-                ask_px = d.get("ask1Price")
-                if bid_px is None and ask_px is None:
-                    continue
-                ts_ms = int(d.get("ts", 0))
-                ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
-                yield {
-                    "symbol": symbol,
-                    "ts": ts,
-                    "bid_px": float(bid_px) if bid_px is not None else None,
-                    "bid_qty": float(d.get("bid1Size", 0.0)),
-                    "ask_px": float(ask_px) if ask_px is not None else None,
-                    "ask_qty": float(d.get("ask1Size", 0.0)),
-                }
+            data = msg.get("data") or {}
+            bid_px = data.get("bid1Price")
+            ask_px = data.get("ask1Price")
+            if bid_px is None and ask_px is None:
+                continue
+            ts_ms = int(data.get("ts", 0))
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            yield {
+                "symbol": symbol,
+                "ts": ts,
+                "bid_px": float(bid_px) if bid_px is not None else None,
+                "bid_qty": float(data.get("bid1Size", 0.0)),
+                "ask_px": float(ask_px) if ask_px is not None else None,
+                "ask_qty": float(data.get("ask1Size", 0.0)),
+            }
 
     async def stream_book_delta(self, symbol: str, depth: int = 1) -> AsyncIterator[dict]:
         """Stream order book deltas for ``symbol``.


### PR DESCRIPTION
## Summary
- Handle Bybit ticker stream `data` as a single dict instead of a list
- Emit best bid/ask updates only when at least one price is present

## Testing
- `pytest tests/test_adapter_base.py -q`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d12c160832d9ca3f1ec649590a0