### PR TITLE
doc: explicar riesgo porcentual

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,37 @@ export BINANCE_FUTURES_TESTNET=true
 Si esta variable no está definida o se establece en `false`, el bot usará el
 entorno real de Binance Futures.
 
+## Gestión de riesgo
+
+El tamaño de cada operación se calcula a partir del capital disponible:
+
+- `equity_pct` indica la fracción de equity utilizada como notional por
+  señal: `notional = equity_total * equity_pct`.
+- `risk_pct` define la pérdida máxima aceptada sobre ese notional:
+  `max_loss = notional * risk_pct`.
+
+El parámetro `strength` de las señales escala el cambio propuesto en la
+posición. Valores mayores a `1.0` permiten piramidar entradas mientras que
+valores menores reducen exposición.
+
+`DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
+superan los límites configurados, detiene el bot o cierra las posiciones
+abiertas.
+
+### Ejemplo para cuenta pequeña
+
+```yaml
+backtest:
+  data: data/examples/btcusdt_1m.csv   # reemplazar con datos del activo elegido
+  symbol: DOGE/USDT
+  strategy: breakout_atr
+  initial_equity: 100
+
+risk:
+  equity_pct: 0.05   # usa el 5% del capital por operación
+  risk_pct: 0.02     # arriesga como máximo el 2% de la cuenta
+```
+
 ## Solución de problemas
 
 Si se muestra el mensaje `System clock offset`, indica que el reloj del

--- a/data/examples/small_account.yaml
+++ b/data/examples/small_account.yaml
@@ -1,0 +1,10 @@
+# Ejemplo de configuración para cuentas pequeñas y activos de bajo valor
+backtest:
+  data: data/examples/btcusdt_1m.csv   # reemplazar con datos del activo elegido
+  symbol: DOGE/USDT
+  strategy: breakout_atr
+  initial_equity: 100
+
+risk:
+  equity_pct: 0.05
+  risk_pct: 0.02

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ Si es la primera vez que lo utiliza, comience por revisar el
 - [Comandos de la CLI](commands.md)
 - [Estrategias disponibles](strategies.md)
 - [Dashboards de monitoreo](dashboards.md)
+- [Gestión de riesgo](risk.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,7 +84,6 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--leverage`: apalancamiento para futuros.
 - `--dry-run`: simula órdenes en testnet.
 - `--stop-loss` y `--take-profit`: porcentajes de la estrategia.
-- `--stop-loss-pct` y `--max-drawdown-pct`: límites del gestor de riesgo.
 
 ## `paper-run`
 Corre una estrategia en modo paper (sin dinero real) y expone métricas.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -1,0 +1,49 @@
+# Gestión de riesgo
+
+## Cálculo de `equity_pct` y `risk_pct`
+
+El capital asignado a cada operación se determina multiplicando la equity
+actual por `equity_pct`:
+
+```
+notional = equity_total * equity_pct
+```
+
+El riesgo máximo permitido sobre esa operación se controla con `risk_pct`:
+
+```
+max_loss = notional * risk_pct
+```
+
+A partir del notional se calcula la cantidad a comprar o vender en función del
+precio del activo.
+
+## Uso de `strength`
+
+Las estrategias pueden emitir señales con un atributo `strength` que escala el
+cambio propuesto en la posición. Un valor mayor a `1.0` permite piramidar
+agregando tamaño; valores entre `0` y `1` reducen exposición y `0` cierra la
+posición.
+
+## DailyGuard y drawdown global
+
+`DailyGuard` monitorea la equity intradía y la racha de pérdidas. Si se
+supera la pérdida diaria permitida o el drawdown intradía, el bot se detiene o
+cierra posiciones según la configuración. Esto complementa el seguimiento del
+drawdown global que realiza el gestor de riesgo.
+
+## Ejemplos
+
+Configuración orientada a una cuenta pequeña operando un activo de bajo valor:
+
+```yaml
+backtest:
+  data: data/examples/btcusdt_1m.csv   # reemplazar con datos del activo elegido
+  symbol: DOGE/USDT
+  strategy: breakout_atr
+  initial_equity: 100
+
+risk:
+  equity_pct: 0.05
+  risk_pct: 0.02
+```


### PR DESCRIPTION
## Summary
- documentar cálculo de `equity_pct` y `risk_pct`
- explicar uso de `strength` y relación con `DailyGuard`
- añadir ejemplo para cuentas pequeñas y activos baratos

## Testing
- `pytest` *(interrumpido: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68adda492b24832d86f1caab9030608f