### PR TITLE
Limit CCXT exchanges to supported list

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -30,6 +30,8 @@ from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
 from ...cli.main import get_adapter_class, get_supported_kinds, _AVAILABLE_VENUES
 
+SUPPORTED_EXCHANGES = ["binance", "okx", "bybit"]
+
 # Persistencia
 try:
     from ...storage.timescale import (
@@ -97,7 +99,8 @@ def ccxt_exchanges():
     """Return exchanges supported by ``ccxt``."""
     if ccxt is None:
         return []
-    return sorted(getattr(ccxt, "exchanges", []))
+    available = getattr(ccxt, "exchanges", [])
+    return [ex for ex in SUPPORTED_EXCHANGES if ex in available]
 
 
 @app.get("/venues/{name}/kinds")


### PR DESCRIPTION
## Summary
- Restrict `/ccxt/exchanges` to a fixed set of supported exchanges

## Testing
- `pytest`
- `PYTHONPATH=src python - <<'PY'
from fastapi.testclient import TestClient
from tradingbot.apps.api.main import app
client = TestClient(app)
print(client.get('/ccxt/exchanges', auth=('admin','admin')).json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b8479d0832d96a84fd41ded7a10