### PR TITLE
Load exchanges dynamically in web UI

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -453,18 +453,9 @@ async function loadExchanges(){
       opt.textContent=ex;
       sel.appendChild(opt);
     }
-    const allowed=[
-      'binance_spot',
-      'binance_futures',
-      'okx_spot',
-      'okx_futures',
-      'bybit_spot',
-      'bybit_futures',
-      'deribit_futures'
-    ];
     const selHist=document.getElementById('dm-exchange');
     selHist.innerHTML='';
-    for(const ex of exchanges.filter(x=>allowed.includes(x))){
+    for(const ex of exchanges){
       const opt=document.createElement('option');
       opt.value=ex;
       opt.textContent=ex;

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -66,16 +66,7 @@
     <div class="grid3" style="margin-top:10px">
       <div>
         <label for="cfg-exchange">Exchange</label>
-        <select id="cfg-exchange">
-          <option value="binance_futures_testnet">Binance Futures Testnet</option>
-          <option value="binance_spot">Binance Spot</option>
-          <option value="bybit_futures">Bybit Futures</option>
-          <option value="bybit_spot">Bybit Spot</option>
-          <option value="deribit_futures">Deribit Futures</option>
-          <option value="deribit_futures_ws">Deribit Futures WS</option>
-          <option value="okx_futures">OKX Futures</option>
-          <option value="okx_spot">OKX Spot</option>
-        </select>
+        <select id="cfg-exchange"></select>
       </div>
       <div>
         <label for="cfg-key">API Key</label>
@@ -97,6 +88,23 @@
 
 <script>
 const api = (path) => `${location.origin}${path}`;
+
+async function loadExchanges(){
+  try{
+    const r = await fetch(api('/ccxt/exchanges'));
+    const exchanges = await r.json();
+    const sel = document.getElementById('cfg-exchange');
+    sel.innerHTML = '';
+    for(const ex of exchanges){
+      const opt = document.createElement('option');
+      opt.value = ex;
+      opt.textContent = ex;
+      sel.appendChild(opt);
+    }
+  }catch(e){
+    console.error(e);
+  }
+}
 
 async function refreshHealth(){
   try {
@@ -174,6 +182,7 @@ async function saveConfig(){
   document.getElementById('cfg-output').textContent = output || 'Credenciales guardadas';
 }
 
+loadExchanges();
 refreshHealth();
 setInterval(refreshHealth, 5000);
 refreshMetrics();


### PR DESCRIPTION
## Summary
- Load exchange options via `/ccxt/exchanges` in the main dashboard
- Remove hardcoded exchange list in historical data page and rely on backend

## Testing
- `pytest tests/test_api_venues.py::test_list_venues -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc791e9ec832d95b9a68e0961eba5