### PR TITLE
Align exchange identifiers across modules

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -29,17 +29,7 @@ from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
 from ...cli.main import get_adapter_class, get_supported_kinds, _AVAILABLE_VENUES
-
-# Exchanges supported through ccxt along with their identifiers and options
-SUPPORTED_EXCHANGES = {
-    "binance_spot": {"ccxt": "binance"},
-    "binance_futures": {"ccxt": "binanceusdm"},
-    "okx_spot": {"ccxt": "okx", "options": {"defaultType": "spot"}},
-    "okx_futures": {"ccxt": "okx", "options": {"defaultType": "swap"}},
-    "bybit_spot": {"ccxt": "bybit", "options": {"defaultType": "spot"}},
-    "bybit_futures": {"ccxt": "bybit", "options": {"defaultType": "swap"}},
-    "deribit_futures": {"ccxt": "deribit"},
-}
+from ...exchanges import SUPPORTED_EXCHANGES
 
 # Persistencia
 try:

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -340,7 +340,7 @@ def backfill(
         ["BTC/USDT"], "--symbols", help="Symbols to download"
     ),
     exchange_name: str = typer.Option(
-        "binance",
+        "binance_spot",
         "--exchange-name",
         callback=_validate_exchange_name,
         help=(

--- a/src/tradingbot/exchanges.py
+++ b/src/tradingbot/exchanges.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 SUPPORTED_EXCHANGES: dict[str, dict] = {
-    "binance": {"ccxt": "binance"},
+    "binance_spot": {"ccxt": "binance"},
     "binance_futures": {"ccxt": "binanceusdm"},
-    "okx": {"ccxt": "okx", "options": {"options": {"defaultType": "spot"}}},
+    "okx_spot": {"ccxt": "okx", "options": {"options": {"defaultType": "spot"}}},
     "okx_futures": {"ccxt": "okx", "options": {"options": {"defaultType": "swap"}}},
-    "bybit": {"ccxt": "bybit", "options": {"options": {"defaultType": "spot"}}},
+    "bybit_spot": {"ccxt": "bybit", "options": {"options": {"defaultType": "spot"}}},
     "bybit_futures": {"ccxt": "bybit", "options": {"options": {"defaultType": "swap"}}},
-    "deribit": {"ccxt": "deribit"},
+    "deribit_futures": {"ccxt": "deribit"},
 }
 
 __all__ = ["SUPPORTED_EXCHANGES"]

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -47,14 +47,16 @@ async def _retry(func, *args, retries: int = 3, delay: float = 1.0, **kwargs):
 async def backfill(
     days: int,
     symbols: Sequence[str],
-    exchange_name: str = "binance",
+    exchange_name: str = "binance_spot",
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> None:
     """Backfill OHLCV bars and trades for *symbols*.
 
-    If *start* or *end* are not provided, the range defaults to the past
-    ``days`` days ending at ``datetime.now(timezone.utc)``.
+    ``exchange_name`` must match the identifiers used by the ingestion
+    command (``binance_spot``, ``binance_futures``, etc.).  If *start* or *end*
+    are not provided, the range defaults to the past ``days`` days ending at
+    ``datetime.now(timezone.utc)``.
     """
 
     if end is None:


### PR DESCRIPTION
## Summary
- Centralize `SUPPORTED_EXCHANGES` and rename entries to `binance_spot`, `binance_futures`, etc.
- Import central exchange mapping in API instead of local copy.
- Update backfill job and CLI command to use new identifiers.

## Testing
- `pytest tests/test_api_venue_kinds.py tests/test_api_bots.py::test_cross_arbitrage_start -q`
- `pytest tests/test_data_ingestion_batch.py::test_backfill_applies_rate_limit -q` *(fails: OSError: Connect call failed ('::1', 5432, 0, 0))*
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53479250832db8ae36052fec0f02