### PR TITLE
Add centralized RiskProfile and integrate risk components

### DIFF
--- a/src/tradingbot/risk/__init__.py
+++ b/src/tradingbot/risk/__init__.py
@@ -1,1 +1,14 @@
+"""Risk management utilities."""
 
+from .profile import RiskProfile
+from .equity_manager import EquityRiskManager
+from .portfolio_guard import PortfolioGuard
+from .daily_guard import DailyGuard, GuardLimits
+
+__all__ = [
+    "RiskProfile",
+    "EquityRiskManager",
+    "PortfolioGuard",
+    "DailyGuard",
+    "GuardLimits",
+]

--- a/src/tradingbot/risk/daily_guard.py
+++ b/src/tradingbot/risk/daily_guard.py
@@ -8,6 +8,7 @@ import asyncio
 
 from ..utils.metrics import RISK_EVENTS
 from ..storage import timescale
+from .profile import RiskProfile
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +24,15 @@ class DailyGuard:
     Controla pérdidas diarias, drawdown y racha de pérdidas.
     Mantiene equity intradía, pérdidas consecutivas y fecha de corte (UTC).
     """
-    def __init__(self, limits: GuardLimits, venue: str, storage_engine=None):
+    def __init__(
+        self,
+        limits: GuardLimits,
+        venue: str,
+        storage_engine=None,
+        profile: RiskProfile | None = None,
+    ):
+        if profile is not None:
+            limits.daily_max_drawdown_pct = profile.max_drawdown_pct
         self.lim = limits
         self.venue = venue
         self._cur_day: date | None = None

--- a/src/tradingbot/risk/equity_manager.py
+++ b/src/tradingbot/risk/equity_manager.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from .manager import RiskManager
+from .profile import RiskProfile
+
+
+class EquityRiskManager(RiskManager):
+    """Specialised :class:`RiskManager` driven by a :class:`RiskProfile`.
+
+    The profile centralises percentage based parameters making it easier to
+    tweak risk appetite from a single place.  Values missing from the profile
+    fall back to those supplied directly via ``RiskManager``'s constructor.
+    """
+
+    def __init__(self, profile: RiskProfile, **kwargs):
+        kwargs.setdefault("stop_loss_pct", profile.risk_per_trade_pct)
+        kwargs.setdefault("max_drawdown_pct", profile.max_drawdown_pct)
+        super().__init__(**kwargs)
+        self.profile = profile
+        # Scaling applies to volatility target/max position when used
+        self.vol_target *= profile.scale_pct
+        self.max_pos *= profile.scale_pct
+        self._base_max_pos = self.max_pos
+        self._base_vol_target = self.vol_target

--- a/src/tradingbot/risk/portfolio_guard.py
+++ b/src/tradingbot/risk/portfolio_guard.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone, timedelta
 from collections import defaultdict, deque
 
 import numpy as np
+from .profile import RiskProfile
 
 @dataclass
 class GuardConfig:
@@ -34,7 +35,9 @@ class GuardState:
     venue_pnl: Dict[str, float] = field(default_factory=dict)
 
 class PortfolioGuard:
-    def __init__(self, cfg: GuardConfig):
+    def __init__(self, cfg: GuardConfig, profile: RiskProfile | None = None):
+        if profile is not None:
+            cfg.soft_cap_pct = profile.scale_pct
         self.cfg = cfg
         self.st = GuardState()
 

--- a/src/tradingbot/risk/profile.py
+++ b/src/tradingbot/risk/profile.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import json
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class RiskProfile:
+    """Configuration container for percentage based risk parameters.
+
+    Attributes
+    ----------
+    risk_per_trade_pct:
+        Fraction of equity to risk on a single trade (e.g. ``0.02`` for 2%).
+    max_drawdown_pct:
+        Maximum allowed drawdown expressed as fraction of peak equity.
+    scale_pct:
+        Multiplicative factor applied to scalable limits (``1.0`` leaves
+        original values untouched).
+    """
+
+    risk_per_trade_pct: float = 0.01
+    max_drawdown_pct: float = 0.2
+    scale_pct: float = 1.0
+
+    # ------------------------------------------------------------------
+    # serialisation helpers
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RiskProfile":
+        return cls(
+            risk_per_trade_pct=float(data.get("risk_per_trade_pct", 0.01)),
+            max_drawdown_pct=float(data.get("max_drawdown_pct", 0.2)),
+            scale_pct=float(data.get("scale_pct", 1.0)),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    # YAML --------------------------------------------------------------
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "RiskProfile":
+        with open(path, "r", encoding="utf8") as fh:
+            data = yaml.safe_load(fh) or {}
+        return cls.from_dict(data)
+
+    def to_yaml(self, path: str | Path) -> None:
+        with open(path, "w", encoding="utf8") as fh:
+            yaml.safe_dump(self.to_dict(), fh)
+
+    # JSON --------------------------------------------------------------
+    @classmethod
+    def from_json(cls, path: str | Path) -> "RiskProfile":
+        with open(path, "r", encoding="utf8") as fh:
+            data = json.load(fh)
+        return cls.from_dict(data)
+
+    def to_json(self, path: str | Path, *, indent: int = 2) -> None:
+        with open(path, "w", encoding="utf8") as fh:
+            json.dump(self.to_dict(), fh, indent=indent)

--- a/tests/test_risk_profile.py
+++ b/tests/test_risk_profile.py
@@ -1,0 +1,36 @@
+from tradingbot.risk import (
+    RiskProfile,
+    EquityRiskManager,
+    PortfolioGuard,
+    DailyGuard,
+    GuardLimits,
+)
+from tradingbot.risk.portfolio_guard import GuardConfig
+
+
+def test_profile_serialisation(tmp_path):
+    profile = RiskProfile(risk_per_trade_pct=0.02, max_drawdown_pct=0.1, scale_pct=1.5)
+    yfile = tmp_path / "profile.yaml"
+    jfile = tmp_path / "profile.json"
+
+    profile.to_yaml(yfile)
+    profile.to_json(jfile)
+
+    assert RiskProfile.from_yaml(yfile) == profile
+    assert RiskProfile.from_json(jfile) == profile
+
+
+def test_components_read_profile():
+    profile = RiskProfile(risk_per_trade_pct=0.03, max_drawdown_pct=0.07, scale_pct=0.5)
+
+    rm = EquityRiskManager(profile)
+    assert rm.stop_loss_pct == profile.risk_per_trade_pct
+    assert rm.max_drawdown_pct == profile.max_drawdown_pct
+    assert rm.max_pos == 1.0 * profile.scale_pct
+
+    pg_cfg = GuardConfig()
+    pg = PortfolioGuard(pg_cfg, profile=profile)
+    assert pg.cfg.soft_cap_pct == profile.scale_pct
+
+    dg = DailyGuard(GuardLimits(), venue="paper", profile=profile)
+    assert dg.lim.daily_max_drawdown_pct == profile.max_drawdown_pct


### PR DESCRIPTION
## Summary
- add `RiskProfile` with JSON/YAML persistence
- introduce `EquityRiskManager` driven by a risk profile
- allow `PortfolioGuard` and `DailyGuard` to read scaling and drawdown limits from the profile
- cover new profile features with tests

## Testing
- `pytest` (killed after partial run)
- `pytest tests/test_risk_profile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc8c78028832d90cebd62847364ee