### PR TITLE
Normalize Deribit WS symbols

### DIFF
--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -30,6 +30,18 @@ class DeribitWSAdapter(ExchangeAdapter):
         )
         self.name = "deribit_futures_ws_testnet" if testnet else "deribit_futures_ws"
 
+    # ------------------------------------------------------------------
+    @staticmethod
+    def normalize(symbol: str) -> str:
+        """Return Deribit instrument name for ``symbol``.
+
+        The websocket adapter shares the symbol mapping with the REST
+        adapter so users can pass generic pairs like ``ETHUSDT`` and obtain
+        the venue specific instrument ``ETH-PERPETUAL``.
+        """
+
+        return DeribitAdapter.normalize(symbol)
+
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         """Stream trades from Deribit public websocket.
 
@@ -38,7 +50,8 @@ class DeribitWSAdapter(ExchangeAdapter):
         desconexión.
         """
 
-        channel = f"trades.{symbol}"
+        sym = self.normalize(symbol)
+        channel = f"trades.{sym}"
         sub = {
             "jsonrpc": "2.0",
             "method": "public/subscribe",
@@ -53,11 +66,12 @@ class DeribitWSAdapter(ExchangeAdapter):
                     params = msg.get("params") or {}
                     for t in params.get("data") or []:
                         price = float(t.get("price") or 0.0)
-                        amount = float(t.get("amount") or t.get("size") or 0.0)
+                        qty = float(t.get("amount") or t.get("size") or 0.0)
+                        side = str(t.get("direction") or t.get("side") or "").lower()
                         ts_ms = int(t.get("timestamp") or t.get("time") or 0)
                         ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
-                        self.state.last_px[symbol] = price
-                        yield {"price": price, "amount": amount, "ts": ts}
+                        self.state.last_px[sym] = price
+                        yield self.normalize_trade(sym, ts, price, qty, side)
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # pragma: no cover - reconnection path
@@ -67,12 +81,13 @@ class DeribitWSAdapter(ExchangeAdapter):
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         """Stream order book snapshots from Deribit."""
 
+        sym = self.normalize(symbol)
         if self.rest and hasattr(self.rest, "stream_order_book"):
-            async for ob in self.rest.stream_order_book(symbol, depth):
+            async for ob in self.rest.stream_order_book(sym, depth):
                 yield ob
             return
 
-        channel = f"book.{depth}.{symbol}"
+        channel = f"book.{depth}.{sym}"
         sub = {
             "jsonrpc": "2.0",
             "method": "public/subscribe",
@@ -87,21 +102,22 @@ class DeribitWSAdapter(ExchangeAdapter):
             asks = [[float(p), float(q)] for p, q, *_ in data.get("asks", [])]
             ts_ms = int(data.get("timestamp") or data.get("ts") or 0)
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
-            self.state.order_book[symbol] = {"bids": bids, "asks": asks}
-            yield self.normalize_order_book(symbol, ts, bids, asks)
+            self.state.order_book[sym] = {"bids": bids, "asks": asks}
+            yield self.normalize_order_book(sym, ts, bids, asks)
 
     stream_orderbook = stream_order_book
 
     async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
         """Stream best bid/ask levels for ``symbol``."""
 
-        async for ob in self.stream_order_book(symbol, depth=1):
+        sym = self.normalize(symbol)
+        async for ob in self.stream_order_book(sym, depth=1):
             bid_px = ob.get("bid_px", [])
             ask_px = ob.get("ask_px", [])
             bid_qty = ob.get("bid_qty", [])
             ask_qty = ob.get("ask_qty", [])
             yield {
-                "symbol": symbol,
+                "symbol": sym,
                 "ts": ob.get("ts"),
                 "bid_px": bid_px[0] if bid_px else None,
                 "bid_qty": bid_qty[0] if bid_qty else 0.0,
@@ -112,8 +128,9 @@ class DeribitWSAdapter(ExchangeAdapter):
     async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         """Stream order book deltas relative to previous snapshots."""
 
+        sym = self.normalize(symbol)
         prev: dict | None = None
-        async for ob in self.stream_order_book(symbol, depth):
+        async for ob in self.stream_order_book(sym, depth):
             curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
             curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
             if prev is None:
@@ -128,7 +145,7 @@ class DeribitWSAdapter(ExchangeAdapter):
                 delta_asks += [[p, 0.0] for p in prev_asks.keys() - {p for p, _ in curr_asks}]
             prev = ob
             yield {
-                "symbol": symbol,
+                "symbol": sym,
                 "ts": ob.get("ts"),
                 "bid_px": [p for p, _ in delta_bids],
                 "bid_qty": [q for _, q in delta_bids],
@@ -139,17 +156,19 @@ class DeribitWSAdapter(ExchangeAdapter):
     async def stream_funding(self, symbol: str) -> AsyncIterator[dict]:
         if not self.rest:
             raise NotImplementedError("Funding stream requires REST adapter")
+        sym = self.normalize(symbol)
         while True:
-            data = await self.fetch_funding(symbol)
-            yield {"symbol": symbol, **data}
+            data = await self.fetch_funding(sym)
+            yield {"symbol": sym, **data}
             await asyncio.sleep(60)
 
     async def stream_open_interest(self, symbol: str) -> AsyncIterator[dict]:
         if not self.rest:
             raise NotImplementedError("Open interest stream requires REST adapter")
+        sym = self.normalize(symbol)
         while True:
-            data = await self.fetch_oi(symbol)
-            yield {"symbol": symbol, **data}
+            data = await self.fetch_oi(sym)
+            yield {"symbol": sym, **data}
             await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):


### PR DESCRIPTION
## Summary
- add shared symbol normalization mapping ETHUSDT -> ETH-PERPETUAL
- subscribe to Deribit WS channels using normalized instrument names
- return normalized symbols from BBA, order book and other streams

## Testing
- `pytest tests/test_deribit_connector.py::test_rest_normalization_deribit -q`
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing -q`
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_to_rest -q`
- ⚠️ `pytest tests/test_deribit_connector.py::test_stream_trades_and_orderbook -q` (hangs)

------
https://chatgpt.com/codex/tasks/task_e_68a95a88a194832da214eb083f3e1c4f