### PR TITLE
Flatten exchange options and centralize defaultType

### DIFF
--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -43,12 +43,14 @@ class BinanceWSAdapter(ExchangeAdapter):
         if self.rest is None and (api_key or api_secret):
             if ccxt is None:
                 raise RuntimeError("ccxt no está instalado")
-            self.rest = ccxt.binance({
-                "apiKey": api_key or "",
-                "secret": api_secret or "",
-                "enableRateLimit": True,
-                "options": {"defaultType": "future"},
-            })
+            self.rest = ccxt.binance(
+                {
+                    "apiKey": api_key or "",
+                    "secret": api_secret or "",
+                    "enableRateLimit": True,
+                }
+            )
+            self.rest.options["defaultType"] = "future"
 
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _binance_symbol_stream(normalize(symbol))

--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -42,14 +42,16 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         self.testnet = testnet
 
         if testnet:
-            self.rest = ccxt.binanceusdm({
-                "apiKey": api_key or settings.binance_futures_api_key,
-                "secret": api_secret or settings.binance_futures_api_secret,
-                "enableRateLimit": True,
-                "options": {"defaultType": "future"},
-            })
+            self.rest = ccxt.binanceusdm(
+                {
+                    "apiKey": api_key or settings.binance_futures_api_key,
+                    "secret": api_secret or settings.binance_futures_api_secret,
+                    "enableRateLimit": True,
+                }
+            )
         else:
             self.rest = ccxt.binanceusdm()
+        self.rest.options["defaultType"] = "future"
         self.maker_fee_bps = float(
             maker_fee_bps
             if maker_fee_bps is not None

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -42,12 +42,14 @@ class BinanceSpotAdapter(ExchangeAdapter):
         key = api_key or (settings.binance_testnet_api_key if testnet else settings.binance_api_key)
         secret = api_secret or (settings.binance_testnet_api_secret if testnet else settings.binance_api_secret)
 
-        self.rest = ccxt.binance({
-            "apiKey": key,
-            "secret": secret,
-            "enableRateLimit": True,
-            "options": {"defaultType": "spot"},
-        })
+        self.rest = ccxt.binance(
+            {
+                "apiKey": key,
+                "secret": secret,
+                "enableRateLimit": True,
+            }
+        )
+        self.rest.options["defaultType"] = "spot"
         self.maker_fee_bps = float(
             maker_fee_bps
             if maker_fee_bps is not None

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -42,12 +42,14 @@ class BybitFuturesAdapter(ExchangeAdapter):
         key = api_key or (settings.bybit_testnet_api_key if testnet else settings.bybit_api_key)
         secret = api_secret or (settings.bybit_testnet_api_secret if testnet else settings.bybit_api_secret)
 
-        self.rest = ccxt.bybit({
-            "apiKey": key,
-            "secret": secret,
-            "enableRateLimit": True,
-            "options": {"defaultType": "swap"},
-        })
+        self.rest = ccxt.bybit(
+            {
+                "apiKey": key,
+                "secret": secret,
+                "enableRateLimit": True,
+            }
+        )
+        self.rest.options["defaultType"] = "swap"
         self.rest.set_sandbox_mode(testnet)
         # Validar permisos de la clave
         validate_scopes(self.rest, log)

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -36,10 +36,10 @@ class BybitSpotAdapter(ExchangeAdapter):
                 "apiKey": key,
                 "secret": secret,
                 "enableRateLimit": True,
-                "options": {"defaultType": "spot"},
                 "testnet": testnet,
             }
         )
+        self.rest.options["defaultType"] = "spot"
         self.rest.set_sandbox_mode(testnet)
         # Advertir si la clave carece de permisos de trade o tiene retiros habilitados
         validate_scopes(self.rest, log)

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -42,13 +42,15 @@ class OKXFuturesAdapter(ExchangeAdapter):
             settings.okx_testnet_api_passphrase if testnet else settings.okx_api_passphrase
         )
 
-        self.rest = ccxt.okx({
-            "apiKey": key,
-            "secret": secret,
-            "password": passphrase,
-            "enableRateLimit": True,
-            "options": {"defaultType": "swap"},
-        })
+        self.rest = ccxt.okx(
+            {
+                "apiKey": key,
+                "secret": secret,
+                "password": passphrase,
+                "enableRateLimit": True,
+            }
+        )
+        self.rest.options["defaultType"] = "swap"
         self.rest.set_sandbox_mode(testnet)
         # Validar permisos disponibles
         validate_scopes(self.rest, log)

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -42,9 +42,9 @@ class OKXSpotAdapter(ExchangeAdapter):
                 "secret": secret,
                 "password": passphrase,
                 "enableRateLimit": True,
-                "options": {"defaultType": "spot"},
             }
         )
