### PR TITLE
Expand exchange mapping and CLI validation

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -343,7 +343,10 @@ def backfill(
         "binance",
         "--exchange-name",
         callback=_validate_exchange_name,
-        help=f"ccxt exchange name ({_EXCHANGE_CHOICES})",
+        help=(
+            "Exchange to use. Choose from spot/futures venues or Deribit:"
+            f" {_EXCHANGE_CHOICES}"
+        ),
     ),
     start: str | None = typer.Option(
         None, "--start", help="Start datetime in ISO format"

--- a/src/tradingbot/exchanges.py
+++ b/src/tradingbot/exchanges.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 SUPPORTED_EXCHANGES: dict[str, dict] = {
     "binance": {"ccxt": "binance"},
+    "binance_futures": {"ccxt": "binanceusdm"},
     "okx": {"ccxt": "okx", "options": {"options": {"defaultType": "spot"}}},
+    "okx_futures": {"ccxt": "okx", "options": {"options": {"defaultType": "swap"}}},
     "bybit": {"ccxt": "bybit", "options": {"options": {"defaultType": "spot"}}},
+    "bybit_futures": {"ccxt": "bybit", "options": {"options": {"defaultType": "swap"}}},
+    "deribit": {"ccxt": "deribit"},
 }
 
 __all__ = ["SUPPORTED_EXCHANGES"]

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -77,10 +77,9 @@ async def backfill(
     else:
         logger.info("Backfill start: %d day(s) for %s", days, ", ".join(symbols))
 
-    try:
-        info = SUPPORTED_EXCHANGES[exchange_name]
-    except KeyError as exc:
-        raise ValueError(f"Exchange {exchange_name!r} not supported") from exc
+    info = SUPPORTED_EXCHANGES.get(exchange_name)
+    if info is None:
+        raise ValueError(f"Exchange {exchange_name!r} not supported")
 
     ex_class = getattr(ccxt, info["ccxt"])
     ex = ex_class({"enableRateLimit": False, **info.get("options", {})})


### PR DESCRIPTION
## Summary
- extend SUPPORTED_EXCHANGES with futures and Deribit entries
- use mapping in backfill job to configure ccxt exchanges
- restrict `backfill --exchange-name` to supported names with clearer help text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab4af3a560832da910d255339faf1f