### PR TITLE
Adjust strategy info placement in backtest form

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -53,7 +53,6 @@
         <label for="bt-strategy">Estrategia</label>
         <select id="bt-strategy"></select>
       </div>
-      <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
       <div id="field-config">
         <label for="bt-config">Archivo config</label>
         <input id="bt-config" placeholder="config.yaml"/>
@@ -71,6 +70,7 @@
         <input id="bt-end" type="date"/>
       </div>
     </div>
+    <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
     <pre id="bt-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>


### PR DESCRIPTION
## Summary
- place strategy info paragraph after date fields and before Run button on backtest page

## Testing
- `pytest tests/test_api_ccxt_exchanges.py::test_ccxt_exchanges_includes_testnet -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8f141d7c832dbb1c60d85a1563f1