### PR TITLE
Normalize symbols before persisting

### DIFF
--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -232,7 +232,7 @@ def persist_funding(
                     [
                         f["ts"].isoformat(),
                         f["exchange"],
-                        f["symbol"],
+                        normalize(f["symbol"]),
                         f["rate"],
                         f.get("interval_sec", 0),
                     ]
@@ -249,7 +249,7 @@ def persist_funding(
                 engine,
                 ts=f["ts"],
                 exchange=f["exchange"],
-                symbol=f["symbol"],
+                symbol=normalize(f["symbol"]),
                 rate=f["rate"],
                 interval_sec=f.get("interval_sec", 0),
             )
@@ -266,7 +266,9 @@ def persist_open_interest(
         with csv_path.open("a", newline="") as fh:
             writer = csv.writer(fh)
             for r in records:
-                writer.writerow([r["ts"].isoformat(), r["exchange"], r["symbol"], r["oi"]])
+                writer.writerow(
+                    [r["ts"].isoformat(), r["exchange"], normalize(r["symbol"]), r["oi"]]
+                )
         return
 
     storage = _get_storage(backend)
@@ -279,7 +281,7 @@ def persist_open_interest(
                 engine,
                 ts=r["ts"],
                 exchange=r["exchange"],
-                symbol=r["symbol"],
+                symbol=normalize(r["symbol"]),
                 oi=r["oi"],
             )
         except Exception as exc:  # pragma: no cover - logging only

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from sqlalchemy import create_engine, text
 
 from ..config import settings
+from ..core.symbols import normalize
 
 log = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def insert_trade(engine, t):
             dict(
                 ts=ts,
                 exchange=t.exchange,
-                symbol=t.symbol,
+                symbol=normalize(getattr(t, "symbol", "")),
                 px=t.price,
                 qty=t.qty,
                 side=t.side,
@@ -98,7 +99,7 @@ def insert_orderbook(
     payload = dict(
         ts=ts,
         exchange=exchange,
-        symbol=symbol,
+        symbol=normalize(symbol),
         bid_px=json.dumps(bid_px),
         bid_qty=json.dumps(bid_qty),
         ask_px=json.dumps(ask_px),
@@ -141,7 +142,7 @@ def insert_bba(
             dict(
                 ts=ts,
                 exchange=exchange,
-                symbol=symbol,
+                symbol=normalize(symbol),
                 bid_px=bid_px,
                 bid_qty=bid_qty,
                 ask_px=ask_px,
@@ -166,7 +167,7 @@ def insert_book_delta(
     payload = dict(
         ts=ts,
         exchange=exchange,
-        symbol=symbol,
+        symbol=normalize(symbol),
         bid_px=json.dumps(bid_px),
         bid_qty=json.dumps(bid_qty),
         ask_px=json.dumps(ask_px),
@@ -196,7 +197,7 @@ def insert_bar_1m(engine, exchange: str, symbol: str, ts, o: float, h: float,
                 VALUES (:ts, '1m', :exchange, :symbol, :o, :h, :l, :c, :v)
                 """
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, o=o, h=h, l=l, c=c, v=v),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), o=o, h=h, l=l, c=c, v=v),
         )
 
 
@@ -210,7 +211,7 @@ def insert_funding(engine, *, ts, exchange: str, symbol: str, rate: float, inter
                 VALUES (:ts, :exchange, :symbol, :rate, :interval_sec)
                 """
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, rate=rate, interval_sec=interval_sec),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), rate=rate, interval_sec=interval_sec),
         )
 
 
@@ -224,7 +225,7 @@ def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):
                 VALUES (:ts, :exchange, :symbol, :oi)
                 """
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, oi=oi),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), oi=oi),
         )
 
 
@@ -238,7 +239,7 @@ def insert_basis(engine, *, ts, exchange: str, symbol: str, basis: float):
                 VALUES (:ts, :exchange, :symbol, :basis)
                 """
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, basis=basis),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), basis=basis),
         )
 
 
@@ -260,7 +261,7 @@ def insert_order(
     payload = dict(
         strategy=strategy,
         exchange=exchange,
-        symbol=symbol,
+        symbol=normalize(symbol),
         side=side,
         type=type_,
         qty=qty,
@@ -343,7 +344,7 @@ def insert_cross_signal(
                 """
             ),
             dict(
-                symbol=symbol,
+                symbol=normalize(symbol),
                 spot_exchange=spot_exchange,
                 perp_exchange=perp_exchange,
                 spot_px=spot_px,

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from sqlalchemy import create_engine, text
 
 from ..config import settings
+from ..core.symbols import normalize
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ def insert_trades(engine, trades: Iterable[Any]):
         dict(
             ts=t.ts,
             exchange=t.exchange,
-            symbol=t.symbol,
+            symbol=normalize(getattr(t, "symbol", "")),
             px=t.price,
             qty=t.qty,
             side=t.side,
@@ -73,7 +74,7 @@ def insert_bars_1m(engine, bars: Iterable[Any]):
         dict(
             ts=b.ts,
             exchange=b.exchange,
-            symbol=b.symbol,
+            symbol=normalize(getattr(b, "symbol", "")),
             o=b.o,
             h=b.h,
             l=b.l,
@@ -101,7 +102,16 @@ def insert_bar_1m(engine, exchange: str, symbol: str, ts, o: float, h: float,
                   low: float, c: float, v: float):
     """Insert a single 1-minute OHLCV bar into TimescaleDB."""
 
-    bar = SimpleNamespace(ts=ts, exchange=exchange, symbol=symbol, o=o, h=h, l=low, c=c, v=v)
+    bar = SimpleNamespace(
+        ts=ts,
+        exchange=exchange,
+        symbol=normalize(symbol),
+        o=o,
+        h=h,
+        l=low,
+        c=c,
+        v=v,
+    )
     insert_bars_1m(engine, [bar])
 
 def insert_funding(
@@ -126,7 +136,7 @@ def insert_funding(
             dict(
                 ts=ts,
                 exchange=exchange,
-                symbol=symbol,
+                symbol=normalize(symbol),
                 rate=rate,
                 interval_sec=interval_sec,
             ),
@@ -143,7 +153,7 @@ def insert_open_interest(engine, *, ts, exchange: str, symbol: str, oi: float):
             VALUES (:ts, :exchange, :symbol, :oi)
         '''
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, oi=oi),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), oi=oi),
         )
 
 
@@ -157,18 +167,28 @@ def insert_basis(engine, *, ts, exchange: str, symbol: str, basis: float):
             VALUES (:ts, :exchange, :symbol, :basis)
         '''
             ),
-            dict(ts=ts, exchange=exchange, symbol=symbol, basis=basis),
+            dict(ts=ts, exchange=exchange, symbol=normalize(symbol), basis=basis),
         )
 
 def insert_orderbook(engine, *, ts, exchange: str, symbol: str,
                      bid_px: list[float], bid_qty: list[float],
                      ask_px: list[float], ask_qty: list[float]):
     with engine.begin() as conn:
-        conn.execute(text('''
+        conn.execute(
+            text('''
             INSERT INTO market.orderbook (ts, exchange, symbol, bid_px, bid_qty, ask_px, ask_qty)
             VALUES (:ts, :exchange, :symbol, :bid_px, :bid_qty, :ask_px, :ask_qty)
-        '''), dict(ts=ts, exchange=exchange, symbol=symbol,
-                   bid_px=bid_px, bid_qty=bid_qty, ask_px=ask_px, ask_qty=ask_qty))
+        '''),
+            dict(
+                ts=ts,
+                exchange=exchange,
+                symbol=normalize(symbol),
+                bid_px=bid_px,
+                bid_qty=bid_qty,
+                ask_px=ask_px,
+                ask_qty=ask_qty,
+            ),
+        )
 
 
 def insert_bba(
@@ -195,7 +215,7 @@ def insert_bba(
             dict(
                 ts=ts,
                 exchange=exchange,
-                symbol=symbol,
+                symbol=normalize(symbol),
                 bid_px=bid_px,
                 bid_qty=bid_qty,
                 ask_px=ask_px,
@@ -228,7 +248,7 @@ def insert_book_delta(
             dict(
                 ts=ts,
                 exchange=exchange,
-                symbol=symbol,
+                symbol=normalize(symbol),
                 bid_px=bid_px,
                 bid_qty=bid_qty,
                 ask_px=ask_px,
@@ -241,7 +261,7 @@ def insert_order(engine, *, strategy: str, exchange: str, symbol: str, side: str
         conn.execute(text('''
             INSERT INTO market.orders (strategy, exchange, symbol, side, type, qty, px, status, ext_order_id, notes)
             VALUES (:strategy, :exchange, :symbol, :side, :type, :qty, :px, :status, :ext_order_id, :notes)
-        '''), dict(strategy=strategy, exchange=exchange, symbol=symbol, side=side, type=type_, qty=qty, px=px, status=status, ext_order_id=ext_order_id, notes=notes))
+        '''), dict(strategy=strategy, exchange=exchange, symbol=normalize(symbol), side=side, type=type_, qty=qty, px=px, status=status, ext_order_id=ext_order_id, notes=notes))
 
 def insert_tri_signal(engine, *, exchange: str, base: str, mid: str, quote: str, direction: str, edge: float, notional_quote: float, taker_fee_bps: float, buffer_bps: float, bq: float, mq: float, mb: float):
     with engine.begin() as conn:
@@ -258,7 +278,7 @@ def insert_cross_signal(engine, *, symbol: str, spot_exchange: str, perp_exchang
         conn.execute(text('''
             INSERT INTO market.cross_signals (symbol, spot_exchange, perp_exchange, spot_px, perp_px, edge)
             VALUES (:symbol, :spot_exchange, :perp_exchange, :spot_px, :perp_px, :edge)
-        '''), dict(symbol=symbol, spot_exchange=spot_exchange, perp_exchange=perp_exchange,
+        '''), dict(symbol=normalize(symbol), spot_exchange=spot_exchange, perp_exchange=perp_exchange,
                    spot_px=spot_px, perp_px=perp_px, edge=edge))
 
 def select_bars(
@@ -350,7 +370,7 @@ def insert_portfolio_snapshot(engine, *, venue: str, symbol: str, position: floa
         conn.execute(text('''
             INSERT INTO market.portfolio_snapshots (venue, symbol, position, price, notional_usd)
             VALUES (:venue, :symbol, :position, :price, :notional_usd)
-        '''), dict(venue=venue, symbol=symbol, position=position, price=price, notional_usd=notional_usd))
+        '''), dict(venue=venue, symbol=normalize(symbol), position=position, price=price, notional_usd=notional_usd))
 
 def select_latest_portfolio(engine, venue: str, limit_per_symbol: int = 1) -> list[dict]:
     # Trae la última fila por símbolo para un venue
@@ -368,7 +388,7 @@ def insert_risk_event(engine, *, venue: str, symbol: str, kind: str, message: st
         conn.execute(text('''
             INSERT INTO market.risk_events (venue, symbol, kind, message, details)
             VALUES (:venue, :symbol, :kind, :message, :details)
-        '''), dict(venue=venue, symbol=symbol, kind=kind, message=message, details=details or {}))
+        '''), dict(venue=venue, symbol=normalize(symbol), kind=kind, message=message, details=details or {}))
 
 def select_recent_risk_events(engine, venue: str, limit: int = 50) -> list[dict]:
     with engine.begin() as conn:
@@ -391,14 +411,14 @@ def upsert_position(engine, *, venue: str, symbol: str, qty: float, avg_price: f
                 avg_price = EXCLUDED.avg_price,
                 realized_pnl = EXCLUDED.realized_pnl,
                 fees_paid = EXCLUDED.fees_paid
-        '''), dict(venue=venue, symbol=symbol, qty=qty, avg_price=avg_price, realized_pnl=realized_pnl, fees_paid=fees_paid))
+        '''), dict(venue=venue, symbol=normalize(symbol), qty=qty, avg_price=avg_price, realized_pnl=realized_pnl, fees_paid=fees_paid))
 
 def insert_pnl_snapshot(engine, *, venue: str, symbol: str, qty: float, price: float, avg_price: float, upnl: float, rpnl: float, fees: float):
     with engine.begin() as conn:
         conn.execute(text('''
             INSERT INTO market.pnl_snapshots (venue, symbol, qty, price, avg_price, upnl, rpnl, fees)
             VALUES (:venue, :symbol, :qty, :price, :avg_price, :upnl, :rpnl, :fees)
-        '''), dict(venue=venue, symbol=symbol, qty=qty, price=price, avg_price=avg_price, upnl=upnl, rpnl=rpnl, fees=fees))
+        '''), dict(venue=venue, symbol=normalize(symbol), qty=qty, price=price, avg_price=avg_price, upnl=upnl, rpnl=rpnl, fees=fees))
 
 def select_pnl_summary(engine, venue: str, symbol: str | None = None) -> dict:
     with engine.begin() as conn:
@@ -523,14 +543,22 @@ def insert_fill(engine, *, ts, venue: str, strategy: str, symbol: str, side: str
     with engine.begin() as conn:
         conn.execute(text('''
             INSERT INTO market.fills (ts, venue, strategy, symbol, side, type, qty, price, notional, fee_usdt, reduce_only, ext_order_id, raw)
-            VALUES (:ts, :venue, :strategy, :symbol, :side, :type, :qty, :price, 
+            VALUES (:ts, :venue, :strategy, :symbol, :side, :type, :qty, :price,
                     CASE WHEN :price IS NULL THEN NULL ELSE :qty * :price END,
                     :fee_usdt, :reduce_only, :ext_order_id, :raw)
         '''), dict(
-            ts=ts, venue=venue, strategy=strategy, symbol=symbol, side=side, type=type_,
-            qty=float(qty), price=(float(price) if price is not None else None),
+            ts=ts,
+            venue=venue,
+            strategy=strategy,
+            symbol=normalize(symbol),
+            side=side,
+            type=type_,
+            qty=float(qty),
+            price=(float(price) if price is not None else None),
             fee_usdt=(float(fee_usdt) if fee_usdt is not None else None),
-            reduce_only=bool(reduce_only), ext_order_id=ext_order_id, raw=raw or {}
+            reduce_only=bool(reduce_only),
+            ext_order_id=ext_order_id,
+            raw=raw or {},
         ))
 
 def select_recent_fills(engine, venue: str, symbol: str | None = None, limit: int = 100) -> list[dict]:
@@ -684,13 +712,18 @@ def upsert_oco(engine, *, venue: str, symbol: str, side: str,
       SET status='cancelled', updated_at=now()
       WHERE venue=:venue AND symbol=:symbol AND status='active'
     """)
+    norm_symbol = normalize(symbol)
     with engine.begin() as conn:
-        conn.execute(sql_cancel_old, {"venue": venue, "symbol": symbol})
+        conn.execute(sql_cancel_old, {"venue": venue, "symbol": norm_symbol})
         conn.execute(sql, {
-            "venue": venue, "symbol": symbol, "side": side,
-            "qty": float(qty), "entry_price": float(entry_price),
-            "sl_price": float(sl_price), "tp_price": float(tp_price),
-            "status": status
+            "venue": venue,
+            "symbol": norm_symbol,
+            "side": side,
+            "qty": float(qty),
+            "entry_price": float(entry_price),
+            "sl_price": float(sl_price),
+            "tp_price": float(tp_price),
+            "status": status,
         })
 
 def update_oco_active(engine, *, venue: str, symbol: str,
@@ -700,11 +733,15 @@ def update_oco_active(engine, *, venue: str, symbol: str,
       SET qty=:qty, entry_price=:entry_price, sl_price=:sl_price, tp_price=:tp_price, updated_at=now()
       WHERE venue=:venue AND symbol=:symbol AND status='active'
     """)
+    norm_symbol = normalize(symbol)
     with engine.begin() as conn:
         conn.execute(sql, {
-            "venue": venue, "symbol": symbol,
-            "qty": float(qty), "entry_price": float(entry_price),
-            "sl_price": float(sl_price), "tp_price": float(tp_price)
+            "venue": venue,
+            "symbol": norm_symbol,
+            "qty": float(qty),
+            "entry_price": float(entry_price),
+            "sl_price": float(sl_price),
+            "tp_price": float(tp_price),
         })
 
 def mark_oco_triggered(engine, *, venue: str, symbol: str, triggered: str):
@@ -713,8 +750,9 @@ def mark_oco_triggered(engine, *, venue: str, symbol: str, triggered: str):
       SET status='triggered', triggered=:triggered, updated_at=now()
       WHERE venue=:venue AND symbol=:symbol AND status='active'
     """)
+    norm_symbol = normalize(symbol)
     with engine.begin() as conn:
-        conn.execute(sql, {"venue": venue, "symbol": symbol, "triggered": triggered})
+        conn.execute(sql, {"venue": venue, "symbol": norm_symbol, "triggered": triggered})
 
 def cancel_oco(engine, *, venue: str, symbol: str):
     sql = text("""
@@ -722,8 +760,9 @@ def cancel_oco(engine, *, venue: str, symbol: str):
       SET status='cancelled', updated_at=now()
       WHERE venue=:venue AND symbol=:symbol AND status='active'
     """)
+    norm_symbol = normalize(symbol)
     with engine.begin() as conn:
-        conn.execute(sql, {"venue": venue, "symbol": symbol})
+        conn.execute(sql, {"venue": venue, "symbol": norm_symbol})
 
 def load_active_oco_by_symbols(engine, *, venue: str, symbols: list[str]):
     if not symbols:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -227,7 +227,7 @@ def test_persist_funding(monkeypatch):
     record = {
         "ts": ts,
         "exchange": "binance",
-        "symbol": "BTCUSDT",
+        "symbol": "btc/usdt",
         "rate": 0.002,
         "interval_sec": 7200,
     }
@@ -235,10 +235,10 @@ def test_persist_funding(monkeypatch):
 
     with engine.begin() as conn:
         row = conn.execute(
-            text("SELECT rate, interval_sec FROM funding")
+            text("SELECT symbol, rate, interval_sec FROM funding")
         ).fetchone()
 
-    assert row == (0.002, 7200)
+    assert row == ("BTCUSDT", 0.002, 7200)
 
 
 def test_persist_open_interest(monkeypatch):
@@ -248,15 +248,15 @@ def test_persist_open_interest(monkeypatch):
     record = {
         "ts": ts,
         "exchange": "binance",
-        "symbol": "BTCUSDT",
+        "symbol": "btc-usdt",
         "oi": 321.0,
     }
     ingestion.persist_open_interest([record], backend="quest")
 
     with engine.begin() as conn:
-        row = conn.execute(text("SELECT oi FROM open_interest")).fetchone()
+        row = conn.execute(text("SELECT symbol, oi FROM open_interest")).fetchone()
 
-    assert row == (321.0,)
+    assert row == ("BTCUSDT", 321.0)
 
 
 def test_insert_order_timescale():
@@ -267,7 +267,7 @@ def test_insert_order_timescale():
         engine,
         strategy="s",
         exchange="binance",
-        symbol="BTCUSDT",
+        symbol="btc/usdt",
         side="buy",
         type_="limit",
         qty=1.0,
@@ -323,7 +323,7 @@ def test_insert_trade_timescale_ts():
     t = SimpleNamespace(
         ts="2024-01-01T00:00:00",
         exchange="binance",
-        symbol="BTCUSDT",
+        symbol="btc-usdt",
         price=100.0,
         qty=1.0,
         side="buy",


### PR DESCRIPTION
## Summary
- Normalize trading symbols before storing data to TimescaleDB and QuestDB
- Normalize symbols in ingestion routines and CSV output
- Add tests covering symbol normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe65ac280832d93e88ec58c79c920