### PR TITLE
Add open interest and basis tables for QuestDB

### DIFF
--- a/bin/start_questdb.sh
+++ b/bin/start_questdb.sh
@@ -3,3 +3,11 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd)
 cd "$SCRIPT_DIR/.."
 docker compose -f sql/docker-compose.questdb.yml up -d
+
+# Wait for QuestDB to be ready
+until curl -f http://localhost:9000/health >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Apply database schema
+psql -h localhost -p 8812 -U admin -d qdb -f sql/schema_quest.sql

--- a/bin/start_stack.sh
+++ b/bin/start_stack.sh
@@ -11,3 +11,11 @@ done
 
 # Apply database schema
 PGPASSWORD=postgres psql -h localhost -U postgres -d trading -f sql/schema_timescale.sql
+
+# Wait for QuestDB to be ready
+until curl -f http://localhost:9000/health >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Apply QuestDB schema
+psql -h localhost -p 8812 -U admin -d qdb -f sql/schema_quest.sql

--- a/sql/schema_quest.sql
+++ b/sql/schema_quest.sql
@@ -39,3 +39,17 @@ CREATE TABLE IF NOT EXISTS funding (
     rate DOUBLE,
     interval_sec LONG
 ) timestamp(ts) PARTITION BY DAY;
+
+CREATE TABLE IF NOT EXISTS open_interest (
+    ts TIMESTAMP,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    oi DOUBLE
+) timestamp(ts) PARTITION BY DAY;
+
+CREATE TABLE IF NOT EXISTS basis (
+    ts TIMESTAMP,
+    exchange SYMBOL,
+    symbol SYMBOL,
+    basis DOUBLE
+) timestamp(ts) PARTITION BY DAY;


### PR DESCRIPTION
## Summary
- create `open_interest` and `basis` tables in QuestDB schema
- load QuestDB schema during stack startup scripts

## Testing
- `pytest tests/test_data_pollers.py -q`
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4ff191fc832d95ec28f66f50fc5c