### PR TITLE
Handle Deribit heartbeat and validate order book depth

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import time
 import random
+import json
 
 import websockets
 
@@ -169,6 +170,22 @@ class ExchangeAdapter(ABC):
                     try:
                         while True:
                             msg = await ws.recv()
+                            try:
+                                data = json.loads(msg)
+                            except Exception:
+                                yield msg
+                                continue
+                            if data.get("method") == "heartbeat":
+                                await ws.send(
+                                    json.dumps(
+                                        {
+                                            "jsonrpc": "2.0",
+                                            "id": 0,
+                                            "method": "public/respond-heartbeat",
+                                        }
+                                    )
+                                )
+                                continue
                             yield msg
                     finally:
                         ping_task.cancel()

--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -82,8 +82,13 @@ class DeribitWSAdapter(ExchangeAdapter):
                 log.warning("WS trades disconnected (%s), reconnecting ...", e)
                 await asyncio.sleep(1.0)
 
+    ORDER_BOOK_DEPTHS = {1, 5, 10, 20, 30, 50}
+
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         """Stream order book snapshots from Deribit."""
+
+        if depth not in self.ORDER_BOOK_DEPTHS:
+            raise ValueError(f"depth must be one of {sorted(self.ORDER_BOOK_DEPTHS)}")
 
         sym = normalize(symbol)
         if self.rest:
@@ -94,7 +99,7 @@ class DeribitWSAdapter(ExchangeAdapter):
             except (NotImplementedError, AttributeError):
                 pass
 
-        channel = f"book.{sym}.{depth}.100ms"
+        channel = f"book.{sym}.none.{depth}.100ms"
         sub = {
             "jsonrpc": "2.0",
             "method": "public/subscribe",


### PR DESCRIPTION
## Summary
- reply to Deribit heartbeat messages within websocket helper
- validate Deribit order book depth and include channel group segment

## Testing
- `pytest tests/test_deribit_connector.py::test_deribit_ws_adapter_parsing -q`
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fcb73ff0832d8efc0eacf45be57f