### PR TITLE
Replace max_pos with equity percentage

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -81,9 +81,9 @@
         <label for="bt-trade-qty">Tamaño orden</label>
         <input id="bt-trade-qty" type="number" step="any"/>
       </div>
-      <div id="field-max-pos">
-        <label for="bt-max-pos">Posición máxima</label>
-        <input id="bt-max-pos" type="number" step="any"/>
+      <div id="field-max-equity-pct">
+        <label for="bt-max-equity-pct">Equity máx %</label>
+        <input id="bt-max-equity-pct" type="number" step="any"/>
       </div>
       <div id="field-stop-loss-pct">
         <label for="bt-stop-loss-pct">Stop loss %</label>
@@ -288,7 +288,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-trade-qty','field-max-pos','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+  ['field-trade-qty','field-max-equity-pct','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -345,12 +345,12 @@ async function runBacktest(){
   }
   if(mode!=='walk'){
     const tq=document.getElementById('bt-trade-qty').value.trim();
-    const mp=document.getElementById('bt-max-pos').value.trim();
+    const me=document.getElementById('bt-max-equity-pct').value.trim();
     const sl=document.getElementById('bt-stop-loss-pct').value.trim();
     const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
     if(tq) cmd+=` --trade-qty ${tq}`;
-    if(mp) cmd+=` --max-pos ${mp}`;
+    if(me) cmd+=` --max-equity-pct ${me}`;
     if(sl) cmd+=` --stop-loss-pct ${sl}`;
     if(dd) cmd+=` --max-drawdown-pct ${dd}`;
     if(mn) cmd+=` --max-notional ${mn}`;

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -146,7 +146,7 @@ class EventDrivenBacktestEngine:
         seed: int | None = None,
         initial_equity: float = 0.0,
         trade_qty: float = 1.0,
-        max_pos: float = 1.0,
+        max_equity_pct: float = 1.0,
         max_drawdown_pct: float = 0.0,
         stop_loss_pct: float = 0.0,
         max_notional: float = 0.0,
@@ -172,7 +172,7 @@ class EventDrivenBacktestEngine:
 
         self.initial_equity = float(initial_equity)
         self.trade_qty = float(trade_qty)
-        self._max_pos = float(max_pos)
+        self._max_equity_pct = float(max_equity_pct)
         self._max_drawdown_pct = float(max_drawdown_pct)
         self._stop_loss_pct = float(stop_loss_pct)
         self._max_notional = float(max_notional)
@@ -209,7 +209,7 @@ class EventDrivenBacktestEngine:
                 else None
             )
             self.risk[key] = RiskManager(
-                max_pos=self._max_pos,
+                max_equity_pct=self._max_equity_pct,
                 stop_loss_pct=self._stop_loss_pct,
                 max_drawdown_pct=self._max_drawdown_pct,
                 limits=limits,
@@ -490,7 +490,7 @@ def run_backtest_csv(
     stress: StressConfig | None = None,
     seed: int | None = None,
     trade_qty: float = 1.0,
-    max_pos: float = 1.0,
+    max_equity_pct: float = 1.0,
     max_drawdown_pct: float = 0.0,
     stop_loss_pct: float = 0.0,
     max_notional: float = 0.0,
@@ -511,7 +511,7 @@ def run_backtest_csv(
         stress=stress,
         seed=seed,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        max_equity_pct=max_equity_pct,
         max_drawdown_pct=max_drawdown_pct,
         stop_loss_pct=stop_loss_pct,
         max_notional=max_notional,
@@ -538,7 +538,7 @@ def run_backtest_mlflow(
     seed: int | None = None,
     experiment: str = "backtest",
     trade_qty: float = 1.0,
-    max_pos: float = 1.0,
+    max_equity_pct: float = 1.0,
     max_drawdown_pct: float = 0.0,
     stop_loss_pct: float = 0.0,
     max_notional: float = 0.0,
@@ -572,7 +572,7 @@ def run_backtest_mlflow(
             stress=stress,
             seed=seed,
             trade_qty=trade_qty,
-            max_pos=max_pos,
+            max_equity_pct=max_equity_pct,
             max_drawdown_pct=max_drawdown_pct,
             stop_loss_pct=stop_loss_pct,
             max_notional=max_notional,

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -881,7 +881,9 @@ def backtest(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    max_equity_pct: float = typer.Option(
+        1.0, "--max-equity-pct", help="Max equity percentage"
+    ),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -902,7 +904,7 @@ def backtest(
         [(strategy, symbol)],
         initial_equity=capital,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        max_equity_pct=max_equity_pct,
         stop_loss_pct=stop_loss_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
@@ -917,7 +919,9 @@ def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    max_equity_pct: float = typer.Option(
+        1.0, "--max-equity-pct", help="Max equity percentage"
+    ),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -958,7 +962,7 @@ def backtest_cfg(
             [(strategy, symbol)],
             initial_equity=capital,
             trade_qty=trade_qty,
-            max_pos=max_pos,
+            max_equity_pct=max_equity_pct,
             stop_loss_pct=stop_loss_pct,
             max_drawdown_pct=max_drawdown_pct,
             max_notional=max_notional,
@@ -990,7 +994,9 @@ def backtest_db(
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    max_equity_pct: float = typer.Option(
+        1.0, "--max-equity-pct", help="Max equity percentage"
+    ),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -1039,7 +1045,7 @@ def backtest_db(
         [(strategy, symbol)],
         initial_equity=capital,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        max_equity_pct=max_equity_pct,
         stop_loss_pct=stop_loss_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -103,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_equity_pct=1.0)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -49,7 +49,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_equity_pct=1.0)
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -108,7 +108,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_equity_pct=1.0)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_usdt=total_cap_usdt,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -74,7 +74,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_equity_pct=1.0)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,4 +106,4 @@ def breakout_df_sell():
 def risk_manager():
     from tradingbot.risk.manager import RiskManager
 
-    return RiskManager(max_pos=5)
+    return RiskManager(max_equity_pct=5)

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -27,7 +27,7 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         slippage=SlippageModel(volume_impact=0.0),
     )
     risk = engine.risk[("alwaysbuy", sym)]
-    risk.max_pos = 1.0
+    risk.max_equity_pct = 1.0
     result = engine.run()
     assert len(result["fills"]) == 1
     avg_price = result["orders"][0]["avg_price"]

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -50,7 +50,7 @@ def test_correlation_service_window_rolls():
 
 def test_risk_service_uses_correlation_service():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(max_equity_pct=10, vol_target=0.02)
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)
     now = datetime.now(timezone.utc)
@@ -89,7 +89,7 @@ def test_correlation_guard_groups_and_cap():
 
 
 def test_update_correlation_uses_guard_for_global_cap():
-    rm = RiskManager(max_pos=12)
+    rm = RiskManager(max_equity_pct=12)
     pairs = {
         ("BTC", "ETH"): 0.9,
         ("ETH", "SOL"): 0.85,
@@ -97,4 +97,4 @@ def test_update_correlation_uses_guard_for_global_cap():
     }
     exceeded = rm.update_correlation(pairs, 0.8)
     assert set(exceeded) == {("BTC", "ETH"), ("ETH", "SOL")}
-    assert rm.max_pos == pytest.approx(4.0)
+    assert rm.max_equity_pct == pytest.approx(4.0)

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -87,7 +87,7 @@ class DummyExec:
 async def test_bybit_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "RiskManager", lambda max_equity_pct: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
@@ -147,7 +147,7 @@ async def test_run_real(monkeypatch):
     rr = importlib.reload(rr)
     monkeypatch.setattr(rr, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rr, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rr, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rr, "RiskManager", lambda max_equity_pct: DummyRisk())
     monkeypatch.setattr(rr, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rr, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rr, "PaperAdapter", DummyBroker)
@@ -200,7 +200,7 @@ class DummyExec2(DummyExec):
 async def test_okx_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "RiskManager", lambda max_equity_pct: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -20,7 +20,7 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.positions" (venue, symbol, qty, avg_price, realized_pnl, fees_paid) VALUES ("paper", "BTCUSDT", 1.5, 10000, 0, 0);'))
         conn.execute(text('INSERT INTO "market.oco_orders" (venue, symbol, side, qty, entry_price, sl_price, tp_price, status) VALUES ("paper", "BTCUSDT", "long", 1.5, 10000, 9500, 10500, "active");'))
 
-    rm = RiskManager(max_pos=5)
+    rm = RiskManager(max_equity_pct=5)
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1e6, per_symbol_cap_usdt=1e6, venue="paper"))
     risk = RiskService(rm, guard)
 

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -18,7 +18,7 @@ def test_covariance_and_aggregation():
 
 
 def test_adjust_size_and_portfolio_risk():
-    rm = RiskManager(max_pos=2)
+    rm = RiskManager(max_equity_pct=2)
     corr = {("A", "B"): 0.9}
     size = rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
     assert size == pytest.approx(1.0)
@@ -33,12 +33,12 @@ def test_adjust_size_and_portfolio_risk():
 
 
 def test_de_risk_reduces_exposure():
-    rm = RiskManager(max_pos=10, vol_target=1.0)
+    rm = RiskManager(max_equity_pct=10, vol_target=1.0)
     rm.update_pnl(100)
-    assert rm.max_pos == pytest.approx(10)
+    assert rm.max_equity_pct == pytest.approx(10)
     rm.update_pnl(-30)  # drawdown 30%
-    assert rm.max_pos == pytest.approx(5)
+    assert rm.max_equity_pct == pytest.approx(5)
     assert rm.vol_target == pytest.approx(0.5)
     rm.update_pnl(-25)  # drawdown 55%
-    assert rm.max_pos == pytest.approx(2.5)
+    assert rm.max_equity_pct == pytest.approx(2.5)
     assert rm.vol_target == pytest.approx(0.25)

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -12,7 +12,7 @@ from tradingbot.risk.limits import RiskLimits
 
 
 def test_stop_loss_sets_reason():
-    rm = RiskManager(max_pos=1, stop_loss_pct=0.05)
+    rm = RiskManager(max_equity_pct=1, stop_loss_pct=0.05)
     rm.set_position(1)
     assert rm.check_limits(100)
     assert not rm.check_limits(94)
@@ -22,7 +22,7 @@ def test_stop_loss_sets_reason():
 
 
 def test_drawdown_sets_reason():
-    rm = RiskManager(max_pos=1, max_drawdown_pct=0.05)
+    rm = RiskManager(max_equity_pct=1, max_drawdown_pct=0.05)
     rm.set_position(1)
     assert rm.check_limits(100)
     assert rm.check_limits(110)
@@ -33,7 +33,7 @@ def test_drawdown_sets_reason():
 
 
 def test_manual_kill_switch_records_reason():
-    rm = RiskManager(max_pos=1)
+    rm = RiskManager(max_equity_pct=1)
     rm.kill_switch("manual")
     assert rm.enabled is False
     assert rm.last_kill_reason == "manual"
@@ -41,7 +41,7 @@ def test_manual_kill_switch_records_reason():
 
 
 def test_reset_clears_kill_switch():
-    rm = RiskManager(max_pos=1)
+    rm = RiskManager(max_equity_pct=1)
     rm.kill_switch("manual")
     assert rm.enabled is False
     assert KILL_SWITCH_ACTIVE._value.get() == 1.0
@@ -53,7 +53,7 @@ def test_reset_clears_kill_switch():
 
 
 def test_daily_loss_limit_triggers_kill_switch():
-    rm = RiskManager(max_pos=1, daily_loss_limit=50)
+    rm = RiskManager(max_equity_pct=1, daily_loss_limit=50)
     rm.set_position(1)
     rm.check_limits(100)
     rm.update_pnl(-60)
@@ -85,7 +85,7 @@ async def test_update_correlation_emits_pause():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=8, bus=bus)
+    rm = RiskManager(max_equity_pct=8, bus=bus)
     pairs = {("BTC", "ETH"): 0.9}
     exceeded = rm.update_correlation(pairs, 0.8)
     await asyncio.sleep(0)
@@ -98,7 +98,7 @@ async def test_update_covariance_emits_pause():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=8, bus=bus)
+    rm = RiskManager(max_equity_pct=8, bus=bus)
     cov = {
         ("BTC", "BTC"): 0.04,
         ("ETH", "ETH"): 0.04,

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -24,7 +24,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(max_pos=2.0, bus=bus)
+    rm = RiskManager(max_equity_pct=2.0, bus=bus)
     guard = PortfolioGuard(
         GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="test")
     )
