### PR TITLE
feat(api): map supported exchanges

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -30,7 +30,12 @@ from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
 from ...cli.main import get_adapter_class, get_supported_kinds, _AVAILABLE_VENUES
 
-SUPPORTED_EXCHANGES = ["binance", "okx", "bybit"]
+# Exchanges supported through ccxt along with their identifiers and options
+SUPPORTED_EXCHANGES = {
+    "binance_futures": {"ccxt": "binanceusdm"},
+    "okx_futures": {"ccxt": "okx", "options": {"defaultType": "swap"}},
+    "bybit_futures": {"ccxt": "bybit", "options": {"defaultType": "swap"}},
+}
 
 # Persistencia
 try:
@@ -100,7 +105,7 @@ def ccxt_exchanges():
     if ccxt is None:
         return []
     available = getattr(ccxt, "exchanges", [])
-    return [ex for ex in SUPPORTED_EXCHANGES if ex in available]
+    return [name for name, ex in SUPPORTED_EXCHANGES.items() if ex["ccxt"] in available]
 
 
 @app.get("/venues/{name}/kinds")

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -77,9 +77,9 @@
       <div id="field-exchange-name">
         <label for="dm-exchange-name">Exchange</label>
         <select id="dm-exchange-name">
-          <option value="binance">binance</option>
-          <option value="okx">okx</option>
-          <option value="bybit">bybit</option>
+          <option value="binance_futures">binance_futures</option>
+          <option value="okx_futures">okx_futures</option>
+          <option value="bybit_futures">bybit_futures</option>
         </select>
       </div>
       <div id="field-source">


### PR DESCRIPTION
## Summary
- map supported exchanges with ccxt identifiers and options
- filter `/ccxt/exchanges` against ccxt available exchanges
- update default exchange names in data management page

## Testing
- `pytest` *(fails: process killed)*
- `pytest tests/test_adapter_base.py::test_normalize_helpers -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab423b505c832da8198af284ac5b0c