### PR TITLE
feat(backtest): add risk controls to CLI and engine

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -77,6 +77,26 @@
         <label for="bt-end">Fin</label>
         <input id="bt-end" type="date"/>
       </div>
+      <div id="field-trade-qty">
+        <label for="bt-trade-qty">Tamaño orden</label>
+        <input id="bt-trade-qty" type="number" step="any"/>
+      </div>
+      <div id="field-max-pos">
+        <label for="bt-max-pos">Posición máxima</label>
+        <input id="bt-max-pos" type="number" step="any"/>
+      </div>
+      <div id="field-stop-loss-pct">
+        <label for="bt-stop-loss-pct">Stop loss %</label>
+        <input id="bt-stop-loss-pct" type="number" step="any"/>
+      </div>
+      <div id="field-max-dd-pct">
+        <label for="bt-max-drawdown-pct">Drawdown máx %</label>
+        <input id="bt-max-drawdown-pct" type="number" step="any"/>
+      </div>
+      <div id="field-max-notional">
+        <label for="bt-max-notional">Notional máximo</label>
+        <input id="bt-max-notional" type="number" step="any"/>
+      </div>
     </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
@@ -261,6 +281,10 @@ function updateBtFields(){
   document.getElementById('bt-venue').style.display=mode==='db'?'':'none';
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
+  const showRisk = mode!=='walk';
+  ['field-trade-qty','field-max-pos','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+    document.getElementById(id).style.display=showRisk?'':'none';
+  });
 }
 
 function updateStrategyInfo(){
@@ -312,6 +336,18 @@ async function runBacktest(){
   }
   if(capital && mode!=='walk'){
     cmd+=` --capital ${capital}`;
+  }
+  if(mode!=='walk'){
+    const tq=document.getElementById('bt-trade-qty').value.trim();
+    const mp=document.getElementById('bt-max-pos').value.trim();
+    const sl=document.getElementById('bt-stop-loss-pct').value.trim();
+    const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
+    const mn=document.getElementById('bt-max-notional').value.trim();
+    if(tq) cmd+=` --trade-qty ${tq}`;
+    if(mp) cmd+=` --max-pos ${mp}`;
+    if(sl) cmd+=` --stop-loss-pct ${sl}`;
+    if(dd) cmd+=` --max-drawdown-pct ${dd}`;
+    if(mn) cmd+=` --max-notional ${mn}`;
   }
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -13,6 +13,7 @@ import pandas as pd
 import random
 
 from ..risk.manager import RiskManager
+from ..risk.limits import RiskLimits
 from ..strategies import STRATEGIES
 from ..data.features import returns, calc_ofi
 
@@ -144,6 +145,11 @@ class EventDrivenBacktestEngine:
         stress: StressConfig | None = None,
         seed: int | None = None,
         initial_equity: float = 0.0,
+        trade_qty: float = 1.0,
+        max_pos: float = 1.0,
+        max_drawdown_pct: float = 0.0,
+        stop_loss_pct: float = 0.0,
+        max_notional: float = 0.0,
     ) -> None:
         self.data = data
         self.latency = int(latency)
@@ -165,6 +171,11 @@ class EventDrivenBacktestEngine:
             self.slippage.spread_mult *= self.stress.spread
 
         self.initial_equity = float(initial_equity)
+        self.trade_qty = float(trade_qty)
+        self._max_pos = float(max_pos)
+        self._max_drawdown_pct = float(max_drawdown_pct)
+        self._stop_loss_pct = float(stop_loss_pct)
+        self._max_notional = float(max_notional)
 
         # Exchange specific configurations
         self.exchange_latency: Dict[str, int] = {}
@@ -192,7 +203,17 @@ class EventDrivenBacktestEngine:
                 raise ValueError(f"unknown strategy: {strat_name}")
             key = (strat_name, symbol)
             self.strategies[key] = strat_cls()
-            self.risk[key] = RiskManager(max_pos=1.0)
+            limits = (
+                RiskLimits(max_notional=self._max_notional)
+                if self._max_notional > 0
+                else None
+            )
+            self.risk[key] = RiskManager(
+                max_pos=self._max_pos,
+                stop_loss_pct=self._stop_loss_pct,
+                max_drawdown_pct=self._max_drawdown_pct,
+                limits=limits,
+            )
             self.strategy_exchange[key] = exchange
 
     # ------------------------------------------------------------------
@@ -312,8 +333,10 @@ class EventDrivenBacktestEngine:
                 order.filled_qty += fill_qty
                 order.remaining_qty -= fill_qty
                 order.total_cost += price * fill_qty
