### PR TITLE
feat: validate ccxt exchange for backfill

### DIFF
--- a/src/tradingbot/exchanges.py
+++ b/src/tradingbot/exchanges.py
@@ -1,0 +1,11 @@
+"""Exchange configuration shared across modules."""
+
+from __future__ import annotations
+
+SUPPORTED_EXCHANGES: dict[str, dict] = {
+    "binance": {"ccxt": "binance"},
+    "okx": {"ccxt": "okx", "options": {"options": {"defaultType": "spot"}}},
+    "bybit": {"ccxt": "bybit", "options": {"options": {"defaultType": "spot"}}},
+}
+
+__all__ = ["SUPPORTED_EXCHANGES"]

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -10,6 +10,7 @@ import ccxt.async_support as ccxt
 import logging
 
 from ..storage.async_timescale import AsyncTimescaleClient
+from ..exchanges import SUPPORTED_EXCHANGES
 
 logger = logging.getLogger(__name__)
 
@@ -77,11 +78,12 @@ async def backfill(
         logger.info("Backfill start: %d day(s) for %s", days, ", ".join(symbols))
 
     try:
-        ex_class = getattr(ccxt, exchange_name)
-    except AttributeError as exc:
+        info = SUPPORTED_EXCHANGES[exchange_name]
+    except KeyError as exc:
         raise ValueError(f"Exchange {exchange_name!r} not supported") from exc
 
-    ex = ex_class({"enableRateLimit": False})
+    ex_class = getattr(ccxt, info["ccxt"])
+    ex = ex_class({"enableRateLimit": False, **info.get("options", {})})
     ex.id = exchange_name
     delay = getattr(ex, "rateLimit", 1000) / 1000
 


### PR DESCRIPTION
## Summary
- centralize supported ccxt exchanges
- use exchange metadata for backfill jobs
- validate `--exchange-name` CLI option against supported exchanges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab423cff64832d8315568b06482ce6