### PR TITLE
Fix Bybit adapters BBA timestamps

### DIFF
--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -75,7 +75,8 @@ class BybitSpotAdapter(ExchangeAdapter):
                 continue
             bids = [[float(p), float(q)] for p, q, *_ in data.get("b", [])]
             asks = [[float(p), float(q)] for p, q, *_ in data.get("a", [])]
-            ts = datetime.fromtimestamp(int(data.get("ts", 0)) / 1000, tz=timezone.utc)
+            ts_ms = int(msg.get("ts") or data.get("ts", 0))
+            ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
             self.state.order_book[symbol] = {"bids": bids, "asks": asks}
             yield self.normalize_order_book(symbol, ts, bids, asks)
 
@@ -86,8 +87,17 @@ class BybitSpotAdapter(ExchangeAdapter):
 
         async for ob in self.stream_order_book(symbol):
             bid = ob.get("bid_px", [None])[0]
+            bid_qty = ob.get("bid_qty", [None])[0]
             ask = ob.get("ask_px", [None])[0]
-            yield {"symbol": symbol, "ts": ob.get("ts"), "bid": bid, "ask": ask}
+            ask_qty = ob.get("ask_qty", [None])[0]
+            yield {
+                "symbol": symbol,
+                "ts": ob.get("ts"),
+                "bid_px": bid,
+                "bid_qty": bid_qty,
+                "ask_px": ask,
+                "ask_qty": ask_qty,
+            }
 
     async def stream_book_delta(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         """Yield incremental book updates for ``symbol``."""

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -139,7 +139,7 @@ class BybitWSAdapter(ExchangeAdapter):
             ask_px = data.get("ask1Price")
             if bid_px is None and ask_px is None:
                 continue
-            ts_ms = int(data.get("ts", 0))
+            ts_ms = int(msg.get("ts") or data.get("ts", 0))
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
             yield {
                 "symbol": symbol,


### PR DESCRIPTION
## Summary
- Normalize BBA output for Bybit spot and futures adapters and propagate bid/ask sizes
- Use message timestamps when available to avoid missing `ts` values in BBA and order book
- Ensure websocket BBA stream uses message-level timestamp for accuracy

## Testing
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb10d9098832dbaf72f891afafc93