### PR TITLE
Add Deribit altcoin instrument mappings

### DIFF
--- a/docs/venues.md
+++ b/docs/venues.md
@@ -18,3 +18,6 @@ target and the primary connection method used by each adapter.
 | deribit | Perpetual futures | REST |
 | deribit_ws | Perpetual futures | WebSocket |
 
+Deribit ofrece perpetuos no solo de BTC y ETH sino también de varios altcoins
+como SOL, XRP, MATIC, DOT, ADA, DOGE, LTC y TRX.
+

--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -43,8 +43,9 @@ class DeribitAdapter(ExchangeAdapter):
     name = "deribit_futures"
     supported_kinds = ["trades", "funding"]  # ``open_interest`` no disponible
 
-    # Deribit únicamente lista perpetuos de BTC y ETH.  Este mapa traduce
-    # símbolos genéricos (``ETHUSDT``) al identificador oficial del venue
+    # Deribit listaba originalmente únicamente perpetuos de BTC y ETH pero ha
+    # ampliado su oferta con varios altcoins.  Este mapa traduce símbolos
+    # genéricos (``ETHUSDT``) al identificador oficial del venue
     # (``ETH-PERPETUAL``).  Las claves se almacenan ya normalizadas mediante
     # :func:`tradingbot.core.symbols.normalize` para aceptar múltiples
     # variantes de entrada ("ETH/USDT", "eth-perp", etc.).
@@ -57,6 +58,38 @@ class DeribitAdapter(ExchangeAdapter):
         "ETHUSD": "ETH-PERPETUAL",
         "ETHPERP": "ETH-PERPETUAL",
         "ETHPERPETUAL": "ETH-PERPETUAL",
+        "SOLUSDT": "SOL-PERPETUAL",
+        "SOLUSD": "SOL-PERPETUAL",
+        "SOLPERP": "SOL-PERPETUAL",
+        "SOLPERPETUAL": "SOL-PERPETUAL",
+        "XRPUSDT": "XRP-PERPETUAL",
+        "XRPUSD": "XRP-PERPETUAL",
+        "XRPPERP": "XRP-PERPETUAL",
+        "XRPPERPETUAL": "XRP-PERPETUAL",
+        "MATICUSDT": "MATIC-PERPETUAL",
+        "MATICUSD": "MATIC-PERPETUAL",
+        "MATICPERP": "MATIC-PERPETUAL",
+        "MATICPERPETUAL": "MATIC-PERPETUAL",
+        "DOTUSDT": "DOT-PERPETUAL",
+        "DOTUSD": "DOT-PERPETUAL",
+        "DOTPERP": "DOT-PERPETUAL",
+        "DOTPERPETUAL": "DOT-PERPETUAL",
+        "ADAUSDT": "ADA-PERPETUAL",
+        "ADAUSD": "ADA-PERPETUAL",
+        "ADAPERP": "ADA-PERPETUAL",
+        "ADAPERPETUAL": "ADA-PERPETUAL",
+        "DOGEUSDT": "DOGE-PERPETUAL",
+        "DOGEUSD": "DOGE-PERPETUAL",
+        "DOGEPERP": "DOGE-PERPETUAL",
+        "DOGEPERPETUAL": "DOGE-PERPETUAL",
+        "LTCUSDT": "LTC-PERPETUAL",
+        "LTCUSD": "LTC-PERPETUAL",
+        "LTCPERP": "LTC-PERPETUAL",
+        "LTCPERPETUAL": "LTC-PERPETUAL",
+        "TRXUSDT": "TRX-PERPETUAL",
+        "TRXUSD": "TRX-PERPETUAL",
+        "TRXPERP": "TRX-PERPETUAL",
+        "TRXPERPETUAL": "TRX-PERPETUAL",
     }
 
     @classmethod

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -584,6 +584,19 @@ async def test_deribit_fetch_methods():
     assert oi["ts"] == datetime.fromtimestamp(1, tz=timezone.utc)
 
 
+@pytest.mark.parametrize(
+    "alias,instrument",
+    [
+        ("SOLUSDT", "SOL-PERPETUAL"),
+        ("XRPUSDT", "XRP-PERPETUAL"),
+        ("MATICUSDT", "MATIC-PERPETUAL"),
+        ("DOTUSDT", "DOT-PERPETUAL"),
+    ],
+)
+def test_deribit_symbol_map_new_instruments(alias, instrument):
+    assert DeribitAdapter.normalize(alias) == instrument
+
+
 @pytest.mark.asyncio
 async def test_request_and_close_async_rest():
     class DummyAdapter(ExchangeAdapter):


### PR DESCRIPTION
## Summary
- expand Deribit adapter with symbol mapping for SOL, XRP, MATIC, DOT, ADA, DOGE, LTC and TRX perpetuals
- document new Deribit altcoin support
- test normalization of new Deribit instruments

## Testing
- `pytest tests/test_adapters.py::test_deribit_symbol_map_new_instruments tests/test_adapters.py::test_deribit_fetch_methods tests/test_deribit_adapter_stream.py::test_stream_trades_dedup tests/test_deribit_connector.py::test_rest_normalization_deribit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3f4379d8832d92555af7e9e06d3a