### PR TITLE
Expose strategy metadata via API and backtest UI

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -402,6 +402,14 @@ def strategies_status():
     }
 
 
+@app.get("/strategies/info")
+def strategies_info():
+    """Return human-readable info for all strategies."""
+    from ...strategies import STRATEGY_INFO
+
+    return STRATEGY_INFO
+
+
 @app.get("/strategies/{name}/schema")
 def strategy_schema(name: str):
     """Return constructor parameters and defaults for a strategy.

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -52,6 +52,7 @@
       <div id="field-strategy">
         <label for="bt-strategy">Estrategia</label>
         <select id="bt-strategy"></select>
+        <p id="bt-strategy-info" class="muted"></p>
       </div>
       <div id="field-config">
         <label for="bt-config">Archivo config</label>
@@ -86,16 +87,19 @@
 <script>
 const api = (path) => `${location.origin}${path}`;
 
+let strategyInfo = {};
+
 async function loadStrategies(){
   try{
-    const r=await fetch(api('/strategies/status'));
-    const j=await r.json();
+    const r=await fetch(api('/strategies/info'));
+    strategyInfo=await r.json();
     const sel=document.getElementById('bt-strategy');
     sel.innerHTML='';
-    Object.keys(j.strategies||{}).forEach(s=>{
+    Object.keys(strategyInfo||{}).forEach(s=>{
       const o=document.createElement('option');
       o.value=s;o.textContent=s;sel.appendChild(o);
     });
+    updateStrategyInfo();
   }catch(e){}
 }
 
@@ -108,6 +112,18 @@ function updateBtFields(){
   document.getElementById('field-venue').style.display=mode==='db'?'':'none';
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
+}
+
+function updateStrategyInfo(){
+  const sel=document.getElementById('bt-strategy').value;
+  const info=strategyInfo[sel];
+  const el=document.getElementById('bt-strategy-info');
+  if(info){
+    const req=(info.requires||[]).join(', ');
+    el.textContent=`${info.desc}${req?` (requiere: ${req})`:''}`;
+  }else{
+    el.textContent='';
+  }
 }
 
 async function runBacktest(){
@@ -156,6 +172,7 @@ async function runCli(){
 }
 
 document.getElementById('bt-mode').addEventListener('change',updateBtFields);
+document.getElementById('bt-strategy').addEventListener('change',updateStrategyInfo);
 document.getElementById('bt-run').addEventListener('click',runBacktest);
 document.getElementById('cli-run').addEventListener('click',runCli);
 updateBtFields();

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -27,6 +27,58 @@ STRATEGIES = {
     MeanRevOFI.name: MeanRevOFI,
 }
 
+# Human-readable information about each strategy
+STRATEGY_INFO = {
+    "breakout_atr": {
+        "desc": "Breakout based on ATR and Keltner channels",
+        "requires": ["ohlcv"],
+    },
+    "breakout_vol": {
+        "desc": "Volatility breakout using rolling standard deviation",
+        "requires": ["ohlcv"],
+    },
+    "momentum": {
+        "desc": "RSI-based momentum strategy",
+        "requires": ["ohlcv"],
+    },
+    "mean_reversion": {
+        "desc": "RSI mean reversion strategy",
+        "requires": ["ohlcv"],
+    },
+    "triangular_arb": {
+        "desc": "Naive triangular arbitrage across three markets",
+        "requires": ["prices"],
+    },
+    "cash_and_carry": {
+        "desc": "Cash and carry using spot, perp and funding basis",
+        "requires": ["spot", "perp", "funding"],
+    },
+    "order_flow": {
+        "desc": "Order flow imbalance from book deltas",
+        "requires": ["bba", "book_delta"],
+    },
+    "depth_imbalance": {
+        "desc": "Depth imbalance on top of the book",
+        "requires": ["bba", "book_delta"],
+    },
+    "liquidity_events": {
+        "desc": "Liquidity vacuum and gap events",
+        "requires": ["bba", "book_delta"],
+    },
+    "triple_barrier": {
+        "desc": "Triple-barrier labeling with boosting model",
+        "requires": ["ohlcv"],
+    },
+    "ml": {
+        "desc": "Machine learning driven strategy",
+        "requires": ["features"],
+    },
+    "mean_rev_ofi": {
+        "desc": "OFI z-score mean reversion under low volatility",
+        "requires": ["ohlcv", "book_delta"],
+    },
+}
+
 __all__ = [
     "BreakoutATR",
     "BreakoutVol",
@@ -41,4 +93,5 @@ __all__ = [
     "MLStrategy",
     "MeanRevOFI",
     "STRATEGIES",
+    "STRATEGY_INFO",
 ]


### PR DESCRIPTION
## Summary
- Add `STRATEGY_INFO` metadata for all strategies
- Expose new `/strategies/info` API endpoint
- Show selected strategy description and required data in backtest page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf70e0758832d8b4d2313858ce9d4