### PR TITLE
Propagar testnet a adaptadores spot

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -56,11 +56,10 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
                       max_consecutive_losses: int, corr_threshold: float,
                       config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
-    ws_kwargs: Dict[str, Any] = {}
-    exec_kwargs: Dict[str, Any] = {}
+    ws_kwargs: Dict[str, Any] = {"testnet": True}
+    exec_kwargs: Dict[str, Any] = {"testnet": True}
     if market == "futures":
-        ws_kwargs["testnet"] = True
-        exec_kwargs.update({"leverage": leverage, "testnet": True})
+        exec_kwargs["leverage"] = leverage
     try:
         ws = ws_cls(**ws_kwargs)
     except TypeError:


### PR DESCRIPTION
## Resumen
- aplica la bandera `testnet` a todos los mercados en `runner_testnet`
- permite que los adaptadores spot de Bybit y OKX usen endpoints de prueba

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abd7d7f064832db89ccbbb0bcc3059