### PR TITLE
Apply testnet flag to spot adapters

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -56,11 +56,10 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
                       max_consecutive_losses: int, corr_threshold: float,
                       config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
-    ws_kwargs: Dict[str, Any] = {}
-    exec_kwargs: Dict[str, Any] = {}
+    ws_kwargs: Dict[str, Any] = {"testnet": True}
+    exec_kwargs: Dict[str, Any] = {"testnet": True}
     if market == "futures":
-        ws_kwargs["testnet"] = True
-        exec_kwargs.update({"leverage": leverage, "testnet": True})
+        exec_kwargs["leverage"] = leverage
     try:
         ws = ws_cls(**ws_kwargs)
     except TypeError:


### PR DESCRIPTION
## Summary
- always set `testnet=True` for websocket and execution adapters so spot markets use testnet endpoints too

## Testing
- `pytest tests/test_live_runner.py::test_binance_spot_testnet` *(fails: connection to PostgreSQL refused)*
- `PYTHONPATH=src python - <<'PY'
from tradingbot.adapters.binance_spot_ws import BinanceSpotWSAdapter
ws = BinanceSpotWSAdapter(testnet=True)
print(ws.ws_base)
PY`
- `PYTHONPATH=src python - <<'PY'
from tradingbot.adapters.binance_spot import BinanceSpotAdapter
try:
    a = BinanceSpotAdapter(testnet=True)
    print('name', a.name)
except Exception as e:
    print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68abdd3214c4832d80933da0008ab715