### PR TITLE
feat: add equity-based risk manager

### DIFF
--- a/src/tradingbot/risk/__init__.py
+++ b/src/tradingbot/risk/__init__.py
@@ -1,1 +1,3 @@
+from .equity_manager import EquityRiskManager
 
+__all__ = ["EquityRiskManager"]

--- a/src/tradingbot/risk/equity_manager.py
+++ b/src/tradingbot/risk/equity_manager.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class EquityRiskManager:
+    """Simple equity-based risk manager.
+
+    Tracks peak equity and per-position PnL to allow dynamic resizing of
+    positions.  Stop-loss and trailing stop limits are expressed as
+    percentages of account equity rather than price levels.
+    """
+
+    equity: float
+    stop_loss_pct: float = 0.0
+    trailing_stop_pct: float = 0.0
+
+    peak_equity: float = field(init=False)
+    pnl_positions: Dict[str, float] = field(default_factory=dict, init=False)
+    _pnl_peaks: Dict[str, float] = field(default_factory=dict, init=False)
+    _signals: Dict[str, float] = field(default_factory=dict, init=False)
+    _positions: Dict[str, float] = field(default_factory=dict, init=False)
+    enabled: bool = field(default=True, init=False)
+
+    def __post_init__(self) -> None:
+        self.equity = float(self.equity)
+        self.stop_loss_pct = abs(self.stop_loss_pct)
+        self.trailing_stop_pct = abs(self.trailing_stop_pct)
+        self.peak_equity = self.equity
+        self.entry_equity = self.equity
+
+    # ------------------------------------------------------------------
+    # Tracking helpers
+    def update_equity(self, equity: float) -> None:
+        """Update current equity and peak."""
+        self.equity = float(equity)
+        if self.equity > self.peak_equity:
+            self.peak_equity = self.equity
+
+    def update_position_pnl(self, symbol: str, pnl: float) -> None:
+        """Store latest PnL for ``symbol`` and keep peak PnL."""
+        self.pnl_positions[symbol] = float(pnl)
+        peak = self._pnl_peaks.get(symbol)
+        if peak is None or pnl > peak:
+            self._pnl_peaks[symbol] = float(pnl)
+
+    # ------------------------------------------------------------------
+    # Position sizing helpers
+    def increase_position(
+        self,
+        symbol: str,
+        qty: float,
+        signal: float,
+        pnl_positive_threshold: float,
+        increment_pct: float = 0.5,
+    ) -> float:
+        """Increase ``qty`` if ``signal`` grows or PnL exceeds threshold."""
+        prev_signal = self._signals.get(symbol, float("-inf"))
+        pnl = self.pnl_positions.get(symbol, 0.0)
+        new_qty = qty
+        if signal > prev_signal or pnl > pnl_positive_threshold:
+            new_qty = qty * (1 + increment_pct)
+        self._signals[symbol] = signal
+        self._positions[symbol] = new_qty
+        return new_qty
+
+    def reduce_position_on_trailing_stop(self, symbol: str, qty: float) -> float:
+        """Reduce position size if PnL retraces by ``trailing_stop_pct``."""
+        pnl = self.pnl_positions.get(symbol, 0.0)
+        peak = self._pnl_peaks.get(symbol, pnl)
+        if peak > 0:
+            retracement = (peak - pnl) / peak
+            if self.trailing_stop_pct > 0 and retracement >= self.trailing_stop_pct:
+                new_qty = qty * 0.5
+                self._positions[symbol] = new_qty
+                return new_qty
+        self._positions[symbol] = qty
+        return qty
+
+    # ------------------------------------------------------------------
+    # Limit checks
+    def check_limits(self, equity: float) -> bool:
+        """Check stop-loss and trailing stop based on ``equity``."""
+        if not self.enabled:
+            return False
+        self.update_equity(equity)
+        loss_pct = 0.0
+        if self.entry_equity > 0:
+            loss_pct = (self.entry_equity - self.equity) / self.entry_equity
+        drawdown = 0.0
+        if self.peak_equity > 0:
+            drawdown = (self.peak_equity - self.equity) / self.peak_equity
+        if self.stop_loss_pct > 0 and loss_pct >= self.stop_loss_pct:
+            self.enabled = False
+            return False
+        if self.trailing_stop_pct > 0 and drawdown >= self.trailing_stop_pct:
+            self.enabled = False
+            return False
+        return True

--- a/tests/test_equity_risk_manager.py
+++ b/tests/test_equity_risk_manager.py
@@ -1,0 +1,30 @@
+import math
+
+from tradingbot.risk import EquityRiskManager
+
+
+def test_peak_equity_and_limits():
+    m = EquityRiskManager(1000, stop_loss_pct=0.1, trailing_stop_pct=0.2)
+    assert m.check_limits(1000)
+    assert m.check_limits(1200)
+    assert math.isclose(m.peak_equity, 1200)
+    assert m.check_limits(1100)  # drawdown < 20%
+    assert not m.check_limits(900)  # 10% stop loss
+
+
+def test_increase_and_trailing_reduction():
+    m = EquityRiskManager(1000, stop_loss_pct=0.5, trailing_stop_pct=0.2)
+    qty = m.increase_position("BTC", 1.0, signal=0.5, pnl_positive_threshold=10)
+    assert qty > 1.0
+
+    m.update_position_pnl("BTC", 15)
+    qty2 = m.increase_position("BTC", qty, signal=0.4, pnl_positive_threshold=10)
+    assert qty2 > qty
+
+    m.update_position_pnl("BTC", 50)
+    qty3 = m.reduce_position_on_trailing_stop("BTC", qty2)
+    assert qty3 == qty2
+
+    m.update_position_pnl("BTC", 35)  # 30% retrace from 50
+    qty4 = m.reduce_position_on_trailing_stop("BTC", qty3)
+    assert qty4 < qty3


### PR DESCRIPTION
## Summary
- add EquityRiskManager to monitor peak equity and per-position PnL
- support dynamic position scaling and trailing stop reductions
- expose new risk manager via risk package

## Testing
- `pytest tests/test_equity_risk_manager.py -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68adc8a14084832d8aea9d5ec7f4e496