### PR TITLE
chore: drop Deribit open interest kind

### DIFF
--- a/docs/supported_kinds.md
+++ b/docs/supported_kinds.md
@@ -19,7 +19,7 @@ connecting to test environments.
 | okx_spot | trades, orderbook, bba, delta |
 | okx_futures | trades, orderbook, bba, delta, funding, open_interest |
 | okx_futures_ws | trades, orderbook, bba, delta, funding, open_interest |
-| deribit_futures | trades, funding, open_interest |
+| deribit_futures | trades, funding |
 | deribit_futures_ws | trades, orderbook, bba, delta |
 
 This reference aims to keep the UI and CLI documentation aligned with the

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -32,6 +32,7 @@ class DeribitAdapter(ExchangeAdapter):
     """Adapter simple para Deribit (perpetuos)."""
 
     name = "deribit_futures"
+    supported_kinds = ["trades", "funding"]
 
     # Deribit únicamente lista perpetuos de BTC y ETH.  Este mapa traduce
     # símbolos genéricos (``ETHUSDT``) al identificador oficial del venue

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -68,7 +68,7 @@ EXPECTED_KINDS = {
         "funding",
         "open_interest",
     },
-    "deribit_futures": {"trades", "funding", "open_interest"},
+    "deribit_futures": {"trades", "funding"},
     "deribit_futures_ws": {
         "trades",
         "orderbook",


### PR DESCRIPTION
## Summary
- restrict Deribit adapter supported kinds to trades and funding
- adjust CLI tests and docs to omit Deribit open interest

## Testing
- `pytest tests/test_cli_supported_kinds.py::test_get_supported_kinds -q`
- `pytest tests/test_api_venue_kinds.py::test_venue_kinds_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68a95a87a37c832d9adf7cd6372031e5