### PR TITLE
Normalize symbol before persisting backfill data

### DIFF
--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -9,6 +9,7 @@ from typing import Sequence
 import ccxt.async_support as ccxt
 import logging
 
+from tradingbot.core.symbols import normalize
 from ..storage.async_timescale import AsyncTimescaleClient
 from ..exchanges import SUPPORTED_EXCHANGES
 
@@ -97,7 +98,7 @@ async def backfill(
     try:
         for symbol in symbols:
             logger.info("Procesando %s", symbol)
-            db_symbol = symbol.replace("/", "")
+            db_symbol = normalize(symbol)
 
             # --- OHLCV backfill -------------------------------------------------
             since = start_ms

--- a/tests/test_backfill_persistence.py
+++ b/tests/test_backfill_persistence.py
@@ -75,7 +75,8 @@ async def setup_db():
 
 
 @pytest.mark.asyncio
-async def test_backfill_persists_data(monkeypatch, setup_db):
+@pytest.mark.parametrize("input_symbol", ["BTC/USDT", "BTC-USDT"])
+async def test_backfill_persists_data(monkeypatch, setup_db, input_symbol):
     monkeypatch.setenv("PG_HOST", "localhost")
     monkeypatch.setenv("PG_USER", "postgres")
     monkeypatch.setenv("PG_PASSWORD", "postgres")
@@ -85,7 +86,7 @@ async def test_backfill_persists_data(monkeypatch, setup_db):
 
     monkeypatch.setattr(job_backfill.ccxt, "binance", lambda *_, **__: DummyExchange())
 
-    await job_backfill.backfill(days=1, symbols=["BTC/USDT"])
+    await job_backfill.backfill(days=1, symbols=[input_symbol])
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient
 
@@ -101,7 +102,8 @@ async def test_backfill_persists_data(monkeypatch, setup_db):
 
 
 @pytest.mark.asyncio
-async def test_backfill_overlapping_range(monkeypatch, setup_db):
+@pytest.mark.parametrize("input_symbol", ["BTC/USDT", "BTC-USDT"])
+async def test_backfill_overlapping_range(monkeypatch, setup_db, input_symbol):
     # Ensure database is empty
     dsn = "postgresql+asyncpg://postgres:postgres@localhost/tradebot_test"
     eng = create_async_engine(dsn, echo=False)
@@ -121,11 +123,11 @@ async def test_backfill_overlapping_range(monkeypatch, setup_db):
 
     start1 = datetime(2023, 1, 1, tzinfo=timezone.utc)
     end1 = start1 + timedelta(minutes=2)
-    await job_backfill.backfill(days=1, symbols=["BTC/USDT"], start=start1, end=end1)
+    await job_backfill.backfill(days=1, symbols=[input_symbol], start=start1, end=end1)
 
     start2 = start1 + timedelta(minutes=1)
     end2 = start2 + timedelta(minutes=2)
-    await job_backfill.backfill(days=1, symbols=["BTC/USDT"], start=start2, end=end2)
+    await job_backfill.backfill(days=1, symbols=[input_symbol], start=start2, end=end2)
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient
 


### PR DESCRIPTION
## Summary
- use `tradingbot.core.symbols.normalize` when persisting backfilled data
- add backfill tests covering symbols with hyphen separators

## Testing
- `pytest tests/test_backfill_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab532d0840832d9db4c9f095f879fe