### PR TITLE
refactor: update okx ws subscribe schema

### DIFF
--- a/src/tradingbot/adapters/okx_ws.py
+++ b/src/tradingbot/adapters/okx_ws.py
@@ -67,7 +67,7 @@ class OKXWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self._normalize(symbol)
-        sub = {"op": "subscribe", "args": [f"trades:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
@@ -97,7 +97,7 @@ class OKXWSAdapter(ExchangeAdapter):
         channel = self.DEPTH_TO_CHANNEL.get(depth)
         if channel is None:
             raise ValueError(f"depth must be one of {sorted(self.DEPTH_TO_CHANNEL)}")
-        sub = {"op": "subscribe", "args": [f"{channel}:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": channel, "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
@@ -123,7 +123,7 @@ class OKXWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self._normalize(symbol)
-        sub = {"op": "subscribe", "args": [f"bbo-tbt:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": "bbo-tbt", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
@@ -174,7 +174,7 @@ class OKXWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self._normalize(symbol)
-        sub = {"op": "subscribe", "args": [f"funding-rate:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": "funding-rate", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
@@ -196,7 +196,7 @@ class OKXWSAdapter(ExchangeAdapter):
 
         url = self.ws_public_url
         sym = self._normalize(symbol)
-        sub = {"op": "subscribe", "args": [f"open-interest:{sym}"]}
+        sub = {"op": "subscribe", "args": [{"channel": "open-interest", "instId": sym}]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -188,7 +188,13 @@ async def test_stream_trades(connector_cls, messages, monkeypatch):
     assert trade1.price == 1.0
     assert trade2.price == 3.0
     await gen.aclose()
-    assert ws.sent[0] == c._ws_trades_subscribe("BTCUSDT")
+    if connector_cls is OKXConnector:
+        assert json.loads(ws.sent[0]) == {
+            "op": "subscribe",
+            "args": [{"channel": "trades", "instId": "BTCUSDT"}],
+        }
+    else:
+        assert ws.sent[0] == c._ws_trades_subscribe("BTCUSDT")
 
 
 class DummyOrderRest:


### PR DESCRIPTION
## Summary
- refactor OKX websocket streams to use `{channel, instId}` subscription format
- update tests and mocks for new OKX subscription schema

## Testing
- `pytest tests/test_okx_ws_adapter.py tests/test_connectors.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa027f35d0832da146ead1d03d0a5a