### PR TITLE
Add detailed logging for backtests

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -195,6 +195,12 @@ class EventDrivenBacktestEngine:
     # ------------------------------------------------------------------
     def run(self) -> dict:
         """Execute the backtest and return summary results."""
+        max_len = max(len(df) for df in self.data.values())
+        log.info(
+            "Ejecutando backtest con %d estrategias y %d barras",
+            len(self.strategies),
+            max_len,
+        )
 
         equity = 0.0
         fills: List[tuple] = []
@@ -204,8 +210,9 @@ class EventDrivenBacktestEngine:
         funding_total = 0.0
         equity_curve: List[float] = []
 
-        max_len = max(len(df) for df in self.data.values())
         for i in range(max_len):
+            if i and i % 1000 == 0:
+                log.info("Progreso: %d/%d barras", i, max_len)
             # Actualiza límites por correlación/covarianza con retornos recientes
             if i >= self.window:
                 returns_dict: Dict[str, List[float]] = {}
@@ -423,7 +430,12 @@ class EventDrivenBacktestEngine:
             "max_drawdown": max_drawdown,
             "equity_curve": equity_curve,
         }
-        log.info("Backtest result: %s", result)
+        log.info(
+            "Backtest finalizado: equity %.2f, fills %d, drawdown %.2f%%",
+            result["equity"],
+            len(result["fills"]),
+            result["max_drawdown"] * 100,
+        )
         return result
 
 

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -70,6 +70,7 @@ from tradingbot.core.symbols import normalize
 from tradingbot.utils.time_sync import check_ntp_offset
 from ..exchanges import SUPPORTED_EXCHANGES
 
+log = logging.getLogger(__name__)
 
 _OFFSET_THRESHOLD = float(os.getenv("NTP_OFFSET_THRESHOLD", "1.0"))
 try:
@@ -878,11 +879,18 @@ def backtest(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
 ) -> None:
     """Run a simple vectorised backtest from a CSV file."""
+    from pathlib import Path
+
+    import pandas as pd
+
+    from ..backtest.event_engine import EventDrivenBacktestEngine
 
     setup_logging()
-    from ..backtest.event_engine import run_backtest_csv
-
-    result = run_backtest_csv({symbol: data}, [(strategy, symbol)])
+    log.info("Iniciando backtest CSV: %s %s", symbol, data)
+    df = pd.read_csv(Path(data))
+    log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
+    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
+    result = eng.run()
     typer.echo(result)
     typer.echo(generate_report(result))
 
@@ -909,13 +917,19 @@ def backtest_cfg(config: str) -> None:
         version_base=None,
     )
     def _run(cfg) -> None:  # type: ignore[override]
-        from ..backtest.event_engine import run_backtest_csv
+        import pandas as pd
+
+        from ..backtest.event_engine import EventDrivenBacktestEngine
 
         data = cfg.backtest.data
         symbol = cfg.backtest.symbol
         strategy = cfg.backtest.strategy
 
-        result = run_backtest_csv({symbol: data}, [(strategy, symbol)])
+        log.info("Iniciando backtest CSV: %s %s", symbol, data)
+        df = pd.read_csv(data)
+        log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
+        eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
+        result = eng.run()
         typer.echo(OmegaConf.to_yaml(cfg))
         typer.echo(result)
         typer.echo(generate_report(result))
@@ -949,6 +963,14 @@ def backtest_db(
     from ..backtest.event_engine import EventDrivenBacktestEngine
 
     setup_logging()
+    log.info(
+        "Iniciando backtest DB: %s %s %s–%s (%s)",
+        venue,
+        symbol,
+        start,
+        end,
+        timeframe,
+    )
     engine = get_engine()
     start_dt = datetime.fromisoformat(start)
     end_dt = datetime.fromisoformat(end)
@@ -971,6 +993,7 @@ def backtest_db(
         )
         .set_index("ts")
     )
+    log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
     eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
     result = eng.run()
     typer.echo(result)

--- a/src/tradingbot/logging_conf.py
+++ b/src/tradingbot/logging_conf.py
@@ -30,7 +30,9 @@ def setup_logging():
     logging.basicConfig(level=level, handlers=handlers)
 
     if settings.log_json and jsonlogger is not None:
-        formatter: logging.Formatter = jsonlogger.JsonFormatter()
+        formatter: logging.Formatter = jsonlogger.JsonFormatter(
+            "%(asctime)s %(levelname)s %(name)s %(message)s"
+        )
     else:
         formatter = logging.Formatter(
             "%(asctime)s | %(levelname)s | %(name)s | %(message)s"


### PR DESCRIPTION
## Summary
- add logging for CLI backtest commands and database reader
- log progress and final summary in event-driven backtest engine
- ensure logging formatter always outputs timestamp and level

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aceadbb6a8832dbb249029b0214d1f