### PR TITLE
feat: reuse data descriptions

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -83,6 +83,7 @@
     <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+<script src="/static/data-info.js"></script>
 <script>
 const api = (path) => `${location.origin}${path}`;
 
@@ -191,7 +192,10 @@ function updateStrategyInfo(){
   if(info.desc){
     let html=`<p>${info.desc}</p>`;
     if(info.requires && info.requires.length){
-      html+=`<p>Requiere:</p><ul>${info.requires.map(r=>`<li>${r}</li>`).join('')}</ul>`;
+      html+=`<p>Requiere:</p><ul>${info.requires.map(r=>{
+        const raw = DATA_INFO[r] || r;
+        return `<li>${raw.replace(/^([^:]+:)/, '<span class="desc-lead">$1</span>')}</li>`;
+      }).join('')}</ul>`;
     }
     el.innerHTML=html;
   }else{

--- a/src/tradingbot/apps/api/static/data-info.js
+++ b/src/tradingbot/apps/api/static/data-info.js
@@ -1,0 +1,10 @@
+window.DATA_INFO = {
+  ohlcv: "OHLCV: velas con precios de apertura, máximo, mínimo, cierre y volumen.",
+  prices: "Prices: precios simples de instrumentos individuales.",
+  bba: "BBA (Best Bid & Ask): muestra las mejores posturas de compra (bid) y venta (ask) en el libro de órdenes.",
+  book_delta: "Book delta: cambios recientes en las mejores posturas de compra y venta.",
+  spot: "Spot: datos del mercado al contado.",
+  perp: "Perp: datos del mercado de contratos perpetuos.",
+  funding: "Funding (tasa de financiamiento): pagos periódicos entre compradores y vendedores de perpetuos para alinear el precio con el spot.",
+  features: "Features: características derivadas calculadas a partir de datos crudos.",
+};

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -141,6 +141,7 @@
     <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+<script src="/static/data-info.js"></script>
 <script>
 const api = (path) => `${location.origin}${path}`;
 let currentJob=null;
@@ -156,14 +157,12 @@ const BACKFILL_EXCHANGES=[
   "deribit_futures",
 ];
 const kindDescriptions={
-  bba:"BBA (Best Bid & Ask): muestra las mejores posturas de compra (bid) y venta (ask) en el libro de órdenes.",
+  ...DATA_INFO,
   open_interest:"Open interest: cantidad total de contratos abiertos (posiciones vigentes) en un mercado de derivados.",
-  funding:"Funding (tasa de financiamiento): pagos periódicos entre compradores y vendedores de perpetuos para alinear el precio con el spot.",
   trades:"Trades: cada transacción ejecutada (precio, cantidad y lado).",
   trades_multi:"Trades multi: agrupa transacciones de varios símbolos en una sola conexión.",
   orderbook:"Order book: niveles completos de posturas de compra y venta hasta la profundidad solicitada.",
   delta:"Book delta: cambios recientes en las mejores posturas de compra y venta.",
-  book_delta:"Book delta: cambios recientes en las mejores posturas de compra y venta."
 };
 
 function showWorking() {


### PR DESCRIPTION
## Summary
- centralize data descriptions for various kinds
- reuse description map in data and backtest pages

## Testing
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac875153b8832dbf9c8e737e11e63e