### PR TITLE
feat: add date range to ingest-historical

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -194,8 +194,9 @@ desc.innerHTML = raw.replace(/^([^:]+:)/, '<span class="desc-lead">$1</span>');
   const end=document.getElementById('dm-end').value;
   const showDays=act==='backfill' && !(start && end);
   document.getElementById('field-days').style.display=showDays?'':'none';
-  document.getElementById('field-start').style.display=act==='backfill'?'':'none';
-  document.getElementById('field-end').style.display=act==='backfill'?'':'none';
+  const showRange=act==='backfill' || act==='ingest-historical';
+  document.getElementById('field-start').style.display=showRange?'':'none';
+  document.getElementById('field-end').style.display=showRange?'':'none';
   document.getElementById('field-exchange-name').style.display=act==='backfill'?'':'none';
   const hist=act==='ingest-historical';
   document.getElementById('field-source').style.display=hist?'':'none';
@@ -258,10 +259,27 @@ async function runData(){
     const depth=document.getElementById('dm-hdepth').value;
     const limit=document.getElementById('dm-hlimit').value;
     const backend=document.getElementById('dm-backend').value;
+    const start=document.getElementById('dm-start').value;
+    const end=document.getElementById('dm-end').value;
     cmd=`ingest-historical ${src} ${sym} --kind ${kind} --backend ${backend}`;
     if(src==='kaiko' && ex) cmd+=` --exchange ${ex}`;
     if(kind==='orderbook') cmd+=` --depth ${depth}`;
     if(kind==='trades') cmd+=` --limit ${limit}`;
+    if(start && end){
+      const s=new Date(start);
+      const e=new Date(end);
+      if(!(s<e)){
+        out.textContent='Rango inválido (inicio debe ser menor que fin)';
+        out.scrollTop = out.scrollHeight;
+        runBtn.disabled=false;
+        runBtn.textContent='Ejecutar';
+        return;
+      }
+      cmd+=` --start ${s.toISOString()} --end ${e.toISOString()}`;
+    }else{
+      if(start) cmd+=` --start ${new Date(start).toISOString()}`;
+      if(end) cmd+=` --end ${new Date(end).toISOString()}`;
+    }
   }
   out.textContent='Iniciando...\n';
   out.scrollTop = out.scrollHeight;

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -391,6 +391,8 @@ def ingest_historical(
     backend: str = typer.Option("timescale", help="Backend de storage"),
     limit: int = typer.Option(100, help="Límite de trades"),
     depth: int = typer.Option(10, help="Profundidad del order book"),
+    start: str | None = typer.Option(None, "--start", help="Inicio ISO8601"),
+    end: str | None = typer.Option(None, "--end", help="Fin ISO8601"),
 ) -> None:
     """Descargar datos históricos usando Kaiko o CoinAPI."""
 
