### PR TITLE
feat: add target equity percentage to strategy signals

### DIFF
--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -32,7 +32,7 @@ class Arbitrage(Strategy):
         replace this with a real implementation later on.
         """
 
-        return Signal("flat", 0.0)
+        return Signal("flat", 0.0, target_pct=0.0)
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -178,5 +178,5 @@ class TriangularArb(Strategy):
         edge = compute_edge(prices, self.taker_fee_bps, self.buffer_bps)
         if edge and edge.net > self.min_edge:
             side = "buy" if edge.direction == "b->m" else "sell"
-            return Signal(side, edge.net)
-        return Signal("flat", 0.0)
+            return Signal(side, edge.net, target_pct=edge.net)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -9,11 +9,31 @@ import yaml
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
 
+
 @dataclass
 class Signal:
+    """Simple representation of a trading signal.
+
+    Attributes
+    ----------
+    side:
+        ``"buy"``, ``"sell"`` or ``"flat"``.
+    strength:
+        Relative magnitude of the signal.  This value is left unchanged for
+        compatibility with existing risk sizing logic.
+    reduce_only:
+        When ``True`` the signal should only reduce an existing position.
+    target_pct:
+        Desired fraction (0–1) of account equity the strategy wants to hold
+        after acting on this signal.  A target above the current exposure
+        implies scaling the position up while a lower value means scaling
+        down.
+    """
+
     side: str  # 'buy' | 'sell' | 'flat'
     strength: float = 1.0
     reduce_only: bool = False
+    target_pct: float = 1.0
 
 class Strategy(ABC):
     name: str

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -28,7 +28,7 @@ class BreakoutATR(Strategy):
         upper, lower = keltner_channels(df, self.ema_n, self.atr_n, self.mult)
         last_close = df["close"].iloc[-1]
         if last_close > upper.iloc[-1]:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if last_close < lower.iloc[-1]:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -38,7 +38,7 @@ class BreakoutVol(Strategy):
         upper = mean + self.mult * std
         lower = mean - self.mult * std
         if last > upper:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if last < lower:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -67,11 +67,11 @@ class CashAndCarry(Strategy):
         basis = (perp - spot) / spot
         if funding > 0 and basis > self.cfg.threshold:
             self._persist_signal(basis, spot, perp)
-            return Signal("buy", basis)
+            return Signal("buy", basis, target_pct=basis)
         if funding < 0 and basis < -self.cfg.threshold:
             self._persist_signal(basis, spot, perp)
-            return Signal("sell", -basis)
-        return Signal("flat", 0.0)
+            return Signal("sell", -basis, target_pct=-basis)
+        return Signal("flat", 0.0, target_pct=0.0)
 
     def _persist_signal(self, basis: float, spot_px: float, perp_px: float) -> None:
         if self.engine is None:

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -28,7 +28,7 @@ class DepthImbalance(Strategy):
         di_series = depth_imbalance(df[list(needed)])
         di_mean = di_series.iloc[-self.window :].mean()
         if di_mean > self.threshold:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if di_mean < -self.threshold:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -30,13 +30,13 @@ class LiquidityEvents(Strategy):
 
         vac = book_vacuum(df[list({"bid_qty", "ask_qty"})], self.vacuum_threshold).iloc[-1]
         if vac > 0:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if vac < 0:
-            return Signal("sell", 1.0)
+            return Signal("sell", 1.0, target_pct=1.0)
 
         gap = liquidity_gap(df[list({"bid_px", "ask_px"})], self.gap_threshold).iloc[-1]
         if gap > 0:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if gap < 0:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -57,10 +57,10 @@ class MeanRevOFI(Strategy):
         vol = returns(df).rolling(self.vol_window).std().iloc[-1]
 
         if pd.isna(zscore) or pd.isna(vol) or vol >= self.vol_threshold:
-            return Signal("flat", 0.0)
+            return Signal("flat", 0.0, target_pct=0.0)
 
         if zscore > self.zscore_threshold:
-            return Signal("sell", 1.0)
+            return Signal("sell", 1.0, target_pct=1.0)
         if zscore < -self.zscore_threshold:
-            return Signal("buy", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("buy", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -37,10 +37,10 @@ class MeanReversion(Strategy):
         if {"bid_qty", "ask_qty"}.issubset(df.columns):
             ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
         if last_rsi > self.upper and ofi_val <= 0:
-            return Signal("sell", 1.0)
+            return Signal("sell", 1.0, target_pct=1.0)
         if last_rsi < self.lower and ofi_val >= 0:
-            return Signal("buy", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("buy", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -81,10 +81,10 @@ class MLStrategy(Strategy):
         except NotFittedError:
             return None
         if proba >= self.threshold:
-            return Signal("buy", proba)
+            return Signal("buy", proba, target_pct=proba)
         if proba <= 1 - self.threshold:
-            return Signal("sell", 1 - proba)
-        return Signal("flat", 1.0 - abs(0.5 - proba) * 2)
+            return Signal("sell", 1 - proba, target_pct=1 - proba)
+        return Signal("flat", 1.0 - abs(0.5 - proba) * 2, target_pct=1.0 - abs(0.5 - proba) * 2)
 
 
 __all__ = ["MLStrategy"]

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -34,10 +34,10 @@ class Momentum(Strategy):
         if {"bid_qty", "ask_qty"}.issubset(df.columns):
             ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
         if last_rsi > self.threshold and ofi_val >= 0:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if last_rsi < 100 - self.threshold and ofi_val <= 0:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -26,7 +26,7 @@ class OrderFlow(Strategy):
         ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
         if ofi_mean > self.buy_threshold:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if ofi_mean < -self.sell_threshold:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -144,13 +144,13 @@ class TripleBarrier(Strategy):
         x_last = features.iloc[[-1]]
         pred = self.model.predict(x_last)[0]
         if pred == 0:
-            return Signal("flat", 0.0)
+            return Signal("flat", 0.0, target_pct=0.0)
         if self.meta_fitted:
             meta_pred = self.meta_model.predict(x_last)[0]
             if meta_pred == 0:
-                return Signal("flat", 0.0)
+                return Signal("flat", 0.0, target_pct=0.0)
         if pred == 1:
-            return Signal("buy", 1.0)
+            return Signal("buy", 1.0, target_pct=1.0)
         if pred == -1:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            return Signal("sell", 1.0, target_pct=1.0)
+        return Signal("flat", 0.0, target_pct=0.0)

--- a/tests/test_arbitrage_triangular.py
+++ b/tests/test_arbitrage_triangular.py
@@ -8,6 +8,7 @@ def test_triangular_arb_buy_signal():
     sig = strat.on_bar({"prices": prices})
     assert sig.side == "buy"
     assert sig.strength == pytest.approx(0.05)
+    assert sig.target_pct == pytest.approx(0.05)
 
 
 def test_triangular_arb_sell_signal():
@@ -16,6 +17,7 @@ def test_triangular_arb_sell_signal():
     sig = strat.on_bar({"prices": prices})
     assert sig.side == "sell"
     assert sig.strength == pytest.approx(0.05)
+    assert sig.target_pct == pytest.approx(0.05)
 
 
 def test_triangular_arb_flat_when_incomplete_prices():
@@ -23,6 +25,7 @@ def test_triangular_arb_flat_when_incomplete_prices():
     sig = strat.on_bar({"prices": {"bq": 100.0, "mq": None, "mb": 2.0}})
     assert sig.side == "flat"
     assert sig.strength == pytest.approx(0.0)
+    assert sig.target_pct == pytest.approx(0.0)
 
 
 def test_triangular_arb_with_fees():
@@ -31,3 +34,4 @@ def test_triangular_arb_with_fees():
     sig = strat.on_bar({"prices": prices})
     assert sig.side == "buy"
     assert sig.strength == pytest.approx(0.046853, rel=1e-3)
+    assert sig.target_pct == pytest.approx(0.046853, rel=1e-3)

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -29,7 +29,7 @@ class AlwaysBuy:
     name = "always_buy"
 
     def on_trade(self, trade):
-        return Signal("buy", 1.0)
+        return Signal("buy", 1.0, target_pct=1.0)
 
 
 @pytest.mark.asyncio
@@ -74,7 +74,7 @@ async def test_daemon_adjusts_size_for_correlation():
     daemon.price_history["BBB"] = deque([2, 4, 6, 8], maxlen=10)
 
     trade = type("T", (), {"symbol": "AAA", "price": 4.0})
-    sig = Signal("buy", 1.0)
+    sig = Signal("buy", 1.0, target_pct=1.0)
 
     await daemon._on_signal({"signal": sig, "trade": trade})
 
@@ -92,7 +92,7 @@ async def test_daemon_emits_event_on_high_correlation():
     daemon.price_history["AAA"] = deque([1, 2, 3], maxlen=5)
     daemon.price_history["BBB"] = deque([2, 4, 6], maxlen=5)
     trade = type("T", (), {"symbol": "AAA", "price": 4.0})
-    sig = Signal("buy", 1.0)
+    sig = Signal("buy", 1.0, target_pct=1.0)
     await daemon._on_signal({"signal": sig, "trade": trade})
     await asyncio.sleep(0)
     assert risk.max_pos == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- extend `Signal` with `target_pct` to express desired equity exposure
- map all strategies to populate `target_pct` alongside existing strength
- document new field and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adc8b04b60832d999ae5088be1468d