### PR TITLE
fix: track initial equity for pnl

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -425,8 +425,7 @@ class EventDrivenBacktestEngine:
             }
             for o in orders
         ]
-        initial_capital = getattr(self, "initial_capital", 0.0)
-        pnl = equity - initial_capital
+
         result = {
             "equity": equity,
             "pnl": pnl,
@@ -434,7 +433,6 @@ class EventDrivenBacktestEngine:
             "orders": orders_summary,
             "slippage": slippage_total,
             "funding": funding_total,
-            "pnl": pnl,
             "sharpe": sharpe,
             "max_drawdown": max_drawdown,
             "equity_curve": equity_curve,


### PR DESCRIPTION
## Summary
- ensure EventDrivenBacktestEngine tracks initial equity and computes PnL relative to it

## Testing
- `pytest tests/test_backtest_engine.py -q`
- `PYTHONPATH=src python - <<'PY'
from tradingbot.backtesting.engine import EventDrivenBacktestEngine
import pandas as pd
from tradingbot.logging_conf import setup_logging
setup_logging()
rng = pd.date_range('2021-01-01', periods=2, freq='T')
df = pd.DataFrame({'open':[1,2], 'high':[1,2], 'low':[1,2], 'close':[1,2], 'volume':[1,1]}, index=rng)
engine = EventDrivenBacktestEngine({'BTC/USDT': df}, [], initial_equity=1000)
engine.run()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad2b174720832dbf4761966fd71cf6