### PR TITLE
Use conf dict for backfill exchange options

### DIFF
--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -85,7 +85,10 @@ async def backfill(
         raise ValueError(f"Exchange {exchange_name!r} not supported")
 
     ex_class = getattr(ccxt, info["ccxt"])
-    ex = ex_class({"enableRateLimit": False, **info.get("options", {})})
+    conf = {"enableRateLimit": False}
+    if info.get("options"):
+        conf["options"] = info["options"]
+    ex = ex_class(conf)
     ex.id = exchange_name
     delay = getattr(ex, "rateLimit", 1000) / 1000
 


### PR DESCRIPTION
## Summary
- Build ccxt exchange config as `conf` with `enableRateLimit` default
- Forward optional exchange-specific options under `conf['options']`
- Instantiate exchange with single config dict

## Testing
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5efb6af4832d999d85b80cbf6064