+        self.rest.options["defaultType"] = "spot"
         self.rest.set_sandbox_mode(testnet)
         # Validar permisos disponibles en la API key
         validate_scopes(self.rest, log)

--- a/src/tradingbot/exchanges.py
+++ b/src/tradingbot/exchanges.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 SUPPORTED_EXCHANGES: dict[str, dict] = {
-    "binance_spot": {"ccxt": "binance", "options": {"defaultType": "spot"}},
-    "binance_futures": {"ccxt": "binanceusdm", "options": {"defaultType": "future"}},
-    "okx_spot": {"ccxt": "okx", "options": {"defaultType": "spot"}},
-    "okx_futures": {"ccxt": "okx", "options": {"defaultType": "swap"}},
-    "bybit_spot": {"ccxt": "bybit", "options": {"defaultType": "spot"}},
-    "bybit_futures": {"ccxt": "bybit", "options": {"defaultType": "swap"}},
-    "deribit_futures": {"ccxt": "deribit", "options": {"defaultType": "future"}},
+    "binance_spot": {"ccxt": "binance", "defaultType": "spot"},
+    "binance_futures": {"ccxt": "binanceusdm", "defaultType": "future"},
+    "okx_spot": {"ccxt": "okx", "defaultType": "spot"},
+    "okx_futures": {"ccxt": "okx", "defaultType": "swap"},
+    "bybit_spot": {"ccxt": "bybit", "defaultType": "spot"},
+    "bybit_futures": {"ccxt": "bybit", "defaultType": "swap"},
+    "deribit_futures": {"ccxt": "deribit", "defaultType": "future"},
 }
 
 __all__ = ["SUPPORTED_EXCHANGES"]

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -92,8 +92,8 @@ async def backfill(
 
     ex_class = getattr(ccxt, info["ccxt"])
     conf = {"enableRateLimit": True}
-    if info.get("options"):
-        conf["options"] = info["options"]
+    if info.get("defaultType"):
+        conf["options"] = {"defaultType": info["defaultType"]}
     ex = ex_class(conf)
     ex.id = exchange_name
 

--- a/src/tradingbot/market/exchange_meta.py
+++ b/src/tradingbot/market/exchange_meta.py
@@ -20,12 +20,14 @@ class ExchangeMeta:
     def binanceusdm_testnet(cls, api_key: Optional[str] = None, api_secret: Optional[str] = None):
         if ccxt is None:
             raise RuntimeError("ccxt no disponible")
-        client = ccxt.binanceusdm({
-            "apiKey": api_key,
-            "secret": api_secret,
-            "enableRateLimit": True,
-            "options": {"defaultType": "future"},
-        })
+        client = ccxt.binanceusdm(
+            {
+                "apiKey": api_key,
+                "secret": api_secret,
+                "enableRateLimit": True,
+            }
+        )
+        client.options["defaultType"] = "future"
         client.set_sandbox_mode(True)
         return cls(name="binanceusdm_testnet", client=client)
 
@@ -33,12 +35,14 @@ class ExchangeMeta:
     def binance_spot_testnet(cls, api_key: Optional[str] = None, api_secret: Optional[str] = None):
         if ccxt is None:
             raise RuntimeError("ccxt no disponible")
-        client = ccxt.binance({
-            "apiKey": api_key,
-            "secret": api_secret,
-            "enableRateLimit": True,
-            "options": {"defaultType": "spot"},
-        })
+        client = ccxt.binance(
+            {
+                "apiKey": api_key,
+                "secret": api_secret,
+                "enableRateLimit": True,
+            }
+        )
+        client.options["defaultType"] = "spot"
         client.set_sandbox_mode(True)
         return cls(name="binance_spot_testnet", client=client)
 
@@ -46,12 +50,14 @@ class ExchangeMeta:
     def binance_spot(cls, api_key: Optional[str] = None, api_secret: Optional[str] = None):
         if ccxt is None:
             raise RuntimeError("ccxt no disponible")
-        client = ccxt.binance({
-            "apiKey": api_key,
-            "secret": api_secret,
-            "enableRateLimit": True,
-            "options": {"defaultType": "spot"},
-        })
+        client = ccxt.binance(
+            {
+                "apiKey": api_key,
+                "secret": api_secret,
+                "enableRateLimit": True,
+            }
+        )
+        client.options["defaultType"] = "spot"
         return cls(name="binance_spot", client=client)
 
     def load_markets(self):


### PR DESCRIPTION
## Summary
- define `defaultType` directly in SUPPORTED_EXCHANGES and remove nested `options`
- update adapters and exchange meta to set `defaultType` without nested dicts
- use top-level `defaultType` during backfill configuration

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'db/schema.sql')*


------
https://chatgpt.com/codex/tasks/task_e_68abe659bf24832d97e38eb6a3390d95