### PR TITLE
Handle CSV backend without database engine

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -232,19 +232,28 @@ def ingest(
         tasks = []
         for sym in symbols:
             if kind == "orderbook":
-                tasks.append(
-                    asyncio.create_task(
-                        ing.run_orderbook_stream(
-                            adapter,
-                            sym,
-                            depth,
-                            bus,
-                            engine,
-                            persist=persist,
-                            backend=backend,
+                if persist and backend == "csv":
+                    tasks.append(
+                        asyncio.create_task(
+                            ing.stream_orderbook(
+                                adapter, sym, depth, backend="csv"
+                            )
                         )
                     )
-                )
+                else:
+                    tasks.append(
+                        asyncio.create_task(
+                            ing.run_orderbook_stream(
+                                adapter,
+                                sym,
+                                depth,
+                                bus,
+                                engine,
+                                persist=persist,
+                                backend=backend,
+                            )
+                        )
+                    )
             elif kind == "trades":
                 async def _t(symbol: str) -> None:
                     async for d in adapter.stream_trades(symbol):


### PR DESCRIPTION
## Summary
- handle `csv` backend for orderbook ingestion in CLI without requiring a DB engine
- stream order books directly to CSV persistence when requested

## Testing
- `pytest tests/test_data_ingestion.py::test_cli_ingest_csv_creates_file -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe65ba750832d9bea84a023608f06