### PR TITLE
Expose PnL in backtest output and UI summary

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -190,6 +190,7 @@ let strategyInfo = strategies;
 function appendSummary(text){
   try{
     const eq=text.match(/'equity':\s*([0-9\.e+-]+)/);
+    const pnl=text.match(/'pnl':\s*([0-9\.e+-]+)/);
     const slip=text.match(/'slippage':\s*([0-9\.e+-]+)/);
     const dd=text.match(/'max_drawdown':\s*([0-9\.e+-]+)/);
     const fillsMatch=text.match(/'fills':\s*\[(.*)\]/s);
@@ -200,6 +201,7 @@ function appendSummary(text){
     const lines=[
       '',
       `equity final ≈ ${eq?parseFloat(eq[1]).toFixed(2):'N/A'}`,
+      `pnl total ≈ ${pnl?parseFloat(pnl[1]).toFixed(2):'N/A'}`,
       `${fills} fills (operaciones ejecutadas)`,
       `slippage total ≈ ${slip?parseFloat(slip[1]).toFixed(2):'N/A'}`,
       `drawdown máximo ≈ ${dd?parseFloat(dd[1]).toFixed(2):'N/A'}`,

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -420,8 +420,11 @@ class EventDrivenBacktestEngine:
             }
             for o in orders
         ]
+        initial_capital = getattr(self, "initial_capital", 0.0)
+        pnl = equity - initial_capital
         result = {
             "equity": equity,
+            "pnl": pnl,
             "fills": fills,
             "orders": orders_summary,
             "slippage": slippage_total,
@@ -431,8 +434,9 @@ class EventDrivenBacktestEngine:
             "equity_curve": equity_curve,
         }
         log.info(
-            "Backtest finalizado: equity %.2f, fills %d, drawdown %.2f%%",
+            "Backtest finalizado: equity %.2f, pnl %.2f, fills %d, drawdown %.2f%%",
             result["equity"],
+            result["pnl"],
             len(result["fills"]),
             result["max_drawdown"] * 100,
         )


### PR DESCRIPTION
## Summary
- Compute profit and loss in the event-driven backtest engine and log it alongside final equity
- Parse and display PnL in the backtest HTML summary

## Testing
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage tests/test_backtest_report.py::test_generate_report_basic tests/test_smoke.py::test_metrics_endpoint_exposed -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad05106790832dba52231cbb206e8c