-                if order.remaining_qty <= 1e-9 and order.latency is None:
-                    order.latency = i - order.place_index
+                if order.remaining_qty <= 1e-9:
+                    if order.latency is None:
+                        order.latency = i - order.place_index
+                    self.risk[(order.strategy, order.symbol)].complete_order()
                 fills.append(
                     (
                         bar.get("timestamp", i),
@@ -338,6 +361,9 @@ class EventDrivenBacktestEngine:
                 if sig is None or sig.side == "flat":
                     continue
                 risk = self.risk[(strat_name, symbol)]
+                place_price = float(df["close"].iloc[i])
+                if not risk.check_limits(place_price):
+                    continue
                 delta = risk.size(sig.side, sig.strength)
                 rets = returns(window_df).dropna()
                 symbol_vol = float(rets.std()) if not rets.empty else 0.0
@@ -345,11 +371,15 @@ class EventDrivenBacktestEngine:
                 if abs(delta) < 1e-9:
                     continue
                 side = "buy" if delta > 0 else "sell"
-                qty = abs(delta)
+                qty = min(abs(delta), self.trade_qty)
+                if qty < 1e-9:
+                    continue
+                notional = qty * place_price
+                if not risk.register_order(notional):
+                    continue
                 exchange = self.strategy_exchange[(strat_name, symbol)]
                 base_latency = self.exchange_latency.get(exchange, self.latency)
                 exec_index = i + int(base_latency * self.stress.latency)
-                place_price = float(df["close"].iloc[i])
                 queue_pos = 0.0
                 if self.use_l2:
                     vol_key = "ask_size" if side == "buy" else "bid_size"
@@ -461,6 +491,11 @@ def run_backtest_csv(
     cancel_unfilled: bool = False,
     stress: StressConfig | None = None,
     seed: int | None = None,
+    trade_qty: float = 1.0,
+    max_pos: float = 1.0,
+    max_drawdown_pct: float = 0.0,
+    stop_loss_pct: float = 0.0,
+    max_notional: float = 0.0,
 ) -> dict:
     """Convenience wrapper to run the engine from CSV files."""
 
@@ -477,6 +512,11 @@ def run_backtest_csv(
         cancel_unfilled=cancel_unfilled,
         stress=stress,
         seed=seed,
+        trade_qty=trade_qty,
+        max_pos=max_pos,
+        max_drawdown_pct=max_drawdown_pct,
+        stop_loss_pct=stop_loss_pct,
+        max_notional=max_notional,
     )
     return engine.run()
 
@@ -499,6 +539,11 @@ def run_backtest_mlflow(
     stress: StressConfig | None = None,
     seed: int | None = None,
     experiment: str = "backtest",
+    trade_qty: float = 1.0,
+    max_pos: float = 1.0,
+    max_drawdown_pct: float = 0.0,
+    stop_loss_pct: float = 0.0,
+    max_notional: float = 0.0,
 ) -> dict:
     """Run the backtest and log results to an MLflow run.
 
@@ -528,6 +573,11 @@ def run_backtest_mlflow(
             cancel_unfilled=cancel_unfilled,
             stress=stress,
             seed=seed,
+            trade_qty=trade_qty,
+            max_pos=max_pos,
+            max_drawdown_pct=max_drawdown_pct,
+            stop_loss_pct=stop_loss_pct,
+            max_notional=max_notional,
         )
         log_backtest_metrics(result)
         return result

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -878,6 +878,11 @@ def backtest(
     symbol: str = "BTC/USDT",
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
+    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
+    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
+    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a simple vectorised backtest from a CSV file."""
     from pathlib import Path
@@ -890,14 +895,31 @@ def backtest(
     log.info("Iniciando backtest CSV: %s %s", symbol, data)
     df = pd.read_csv(Path(data))
     log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
+    eng = EventDrivenBacktestEngine(
+        {symbol: df},
+        [(strategy, symbol)],
+        initial_equity=capital,
+        trade_qty=trade_qty,
+        max_pos=max_pos,
+        stop_loss_pct=stop_loss_pct,
+        max_drawdown_pct=max_drawdown_pct,
+        max_notional=max_notional,
+    )
     result = eng.run()
     typer.echo(result)
     typer.echo(generate_report(result))
 
 
 @app.command("backtest-cfg")
-def backtest_cfg(config: str, capital: float = typer.Option(0.0, help="Capital inicial")) -> None:
+def backtest_cfg(
+    config: str,
+    capital: float = typer.Option(0.0, help="Capital inicial"),
+    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
+    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
+    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
+) -> None:
     """Run a backtest using a Hydra YAML configuration."""
 
     from pathlib import Path
@@ -929,7 +951,16 @@ def backtest_cfg(config: str, capital: float = typer.Option(0.0, help="Capital i
         log.info("Iniciando backtest CSV: %s %s", symbol, data)
         df = pd.read_csv(data)
         log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-        eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
+        eng = EventDrivenBacktestEngine(
+            {symbol: df},
+            [(strategy, symbol)],
+            initial_equity=capital,
+            trade_qty=trade_qty,
+            max_pos=max_pos,
+            stop_loss_pct=stop_loss_pct,
+            max_drawdown_pct=max_drawdown_pct,
+            max_notional=max_notional,
+        )
         result = eng.run()
         typer.echo(OmegaConf.to_yaml(cfg))
         typer.echo(result)
@@ -956,6 +987,11 @@ def backtest_db(
     end: str = typer.Option(..., help="End date YYYY-MM-DD"),
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
+    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
+    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
+    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a backtest using data stored in the database."""
 
@@ -996,7 +1032,16 @@ def backtest_db(
         .set_index("ts")
     )
     log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
-    eng = EventDrivenBacktestEngine({symbol: df}, [(strategy, symbol)], initial_equity=capital)
+    eng = EventDrivenBacktestEngine(
+        {symbol: df},
+        [(strategy, symbol)],
+        initial_equity=capital,
+        trade_qty=trade_qty,
+        max_pos=max_pos,
+        stop_loss_pct=stop_loss_pct,
+        max_drawdown_pct=max_drawdown_pct,
+        max_notional=max_notional,
+    )
     result = eng.run()
     typer.echo(result)
     typer.echo(generate_report(result))


### PR DESCRIPTION
## Summary
- expose trade sizing and risk parameters in backtest CLI and web UI
- integrate RiskManager limits into event-driven backtest engine
- allow CSV and DB backtests to honour stop-loss, drawdown and notional limits

## Testing
- `pytest -q` *(killed: process out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad329a9858832d92c50cb94a08f035