### PR TITLE
Fix OKX order book subscriptions

### DIFF
--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -89,7 +89,7 @@ class OKXSpotAdapter(ExchangeAdapter):
         channel = self.DEPTH_TO_CHANNEL.get(depth)
         if channel is None:
             raise ValueError(f"depth must be one of {sorted(self.DEPTH_TO_CHANNEL)}")
-        sub = {"op": "subscribe", "args": [f"{channel}:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": channel, "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
@@ -112,7 +112,7 @@ class OKXSpotAdapter(ExchangeAdapter):
     async def stream_bba(self, symbol: str) -> AsyncIterator[dict]:
         """Emit best bid/ask quotes for ``symbol`` using bbo channel."""
 
-        async for ob in self.stream_order_book(symbol):
+        async for ob in self.stream_order_book(symbol, 1):
             bid_px = ob.get("bid_px", [None])[0]
             bid_qty = ob.get("bid_qty", [None])[0]
             ask_px = ob.get("ask_px", [None])[0]
@@ -126,7 +126,7 @@ class OKXSpotAdapter(ExchangeAdapter):
                 "ask_qty": ask_qty,
             }
 
-    async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
+    async def stream_book_delta(self, symbol: str, depth: int = 5) -> AsyncIterator[dict]:
         """Yield incremental order book updates for ``symbol``."""
 
         prev: dict | None = None


### PR DESCRIPTION
## Summary
- Use object args for OKX order book subscriptions
- Ensure stream_bba uses bbo channel
- Set valid default depth for stream_book_delta

## Testing
- `python -m py_compile src/tradingbot/adapters/okx_futures.py src/tradingbot/adapters/okx_spot.py`
- `pytest tests/test_adapters.py::test_registered_adapters_are_subclasses -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9fcb643bc832dac3c61c01bcb3d9c