### PR TITLE
fix: simplify ccxt exchange options

### DIFF
--- a/src/tradingbot/exchanges.py
+++ b/src/tradingbot/exchanges.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 SUPPORTED_EXCHANGES: dict[str, dict] = {
     "binance": {"ccxt": "binance"},
     "binance_futures": {"ccxt": "binanceusdm"},
-    "okx": {"ccxt": "okx", "options": {"options": {"defaultType": "spot"}}},
-    "okx_futures": {"ccxt": "okx", "options": {"options": {"defaultType": "swap"}}},
-    "bybit": {"ccxt": "bybit", "options": {"options": {"defaultType": "spot"}}},
-    "bybit_futures": {"ccxt": "bybit", "options": {"options": {"defaultType": "swap"}}},
+    "okx": {"ccxt": "okx", "options": {"defaultType": "spot"}},
+    "okx_futures": {"ccxt": "okx", "options": {"defaultType": "swap"}},
+    "bybit": {"ccxt": "bybit", "options": {"defaultType": "spot"}},
+    "bybit_futures": {"ccxt": "bybit", "options": {"defaultType": "swap"}},
     "deribit": {"ccxt": "deribit"},
 }
 


### PR DESCRIPTION
## Summary
- streamline ccxt config for okx and bybit exchanges by removing redundant nested `options`

## Testing
- `pytest tests/test_adapters.py::test_adapter_testnet_selection -q`
- `pytest tests/test_data_ingestion_batch.py::test_backfill_applies_rate_limit -q` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68ab5326b518832da0e6004e8da8e9b8