### PR TITLE
Filter allowed exchanges for historical ingestion

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -467,9 +467,16 @@ async function loadExchanges(){
     }
     const r=await fetch(api('/ccxt/exchanges'));
     const exchanges=await r.json();
+    const allowed=[
+      "binance_spot", "binance_futures",
+      "okx_spot", "okx_futures",
+      "bybit_spot", "bybit_futures",
+      "deribit_futures"
+    ];
     const selHist=document.getElementById('dm-exchange');
     selHist.innerHTML='';
-    for(const ex of exchanges){
+    for(const ex of allowed){
+      if(!exchanges.includes(ex)) continue;
       const opt=document.createElement('option');
       opt.value=ex;
       opt.textContent=ex;


### PR DESCRIPTION
## Summary
- Filter `/ccxt/exchanges` results using a fixed allowlist for the historical data exchange selector

## Testing
- `pytest tests/test_api_ccxt_exchanges.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7108d068832dbe8451eff0406410