### PR TITLE
docs: clarify system clock offset warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ export BINANCE_FUTURES_TESTNET=true
 Si esta variable no está definida o se establece en `false`, el bot usará el
 entorno real de Binance Futures.
 
+## Solución de problemas
+
+Si se muestra el mensaje `System clock offset`, indica que el reloj del
+sistema tiene un desfase horario. Se recomienda sincronizar el reloj con un
+servidor NTP para evitar inconsistencias.
+
 ## Recursos
 
 - [Blueprint de arquitectura](BLUEPRINT.md)


### PR DESCRIPTION
## Summary
- document System clock offset warning and advise NTP sync

## Testing
- `pytest tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c33909d0832d9ac24eb98861cf45