### PR TITLE
Define allowed backfill exchanges

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -76,10 +76,14 @@
       </div>
       <div id="field-exchange-name">
         <label for="dm-exchange-name">Exchange</label>
-        <select id="dm-exchange-name">
+        <select id="dm-exchange-name" title="binance_spot, binance_futures, okx_spot, okx_futures, bybit_spot, bybit_futures, deribit_futures">
+          <option value="binance_spot">binance_spot</option>
           <option value="binance_futures">binance_futures</option>
+          <option value="okx_spot">okx_spot</option>
           <option value="okx_futures">okx_futures</option>
+          <option value="bybit_spot">bybit_spot</option>
           <option value="bybit_futures">bybit_futures</option>
+          <option value="deribit_futures">deribit_futures</option>
         </select>
       </div>
       <div id="field-source">
@@ -167,6 +171,15 @@ const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
 let evt=null;
 let kindsWithDepth=[];
+const BACKFILL_EXCHANGES=[
+  "binance_spot",
+  "binance_futures",
+  "okx_spot",
+  "okx_futures",
+  "bybit_spot",
+  "bybit_futures",
+  "deribit_futures",
+];
 const kindDescriptions={
   bba:"BBA (Best Bid & Ask): muestra las mejores posturas de compra (bid) y venta (ask) en el libro de órdenes.",
   open_interest:"Open interest: cantidad total de contratos abiertos (posiciones vigentes) en un mercado de derivados.",
@@ -444,17 +457,16 @@ async function loadVenues(){
 
 async function loadExchanges(){
   try{
-    const r=await fetch(api('/ccxt/exchanges'));
-    const exchanges=await r.json();
     const sel=document.getElementById('dm-exchange-name');
-    const rest=exchanges.filter(e=>!e.endsWith('_ws'));
     sel.innerHTML='';
-    for(const ex of rest){
+    for(const ex of BACKFILL_EXCHANGES){
       const opt=document.createElement('option');
       opt.value=ex;
       opt.textContent=ex;
       sel.appendChild(opt);
     }
+    const r=await fetch(api('/ccxt/exchanges'));
+    const exchanges=await r.json();
     const selHist=document.getElementById('dm-exchange');
     selHist.innerHTML='';
     for(const ex of exchanges){

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -31,6 +31,7 @@ import ast
 import textwrap
 from typing import List
 
+import click
 import typer
 
 from .. import adapters
@@ -98,6 +99,16 @@ def get_adapter_class(name: str) -> type[adapters.ExchangeAdapter] | None:
 
 
 _VENUE_CHOICES = ", ".join(sorted(SUPPORTED_EXCHANGES))
+
+BACKFILL_EXCHANGES = [
+    "binance_spot",
+    "binance_futures",
+    "okx_spot",
+    "okx_futures",
+    "bybit_spot",
+    "bybit_futures",
+    "deribit_futures",
+]
 
 
 def _validate_venue(value: str) -> str:
@@ -365,14 +376,15 @@ def backfill(
     symbols: List[str] = typer.Option(
         ["BTC/USDT"], "--symbols", help="Symbols to download"
     ),
-    venue: str = typer.Option(
+    exchange: str = typer.Option(
         "binance_spot",
-        "--venue",
+        "--exchange",
         "--exchange-name",
-        callback=_validate_venue,
+        "--venue",
+        click.Choice(BACKFILL_EXCHANGES),
         help=(
-            "Venue to use. Choose from spot/futures venues or Deribit:"
-            f" {_VENUE_CHOICES}"
+            "Exchange to backfill. Choose from: "
+            f"{', '.join(BACKFILL_EXCHANGES)}"
         ),
     ),
     start: str | None = typer.Option(
@@ -400,7 +412,7 @@ def backfill(
         run_backfill(
             days=days,
             symbols=symbols,
-            exchange_name=venue,
+            exchange_name=exchange,
             start=_parse(start),
             end=_parse(end),
         )


### PR DESCRIPTION
## Summary
- Restrict `backfill` CLI command to a fixed list of supported exchanges
- Populate backfill UI select with the same fixed exchange list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac025f5748832d88191ad6c5995d16