### PR TITLE
Expose strategy metadata via API and UI

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -408,6 +408,14 @@ def strategies_status():
     }
 
 
+@app.get("/strategies/info")
+def strategies_info():
+    """Return metadata for available strategies."""
+    from ...strategies import STRATEGY_INFO
+
+    return STRATEGY_INFO
+
+
 @app.get("/strategies/{name}/schema")
 def strategy_schema(name: str):
     """Return constructor parameters and defaults for a strategy.

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -53,6 +53,7 @@
         <label for="bt-strategy">Estrategia</label>
         <select id="bt-strategy"></select>
       </div>
+      <p id="bt-strategy-info" class="muted" style="grid-column:1 / -1;"></p>
       <div id="field-config">
         <label for="bt-config">Archivo config</label>
         <input id="bt-config" placeholder="config.yaml"/>
@@ -86,6 +87,8 @@
 <script>
 const api = (path) => `${location.origin}${path}`;
 
+let strategyInfo = {};
+
 async function loadExchanges(){
   try{
     const r = await fetch(api('/ccxt/exchanges'));
@@ -113,7 +116,10 @@ async function loadStrategies(){
       const o=document.createElement('option');
       o.value=s;o.textContent=s;sel.appendChild(o);
     });
-  }catch(e){}
+    const infoResp=await fetch(api('/strategies/info'));
+    strategyInfo=await infoResp.json();
+    updateStrategyInfo();
+  }catch(e){console.error(e);}
 }
 
 function updateBtFields(){
@@ -126,6 +132,18 @@ function updateBtFields(){
   document.getElementById('bt-venue').style.display=mode==='db'?'':'none';
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
+}
+
+function updateStrategyInfo(){
+  const sel=document.getElementById('bt-strategy');
+  const info=strategyInfo[sel.value]||{};
+  const el=document.getElementById('bt-strategy-info');
+  if(info.desc){
+    const req=(info.requires||[]).join(', ');
+    el.textContent=`${info.desc}. Requiere: ${req}`;
+  }else{
+    el.textContent='';
+  }
 }
 
 async function runBacktest(){
@@ -176,6 +194,7 @@ async function runCli(){
 document.getElementById('bt-mode').addEventListener('change',updateBtFields);
 document.getElementById('bt-run').addEventListener('click',runBacktest);
 document.getElementById('cli-run').addEventListener('click',runCli);
+document.getElementById('bt-strategy').addEventListener('change',updateStrategyInfo);
 updateBtFields();
 loadStrategies();
 loadExchanges();

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -27,6 +27,61 @@ STRATEGIES = {
     MeanRevOFI.name: MeanRevOFI,
 }
 
+# Metadata describing each strategy.  ``desc`` provides a short human
+# readable description while ``requires`` lists the data inputs needed by the
+# strategy when running in real time or backtests.  This information is used by
+# the API and front-end to display helpful details to the user.
+STRATEGY_INFO: dict[str, dict] = {
+    "breakout_atr": {
+        "desc": "Ruptura basada en canales ATR",
+        "requires": ["ohlcv"],
+    },
+    "breakout_vol": {
+        "desc": "Ruptura por volatilidad",
+        "requires": ["ohlcv"],
+    },
+    "momentum": {
+        "desc": "Sigue la tendencia con RSI",
+        "requires": ["ohlcv"],
+    },
+    "mean_reversion": {
+        "desc": "Reversión a la media con RSI",
+        "requires": ["ohlcv"],
+    },
+    "triangular_arb": {
+        "desc": "Arbitraje entre tres pares",
+        "requires": ["prices"],
+    },
+    "cash_and_carry": {
+        "desc": "Diferencias entre spot y perp con funding",
+        "requires": ["spot", "perp", "funding"],
+    },
+    "order_flow": {
+        "desc": "Desequilibrio del flujo de órdenes",
+        "requires": ["bba", "book_delta"],
+    },
+    "depth_imbalance": {
+        "desc": "Desequilibrio de profundidad del libro",
+        "requires": ["book_delta"],
+    },
+    "liquidity_events": {
+        "desc": "Detecta vacíos y gaps de liquidez",
+        "requires": ["bba", "book_delta"],
+    },
+    "triple_barrier": {
+        "desc": "Señales con etiquetado de triple barrera",
+        "requires": ["ohlcv"],
+    },
+    "ml": {
+        "desc": "Modelo de machine learning",
+        "requires": ["features"],
+    },
+    "mean_rev_ofi": {
+        "desc": "Reversión a la media con OFI",
+        "requires": ["book_delta"],
+    },
+}
+
 __all__ = [
     "BreakoutATR",
     "BreakoutVol",
@@ -41,4 +96,5 @@ __all__ = [
     "MLStrategy",
     "MeanRevOFI",
     "STRATEGIES",
+    "STRATEGY_INFO",
 ]


### PR DESCRIPTION
## Summary
- add `STRATEGY_INFO` registry with descriptions and required data for each strategy
- expose `/strategies/info` endpoint returning strategy metadata
- show strategy description and required feeds on backtest page

## Testing
- `pytest tests/test_api_venues.py::test_list_venues tests/test_strategies.py::test_breakout_atr_signals -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf9b45d80832d866aba0bc242511b