### PR TITLE
Log debug when fetch_permissions missing in validate_scopes

### DIFF
--- a/src/tradingbot/utils/secrets.py
+++ b/src/tradingbot/utils/secrets.py
@@ -68,10 +68,19 @@ def validate_scopes(
     log = logger or logging.getLogger(__name__)
     try:
         has_perm = getattr(exchange, "has", {}).get("fetchPermissions")
-        if not has_perm:
-            log.debug("fetch_permissions no soportado para %s", getattr(exchange, "id", ""))
+        if not has_perm or not hasattr(exchange, "fetch_permissions"):
+            log.debug(
+                "fetch_permissions no soportado para %s",
+                getattr(exchange, "id", ""),
+            )
             return
         perms = exchange.fetch_permissions()
+    except AttributeError:
+        log.debug(
+            "fetch_permissions no soportado para %s",
+            getattr(exchange, "id", ""),
+        )
+        return
     except Exception as e:  # pragma: no cover - depende del exchange
         log.warning("no se pudieron obtener permisos: %s", e)
         return


### PR DESCRIPTION
## Summary
- fall back to debug log if an exchange lacks `fetch_permissions`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9c3367ee0832da674183d55ab1a0f