### PR TITLE
feat: unify venue names across CLI and API

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -51,6 +51,7 @@ BINANCE_FUTURES_TESTNET=false python -m tradingbot.cli ingest --venue binance_fu
 Descarga datos históricos con límites de velocidad.
 - `--days`: número de días hacia atrás (1 por defecto).
 - `--symbols`: lista de símbolos a descargar.
+- `--venue`: nombre del venue (`binance_spot`, `binance_futures`, etc.).
 - `--start`: fecha inicial en formato ISO.
 - `--end`: fecha final en formato ISO.
 
@@ -76,8 +77,7 @@ pueden definirse con los valores correspondientes.
 
 ## `run-bot`
 Ejecuta el bot en modo en vivo (testnet o real).
-- `--exchange`: nombre del exchange (`binance`).
-- `--market`: `spot` o `futures`.
+- `--venue`: nombre del venue (ej. `binance_spot`, `okx_futures`).
 - `--symbol`: puede repetirse; símbolo a operar.
 - `--testnet`: usa endpoints de prueba.
 - `--trade-qty`: tamaño de la orden.
@@ -95,8 +95,7 @@ Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 
 ## `real-run`
 Ejecuta el bot contra un exchange real.
-- `--exchange`: nombre del exchange.
-- `--market`: `spot` o `futures`.
+- `--venue`: nombre del venue.
 - `--symbol`: puede repetirse.
 - `--trade-qty`: tamaño de la orden.
 - `--leverage`: apalancamiento.
@@ -128,7 +127,7 @@ Ejecuta un backtest basado en un archivo de configuración Hydra.
 
 ## `backtest-db`
 Realiza un backtest usando datos almacenados en la base de datos.
-- `--exchange`: nombre del exchange.
+- `--venue`: nombre del venue.
 - `--symbol`: par a evaluar.
 - `--strategy`: estrategia.
 - `--start` y `--end`: rango de fechas (YYYY-MM-DD).

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -28,7 +28,7 @@ from monitoring.dashboard import router as dashboard_router
 from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
-from ...cli.main import get_adapter_class, get_supported_kinds, _AVAILABLE_VENUES
+from ...cli.main import get_adapter_class, get_supported_kinds
 from ...exchanges import SUPPORTED_EXCHANGES
 
 # Persistencia
@@ -90,7 +90,7 @@ def health():
 @app.get("/venues")
 def list_venues():
     """Return available venues."""
-    return sorted(_AVAILABLE_VENUES)
+    return sorted(SUPPORTED_EXCHANGES)
 
 
 @app.get("/ccxt/exchanges")
@@ -636,8 +636,7 @@ class BotConfig(BaseModel):
     strategy: str
     pairs: list[str] | None = None
     notional: float | None = None
-    exchange: str | None = None
-    market: str | None = None
+    venue: str | None = None
     trade_qty: float | None = None
     leverage: int | None = None
     stop_loss: float | None = None
@@ -688,10 +687,8 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         args.extend(["--symbol", pair])
     if cfg.notional is not None:
         args.extend(["--notional", str(cfg.notional)])
