### PR TITLE
docs: clarify deribit adapter capabilities

### DIFF
--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -1,4 +1,9 @@
-"""REST adapter for Deribit perpetual futures."""
+"""REST adapter for Deribit perpetual futures.
+
+Only streams available via the HTTP API are exposed here.  For order book
+snapshots, best bid/ask (BBA) or incremental book deltas use the websocket
+adapter :mod:`tradingbot.adapters.deribit_ws`.
+"""
 
 from __future__ import annotations
 
@@ -29,10 +34,14 @@ except Exception:  # pragma: no cover
 
 
 class DeribitAdapter(ExchangeAdapter):
-    """Adapter simple para Deribit (perpetuos)."""
+    """Adapter simple para Deribit (perpetuos).
+
+    El streaming de ``orderbook``, ``bba`` y ``delta`` sólo está disponible a
+    través de :mod:`tradingbot.adapters.deribit_ws`.
+    """
 
     name = "deribit_futures"
-    supported_kinds = ["trades", "funding"]
+    supported_kinds = ["trades", "funding"]  # ``open_interest`` no disponible
 
     # Deribit únicamente lista perpetuos de BTC y ETH.  Este mapa traduce
     # símbolos genéricos (``ETHUSDT``) al identificador oficial del venue


### PR DESCRIPTION
## Summary
- document that REST-based Deribit adapter only exposes HTTP streams
- direct users to `deribit_ws` for order book, BBA and delta streams

## Testing
- `pytest tests/test_cli_supported_kinds.py::test_get_supported_kinds -q`
- `pytest tests/test_deribit_connector.py::test_rest_normalization_deribit -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c33167a8832db8d4df34b32f78ee