### PR TITLE
Align backfill tests with new exchange identifiers

### DIFF
--- a/tests/test_backfill_persistence.py
+++ b/tests/test_backfill_persistence.py
@@ -86,7 +86,9 @@ async def test_backfill_persists_data(monkeypatch, setup_db, input_symbol):
 
     monkeypatch.setattr(job_backfill.ccxt, "binance", lambda *_, **__: DummyExchange())
 
-    await job_backfill.backfill(days=1, symbols=[input_symbol])
+    await job_backfill.backfill(
+        days=1, symbols=[input_symbol], exchange_name="binance_spot"
+    )
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient
 
@@ -123,11 +125,23 @@ async def test_backfill_overlapping_range(monkeypatch, setup_db, input_symbol):
 
     start1 = datetime(2023, 1, 1, tzinfo=timezone.utc)
     end1 = start1 + timedelta(minutes=2)
-    await job_backfill.backfill(days=1, symbols=[input_symbol], start=start1, end=end1)
+    await job_backfill.backfill(
+        days=1,
+        symbols=[input_symbol],
+        start=start1,
+        end=end1,
+        exchange_name="binance_spot",
+    )
 
     start2 = start1 + timedelta(minutes=1)
     end2 = start2 + timedelta(minutes=2)
-    await job_backfill.backfill(days=1, symbols=[input_symbol], start=start2, end=end2)
+    await job_backfill.backfill(
+        days=1,
+        symbols=[input_symbol],
+        start=start2,
+        end=end2,
+        exchange_name="binance_spot",
+    )
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient
 


### PR DESCRIPTION
## Summary
- update backfill persistence tests to use new exchange identifiers (e.g. `binance_spot`)
- stub AsyncTimescaleClient in batch backfill test and assert calls using new identifiers

## Testing
- `pytest tests/test_cli_supported_kinds.py tests/test_api_venue_kinds.py tests/test_data_ingestion_batch.py::test_backfill_applies_rate_limit -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb0e9b104832dbcdbdbce4ea929ac