### PR TITLE
Handle missing REST order book method in Deribit WS adapter

### DIFF
--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -86,10 +86,13 @@ class DeribitWSAdapter(ExchangeAdapter):
         """Stream order book snapshots from Deribit."""
 
         sym = normalize(symbol)
-        if self.rest and hasattr(self.rest, "stream_order_book"):
-            async for ob in self.rest.stream_order_book(sym, depth):
-                yield ob
-            return
+        if self.rest:
+            try:
+                async for ob in self.rest.stream_order_book(sym, depth):
+                    yield ob
+                return
+            except (NotImplementedError, AttributeError):
+                pass
 
         channel = f"book.{sym}.{depth}.100ms"
         sub = {


### PR DESCRIPTION
## Summary
- use try/except for REST order book delegation to fall back when NotImplemented or missing

## Testing
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_delegates_to_rest -q`
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing -q`
- `pytest tests/test_deribit_connector.py::test_stream_trades_and_orderbook -q` *(fails: hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d83ac8ac832d86019d32149a4826