-    if cfg.exchange:
-        args.extend(["--exchange", cfg.exchange])
-    if cfg.market:
-        args.extend(["--market", cfg.market])
+    if cfg.venue:
+        args.extend(["--venue", cfg.venue])
     if cfg.trade_qty is not None:
         args.extend(["--trade-qty", str(cfg.trade_qty)])
     if cfg.leverage is not None:

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -130,7 +130,7 @@ async function runBacktest(){
     const strat=document.getElementById('bt-strategy').value.trim();
     const start=document.getElementById('bt-start').value;
     const end=document.getElementById('bt-end').value;
-    cmd=`backtest-db --exchange ${venue} --symbol ${sym} --strategy ${strat} --start ${start} --end ${end}`;
+    cmd=`backtest-db --venue ${venue} --symbol ${sym} --strategy ${strat} --start ${start} --end ${end}`;
   }
   try{
     const r=await fetch(api('/cli/run'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -273,10 +273,10 @@ async function runData(){
         runBtn.textContent='Ejecutar';
         return;
       }
-      cmd=`backfill --start ${s.toISOString()} --end ${e.toISOString()} ${symbols.map(s=>`--symbols ${s}`).join(' ')} --exchange-name ${exchange}`;
+      cmd=`backfill --start ${s.toISOString()} --end ${e.toISOString()} ${symbols.map(s=>`--symbols ${s}`).join(' ')} --venue ${exchange}`;
     }else{
       const days=document.getElementById('dm-days').value;
-      cmd=`backfill --days ${days} ${symbols.map(s=>`--symbols ${s}`).join(' ')} --exchange-name ${exchange}`;
+      cmd=`backfill --days ${days} ${symbols.map(s=>`--symbols ${s}`).join(' ')} --venue ${exchange}`;
     }
   }else{
     const src=document.getElementById('dm-source').value;

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -35,8 +35,7 @@ def test_bot_endpoints(monkeypatch):
     payload = {
         "strategy": "dummy",
         "pairs": ["BTC/USDT"],
-        "exchange": "binance",
-        "market": "spot",
+        "venue": "binance_spot",
         "trade_qty": 1.0,
         "leverage": 1,
         "stop_loss": 0.02,
@@ -51,6 +50,7 @@ def test_bot_endpoints(monkeypatch):
     assert resp.status_code == 200
     pid = resp.json()["pid"]
     argv = list(calls["args"])
+    assert "--venue" in argv and "binance_spot" in argv
     assert "--stop-loss" in argv and "0.02" in argv
     assert "--take-profit" in argv and "0.05" in argv
     assert "--stop-loss-pct" in argv and "0.03" in argv

--- a/tests/test_api_venues.py
+++ b/tests/test_api_venues.py
@@ -2,7 +2,7 @@ import importlib
 
 from fastapi.testclient import TestClient
 
-from tradingbot.cli.main import _AVAILABLE_VENUES
+from tradingbot.exchanges import SUPPORTED_EXCHANGES
 
 
 def get_app():
@@ -19,4 +19,4 @@ def test_list_venues(monkeypatch):
 
     resp = client.get("/venues", auth=("u", "p"))
     assert resp.status_code == 200
-    assert resp.json() == sorted(_AVAILABLE_VENUES)
+    assert resp.json() == sorted(SUPPORTED_EXCHANGES)

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -14,8 +14,7 @@ def test_config_roundtrip():
         "strategy": "mean_reversion",
         "pairs": ["BTC/USDT"],
         "notional": 50,
-        "exchange": "binance",
-        "market": "futures",
+        "venue": "binance_futures",
         "trade_qty": 0.01,
         "leverage": 3,
         "testnet": True,
@@ -41,8 +40,7 @@ def test_start_stop(monkeypatch):
         "/config",
         json={
             "strategy": "dummy",
-            "exchange": "binance",
-            "market": "spot",
+            "venue": "binance_spot",
             "trade_qty": 0.001,
             "leverage": 1,
             "testnet": True,
@@ -76,8 +74,7 @@ def test_start_stop(monkeypatch):
     assert data["pid"] == 123
     assert calls
     argv = list(calls["args"])
-    assert "--exchange" in argv and argv[argv.index("--exchange") + 1] == "binance"
-    assert "--market" in argv and argv[argv.index("--market") + 1] == "spot"
+    assert "--venue" in argv and argv[argv.index("--venue") + 1] == "binance_spot"
     assert "--trade-qty" in argv and argv[argv.index("--trade-qty") + 1] == "0.001"
     assert "--leverage" in argv and argv[argv.index("--leverage") + 1] == "1"
     assert "--testnet" in argv


### PR DESCRIPTION
## Summary
- use centralized `SUPPORTED_EXCHANGES` for API venues and bot configs
- switch CLI commands to `--venue` and validate via `SUPPORTED_EXCHANGES`
- update monitoring panel, docs and static pages to the new venue naming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abe65851d4832db7117cd425c1232e