### PR TITLE
Cast OHLCV columns to floats in backtest command

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -965,7 +965,10 @@ def backtest_db(
         raise typer.Exit()
     df = (
         pd.DataFrame(rows)
-        .rename(columns={"o": "open", "h": "high", "l": "low", "c": "close", "v": "volume"})
+        .astype({"o": float, "h": float, "l": float, "c": float, "v": float})
+        .rename(
+            columns={"o": "open", "h": "high", "l": "low", "c": "close", "v": "volume"}
+        )
         .set_index("ts")
     )
     eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])


### PR DESCRIPTION
## Summary
- Ensure OHLCV columns are cast to float64 in `backtest_db` CLI command to avoid Decimal arithmetic errors.

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_signals -q`
- `PYTHONPATH=src python - <<'PY'
import pandas as pd
from decimal import Decimal
from tradingbot.backtest.event_engine import EventDrivenBacktestEngine
raw = pd.read_csv('data/examples/btcusdt_1m.csv')
rows = []
for _, r in raw.iterrows():
    rows.append({'ts': int(r['timestamp']), 'o': Decimal(str(r['open'])), 'h': Decimal(str(r['high'])), 'l': Decimal(str(r['low'])), 'c': Decimal(str(r['close'])), 'v': Decimal(str(r['volume']))})
df = (
    pd.DataFrame(rows)
    .astype({'o': float, 'h': float, 'l': float, 'c': float, 'v': float})
    .rename(columns={'o':'open','h':'high','l':'low','c':'close','v':'volume'})
    .set_index('ts')
)
eng = EventDrivenBacktestEngine({'BTCUSDT': df}, [('breakout_atr', 'BTCUSDT')])
res = eng.run()
print({'equity': res['equity'], 'orders': len(res['orders'])})
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ace5acdc54832d80960ba792a3ffb5