### PR TITLE
Ensure end events for CLI streams and add backtest safety timer

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -620,6 +620,9 @@ async def _stream_process(proc: asyncio.subprocess.Process):
         for t in tasks:
             t.cancel()
 
+    returncode = await proc.wait()
+    yield f"event: end\ndata: {returncode}\n\n"
+
 
 @app.get("/cli/stream/{job_id}")
 async def cli_stream(job_id: str):
@@ -632,8 +635,6 @@ async def cli_stream(job_id: str):
     async def event_gen():
         async for chunk in _stream_process(proc):
             yield chunk
-        returncode = await proc.wait()
-        yield f"event: end\ndata: {returncode}\n\n"
         _CLI_PROCS.pop(job_id, None)
 
     return StreamingResponse(event_gen(), media_type="text/event-stream")

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -114,6 +114,7 @@ function hideWorking(){
 
 let currentJob=null;
 let evt=null;
+let endTimer=null;
 
 const strategies = {
   breakout_atr: {
@@ -307,9 +308,12 @@ async function runBacktest(){
     currentJob=j.id;
     stopBtn.disabled=false;
     showWorking();
+    if(endTimer){clearTimeout(endTimer);}
+    endTimer=setTimeout(()=>{hideWorking();},60000);
     evt=new EventSource(api(`/cli/stream/${j.id}`));
     evt.onmessage=(e)=>appendOutput(outEl,e.data);
     evt.addEventListener('end',(e)=>{
+      if(endTimer){clearTimeout(endTimer);endTimer=null;}
       stopBtn.disabled=true;
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
@@ -320,6 +324,7 @@ async function runBacktest(){
       appendOutput(outEl,`Proceso finalizado (código ${e.data}).`);
     });
     evt.onerror=()=>{
+      if(endTimer){clearTimeout(endTimer);endTimer=null;}
       appendOutput(outEl,'[error de conexión]');
       stopBtn.disabled=true;
       runBtn.disabled=false;
@@ -327,6 +332,7 @@ async function runBacktest(){
       hideWorking();
     };
   }catch(e){
+    if(endTimer){clearTimeout(endTimer);endTimer=null;}
     appendOutput(outEl,String(e));
     runBtn.disabled=false;
     runBtn.textContent='Ejecutar';
@@ -343,6 +349,7 @@ async function stopBacktest(){
   runBtn.disabled=false;
   runBtn.textContent='Ejecutar';
   currentJob=null;
+  if(endTimer){clearTimeout(endTimer);endTimer=null;}
   hideWorking();
 }
 
@@ -364,6 +371,7 @@ document.getElementById('bt-run').addEventListener('click',runBacktest);
 document.getElementById('bt-stop').addEventListener('click',stopBacktest);
 document.getElementById('bt-clear').addEventListener('click',()=>{
   document.getElementById('bt-output').textContent='';
+  if(endTimer){clearTimeout(endTimer);endTimer=null;}
   hideWorking();
 });
 document.getElementById('cli-run').addEventListener('click',runCli);


### PR DESCRIPTION
## Summary
- Guarantee CLI stream sends `event: end` after process completion even without output
- Add client-side safety timer in backtest UI to hide processing indicator if no end event arrives

## Testing
- `pytest tests/test_api_auth.py::test_basic_auth -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad051248c0832d99f8c1764d89d9a4