### PR TITLE
Exclude testnet venues from backtesting

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,6 +115,10 @@ Inicia trabajadores de ingesta de funding y open interest definidos en un YAML.
 Valida que un archivo YAML de configuración contenga los campos mínimos
 necesarios para backtesting y walk-forward.
 
+Los comandos de backtesting solo aceptan venues en modo live con sufijo
+`*_spot` o `*_futures`; los venues que terminan en `_testnet` o `_ws` son
+rechazados.
+
 ## `backtest`
 Ejecuta un backtest vectorizado desde un archivo CSV.
 - `data`: ruta al CSV.

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -92,7 +92,9 @@ let strategyInfo = {};
 async function loadExchanges(){
   try{
     const r = await fetch(api('/ccxt/exchanges'));
-    const exchanges = await r.json();
+    const exchanges = (await r.json()).filter(
+      ex => !ex.endsWith('_testnet') && !ex.endsWith('_ws')
+    );
     const sel = document.getElementById('bt-venue');
     sel.innerHTML = '';
     for(const ex of exchanges){

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -108,6 +108,16 @@ def _validate_venue(value: str) -> str:
     return value
 
 
+def _validate_backtest_venue(value: str) -> str:
+    """Reject venues not suitable for backtesting."""
+
+    if value.endswith("_testnet") or value.endswith("_ws"):
+        raise typer.BadParameter(
+            "Testnet and WebSocket venues are not supported; use *_spot or *_futures"
+        )
+    return _validate_venue(value)
+
+
 def get_supported_kinds(adapter_cls: type[adapters.ExchangeAdapter]) -> list[str]:
     """Return a sorted list of stream kinds supported by ``adapter_cls``.
 
@@ -890,7 +900,7 @@ def backtest_db(
     venue: str = typer.Option(
         "binance_spot",
         "--venue",
-        callback=_validate_venue,
+        callback=_validate_backtest_venue,
         help=f"Venue name ({_VENUE_CHOICES})",
     ),
     symbol: str = typer.Option(..., "--symbol", help="Trading symbol"),


### PR DESCRIPTION
## Summary
- filter out `_testnet` and `_ws` entries when listing exchanges in the backtest page
- reject `_testnet`/`_ws` venues in `backtest-db` via a new validation helper
- document that only `*_spot` and `*_futures` venues are supported for live backtesting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abfe7cc808832d853416cc0d1c166d