### PR TITLE
Handle CSV backend in orderbook streaming

### DIFF
--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -381,6 +381,11 @@ def test_cli_ingest_csv_creates_file(monkeypatch, tmp_path):
 
     cli_main = importlib.reload(cli_main)
 
+    def fail():
+        raise AssertionError("get_engine should not be called for CSV backend")
+    monkeypatch.setattr("tradingbot.storage.timescale.get_engine", fail)
+    monkeypatch.setattr("tradingbot.storage.quest.get_engine", fail)
+
     class DummyAdapter:
         name = "dummy"
 


### PR DESCRIPTION
## Summary
- write orderbook snapshots to CSV when backend is `csv`
- avoid using database engine for CSV orderbook streaming
- ensure ingest CLI with CSV backend creates `db/orderbook.csv` without touching DB engines

## Testing
- `pytest tests/test_data_ingestion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb0f737e8832d9396b931cebc8dab