### PR TITLE
feat(api): add option to include testnet exchanges

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -94,17 +94,23 @@ def list_venues():
 
 
 @app.get("/ccxt/exchanges")
-def ccxt_exchanges():
-    """Return exchanges supported by ``ccxt``."""
+def ccxt_exchanges(include_testnet: bool = Query(False)):
+    """Return exchanges supported by ``ccxt``.
+
+    By default only live exchanges are returned. Pass ``include_testnet``
+    to append the corresponding ``*_testnet`` variants.
+    """
     if ccxt is None:
         return []
     available = getattr(ccxt, "exchanges", [])
-    return [
-        variant
+    live = [
+        key
         for key, info in SUPPORTED_EXCHANGES.items()
         if info["ccxt"] in available
-        for variant in (key, f"{key}_testnet")
     ]
+    if include_testnet:
+        live += [f"{key}_testnet" for key in live]
+    return live
 
 
 @app.get("/venues/{name}/kinds")

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -91,7 +91,7 @@ const api = (path) => `${location.origin}${path}`;
 
 async function loadExchanges(){
   try{
-    const r = await fetch(api('/ccxt/exchanges'));
+    const r = await fetch(api('/ccxt/exchanges?include_testnet=1'));
     const exchanges = await r.json();
     const sel = document.getElementById('cfg-exchange');
     sel.innerHTML = '';


### PR DESCRIPTION
## Summary
- allow `/ccxt/exchanges` endpoint to optionally include `*_testnet` variants
- ensure dashboard API key selector requests live + testnet exchanges

## Testing
- `pytest` *(killed: signal)*

------
https://chatgpt.com/codex/tasks/task_e_68abf36ac6ec832dba9ea98b332969d0