### PR TITLE
Use percentage-based risk parameters across tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ export BINANCE_FUTURES_TESTNET=true
 Si esta variable no está definida o se establece en `false`, el bot usará el
 entorno real de Binance Futures.
 
+## Gestión de riesgo con porcentajes
+
+Los parámetros de riesgo se definen en términos porcentuales. Por ejemplo,
+para aplicar un stop loss del 2 % y un trailing stop que se active con un
+drawdown del 5 %:
+
+```bash
+python -m tradingbot.cli run --stop-loss-pct 0.02 --max-drawdown-pct 0.05
+```
+
+El gestor de riesgo escalará las posiciones en función de estos porcentajes y
+ajustará automáticamente los precios de stop siguiendo la tendencia.
+
 ## Solución de problemas
 
 Si se muestra el mensaje `System clock offset`, indica que el reloj del

--- a/bin/walk_forward_example.py
+++ b/bin/walk_forward_example.py
@@ -27,8 +27,8 @@ def main() -> None:
     mlflow.set_tracking_uri(args.mlflow_uri)
 
     param_grid = [
-        {"rsi_n": 10, "rsi_threshold": 55},
-        {"rsi_n": 14, "rsi_threshold": 60},
+        {"rsi_n": 10, "rsi_threshold": 55, "stop_loss_pct": 0.02},
+        {"rsi_n": 14, "rsi_threshold": 60, "stop_loss_pct": 0.02},
     ]
     res = run_walk_forward_experiment(
         args.data,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,16 @@ Si es la primera vez que lo utiliza, comience por revisar el
 - [Comandos de la CLI](commands.md)
 - [Estrategias disponibles](strategies.md)
 - [Dashboards de monitoreo](dashboards.md)
+
+## Ejemplo de parámetros porcentuales
+
+El gestor de riesgo utiliza porcentajes tanto para el cálculo de stop loss como
+para el seguimiento (*trailing stop*). Un ejemplo rápido desde la línea de
+comandos:
+
+```bash
+python -m tradingbot.cli run --stop-loss-pct 0.01 --max-drawdown-pct 0.04
+```
+
+Esto aplicará un stop loss del 1 % y reducirá la posición si se produce un
+drawdown del 4 % o más.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -85,6 +85,8 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--dry-run`: simula órdenes en testnet.
 - `--stop-loss` y `--take-profit`: porcentajes de la estrategia.
 - `--stop-loss-pct` y `--max-drawdown-pct`: límites del gestor de riesgo.
+- todos los valores se expresan como proporciones (por ejemplo, `0.02` equivale
+  al 2 %).
 
 ## `paper-run`
 Corre una estrategia en modo paper (sin dinero real) y expone métricas.

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -103,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager()
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -49,7 +49,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager()
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -108,7 +108,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager()
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_usdt=total_cap_usdt,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -74,7 +74,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager()
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,4 +106,4 @@ def breakout_df_sell():
 def risk_manager():
     from tradingbot.risk.manager import RiskManager
 
-    return RiskManager(max_pos=5)
+    return RiskManager()

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -27,7 +27,6 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         slippage=SlippageModel(volume_impact=0.0),
     )
     risk = engine.risk[("alwaysbuy", sym)]
-    risk.max_pos = 1.0
     result = engine.run()
     assert len(result["fills"]) == 1
     avg_price = result["orders"][0]["avg_price"]

--- a/tests/test_basic_strategies.py
+++ b/tests/test_basic_strategies.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from tradingbot.strategies import momentum, mean_reversion
 import tradingbot.strategies.arbitrage as arbitrage
@@ -18,11 +19,9 @@ def test_momentum_backtest():
         "stop_loss": 0.05,
         "take_profit": 0.1,
     }
-    pnl_no_fee = backtest(
-        data,
-        momentum.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
-        "price",
-    )
+    signals = momentum.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0})
+    pnl_no_fee = backtest(data, signals, "price")
+    assert signals["stop_loss"].iloc[0] == pytest.approx(data["price"].iloc[0] * (1 - base_params["stop_loss"]))
     pnl_fee = backtest(
         data,
         momentum.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),
@@ -40,11 +39,9 @@ def test_mean_reversion_backtest():
         "stop_loss": 0.05,
         "take_profit": 0.1,
     }
-    pnl_no_fee = backtest(
-        data,
-        mean_reversion.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
-        "price",
-    )
+    signals = mean_reversion.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0})
+    pnl_no_fee = backtest(data, signals, "price")
+    assert signals["stop_loss"].iloc[0] == pytest.approx(data["price"].iloc[0] * (1 - base_params["stop_loss"]))
     pnl_fee = backtest(
         data,
         mean_reversion.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),
@@ -63,11 +60,9 @@ def test_arbitrage_backtest():
         "stop_loss": 0.05,
         "take_profit": 0.1,
     }
-    pnl_no_fee = backtest(
-        data,
-        arbitrage.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0}),
-        "asset_a",
-    )
+    signals = arbitrage.generate_signals(data, {**base_params, "fee": 0.0, "slippage": 0.0})
+    pnl_no_fee = backtest(data, signals, "asset_a")
+    assert signals["stop_loss"].iloc[0] == pytest.approx(data["asset_a"].iloc[0] * (1 - base_params["stop_loss"]))
     pnl_fee = backtest(
         data,
         arbitrage.generate_signals(data, {**base_params, "fee": 0.01, "slippage": 0.01}),

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -50,7 +50,7 @@ def test_correlation_service_window_rolls():
 
 def test_risk_service_uses_correlation_service():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(vol_target=0.02)
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)
     now = datetime.now(timezone.utc)
@@ -89,7 +89,7 @@ def test_correlation_guard_groups_and_cap():
 
 
 def test_update_correlation_uses_guard_for_global_cap():
-    rm = RiskManager(max_pos=12)
+    rm = RiskManager()
     pairs = {
         ("BTC", "ETH"): 0.9,
         ("ETH", "SOL"): 0.85,
@@ -97,4 +97,4 @@ def test_update_correlation_uses_guard_for_global_cap():
     }
     exceeded = rm.update_correlation(pairs, 0.8)
     assert set(exceeded) == {("BTC", "ETH"), ("ETH", "SOL")}
-    assert rm.max_pos == pytest.approx(4.0)
+    assert rm.max_pos == pytest.approx(1.0 / 3)

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -41,7 +41,7 @@ async def test_daemon_processes_trades():
     paper.update_last_price("BTCUSDT", 100.0)
     router = ExecutionRouter(paper)
     bus = EventBus()
-    risk = RiskManager(max_pos=5, bus=bus)
+    risk = RiskManager(bus=bus)
     daemon = TradeBotDaemon({"feed": adapter}, [AlwaysBuy()], risk, router, ["BTCUSDT"])
     task = asyncio.create_task(daemon.run())
     await asyncio.sleep(0.3)
@@ -67,7 +67,7 @@ async def test_daemon_adjusts_size_for_correlation():
             self.orders.append(order)
             return {"status": "filled"}
 
-    risk = DummyRisk(max_pos=1.0)
+    risk = DummyRisk()
     router = DummyRouter()
     daemon = TradeBotDaemon({}, [], risk, router, ["AAA"], returns_window=10)
     daemon.price_history["AAA"] = deque([1, 2, 3], maxlen=10)
@@ -86,7 +86,7 @@ async def test_daemon_emits_event_on_high_correlation():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    risk = RiskManager(max_pos=2.0, bus=bus)
+    risk = RiskManager(bus=bus)
     router = ExecutionRouter(PaperAdapter())
     daemon = TradeBotDaemon({}, [], risk, router, ["AAA", "BBB"], returns_window=5)
     daemon.price_history["AAA"] = deque([1, 2, 3], maxlen=5)

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -87,7 +87,7 @@ class DummyExec:
 async def test_bybit_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "RiskManager", lambda *a, **k: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
@@ -147,7 +147,7 @@ async def test_run_real(monkeypatch):
     rr = importlib.reload(rr)
     monkeypatch.setattr(rr, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rr, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rr, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rr, "RiskManager", lambda *a, **k: DummyRisk())
     monkeypatch.setattr(rr, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rr, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rr, "PaperAdapter", DummyBroker)
@@ -200,7 +200,7 @@ class DummyExec2(DummyExec):
 async def test_okx_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "RiskManager", lambda *a, **k: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -20,7 +20,7 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.positions" (venue, symbol, qty, avg_price, realized_pnl, fees_paid) VALUES ("paper", "BTCUSDT", 1.5, 10000, 0, 0);'))
         conn.execute(text('INSERT INTO "market.oco_orders" (venue, symbol, side, qty, entry_price, sl_price, tp_price, status) VALUES ("paper", "BTCUSDT", "long", 1.5, 10000, 9500, 10500, "active");'))
 
-    rm = RiskManager(max_pos=5)
+    rm = RiskManager()
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1e6, per_symbol_cap_usdt=1e6, venue="paper"))
     risk = RiskService(rm, guard)
 

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -18,12 +18,12 @@ def test_covariance_and_aggregation():
 
 
 def test_adjust_size_and_portfolio_risk():
-    rm = RiskManager(max_pos=2)
+    rm = RiskManager()
     corr = {("A", "B"): 0.9}
-    size = rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
-    assert size == pytest.approx(1.0)
-    size2 = rm.adjust_size_for_correlation("A", 2.0, corr, 0.95)
-    assert size2 == 2.0
+    size = rm.adjust_size_for_correlation("A", 1.0, corr, 0.8)
+    assert size == pytest.approx(0.5)
+    size2 = rm.adjust_size_for_correlation("A", 1.0, corr, 0.95)
+    assert size2 == 1.0
 
     cov = {("BTC", "BTC"): 0.04}
     assert rm.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
@@ -33,12 +33,12 @@ def test_adjust_size_and_portfolio_risk():
 
 
 def test_de_risk_reduces_exposure():
-    rm = RiskManager(max_pos=10, vol_target=1.0)
+    rm = RiskManager(vol_target=1.0)
     rm.update_pnl(100)
-    assert rm.max_pos == pytest.approx(10)
+    assert rm.max_pos == pytest.approx(1)
     rm.update_pnl(-30)  # drawdown 30%
-    assert rm.max_pos == pytest.approx(5)
+    assert rm.max_pos == pytest.approx(0.5)
     assert rm.vol_target == pytest.approx(0.5)
     rm.update_pnl(-25)  # drawdown 55%
-    assert rm.max_pos == pytest.approx(2.5)
+    assert rm.max_pos == pytest.approx(0.25)
     assert rm.vol_target == pytest.approx(0.25)

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -12,7 +12,7 @@ from tradingbot.risk.limits import RiskLimits
 
 
 def test_stop_loss_sets_reason():
-    rm = RiskManager(max_pos=1, stop_loss_pct=0.05)
+    rm = RiskManager(stop_loss_pct=0.05)
     rm.set_position(1)
     assert rm.check_limits(100)
     assert not rm.check_limits(94)
@@ -22,7 +22,7 @@ def test_stop_loss_sets_reason():
 
 
 def test_drawdown_sets_reason():
-    rm = RiskManager(max_pos=1, max_drawdown_pct=0.05)
+    rm = RiskManager(max_drawdown_pct=0.05)
     rm.set_position(1)
     assert rm.check_limits(100)
     assert rm.check_limits(110)
@@ -33,7 +33,7 @@ def test_drawdown_sets_reason():
 
 
 def test_manual_kill_switch_records_reason():
-    rm = RiskManager(max_pos=1)
+    rm = RiskManager()
     rm.kill_switch("manual")
     assert rm.enabled is False
     assert rm.last_kill_reason == "manual"
@@ -41,7 +41,7 @@ def test_manual_kill_switch_records_reason():
 
 
 def test_reset_clears_kill_switch():
-    rm = RiskManager(max_pos=1)
+    rm = RiskManager()
     rm.kill_switch("manual")
     assert rm.enabled is False
     assert KILL_SWITCH_ACTIVE._value.get() == 1.0
@@ -53,7 +53,7 @@ def test_reset_clears_kill_switch():
 
 
 def test_daily_loss_limit_triggers_kill_switch():
-    rm = RiskManager(max_pos=1, daily_loss_limit=50)
+    rm = RiskManager(daily_loss_limit=50)
     rm.set_position(1)
     rm.check_limits(100)
     rm.update_pnl(-60)
@@ -85,7 +85,7 @@ async def test_update_correlation_emits_pause():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=8, bus=bus)
+    rm = RiskManager(bus=bus)
     pairs = {("BTC", "ETH"): 0.9}
     exceeded = rm.update_correlation(pairs, 0.8)
     await asyncio.sleep(0)
@@ -98,7 +98,7 @@ async def test_update_covariance_emits_pause():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=8, bus=bus)
+    rm = RiskManager(bus=bus)
     cov = {
         ("BTC", "BTC"): 0.04,
         ("ETH", "ETH"): 0.04,

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -24,7 +24,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=2.0, bus=bus)
+    rm = RiskManager(bus=bus)
     guard = PortfolioGuard(
         GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="test")
     )
@@ -35,12 +35,12 @@ async def test_risk_service_correlation_limits_and_sizing():
     exceeded = svc.update_correlation(0.8)
     await asyncio.sleep(0)
     assert exceeded == [("AAA", "BBB")]
-    assert rm.max_pos == pytest.approx(1.0)
+    assert rm.max_pos == pytest.approx(0.5)
     assert events and events[0]["reason"] == "correlation"
 
     allowed, _, delta = svc.check_order(
         "AAA", "buy", 100.0, corr_threshold=0.8
     )
     assert allowed
-    assert delta == pytest.approx(0.5)
+    assert delta == pytest.approx(0.25)
 

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -8,7 +8,7 @@ from tradingbot.risk.position_sizing import vol_target
 
 
 def test_risk_vol_sizing(synthetic_volatility):
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(vol_target=0.02)
     delta = rm.size("buy", symbol="BTC", symbol_vol=synthetic_volatility)
     expected = rm.max_pos + min(
         rm.max_pos, rm.max_pos * rm.vol_target / synthetic_volatility
@@ -25,7 +25,7 @@ def test_vol_target_caps_notional():
 
 
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(vol_target=0.02)
     corr = {("BTC", "ETH"): 0.9}
     delta = rm.size(
         "buy",
@@ -43,7 +43,7 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
 
 def test_risk_service_uses_guard_volatility():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(vol_target=0.02)
     svc = RiskService(rm, guard)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
     allowed, _, delta = svc.check_order("BTC", "buy", price=100.0)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -3,6 +3,7 @@ import yaml
 from tradingbot.strategies.breakout_atr import BreakoutATR
 from tradingbot.strategies.order_flow import OrderFlow
 from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
+from tradingbot.strategies import triple_barrier
 from hypothesis import given, strategies as st
 
 
@@ -63,6 +64,13 @@ vol_threshold: 1.0
 
     sig_buy = strat.on_bar({"window": df_buy})
     assert sig_buy.side == "buy"
+
+
+def test_triple_barrier_percentage_labels():
+    prices = pd.Series([100, 106, 90])
+    labels = triple_barrier.triple_barrier_labels(prices, horizon=2, upper_pct=0.05, lower_pct=0.05)
+    assert labels.iloc[0] == 1
+    assert labels.iloc[1] == -1
 
 
 @given(start=st.floats(1, 10), inc=st.floats(0.1, 5))


### PR DESCRIPTION
## Summary
- validate stop loss, drawdown and trailing logic with percentage-based risk tests
- verify strategies compute stop-loss levels from percentage inputs
- document CLI examples and scripts using percentage risk parameters and drop `max_pos` references in runners

## Testing
- `pytest tests/test_risk.py tests/test_risk_manager_limits.py tests/test_risk_manager_extra.py tests/test_risk_service_correlation.py tests/test_risk_vol_sizing.py tests/test_risk_daily_guard.py tests/test_risk_api.py tests/test_daemon_integration.py tests/test_live_runner.py tests/test_basic_strategies.py tests/test_strategies.py tests/test_correlation_service.py tests/test_rehydrate.py tests/integration/test_recorded_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc8c20b44832d8af7770d664be7a0