### PR TITLE
Guard Deribit trade stream and use 100ms channel

### DIFF
--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -56,7 +56,7 @@ class DeribitWSAdapter(ExchangeAdapter):
         """
 
         sym = self._normalize(symbol)
-        channel = f"trades.{sym}.raw"
+        channel = f"trades.{sym}.100ms"
         sub = {
             "jsonrpc": "2.0",
             "method": "public/subscribe",
@@ -69,8 +69,9 @@ class DeribitWSAdapter(ExchangeAdapter):
                 async for raw in self._ws_messages(self.ws_url, json.dumps(sub)):
                     msg = json.loads(raw)
                     if msg.get("error"):
-                        log.error("WS subscription error: %s", msg)
-                        continue
+                        err = msg.get("error")
+                        log.error("WS subscription error for %s: %s", channel, err)
+                        raise ValueError(f"WS subscription error for {channel}: {err}")
                     params = msg.get("params") or {}
                     if params.get("channel") != channel:
                         raise ValueError(


### PR DESCRIPTION
## Summary
- switch Deribit trade subscription to 100ms channel
- raise clear error when a WS subscription fails
- adjust tests for new channel and error behaviour

## Testing
- `flake8 --max-line-length=120 src/tradingbot/adapters/deribit_ws.py tests/test_deribit_connector.py`
- `pytest tests/test_deribit_connector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa17a1f584832d97fe6b072f818253