### PR TITLE
feat: initialize timescale db schema

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "5432:5432"
     volumes:
       - tsdb-data:/var/lib/postgresql/data
+      - ./sql/schema_timescale.sql:/docker-entrypoint-initdb.d/schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
## Summary
- mount a schema init script for TimescaleDB during container startup

## Testing
- `docker compose down -v && docker compose up -d` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa96823d3c832dbbcaa6372dc50fed