### PR TITLE
Implement OKX symbol normalization for futures and spot

### DIFF
--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -14,7 +14,6 @@ except Exception:  # pragma: no cover
 
 from .base import ExchangeAdapter
 from ..config import settings
-from ..core.symbols import normalize
 from ..utils.secrets import validate_scopes
 from ..execution.venue_adapter import translate_order_flags
 
@@ -61,9 +60,33 @@ class OKXFuturesAdapter(ExchangeAdapter):
         )
         self.name = "okx_futures_testnet" if testnet else "okx_futures"
 
+    @staticmethod
+    def normalize_symbol(symbol: str) -> str:
+        """Return OKX formatted perpetual contract symbol."""
+
+        sym = ExchangeAdapter.normalize_symbol(symbol)
+        if not sym:
+            return sym
+        parts = sym.split("-")
+        base_quote = parts[0]
+        suffix = parts[1] if len(parts) > 1 else "SWAP"
+        quotes = [
+            "USDT",
+            "USDC",
+            "USD",
+            "BTC",
+            "ETH",
+            "EUR",
+            "GBP",
+            "JPY",
+        ]
+        quote = next((q for q in quotes if base_quote.endswith(q)), base_quote[-4:])
+        base = base_quote[: -len(quote)]
+        return f"{base}-{quote}-{suffix}"
+
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
@@ -77,7 +100,7 @@ class OKXFuturesAdapter(ExchangeAdapter):
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = self.ws_public_url
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
@@ -142,18 +165,19 @@ class OKXFuturesAdapter(ExchangeAdapter):
             await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
-        sym = normalize(symbol)
-        method = getattr(self.rest, "fetchFundingRate", None)
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "publicGetPublicFundingRate", None)
         if method is None:
             raise NotImplementedError("Funding not supported")
-        data = await self._request(method, sym)
-        ts = data.get("timestamp") or data.get("time") or data.get("ts") or 0
-        ts = int(ts)
-        if ts > 1e12:
-            ts /= 1000
-        ts_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-        rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
-        return {"ts": ts_dt, "rate": rate}
+        data = await self._request(method, {"instId": sym})
+        lst = data.get("data") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(
+            item.get("fundingTime") or item.get("ts") or item.get("timestamp") or 0
+        )
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        rate = float(item.get("fundingRate") or item.get("rate") or 0.0)
+        return {"ts": ts, "rate": rate}
 
     async def fetch_basis(self, symbol: str):
         """Return the basis (mark - index) for ``symbol``.
@@ -165,7 +189,7 @@ class OKXFuturesAdapter(ExchangeAdapter):
         venue no soporta esta métrica.
         """
 
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         method = getattr(self.rest, "fetchTicker", None)
         if method is None:
             raise NotImplementedError("Basis not supported")
@@ -201,7 +225,7 @@ class OKXFuturesAdapter(ExchangeAdapter):
         ``{"ts": datetime, "oi": float}``.
         """
 
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         method = getattr(self.rest, "publicGetPublicOpenInterest", None)
         if method is None:
             raise NotImplementedError("Open interest not supported")

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -16,7 +16,6 @@ except Exception:  # pragma: no cover
     NetworkError = ExchangeError = Exception
 
 from .base import ExchangeAdapter
-from ..core.symbols import normalize
 from ..utils.secrets import validate_scopes
 
 log = logging.getLogger(__name__)
@@ -35,9 +34,32 @@ class OKXSpotAdapter(ExchangeAdapter):
         # Validar permisos disponibles en la API key
         validate_scopes(self.rest, log)
 
+    @staticmethod
+    def normalize_symbol(symbol: str) -> str:
+        """Return OKX formatted spot symbol."""
+
+        sym = ExchangeAdapter.normalize_symbol(symbol)
+        if not sym:
+            return sym
+        parts = sym.split("-")
+        base_quote = parts[0]
+        quotes = [
+            "USDT",
+            "USDC",
+            "USD",
+            "BTC",
+            "ETH",
+            "EUR",
+            "GBP",
+            "JPY",
+        ]
+        quote = next((q for q in quotes if base_quote.endswith(q)), base_quote[-4:])
+        base = base_quote[: -len(quote)]
+        return f"{base}-{quote}"
+
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://ws.okx.com:8443/ws/v5/public"
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
@@ -51,7 +73,7 @@ class OKXSpotAdapter(ExchangeAdapter):
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
         url = "wss://ws.okx.com:8443/ws/v5/public"
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
@@ -116,18 +138,19 @@ class OKXSpotAdapter(ExchangeAdapter):
             await asyncio.sleep(60)
 
     async def fetch_funding(self, symbol: str):
-        sym = normalize(symbol)
-        method = getattr(self.rest, "fetchFundingRate", None)
+        sym = self.normalize_symbol(symbol)
+        method = getattr(self.rest, "publicGetPublicFundingRate", None)
         if method is None:
             raise NotImplementedError("Funding not supported")
-        data = await self._request(method, sym)
-        ts = data.get("timestamp") or data.get("time") or data.get("ts") or 0
-        ts = int(ts)
-        if ts > 1e12:
-            ts /= 1000
-        ts_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-        rate = float(data.get("fundingRate") or data.get("rate") or data.get("value") or 0.0)
-        return {"ts": ts_dt, "rate": rate}
+        data = await self._request(method, {"instId": sym})
+        lst = data.get("data") or []
+        item = lst[0] if lst else {}
+        ts_ms = int(
+            item.get("fundingTime") or item.get("ts") or item.get("timestamp") or 0
+        )
+        ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+        rate = float(item.get("fundingRate") or item.get("rate") or 0.0)
+        return {"ts": ts, "rate": rate}
 
     async def fetch_basis(self, symbol: str):
         """Return the basis (mark - index) for ``symbol``.
@@ -137,7 +160,7 @@ class OKXSpotAdapter(ExchangeAdapter):
         difference, returning a normalised ``{"ts": datetime, "basis": float}``.
         """
 
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         method = getattr(self.rest, "fetchTicker", None)
         if method is None:
             raise NotImplementedError("Basis not supported")
@@ -170,7 +193,7 @@ class OKXSpotAdapter(ExchangeAdapter):
         ``data`` array and return it as ``{"ts": datetime, "oi": float}``.
         """
 
-        sym = normalize(symbol)
+        sym = self.normalize_symbol(symbol)
         method = getattr(self.rest, "publicGetPublicOpenInterest", None)
         if method is None:
             raise NotImplementedError("Open interest not supported")


### PR DESCRIPTION
## Summary
- add exchange-specific `normalize_symbol` for OKX futures, spot and ws adapters
- use normalized symbols in all streaming and REST calls, including `instId` params
- adjust funding and open interest fetches for OKX REST endpoints

## Testing
- `pytest -q`
- `python - <<'PY' ...` *(funding and ws requests failed: Network is unreachable / proxy rejected connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a9da3d7574832d9efe1ba8e142d21a