### PR TITLE
feat: add initial capital option to backtests

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -57,6 +57,10 @@
         <label for="bt-strategy">Estrategia</label>
         <select id="bt-strategy"></select>
       </div>
+      <div id="field-capital">
+        <label for="bt-capital">Capital inicial</label>
+        <input id="bt-capital" type="number" step="any" placeholder=""/>
+      </div>
       <div id="field-config">
         <label for="bt-config">Archivo config</label>
         <input id="bt-config" placeholder="config.yaml"/>
@@ -282,6 +286,7 @@ async function runBacktest(){
   outEl.textContent='Iniciando...\n';
   let cmd='';
   const mode=document.getElementById('bt-mode').value;
+  const capital=document.getElementById('bt-capital').value.trim();
   if(mode==='csv'){
     const data=document.getElementById('bt-data').value.trim();
     const sym=normalizeSymbol(document.getElementById('bt-symbol').value.trim());
@@ -300,6 +305,9 @@ async function runBacktest(){
     const start=document.getElementById('bt-start').value;
     const end=document.getElementById('bt-end').value;
     cmd=`backtest-db --venue ${venue} --symbol ${sym} --strategy ${strat} --start ${start} --end ${end}`;
+  }
+  if(capital && mode!=='walk'){
+    cmd+=` --capital ${capital}`;
   }
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -877,6 +877,7 @@ def backtest(
     data: str,
     symbol: str = "BTC/USDT",
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
+    capital: float = typer.Option(0.0, help="Capital inicial"),
 ) -> None:
     """Run a simple vectorised backtest from a CSV file."""
     from pathlib import Path
@@ -889,14 +890,14 @@ def backtest(
     log.info("Iniciando backtest CSV: %s %s", symbol, data)
     df = pd.read_csv(Path(data))
     log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
+    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
     result = eng.run()
     typer.echo(result)
     typer.echo(generate_report(result))
 
 
 @app.command("backtest-cfg")
-def backtest_cfg(config: str) -> None:
+def backtest_cfg(config: str, capital: float = typer.Option(0.0, help="Capital inicial")) -> None:
     """Run a backtest using a Hydra YAML configuration."""
 
     from pathlib import Path
@@ -928,7 +929,7 @@ def backtest_cfg(config: str) -> None:
         log.info("Iniciando backtest CSV: %s %s", symbol, data)
         df = pd.read_csv(data)
         log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-        eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
+        eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
         result = eng.run()
         typer.echo(OmegaConf.to_yaml(cfg))
         typer.echo(result)
@@ -954,6 +955,7 @@ def backtest_db(
     start: str = typer.Option(..., help="Start date YYYY-MM-DD"),
     end: str = typer.Option(..., help="End date YYYY-MM-DD"),
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
+    capital: float = typer.Option(0.0, help="Capital inicial"),
 ) -> None:
     """Run a backtest using data stored in the database."""
 
@@ -994,7 +996,7 @@ def backtest_db(
         .set_index("ts")
     )
     log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)])
+    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
     result = eng.run()
     typer.echo(result)
     typer.echo(generate_report(result))


### PR DESCRIPTION
## Summary
- allow setting initial equity in backtesting engine and report PnL
- expose `--capital` flag in CLI backtest commands
- add capital input in web UI and include `--capital` when running commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad050bc984832d9ac4082b5e50c0dd