@@ -407,23 +409,47 @@ def ingest_historical(
         if kind == "orderbook":
             asyncio.run(
                 fetch_orderbook_kaiko(
-                    exchange, symbol, backend=backend, depth=depth
+                    exchange,
+                    symbol,
+                    backend=backend,
+                    depth=depth,
+                    start_time=start,
+                    end_time=end,
                 )
             )
         elif kind == "open_interest":
             connector = KaikoConnector()
             asyncio.run(
                 download_kaiko_open_interest(
-                    connector, exchange, symbol, backend=backend, limit=limit
+                    connector,
+                    exchange,
+                    symbol,
+                    backend=backend,
+                    limit=limit,
+                    start_time=start,
+                    end_time=end,
                 )
             )
         elif kind == "funding":
             connector = KaikoConnector()
-            asyncio.run(download_funding(connector, symbol, backend=backend))
+            asyncio.run(
+                download_funding(
+                    connector,
+                    symbol,
+                    backend=backend,
+                    start_time=start,
+                    end_time=end,
+                )
+            )
         else:
             asyncio.run(
                 fetch_trades_kaiko(
-                    exchange, symbol, backend=backend, limit=limit
+                    exchange,
+                    symbol,
+                    backend=backend,
+                    limit=limit,
+                    start_time=start,
+                    end_time=end,
                 )
             )
     elif source.lower() == "coinapi":
@@ -438,23 +464,44 @@ def ingest_historical(
         if kind == "orderbook":
             asyncio.run(
                 fetch_orderbook_coinapi(
-                    symbol, backend=backend, depth=depth
+                    symbol,
+                    backend=backend,
+                    depth=depth,
+                    start_time=start,
+                    end_time=end,
                 )
             )
         elif kind == "open_interest":
             connector = CoinAPIConnector()
             asyncio.run(
                 download_coinapi_open_interest(
-                    connector, symbol, backend=backend, limit=limit
+                    connector,
+                    symbol,
+                    backend=backend,
+                    limit=limit,
+                    start_time=start,
+                    end_time=end,
                 )
             )
         elif kind == "funding":
             connector = CoinAPIConnector()
-            asyncio.run(download_funding(connector, symbol, backend=backend))
+            asyncio.run(
+                download_funding(
+                    connector,
+                    symbol,
+                    backend=backend,
+                    start_time=start,
+                    end_time=end,
+                )
+            )
         else:
             asyncio.run(
                 fetch_trades_coinapi(
-                    symbol, backend=backend, limit=limit
+                    symbol,
+                    backend=backend,
+                    limit=limit,
+                    start_time=start,
+                    end_time=end,
                 )
             )
     else:  # pragma: no cover - CLI validation

--- a/src/tradingbot/connectors/coinapi.py
+++ b/src/tradingbot/connectors/coinapi.py
@@ -31,11 +31,23 @@ class CoinAPIConnector:
         self.api_key = api_key or os.getenv("COINAPI_KEY", "")
         self._sem = asyncio.Semaphore(rate_limit)
 
-    async def fetch_trades(self, symbol: str, limit: int = 100) -> List[Trade]:
+    async def fetch_trades(
+        self,
+        symbol: str,
+        limit: int = 100,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
+    ) -> List[Trade]:
         url = f"{self._BASE_URL}/trades/{symbol}"
         headers = {"X-CoinAPI-Key": self.api_key}
+        params: dict[str, Any] = {"limit": limit}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, params={"limit": limit}, headers=headers)
+            resp = await client.get(url, params=params, headers=headers)
             resp.raise_for_status()
             data = resp.json()
 
@@ -55,11 +67,23 @@ class CoinAPIConnector:
             )
         return trades
 
-    async def fetch_order_book(self, symbol: str, depth: int = 10) -> OrderBook:
+    async def fetch_order_book(
+        self,
+        symbol: str,
+        depth: int = 10,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
+    ) -> OrderBook:
         url = f"{self._BASE_URL}/orderbooks/current/{symbol}"
         headers = {"X-CoinAPI-Key": self.api_key}
+        params: dict[str, Any] = {}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=headers)
+            resp = await client.get(url, params=params, headers=headers)
             resp.raise_for_status()
             payload = resp.json()
 

--- a/src/tradingbot/connectors/kaiko.py
+++ b/src/tradingbot/connectors/kaiko.py
@@ -33,18 +33,30 @@ class KaikoConnector:
         self._sem = asyncio.Semaphore(rate_limit)
 
     async def fetch_trades(
-        self, exchange: str, pair: str, limit: int = 100
+        self,
+        exchange: str,
+        pair: str,
+        limit: int = 100,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
     ) -> List[Trade]:
         """Fetch recent trades for *pair* on *exchange*.
 
-        Parameters match Kaiko's "recent trades" endpoint. Only a subset of the
-        response fields is mapped to :class:`Trade` objects.
+        Optional ``start_time`` and ``end_time`` parameters (ISO8601 strings) are
+        forwarded to the Kaiko REST API allowing constrained historical
+        downloads when supported by the endpoint.
         """
 
         url = f"{self._BASE_URL}/trades.v1/exchanges/{exchange}/spot/{pair}/recent"
         headers = {"X-Api-Key": self.api_key}
+        params: dict[str, Any] = {"limit": limit}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, params={"limit": limit}, headers=headers)
+            resp = await client.get(url, params=params, headers=headers)
             resp.raise_for_status()
             data = resp.json().get("data", [])
 
