### PR TITLE
Add equity provider interface with cash-aware risk checks

### DIFF
--- a/src/tradingbot/execution/equity_provider.py
+++ b/src/tradingbot/execution/equity_provider.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Mapping, Protocol
+
+
+class EquityProvider(Protocol):
+    """Interface for objects exposing equity and cash information."""
+
+    def equity(self, mark_prices: Mapping[str, float] | None = None) -> float:
+        """Return total account equity in quote currency."""
+        ...
+
+    def available_cash(self) -> float:
+        """Return free quote currency available for new positions."""
+        ...
+
+
+__all__ = ["EquityProvider"]

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -55,6 +55,10 @@ class PaperAdapter(ExchangeAdapter):
     def update_last_price(self, symbol: str, px: float):
         self.state.last_px[symbol] = px
 
+    def available_cash(self) -> float:
+        """Return simulated free cash balance."""
+        return self.state.cash
+
     async def stream_trades(
         self,
         symbol: str,

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -12,7 +12,7 @@ import pandas as pd
 from ..adapters.binance_ws import BinanceWSAdapter
 from ..execution.paper import PaperAdapter
 from ..strategies.breakout_atr import BreakoutATR
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import RiskManager, load_positions, EquityRiskManager
 from ..risk.daily_guard import DailyGuard, GuardLimits
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
@@ -103,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = EquityRiskManager(max_pos=1.0, provider=broker)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
@@ -111,7 +111,7 @@ async def run_live_binance(
         venue="binance",
         soft_cap_pct=soft_cap_pct,
         soft_cap_grace_sec=soft_cap_grace_sec,
-    ))
+    ), provider=broker)
     dguard = DailyGuard(GuardLimits(
         daily_max_loss_usdt=daily_max_loss_usdt,
         daily_max_drawdown_pct=daily_max_drawdown_pct,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -10,7 +10,7 @@ from ..adapters.binance_ws import BinanceWSAdapter
 from ..execution.order_types import Order
 from ..execution.paper import PaperAdapter
 from ..execution.router import ExecutionRouter
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import RiskManager, load_positions, EquityRiskManager
 from ..risk.portfolio_guard import GuardConfig, PortfolioGuard
 from ..risk.service import RiskService
 from ..risk.correlation_service import CorrelationService
@@ -49,8 +49,8 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(max_pos=1.0)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
+    risk_core = EquityRiskManager(max_pos=1.0, provider=broker)
+    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"), provider=broker)
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)
     engine = get_engine() if _CAN_PG else None

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -13,7 +13,7 @@ from ..execution.paper import PaperAdapter
 from ..strategies.arbitrage_triangular import (
     TriRoute, make_symbols, compute_edge, compute_qtys_for_route
 )
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import RiskManager, load_positions, EquityRiskManager
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
 from ..risk.oco import OcoBook, load_active_oco
@@ -51,8 +51,8 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
     fills = 0
     if risk is None:
         risk = RiskService(
-            RiskManager(),
-            PortfolioGuard(GuardConfig(venue="binance")),
+            EquityRiskManager(max_pos=1.0, provider=broker),
+            PortfolioGuard(GuardConfig(venue="binance"), provider=broker),
         )
 
     engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None

--- a/tests/test_equity_provider.py
+++ b/tests/test_equity_provider.py
@@ -1,0 +1,28 @@
+import pytest
+
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.risk.manager import EquityRiskManager
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+
+
+def test_portfolio_guard_blocks_insufficient_cash():
+    broker = PaperAdapter()
+    broker.state.cash = 100.0
+    pg = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=1000.0, venue="paper"), provider=broker)
+    pg.mark_price("BTC/USDT", 50.0)
+    action, reason, _ = pg.soft_cap_decision("BTC/USDT", "buy", 3.0, 50.0)
+    assert action == "block"
+    assert reason == "insufficient_cash"
+
+
+def test_equity_risk_manager_blocks_on_cash():
+    broker = PaperAdapter()
+    broker.state.cash = 100.0
+    rm = EquityRiskManager(max_pos=10, provider=broker)
+    pg = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=1000.0, venue="paper"), provider=broker)
+    risk = RiskService(rm, pg)
+    pg.mark_price("BTC/USDT", 50.0)
+    allowed, reason, _ = risk.check_order("BTC/USDT", "buy", 50.0)
+    assert not allowed
+    assert reason == "insufficient_cash"


### PR DESCRIPTION
## Summary
- define `EquityProvider` protocol for equity and cash queries
- implement cash tracking in adapters, paper broker and risk components
- enforce available cash in risk checks and live runners

## Testing
- `pytest tests/test_equity_provider.py -q`
- `pytest tests/test_risk.py::test_risk_manager_size_property -q`
- `pytest tests/test_risk_daily_guard.py::test_daily_dd_limit_blocks_risk_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc8be1b90832d80810020fdb8d762