### PR TITLE
Validate API keys for Kaiko and CoinAPI

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -430,6 +430,9 @@ def ingest_historical(
 
         if not provider_exchange:
             raise typer.BadParameter("exchange required for Kaiko")
+        if not os.getenv("KAIKO_API_KEY"):
+            typer.echo("KAIKO_API_KEY missing")
+            raise typer.Exit(code=1)
 
         if kind == "orderbook":
             asyncio.run(
@@ -501,6 +504,10 @@ def ingest_historical(
             download_coinapi_open_interest,
             download_funding,
         )
+
+        if not os.getenv("COINAPI_KEY"):
+            typer.echo("COINAPI_KEY missing")
+            raise typer.Exit(code=1)
 
         if kind == "orderbook":
             asyncio.run(

--- a/src/tradingbot/connectors/coinapi.py
+++ b/src/tradingbot/connectors/coinapi.py
@@ -29,6 +29,8 @@ class CoinAPIConnector:
 
     def __init__(self, api_key: str | None = None, rate_limit: int = 5) -> None:
         self.api_key = api_key or os.getenv("COINAPI_KEY", "")
+        if not self.api_key:
+            raise ValueError("COINAPI_KEY missing")
         self._sem = asyncio.Semaphore(rate_limit)
 
     async def fetch_trades(

--- a/src/tradingbot/connectors/kaiko.py
+++ b/src/tradingbot/connectors/kaiko.py
@@ -29,6 +29,8 @@ class KaikoConnector:
 
     def __init__(self, api_key: str | None = None, rate_limit: int = 5) -> None:
         self.api_key = api_key or os.getenv("KAIKO_API_KEY", "")
+        if not self.api_key:
+            raise ValueError("KAIKO_API_KEY missing")
         # very small semaphore based limiter for historical downloads
         self._sem = asyncio.Semaphore(rate_limit)
 

--- a/tests/test_api_key_validation.py
+++ b/tests/test_api_key_validation.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+from typer.testing import CliRunner
+
+from tradingbot.cli.main import app
+
+
+def test_kaiko_connector_requires_api_key(monkeypatch):
+    monkeypatch.delenv("KAIKO_API_KEY", raising=False)
+    from tradingbot.connectors.kaiko import KaikoConnector
+
+    with pytest.raises(ValueError, match="KAIKO_API_KEY missing"):
+        KaikoConnector()
+
+
+def test_coinapi_connector_requires_api_key(monkeypatch):
+    monkeypatch.delenv("COINAPI_KEY", raising=False)
+    from tradingbot.connectors.coinapi import CoinAPIConnector
+
+    with pytest.raises(ValueError, match="COINAPI_KEY missing"):
+        CoinAPIConnector()
+
+
+def test_cli_ingest_historical_reports_missing_key(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.delenv("KAIKO_API_KEY", raising=False)
+    result = runner.invoke(
+        app, ["ingest-historical", "kaiko", "BTC-USD", "--exchange", "binance_spot"]
+    )
+    assert result.exit_code != 0
+    assert "KAIKO_API_KEY missing" in result.stdout
+
+
+def test_cli_ingest_historical_coinapi_missing_key(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.delenv("COINAPI_KEY", raising=False)
+    result = runner.invoke(app, ["ingest-historical", "coinapi", "BTCUSD"])
+    assert result.exit_code != 0
+    assert "COINAPI_KEY missing" in result.stdout


### PR DESCRIPTION
## Summary
- ensure Kaiko and CoinAPI connectors raise clear errors when API keys are missing
- improve `ingest-historical` CLI to report missing keys before making requests
- add regression tests for missing API keys and CLI messaging

## Testing
- `pytest tests/test_api_key_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abefcde320832d8daddc6f57cf83c7