@@ -66,7 +78,13 @@ class KaikoConnector:
         return trades
 
     async def fetch_order_book(
-        self, exchange: str, pair: str, depth: int = 10
+        self,
+        exchange: str,
+        pair: str,
+        depth: int = 10,
+        *,
+        start_time: str | None = None,
+        end_time: str | None = None,
     ) -> OrderBook:
         """Fetch a snapshot of the order book."""
 
@@ -74,7 +92,11 @@ class KaikoConnector:
             f"{self._BASE_URL}/order_book.snapshots.v1/exchanges/{exchange}/spot/{pair}/books/latest"
         )
         headers = {"X-Api-Key": self.api_key}
-        params = {"depth": depth}
+        params: dict[str, Any] = {"depth": depth}
+        if start_time:
+            params["start_time"] = start_time
+        if end_time:
+            params["end_time"] = end_time
         async with httpx.AsyncClient() as client:
             resp = await client.get(url, params=params, headers=headers)
             resp.raise_for_status()

--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -388,6 +388,8 @@ async def fetch_trades_kaiko(
     pair: str,
     *,
     backend: Backends = "timescale",
+    start_time: str | None = None,
+    end_time: str | None = None,
     **params: Any,
 ) -> None:
     """Fetch trades from Kaiko and persist them.
@@ -399,7 +401,11 @@ async def fetch_trades_kaiko(
 
     connector = KaikoConnector()
     raw_trades: Iterable[ConnTrade] = await connector.fetch_trades(
-        exchange, pair, **params
+        exchange,
+        pair,
+        start_time=start_time,
+        end_time=end_time,
+        **params,
     )
     ticks = [
         Tick(
@@ -420,12 +426,20 @@ async def fetch_orderbook_kaiko(
     pair: str,
     *,
     backend: Backends = "timescale",
+    start_time: str | None = None,
+    end_time: str | None = None,
     **params: Any,
 ) -> None:
     """Fetch an order book snapshot from Kaiko and persist it."""
 
     connector = KaikoConnector()
-    ob: ConnOrderBook = await connector.fetch_order_book(exchange, pair, **params)
+    ob: ConnOrderBook = await connector.fetch_order_book(
+        exchange,
+        pair,
+        start_time=start_time,
+        end_time=end_time,
+        **params,
+    )
     snapshot = OrderBook(
         ts=ob.timestamp,
         exchange=exchange,
@@ -580,6 +594,8 @@ async def fetch_trades_coinapi(
     symbol: str,
     *,
     backend: Backends = "timescale",
+    start_time: str | None = None,
+    end_time: str | None = None,
     **params: Any,
 ) -> None:
     """Fetch trades from CoinAPI and persist them.
@@ -590,7 +606,12 @@ async def fetch_trades_coinapi(
     """
 
     connector = CoinAPIConnector()
-    raw_trades: Iterable[ConnTrade] = await connector.fetch_trades(symbol, **params)
+    raw_trades: Iterable[ConnTrade] = await connector.fetch_trades(
+        symbol,
+        start_time=start_time,
+        end_time=end_time,
+        **params,
+    )
     ticks = [
         Tick(
             ts=t.timestamp,
@@ -609,12 +630,19 @@ async def fetch_orderbook_coinapi(
     symbol: str,
     *,
     backend: Backends = "timescale",
+    start_time: str | None = None,
+    end_time: str | None = None,
     **params: Any,
 ) -> None:
     """Fetch an order book snapshot from CoinAPI and persist it."""
 
     connector = CoinAPIConnector()
-    ob: ConnOrderBook = await connector.fetch_order_book(symbol, **params)
+    ob: ConnOrderBook = await connector.fetch_order_book(
+        symbol,
+        start_time=start_time,
+        end_time=end_time,
+        **params,
+    )
     snapshot = OrderBook(
         ts=ob.timestamp,
         exchange=connector.name,


### PR DESCRIPTION
## Summary
- allow passing `--start` and `--end` to `ingest-historical` CLI command
- propagate start/end time to Kaiko and CoinAPI connectors
- expose start/end inputs in data.html UI and include in generated command

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ece2fb0832daeb909bcf9107b75