### PR TITLE
Add exchange select for historical data ingestion

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -91,7 +91,7 @@
       </div>
       <div id="field-exchange">
         <label for="dm-exchange">Exchange</label>
-        <input id="dm-exchange" placeholder="binance"/>
+        <select id="dm-exchange"></select>
       </div>
       <div id="field-hkind">
         <label for="dm-hkind">Tipo</label>
@@ -257,7 +257,7 @@ async function runData(){
   }else{
     const src=document.getElementById('dm-source').value;
     const sym=document.getElementById('dm-symbols').value.trim();
-    const ex=document.getElementById('dm-exchange').value.trim();
+    const ex=document.getElementById('dm-exchange').value;
     const kind=document.getElementById('dm-hkind').value;
     const depth=document.getElementById('dm-hdepth').value;
     const limit=document.getElementById('dm-hlimit').value;
@@ -396,6 +396,23 @@ async function loadExchanges(){
       opt.value=ex;
       opt.textContent=ex;
       sel.appendChild(opt);
+    }
+    const allowed=[
+      'binance_spot',
+      'binance_futures',
+      'okx_spot',
+      'okx_futures',
+      'bybit_spot',
+      'bybit_futures',
+      'deribit_futures'
+    ];
+    const selHist=document.getElementById('dm-exchange');
+    selHist.innerHTML='';
+    for(const ex of exchanges.filter(x=>allowed.includes(x))){
+      const opt=document.createElement('option');
+      opt.value=ex;
+      opt.textContent=ex;
+      selHist.appendChild(opt);
     }
   }catch(e){
     console.error(e);


### PR DESCRIPTION
## Summary
- replace free-text exchange input with dropdown
- populate dropdown with supported CCXT exchanges
- use selected exchange in ingest-historical command

## Testing
- `pytest tests/test_data_ingestion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba33e812c832d93d28fdae42331e7