### PR TITLE
feat: use percentage-based daily loss limits

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -91,7 +91,7 @@ async def run_live_binance(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
     *,
@@ -113,7 +113,7 @@ async def run_live_binance(
         soft_cap_grace_sec=soft_cap_grace_sec,
     ))
     dguard = DailyGuard(GuardLimits(
-        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_loss_pct=daily_max_loss_pct,
         daily_max_drawdown_pct=daily_max_drawdown_pct,
         max_consecutive_losses=max_consecutive_losses,
         halt_action="close_all",

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -93,7 +93,7 @@ async def _run_symbol(
     per_symbol_cap_usdt: float,
     soft_cap_pct: float,
     soft_cap_grace_sec: int,
-    daily_max_loss_usdt: float,
+    daily_max_loss_pct: float,
     daily_max_drawdown_pct: float,
     max_consecutive_losses: int,
     corr_threshold: float,
@@ -120,7 +120,7 @@ async def _run_symbol(
     )
     dguard = DailyGuard(
         GuardLimits(
-            daily_max_loss_usdt=daily_max_loss_usdt,
+            daily_max_loss_pct=daily_max_loss_pct,
             daily_max_drawdown_pct=daily_max_drawdown_pct,
             max_consecutive_losses=max_consecutive_losses,
             halt_action="close_all",
@@ -197,7 +197,7 @@ async def run_live_real(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
@@ -228,7 +228,7 @@ async def run_live_real(
             per_symbol_cap_usdt,
             soft_cap_pct,
             soft_cap_grace_sec,
-            daily_max_loss_usdt,
+            daily_max_loss_pct,
             daily_max_drawdown_pct,
             max_consecutive_losses,
             corr_threshold,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -52,7 +52,7 @@ class _SymbolConfig:
 async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: int,
                       dry_run: bool, total_cap_usdt: float, per_symbol_cap_usdt: float,
                       soft_cap_pct: float, soft_cap_grace_sec: int,
-                      daily_max_loss_usdt: float, daily_max_drawdown_pct: float,
+                      daily_max_loss_pct: float, daily_max_drawdown_pct: float,
                       max_consecutive_losses: int, corr_threshold: float,
                       config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
@@ -83,7 +83,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         soft_cap_grace_sec=soft_cap_grace_sec,
     ))
     dguard = DailyGuard(GuardLimits(
-        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_loss_pct=daily_max_loss_pct,
         daily_max_drawdown_pct=daily_max_drawdown_pct,
         max_consecutive_losses=max_consecutive_losses,
         halt_action="close_all",
@@ -155,7 +155,7 @@ async def run_live_testnet(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
@@ -178,7 +178,7 @@ async def run_live_testnet(
             per_symbol_cap_usdt,
             soft_cap_pct,
             soft_cap_grace_sec,
-            daily_max_loss_usdt,
+            daily_max_loss_pct,
             daily_max_drawdown_pct,
             max_consecutive_losses,
             corr_threshold,

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -109,7 +109,7 @@ async def test_bybit_futures_order(monkeypatch):
         per_symbol_cap_usdt=500.0,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
-        daily_max_loss_usdt=100.0,
+        daily_max_loss_pct=0.1,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
     )
@@ -168,7 +168,7 @@ async def test_run_real(monkeypatch):
         per_symbol_cap_usdt=500.0,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
-        daily_max_loss_usdt=100.0,
+        daily_max_loss_pct=0.1,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
     )
@@ -222,7 +222,7 @@ async def test_okx_futures_order(monkeypatch):
         per_symbol_cap_usdt=500.0,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
-        daily_max_loss_usdt=100.0,
+        daily_max_loss_pct=0.1,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
     )

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -109,8 +109,9 @@ async def test_daily_guard_halts_on_loss():
     from tradingbot.execution.paper import PaperAdapter
 
     broker = PaperAdapter()
+    broker.state.cash = 1000.0
     symbol = "BTC/USDT"
-    guard = DailyGuard(GuardLimits(daily_max_loss_usdt=5.0), venue="paper")
+    guard = DailyGuard(GuardLimits(daily_max_loss_pct=0.01), venue="paper")
 
     broker.update_last_price(symbol, 100.0)
     guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 100.0}))


### PR DESCRIPTION
## Summary
- replace fixed USDT cap with `daily_max_loss_pct` and base limits on opening equity
- refresh drawdown and loss streak tracking when equity shifts and record limit percentage in events
- update live runners and tests to use the new percentage-based limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adc8ad7c04832d831754a250b0abdc