### PR TITLE
Fix Deribit WS channel formats and message filtering

### DIFF
--- a/tests/test_deribit_connector.py
+++ b/tests/test_deribit_connector.py
@@ -123,6 +123,7 @@ async def test_deribit_ws_adapter_parsing(monkeypatch):
     adapter = DeribitWSAdapter(rest=DummyRest([], {}, {}, {}))
 
     trade_msgs = [
+        json.dumps({"error": {"message": "bad"}}),
         json.dumps(
             {
                 "params": {
@@ -136,10 +137,11 @@ async def test_deribit_ws_adapter_parsing(monkeypatch):
                     ]
                 }
             }
-        )
+        ),
     ]
 
     book_msgs = [
+        json.dumps({"params": {}}),
         json.dumps(
             {
                 "params": {
@@ -150,7 +152,7 @@ async def test_deribit_ws_adapter_parsing(monkeypatch):
                     }
                 }
             }
-        )
+        ),
     ]
 
     ws_iter = iter([DummyWS(trade_msgs.copy()), DummyWS(book_msgs.copy())])


### PR DESCRIPTION
## Summary
- Use Deribit's proper channel format for trades and order books
- Ignore websocket messages containing errors or missing data
- Test Deribit WS adapter skips error/empty messages

## Testing
- `pytest -q` *(fails: Killed)*
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing -q`
- `pytest tests/test_deribit_connector.py::test_stream_trades_and_orderbook -q` *(fails: KeyboardInterrupt)*
- `pytest tests/test_deribit_adapter_stream.py::test_stream_trades_dedup -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d2c79e8c832d9f7cc50c203acd4e