### PR TITLE
Add BBA and book delta to historical ingestion

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ Obtiene datos históricos de Kaiko o CoinAPI.
 - `source`: `kaiko` o `coinapi`.
 - `symbol`: par de mercado.
 - `--exchange`: requerido para Kaiko.
-- `--kind`: `trades`, `orderbook`, `open_interest` o `funding`.
+- `--kind`: `trades`, `orderbook`, `bba`, `book_delta`, `open_interest` o `funding`.
 - `--backend`: backend de almacenamiento (por defecto `timescale`).
 - `--limit`: cantidad de registros a traer.
 - `--depth`: profundidad del order book.

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -98,6 +98,8 @@
         <select id="dm-hkind">
           <option value="trades">trades</option>
           <option value="orderbook">orderbook</option>
+          <option value="bba">bba</option>
+          <option value="book_delta">book_delta</option>
           <option value="open_interest">open_interest</option>
           <option value="funding">funding</option>
         </select>
@@ -147,7 +149,8 @@ const kindDescriptions={
   trades:"Trades: cada transacción ejecutada (precio, cantidad y lado).",
   trades_multi:"Trades multi: agrupa transacciones de varios símbolos en una sola conexión.",
   orderbook:"Order book: niveles completos de posturas de compra y venta hasta la profundidad solicitada.",
-  delta:"Book delta: cambios recientes en las mejores posturas de compra y venta."
+  delta:"Book delta: cambios recientes en las mejores posturas de compra y venta.",
+  book_delta:"Book delta: cambios recientes en las mejores posturas de compra y venta."
 };
 
 function showWorking() {
@@ -202,7 +205,7 @@ desc.innerHTML = raw.replace(/^([^:]+:)/, '<span class="desc-lead">$1</span>');
   document.getElementById('field-exchange').style.display=hist && document.getElementById('dm-source').value==='kaiko'?'':'none';
   document.getElementById('field-hkind').style.display=hist?'':'none';
   const hk=document.getElementById('dm-hkind').value;
-  document.getElementById('field-hdepth').style.display=hist && hk==='orderbook'?'':'none';
+  document.getElementById('field-hdepth').style.display=hist && (hk==='orderbook' || hk==='book_delta')?'':'none';
   document.getElementById('field-hlimit').style.display=hist && hk==='trades'?'':'none';
   const persist=document.getElementById('dm-persist').checked;
   document.getElementById('field-backend').style.display=(hist || (act==='ingest' && persist))?'':'none';
@@ -260,7 +263,7 @@ async function runData(){
     const backend=document.getElementById('dm-backend').value;
     cmd=`ingest-historical ${src} ${sym} --kind ${kind} --backend ${backend}`;
     if(src==='kaiko' && ex) cmd+=` --exchange ${ex}`;
-    if(kind==='orderbook') cmd+=` --depth ${depth}`;
+    if(kind==='orderbook' || kind==='book_delta') cmd+=` --depth ${depth}`;
     if(kind==='trades') cmd+=` --limit ${limit}`;
   }
   out.textContent='Iniciando...\n';

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -386,7 +386,8 @@ def ingest_historical(
     symbol: str = typer.Argument(..., help="Símbolo o par"),
     exchange: str = typer.Option("", help="Exchange para Kaiko"),
     kind: str = typer.Option(
-        "trades", help="Tipo de dato: trades, orderbook, open_interest o funding"
+        "trades",
+        help="Tipo de dato: trades, orderbook, bba, book_delta, open_interest o funding",
     ),
     backend: str = typer.Option("timescale", help="Backend de storage"),
     limit: int = typer.Option(100, help="Límite de trades"),
@@ -400,6 +401,8 @@ def ingest_historical(
         from ..data.ingestion import (
             fetch_trades_kaiko,
             fetch_orderbook_kaiko,
+            download_kaiko_bba,
+            download_kaiko_book_delta,
             download_kaiko_open_interest,
             download_funding,
         )
@@ -408,6 +411,20 @@ def ingest_historical(
             asyncio.run(
                 fetch_orderbook_kaiko(
                     exchange, symbol, backend=backend, depth=depth
+                )
+            )
+        elif kind == "bba":
+            connector = KaikoConnector()
+            asyncio.run(
+                download_kaiko_bba(
+                    connector, exchange, symbol, backend=backend
+                )
+            )
+        elif kind == "book_delta":
+            connector = KaikoConnector()
+            asyncio.run(
+                download_kaiko_book_delta(
+                    connector, exchange, symbol, backend=backend, depth=depth
                 )
             )
         elif kind == "open_interest":
@@ -431,6 +448,8 @@ def ingest_historical(
         from ..data.ingestion import (
             fetch_trades_coinapi,
             fetch_orderbook_coinapi,
+            download_coinapi_bba,
+            download_coinapi_book_delta,
             download_coinapi_open_interest,
             download_funding,
         )
@@ -439,6 +458,18 @@ def ingest_historical(
             asyncio.run(
                 fetch_orderbook_coinapi(
                     symbol, backend=backend, depth=depth
+                )
+            )
+        elif kind == "bba":
+            connector = CoinAPIConnector()
+            asyncio.run(
+                download_coinapi_bba(connector, symbol, backend=backend)
+            )
+        elif kind == "book_delta":
+            connector = CoinAPIConnector()
+            asyncio.run(
+                download_coinapi_book_delta(
+                    connector, symbol, backend=backend, depth=depth
                 )
             )
         elif kind == "open_interest":

--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -488,6 +488,64 @@ async def download_kaiko_order_book(
     persist_orderbooks([snapshot], backend=backend)
 
 
+async def download_kaiko_bba(
+    connector: KaikoConnector,
+    exchange: str,
+    pair: str,
+    *,
+    backend: Backends = "timescale",
+    **params: Any,
+) -> None:
+    """Fetch best bid/ask from Kaiko and persist it.
+
+    Kaiko does not provide a dedicated BBA endpoint so the data is
+    derived from an order book snapshot.
+    """
+
+    ob: ConnOrderBook = await connector.fetch_order_book(
+        exchange, pair, depth=1, **params
+    )
+    bid_px, bid_qty = (ob.bids[0] if ob.bids else (None, None))
+    ask_px, ask_qty = (ob.asks[0] if ob.asks else (None, None))
+    record = {
+        "ts": ob.timestamp,
+        "exchange": exchange,
+        "symbol": pair,
+        "bid_px": bid_px,
+        "bid_qty": bid_qty,
+        "ask_px": ask_px,
+        "ask_qty": ask_qty,
+    }
+    persist_bba([record], backend=backend)
+
+
+async def download_kaiko_book_delta(
+    connector: KaikoConnector,
+    exchange: str,
+    pair: str,
+    *,
+    backend: Backends = "timescale",
+    **params: Any,
+) -> None:
+    """Fetch order book data from Kaiko and persist it as deltas.
+
+    When only snapshots are available the delta is approximated by the
+    full order book levels.
+    """
+
+    ob: ConnOrderBook = await connector.fetch_order_book(exchange, pair, **params)
+    record = {
+        "ts": ob.timestamp,
+        "exchange": exchange,
+        "symbol": pair,
+        "bid_px": [p for p, _ in ob.bids],
+        "bid_qty": [q for _, q in ob.bids],
+        "ask_px": [p for p, _ in ob.asks],
+        "ask_qty": [q for _, q in ob.asks],
+    }
+    persist_book_delta([record], backend=backend)
+
+
 async def download_kaiko_open_interest(
     connector: KaikoConnector,
     exchange: str,
@@ -671,6 +729,56 @@ async def download_coinapi_order_book(
         ask_qty=[q for _, q in ob.asks],
     )
     persist_orderbooks([snapshot], backend=backend)
+
+
+async def download_coinapi_bba(
+    connector: CoinAPIConnector,
+    symbol: str,
+    *,
+    backend: Backends = "timescale",
+    **params: Any,
+) -> None:
+    """Fetch best bid/ask from CoinAPI and persist it.
+
+    CoinAPI exposes only order book snapshots; the BBA is derived from the
+    top levels.
+    """
+
+    ob: ConnOrderBook = await connector.fetch_order_book(symbol, depth=1, **params)
+    bid_px, bid_qty = (ob.bids[0] if ob.bids else (None, None))
+    ask_px, ask_qty = (ob.asks[0] if ob.asks else (None, None))
+    record = {
+        "ts": ob.timestamp,
+        "exchange": connector.name,
+        "symbol": symbol,
+        "bid_px": bid_px,
+        "bid_qty": bid_qty,
+        "ask_px": ask_px,
+        "ask_qty": ask_qty,
+    }
+    persist_bba([record], backend=backend)
+
+
+async def download_coinapi_book_delta(
+    connector: CoinAPIConnector,
+    symbol: str,
+    *,
+    backend: Backends = "timescale",
+    **params: Any,
+) -> None:
+    """Fetch order book data from CoinAPI and persist it as deltas."""
+
+    ob: ConnOrderBook = await connector.fetch_order_book(symbol, **params)
+    record = {
+        "ts": ob.timestamp,
+        "exchange": connector.name,
+        "symbol": symbol,
+        "bid_px": [p for p, _ in ob.bids],
+        "bid_qty": [q for _, q in ob.bids],
+        "ask_px": [p for p, _ in ob.asks],
+        "ask_qty": [q for _, q in ob.asks],
+    }
+    persist_book_delta([record], backend=backend)
 
 
 async def download_coinapi_open_interest(


### PR DESCRIPTION
## Summary
- extend `ingest-historical` to handle `bba` and `book_delta`
- derive BBA and order book deltas from snapshots for Kaiko and CoinAPI
- expose new kinds in data UI and update documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9ed425cc832d92db9d21afdb39cf