@@ -35,7 +35,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     exceeded = svc.update_correlation(0.8)
     await asyncio.sleep(0)
     assert exceeded == [("AAA", "BBB")]
-    assert rm.max_pos == pytest.approx(1.0)
+    assert rm.max_equity_pct == pytest.approx(1.0)
     assert events and events[0]["reason"] == "correlation"
 
     allowed, _, delta = svc.check_order(

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -8,10 +8,10 @@ from tradingbot.risk.position_sizing import vol_target
 
 
 def test_risk_vol_sizing(synthetic_volatility):
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(max_equity_pct=10, vol_target=0.02)
     delta = rm.size("buy", symbol="BTC", symbol_vol=synthetic_volatility)
-    expected = rm.max_pos + min(
-        rm.max_pos, rm.max_pos * rm.vol_target / synthetic_volatility
+    expected = rm.max_equity_pct + min(
+        rm.max_equity_pct, rm.max_equity_pct * rm.vol_target / synthetic_volatility
     )
     assert delta == pytest.approx(expected)
 
@@ -25,7 +25,7 @@ def test_vol_target_caps_notional():
 
 
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(max_equity_pct=10, vol_target=0.02)
     corr = {("BTC", "ETH"): 0.9}
     delta = rm.size(
         "buy",
@@ -34,8 +34,8 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
         correlations=corr,
         threshold=0.8,
     )
-    expected = rm.max_pos + min(
-        rm.max_pos, rm.max_pos * rm.vol_target / synthetic_volatility
+    expected = rm.max_equity_pct + min(
+        rm.max_equity_pct, rm.max_equity_pct * rm.vol_target / synthetic_volatility
     )
     expected *= 0.5
     assert delta == pytest.approx(expected)
@@ -43,11 +43,11 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
 
 def test_risk_service_uses_guard_volatility():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
-    rm = RiskManager(max_pos=10, vol_target=0.02)
+    rm = RiskManager(max_equity_pct=10, vol_target=0.02)
     svc = RiskService(rm, guard)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
     allowed, _, delta = svc.check_order("BTC", "buy", price=100.0)
     vol = np.std([0.01, -0.02, 0.03]) * np.sqrt(365)
-    expected = rm.max_pos + min(rm.max_pos, rm.max_pos * rm.vol_target / vol)
+    expected = rm.max_equity_pct + min(rm.max_equity_pct, rm.max_equity_pct * rm.vol_target / vol)
     assert allowed
     assert delta == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- rename `max_pos` parameter to `max_equity_pct` across risk management, CLI, and runners
- update web UI and tests to use equity percentage terminology
- remove remaining references to `max_pos`

## Testing
- `pytest` *(killed: process was terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68adda4b8f2c832da6abc761af410547