### PR TITLE
Validate OKX symbol suffixes in websocket adapter

### DIFF
--- a/src/tradingbot/adapters/okx_ws.py
+++ b/src/tradingbot/adapters/okx_ws.py
@@ -57,7 +57,11 @@ class OKXWSAdapter(ExchangeAdapter):
             "GBP",
             "JPY",
         ]
-        quote = next((q for q in quotes if base_quote.endswith(q)), base_quote[-4:])
+        quote = next((q for q in quotes if base_quote.endswith(q)), None)
+        if quote is None:
+            # ``base_quote`` may include unsupported suffixes like "PERP".
+            unknown = base_quote[-4:]
+            raise ValueError(f"Unsupported quote asset '{unknown}' in symbol '{symbol}'")
         base = base_quote[: -len(quote)]
         return f"{base}-{quote}-{suffix}"
 

--- a/tests/test_okx_ws_adapter.py
+++ b/tests/test_okx_ws_adapter.py
@@ -27,6 +27,20 @@ class DummyRest:
         return {"status": "canceled"}
 
 
+@pytest.mark.parametrize(
+    "symbol, suffix",
+    [
+        ("BTC-PERP", "PERP"),
+        ("BTC-FOO", "FOO"),
+    ],
+)
+def test_normalize_symbol_invalid(symbol, suffix):
+    adapter = OKXWSAdapter()
+    with pytest.raises(ValueError) as excinfo:
+        adapter.normalize_symbol(symbol)
+    assert suffix in str(excinfo.value)
+
+
 @pytest.mark.asyncio
 async def test_fetch_funding_oi_and_orders():
     rest = DummyRest()


### PR DESCRIPTION
## Summary
- raise `ValueError` when OKX websocket symbols contain unsupported quote suffixes like `PERP`
- add unit tests for invalid OKX websocket symbols

## Testing
- `pytest tests/test_okx_ws_adapter.py::test_normalize_symbol_invalid -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3f445a24832dbfdb24b18bc710cc