### PR TITLE
refactor: compute guard caps from equity

### DIFF
--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -539,12 +539,12 @@ class TradeBotDaemon:
         """Adjust portfolio guard limits from external controller."""
         if not self.guard:
             return
-        tot = evt.get("total_cap_usdt")
-        per = evt.get("per_symbol_cap_usdt")
+        tot = evt.get("total_cap_pct")
+        per = evt.get("per_symbol_cap_pct")
         if tot is not None:
-            self.guard.cfg.total_cap_usdt = float(tot)
+            self.guard.cfg.total_cap_pct = float(tot)
         if per is not None:
-            self.guard.cfg.per_symbol_cap_usdt = float(per)
+            self.guard.cfg.per_symbol_cap_pct = float(per)
 
     # ------------------------------------------------------------------
     async def _on_halt(self, _evt: dict) -> None:

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -87,8 +87,8 @@ async def run_live_binance(
     symbol: str = "BTC/USDT",
     fee_bps: float = 1.5,
     persist_pg: bool = False,
-    total_cap_usdt: float = 1000.0,
-    per_symbol_cap_usdt: float = 500.0,
+    total_cap_pct: float = 1.0,
+    per_symbol_cap_pct: float = 0.5,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
     daily_max_loss_usdt: float = 100.0,
@@ -105,13 +105,16 @@ async def run_live_binance(
     broker = PaperAdapter(fee_bps=fee_bps)
     risk_core = RiskManager(max_pos=1.0)
     strat = BreakoutATR(config_path=config_path)
-    guard = PortfolioGuard(GuardConfig(
-        total_cap_usdt=total_cap_usdt,
-        per_symbol_cap_usdt=per_symbol_cap_usdt,
-        venue="binance",
-        soft_cap_pct=soft_cap_pct,
-        soft_cap_grace_sec=soft_cap_grace_sec,
-    ))
+    guard = PortfolioGuard(
+        GuardConfig(
+            total_cap_pct=total_cap_pct,
+            per_symbol_cap_pct=per_symbol_cap_pct,
+            venue="binance",
+            soft_cap_pct=soft_cap_pct,
+            soft_cap_grace_sec=soft_cap_grace_sec,
+        ),
+        equity_provider=lambda: broker.equity(),
+    )
     dguard = DailyGuard(GuardLimits(
         daily_max_loss_usdt=daily_max_loss_usdt,
         daily_max_drawdown_pct=daily_max_drawdown_pct,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -50,7 +50,10 @@ async def run_paper(
     router = ExecutionRouter([broker])
 
     risk_core = RiskManager(max_pos=1.0)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"),
+        equity_provider=lambda: broker.equity(),
+    )
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)
     engine = get_engine() if _CAN_PG else None

--- a/src/tradingbot/risk/portfolio_guard.py
+++ b/src/tradingbot/risk/portfolio_guard.py
@@ -1,7 +1,7 @@
 # src/tradingbot/risk/portfolio_guard.py
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple, Optional, Callable
 from datetime import datetime, timezone, timedelta
 from collections import defaultdict, deque
 
@@ -9,8 +9,8 @@ import numpy as np
 
 @dataclass
 class GuardConfig:
-    total_cap_usdt: float = 1000.0
-    per_symbol_cap_usdt: float = 500.0
+    total_cap_pct: float = 1.0
+    per_symbol_cap_pct: float = 0.5
     venue: str = "binance_spot_testnet"
     # --- Soft caps ---
     soft_cap_pct: float = 0.10            # hasta +10% sobre el cap
@@ -34,9 +34,10 @@ class GuardState:
     venue_pnl: Dict[str, float] = field(default_factory=dict)
 
 class PortfolioGuard:
-    def __init__(self, cfg: GuardConfig):
+    def __init__(self, cfg: GuardConfig, equity_provider: Callable[[], float] | None = None):
         self.cfg = cfg
         self.st = GuardState()
+        self._equity_provider = equity_provider or (lambda: float("inf"))
 
     # ---- utilidades base ----
     def mark_price(self, symbol: str, price: float):
@@ -94,6 +95,13 @@ class PortfolioGuard:
         return float(np.std(rets) * np.sqrt(365))
 
     # ---- hard caps (como antes) ----
+    def _caps_usdt(self) -> Tuple[float, float]:
+        eq = float(self._equity_provider())
+        return (
+            eq * self.cfg.per_symbol_cap_pct,
+            eq * self.cfg.total_cap_pct,
+        )
+
     def would_exceed_caps(self, symbol: str, side: str, add_qty: float, price: float) -> Tuple[bool, str, dict]:
         cur_pos = self.st.positions.get(symbol, 0.0)
         new_pos = cur_pos + (add_qty if side.lower()=="buy" else -add_qty)
@@ -111,10 +119,11 @@ class PortfolioGuard:
         if symbol not in seen:
             total += abs(new_pos) * price
 
-        if sym_exp > self.cfg.per_symbol_cap_usdt:
-            return True, f"per_symbol_cap_usdt excedido ({sym_exp:.2f} > {self.cfg.per_symbol_cap_usdt:.2f})", {"sym_exp": sym_exp, "total": total}
-        if total > self.cfg.total_cap_usdt:
-            return True, f"total_cap_usdt excedido ({total:.2f} > {self.cfg.total_cap_usdt:.2f})", {"sym_exp": sym_exp, "total": total}
+        per_cap, total_cap = self._caps_usdt()
+        if sym_exp > per_cap:
+            return True, f"per_symbol_cap_exceeded ({sym_exp:.2f} > {per_cap:.2f})", {"sym_exp": sym_exp, "total": total}
+        if total > total_cap:
+            return True, f"total_cap_exceeded ({total:.2f} > {total_cap:.2f})", {"sym_exp": sym_exp, "total": total}
         return False, "", {"sym_exp": sym_exp, "total": total}
 
     # ---- soft caps ----
@@ -122,9 +131,10 @@ class PortfolioGuard:
         return datetime.now(timezone.utc)
 
     def _soft_bounds(self) -> Tuple[float, float]:
+        per_cap, total_cap = self._caps_usdt()
         return (
-            self.cfg.per_symbol_cap_usdt * (1.0 + self.cfg.soft_cap_pct),
-            self.cfg.total_cap_usdt * (1.0 + self.cfg.soft_cap_pct),
+            per_cap * (1.0 + self.cfg.soft_cap_pct),
+            total_cap * (1.0 + self.cfg.soft_cap_pct),
         )
 
     def soft_cap_decision(self, symbol: str, side: str, add_qty: float, price: float) -> Tuple[str, str, dict]:
@@ -156,13 +166,14 @@ class PortfolioGuard:
         if symbol not in seen:
             total += abs(new_pos) * price
 
+        per_cap, total_cap = self._caps_usdt()
         per_soft, total_soft = self._soft_bounds()
         # casos
         # 1) dentro de hard caps
-        if sym_exp <= self.cfg.per_symbol_cap_usdt and total <= self.cfg.total_cap_usdt:
+        if sym_exp <= per_cap and total <= total_cap:
             # si había ventanas, se cierran
             self.st.sym_soft_started.pop(symbol, None)
-            if self.st.total_soft_started and total <= self.cfg.total_cap_usdt:
+            if self.st.total_soft_started and total <= total_cap:
                 self.st.total_soft_started = None
             return "allow", "dentro de hard caps", {"sym_exp": sym_exp, "total": total}
 
@@ -177,7 +188,7 @@ class PortfolioGuard:
             self.st.sym_soft_started[symbol] = now
             sym_start = now
         # ventana global
-        if self.st.total_soft_started is None and total > self.cfg.total_cap_usdt:
+        if self.st.total_soft_started is None and total > total_cap:
             self.st.total_soft_started = now
 
         # tiempo restante por las ventanas activas
@@ -203,16 +214,17 @@ class PortfolioGuard:
             return 0.0, "sin posición o precio inválido", {"pos": pos, "price": price}
 
         cur_sym_exp = abs(pos) * price
-        target_sym_exp = min(cur_sym_exp, self.cfg.per_symbol_cap_usdt)
-        if cur_sym_exp > self.cfg.per_symbol_cap_usdt:
+        per_cap, total_cap = self._caps_usdt()
+        target_sym_exp = min(cur_sym_exp, per_cap)
+        if cur_sym_exp > per_cap:
             need_exp_cut = cur_sym_exp - target_sym_exp
             need_qty_cut = need_exp_cut / price
         else:
             need_qty_cut = 0.0
 
         total = self.exposure_total()
-        if total > self.cfg.total_cap_usdt:
-            extra = total - self.cfg.total_cap_usdt
+        if total > total_cap:
+            extra = total - total_cap
             need_qty_cut += extra / price
 
         need_qty_cut = max(0.0, min(abs(pos), need_qty_cut))

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -49,7 +49,10 @@ def test_correlation_service_window_rolls():
 
 
 def test_risk_service_uses_correlation_service():
-    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
+    guard = PortfolioGuard(
+        GuardConfig(per_symbol_cap_pct=0.5, total_cap_pct=1.0),
+        equity_provider=lambda: 20000.0,
+    )
     rm = RiskManager(max_pos=10, vol_target=0.02)
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -88,7 +88,7 @@ async def test_bybit_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
     monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
-    monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
+    monkeypatch.setattr(rt, "PortfolioGuard", lambda config, equity_provider=None: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
 
@@ -105,8 +105,8 @@ async def test_bybit_futures_order(monkeypatch):
         cfg,
         leverage=5,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_usdt=100.0,
@@ -148,7 +148,7 @@ async def test_run_real(monkeypatch):
     monkeypatch.setattr(rr, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rr, "BreakoutATR", lambda: DummyStrat())
     monkeypatch.setattr(rr, "RiskManager", lambda max_pos: DummyRisk())
-    monkeypatch.setattr(rr, "PortfolioGuard", lambda config: DummyPG())
+    monkeypatch.setattr(rr, "PortfolioGuard", lambda config, equity_provider=None: DummyPG())
     monkeypatch.setattr(rr, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rr, "PaperAdapter", DummyBroker)
     monkeypatch.setitem(
@@ -164,8 +164,8 @@ async def test_run_real(monkeypatch):
         cfg,
         leverage=1,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_usdt=100.0,
@@ -201,7 +201,7 @@ async def test_okx_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
     monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
-    monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
+    monkeypatch.setattr(rt, "PortfolioGuard", lambda config, equity_provider=None: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
 
@@ -218,8 +218,8 @@ async def test_okx_futures_order(monkeypatch):
         cfg,
         leverage=7,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_usdt=100.0,

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -21,7 +21,10 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.oco_orders" (venue, symbol, side, qty, entry_price, sl_price, tp_price, status) VALUES ("paper", "BTCUSDT", "long", 1.5, 10000, 9500, 10500, "active");'))
 
     rm = RiskManager(max_pos=5)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1e6, per_symbol_cap_usdt=1e6, venue="paper"))
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper"),
+        equity_provider=lambda: 1e6,
+    )
     risk = RiskService(rm, guard)
 
     # Rehydrate

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -66,7 +66,10 @@ def test_daily_loss_limit_triggers_kill_switch():
 
 def test_risk_service_updates_and_persists(monkeypatch):
     rm = RiskManager()
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1.0, per_symbol_cap_usdt=1.0, venue="X"))
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"),
+        equity_provider=lambda: 1.0,
+    )
     daily = DailyGuard(GuardLimits(), venue="X")
     events: list = []
     monkeypatch.setattr(timescale, "insert_risk_event", lambda engine, **kw: events.append(kw))

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -26,7 +26,8 @@ async def test_risk_service_correlation_limits_and_sizing():
     bus.subscribe("risk:paused", lambda e: events.append(e))
     rm = RiskManager(max_pos=2.0, bus=bus)
     guard = PortfolioGuard(
-        GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="test")
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="test"),
+        equity_provider=lambda: 1000.0,
     )
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -42,7 +42,10 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
 
 
 def test_risk_service_uses_guard_volatility():
-    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
+    guard = PortfolioGuard(
+        GuardConfig(per_symbol_cap_pct=0.5, total_cap_pct=1.0),
+        equity_provider=lambda: 20000.0,
+    )
     rm = RiskManager(max_pos=10, vol_target=0.02)
     svc = RiskService(rm, guard)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])


### PR DESCRIPTION
## Summary
- switch portfolio guard limits to percentage-of-equity caps
- evaluate caps dynamically using injected `equity_provider`
- update live runners and tests for new cap semantics

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68adc8a82ff4832db4760cf8d6a0b04a