### PR TITLE
Normalize symbols across UI and API

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -86,6 +86,10 @@
 <script>
 const api = (path) => `${location.origin}${path}`;
 
+function normalizeSymbol(sym) {
+  return sym.replace(/[^A-Za-z0-9]/g, "");
+}
+
 const strategies = {
   breakout_atr: {
     desc: "Aprovecha rupturas de un canal calculado con el Average True Range (ATR). Compra al superar la banda superior y vende al romper la inferior.",
@@ -225,7 +229,7 @@ async function runBacktest(){
   let cmd='';
   if(mode==='csv'){
     const data=document.getElementById('bt-data').value.trim();
-    const sym=document.getElementById('bt-symbol').value.trim();
+    const sym=normalizeSymbol(document.getElementById('bt-symbol').value.trim());
     const strat=document.getElementById('bt-strategy').value.trim();
     cmd=`backtest ${data} --symbol ${sym} --strategy ${strat}`;
   }else if(mode==='cfg'){
@@ -236,7 +240,7 @@ async function runBacktest(){
     cmd=`walk-forward ${cfg}`;
   }else{
     const venue=document.getElementById('bt-venue').value.trim();
-    const sym=document.getElementById('bt-symbol').value.trim();
+    const sym=normalizeSymbol(document.getElementById('bt-symbol').value.trim());
     const strat=document.getElementById('bt-strategy').value.trim();
     const start=document.getElementById('bt-start').value;
     const end=document.getElementById('bt-end').value;

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -143,6 +143,9 @@
 
 <script>
 const api = (path) => `${location.origin}${path}`;
+function normalizeSymbol(sym) {
+  return sym.replace(/[^A-Za-z0-9]/g, "");
+}
 let currentJob=null;
 let evt=null;
 let kindsWithDepth=[];
@@ -238,7 +241,7 @@ async function runData(){
   runBtn.disabled=true;
   runBtn.textContent='Ejecutando...';
   const act=document.getElementById('dm-action').value;
-  const symbols=document.getElementById('dm-symbols').value.split(',').map(s=>s.trim()).filter(Boolean);
+  const symbols=document.getElementById('dm-symbols').value.split(',').map(s=>normalizeSymbol(s.trim())).filter(Boolean);
   const out=document.getElementById('dm-output');
   let cmd='';
   if(act==='ingest'){
@@ -269,7 +272,7 @@ async function runData(){
     }
   }else{
     const src=document.getElementById('dm-source').value;
-    const sym=document.getElementById('dm-symbols').value.trim();
+    const sym=normalizeSymbol(document.getElementById('dm-symbols').value.trim());
     const ex=document.getElementById('dm-exchange').value;
     const kind=document.getElementById('dm-hkind').value;
     const depth=document.getElementById('dm-hdepth').value;


### PR DESCRIPTION
## Summary
- Add `normalizeSymbol` helper to backtest and data dashboards and sanitize user input before invoking backend
- Normalize incoming symbols in API endpoints, strategy helpers, and funding/basis updates

## Testing
- `pytest tests/test_data_ingestion.py::test_run_orderbook_stream_persists -q`
- `pytest tests/test_backfill_persistence.py -q` *(skipped: PostgreSQL not available)*

------
https://chatgpt.com/codex/tasks/task_e_68acc8363128832da84d6f06874599a6