### PR TITLE
Add orderflow and cross arbitrage strategies to backtest dashboard

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -135,6 +135,14 @@ const strategies = {
     desc: "Busca la reversión a la media basada en el Order Flow Imbalance (OFI) derivado del libro de órdenes.",
     requires: ["book_delta"],
   },
+  orderflow: {
+    desc: "Analiza el flujo de órdenes agresivas vs. pasivas para estimar micro‑tendencias.",
+    requires: ["trades", "book_delta"],
+  },
+  cross_arbitrage: {
+    desc: "Arbitraje del mismo par entre dos exchanges; compra donde esté barato y vende donde esté caro.",
+    requires: ["prices"],
+  },
 };
 
 const dataInfo = {


### PR DESCRIPTION
## Summary
- add `orderflow` strategy showing required trades and book delta data
- add `cross_arbitrage` strategy for dual-exchange price gaps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f12f744832d91960311b1c1613a