### PR TITLE
feat: add testnet support to bybit spot adapter

### DIFF
--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover - ccxt optional during tests
 from .base import ExchangeAdapter
 from ..core.symbols import normalize
 from ..utils.secrets import validate_scopes
+from ..config import settings
 
 log = logging.getLogger(__name__)
 
@@ -24,17 +25,33 @@ class BybitSpotAdapter(ExchangeAdapter):
 
     name = "bybit_spot"
 
-    def __init__(self):
+    def __init__(self, testnet: bool = False):
         super().__init__()
         if ccxt is None:
             raise RuntimeError("ccxt no está instalado")
-        # enableRateLimit respeta límites de la API
-        self.rest = ccxt.bybit({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+        key = settings.bybit_testnet_api_key if testnet else settings.bybit_api_key
+        secret = settings.bybit_testnet_api_secret if testnet else settings.bybit_api_secret
+        self.rest = ccxt.bybit(
+            {
+                "apiKey": key,
+                "secret": secret,
+                "enableRateLimit": True,
+                "options": {"defaultType": "spot"},
+                "testnet": testnet,
+            }
+        )
+        self.rest.set_sandbox_mode(testnet)
         # Advertir si la clave carece de permisos de trade o tiene retiros habilitados
         validate_scopes(self.rest, log)
+        self.ws_public_url = (
+            "wss://stream-testnet.bybit.com/v5/public/spot"
+            if testnet
+            else "wss://stream.bybit.com/v5/public/spot"
+        )
+        self.name = "bybit_spot_testnet" if testnet else "bybit_spot"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
-        url = "wss://stream.bybit.com/v5/public/spot"
+        url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
         async for raw in self._ws_messages(url, json.dumps(sub)):
@@ -48,7 +65,7 @@ class BybitSpotAdapter(ExchangeAdapter):
                 yield self.normalize_trade(symbol, ts, price, qty, side)
 
     async def stream_order_book(self, symbol: str) -> AsyncIterator[dict]:
-        url = "wss://stream.bybit.com/v5/public/spot"
+        url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
         async for raw in self._ws_messages(url, json.dumps(sub)):


### PR DESCRIPTION
## Summary
- add `testnet` flag to Bybit spot adapter
- route WebSocket and REST calls to Bybit testnet when enabled
- select testnet API credentials and name adapter accordingly

## Testing
- `pytest tests/test_adapters.py::test_adapter_testnet_selection tests/test_adapters.py::test_parsing_funding_and_oi[BybitSpotAdapter-_DummyBybitRest-0.01-100.0] tests/test_adapters.py::test_fetch_basis[BybitSpotAdapter-_DummyBybitRest] tests/test_cli_supported_kinds.py::test_get_supported_kinds -q`

------
https://chatgpt.com/codex/tasks/task_e_68abd7cb8ad0832d9f61775f21e24fd3