### PR TITLE
Normalize symbols and map exchange ids

### DIFF
--- a/bin/download_history.py
+++ b/bin/download_history.py
@@ -17,6 +17,7 @@ from tradingbot.data import ingestion
 from tradingbot.types import Bar, OrderBook, Tick
 from tradingbot.connectors.kaiko import KaikoConnector
 from tradingbot.connectors.coinapi import CoinAPIConnector
+from tradingbot.core.symbols import normalize
 
 Backend = Literal["timescale", "quest", "csv"]
 
@@ -72,7 +73,7 @@ async def _download_trades(
                 Tick(
                     ts=datetime.utcfromtimestamp(t["timestamp"] / 1000),
                     exchange=exchange,
-                    symbol=symbol,
+                    symbol=normalize(symbol),
                     price=float(t["price"]),
                     qty=float(t["amount"]),
                     side=t.get("side"),
@@ -100,7 +101,7 @@ async def _download_l2(
         snapshot = OrderBook(
             ts=datetime.utcnow(),
             exchange=exchange,
-            symbol=symbol,
+            symbol=normalize(symbol),
             bid_px=[float(p) for p, _ in bids],
             bid_qty=[float(q) for _, q in bids],
             ask_px=[float(p) for p, _ in asks],

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -250,10 +250,11 @@ def ingest(
                     async for d in adapter.stream_trades(symbol):
                         typer.echo(str(d))
                         if persist:
+                            db_symbol = normalize(symbol)
                             tick = Tick(
                                 ts=d.get("ts"),
                                 exchange=adapter.name,
-                                symbol=symbol,
+                                symbol=db_symbol,
                                 price=float(d.get("price") or 0.0),
                                 qty=float(d.get("qty") or 0.0),
                                 side=d.get("side"),
@@ -266,10 +267,11 @@ def ingest(
                     async for d in adapter.stream_trades_multi(symbols):
                         typer.echo(str(d))
                         if persist:
+                            sym = normalize(d.get("symbol"))
                             tick = Tick(
                                 ts=d.get("ts"),
                                 exchange=adapter.name,
-                                symbol=d.get("symbol"),
+                                symbol=sym,
                                 price=float(d.get("price") or 0.0),
                                 qty=float(d.get("qty") or 0.0),
                                 side=d.get("side"),
@@ -284,7 +286,7 @@ def ingest(
                         typer.echo(str(d))
                         if persist:
                             data = dict(d)
-                            data.update({"exchange": adapter.name, "symbol": symbol})
+                            data.update({"exchange": adapter.name, "symbol": normalize(symbol)})
                             ing.persist_bba([data], backend=backend)
 
                 tasks.append(asyncio.create_task(_b(sym)))
@@ -294,7 +296,7 @@ def ingest(
                         typer.echo(str(d))
                         if persist:
                             data = dict(d)
-                            data.update({"exchange": adapter.name, "symbol": symbol})
+                            data.update({"exchange": adapter.name, "symbol": normalize(symbol)})
                             ing.persist_book_delta([data], backend=backend)
 
                 tasks.append(asyncio.create_task(_d(sym)))
@@ -395,6 +397,15 @@ def ingest_historical(
     """Descargar datos históricos usando Kaiko o CoinAPI."""
 
     setup_logging()
+    provider_exchange = exchange
+    if exchange:
+        info = SUPPORTED_EXCHANGES.get(exchange)
+        if info is None:
+            raise typer.BadParameter(
+                f"Exchange inválido: {exchange}. Usa uno de: {_EXCHANGE_CHOICES}"
+            )
+        provider_exchange = info.get("ccxt", exchange)
+
     if source.lower() == "kaiko":
         from ..connectors.kaiko import KaikoConnector
         from ..data.ingestion import (
@@ -407,14 +418,14 @@ def ingest_historical(
         if kind == "orderbook":
             asyncio.run(
                 fetch_orderbook_kaiko(
-                    exchange, symbol, backend=backend, depth=depth
+                    provider_exchange, symbol, backend=backend, depth=depth
                 )
             )
         elif kind == "open_interest":
             connector = KaikoConnector()
             asyncio.run(
                 download_kaiko_open_interest(
-                    connector, exchange, symbol, backend=backend, limit=limit
+                    connector, provider_exchange, symbol, backend=backend, limit=limit
                 )
             )
         elif kind == "funding":
@@ -423,7 +434,7 @@ def ingest_historical(
         else:
             asyncio.run(
                 fetch_trades_kaiko(
-                    exchange, symbol, backend=backend, limit=limit
+                    provider_exchange, symbol, backend=backend, limit=limit
                 )
             )
     elif source.lower() == "coinapi":


### PR DESCRIPTION
## Summary
- Normalize trading pairs before persisting trades, order books, BBAs and book deltas
- Validate CLI exchange option against SUPPORTED_EXCHANGES and map to provider names
- Persist normalized symbols in historical download script

## Testing
- `pytest tests/test_data_ingestion_batch.py::test_download_kaiko_open_interest_persists -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ed86930832d8e633f73c00201ff