### PR TITLE
Expose testnet exchange variants in ccxt list

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -100,9 +100,10 @@ def ccxt_exchanges():
         return []
     available = getattr(ccxt, "exchanges", [])
     return [
-        key
+        variant
         for key, info in SUPPORTED_EXCHANGES.items()
         if info["ccxt"] in available
+        for variant in (key, f"{key}_testnet")
     ]
 
 

--- a/tests/test_api_ccxt_exchanges.py
+++ b/tests/test_api_ccxt_exchanges.py
@@ -1,0 +1,28 @@
+import importlib
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from tradingbot.exchanges import SUPPORTED_EXCHANGES
+
+
+def test_ccxt_exchanges_includes_testnet(monkeypatch):
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+
+    import tradingbot.apps.api.main as main
+    importlib.reload(main)
+
+    dummy_ccxt = SimpleNamespace(
+        exchanges=[info["ccxt"] for info in SUPPORTED_EXCHANGES.values()]
+    )
+    monkeypatch.setattr(main, "ccxt", dummy_ccxt)
+
+    client = TestClient(main.app)
+    resp = client.get("/ccxt/exchanges", auth=("u", "p"))
+    assert resp.status_code == 200
+    expected = []
+    for key in SUPPORTED_EXCHANGES:
+        expected.append(key)
+        expected.append(f"{key}_testnet")
+    assert resp.json() == expected


### PR DESCRIPTION
## Summary
- Extend `/ccxt/exchanges` endpoint to include `<exchange>_testnet` variants for each supported exchange
- Cover new behavior with a FastAPI test

## Testing
- `pytest tests/test_api_ccxt_exchanges.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe235f53c832d97640655932ca27b