### PR TITLE
Define signal strength as equity fraction

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -244,7 +244,7 @@ class RiskManager:
         signal_side:
             "buy" para posición larga, "sell" para corta.
         strength:
-            Factor para escalar la posición objetivo.
+            Fracción de la asignación permitida a la que se desea llegar (0-1).
         symbol:
             Símbolo del activo (necesario si se aplican correlaciones).
         symbol_vol:
@@ -258,7 +258,8 @@ class RiskManager:
         target = self.max_pos * (
             1 if signal_side == "buy" else -1 if signal_side == "sell" else 0
         )
-        delta = (target - self.pos.qty) * strength
+        desired = target * strength
+        delta = desired - self.pos.qty
 
         if symbol_vol > 0:
             delta += self.size_with_volatility(symbol_vol)

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -68,8 +68,26 @@ class RiskService:
     ) -> tuple[bool, str, float]:
         """Check limits and compute sized order before submitting.
 
-        Returns ``(allowed, reason, delta)`` where ``delta`` is the signed size
-        proposed after volatility and correlation adjustments.
+        Parameters
+        ----------
+        symbol:
+            Instrument identifier.
+        side:
+            ``"buy"`` or ``"sell"``.
+        price:
+            Reference price used for limit checks.
+        strength:
+            Desired fraction of the maximum allowed position (0-1).
+        symbol_vol:
+            Optional volatility override for the symbol.
+        corr_threshold:
+            Correlation threshold above which sizing is reduced.
+
+        Returns
+        -------
+        tuple[bool, str, float]
+            ``(allowed, reason, delta)`` where ``delta`` is the signed size
+            proposed after volatility and correlation adjustments.
         """
 
         if symbol_vol is None or symbol_vol <= 0:

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -9,8 +9,24 @@ import yaml
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
 
+
 @dataclass
 class Signal:
+    """Strategy decision representing the desired exposure.
+
+    Attributes
+    ----------
+    side:
+        ``"buy"``, ``"sell"`` or ``"flat"``.
+    strength:
+        Fraction of the allowed equity allocation the strategy wishes to hold
+        (0.0 - 1.0).  A value above the current allocation pyramids the
+        position while a lower value requests de-scaling.
+    reduce_only:
+        When ``True`` the resulting order may only reduce an existing position,
+        preventing accidental position flips during partial exits.
+    """
+
     side: str  # 'buy' | 'sell' | 'flat'
     strength: float = 1.0
     reduce_only: bool = False

--- a/src/tradingbot/strategies/sizing.py
+++ b/src/tradingbot/strategies/sizing.py
@@ -1,0 +1,59 @@
+"""Utility helpers for fractional position sizing.
+
+These helpers illustrate how ``Signal.strength`` maps to actual position
+sizes under the fractional allocation model.
+"""
+
+from .base import Signal
+
+
+def target_signal(side: str, current_fraction: float, target_fraction: float) -> Signal:
+    """Return a :class:`Signal` aiming for ``target_fraction`` of the allocation.
+
+    ``strength`` is set to ``target_fraction``.  When ``target_fraction`` is
+    below ``current_fraction`` a ``reduce_only`` flag is emitted to ensure a
+    partial exit.
+
+    Examples
+    --------
+    >>> target_signal("buy", 0.3, 0.5)
+    Signal(side='buy', strength=0.5, reduce_only=False)
+    >>> target_signal("buy", 0.6, 0.2)
+    Signal(side='buy', strength=0.2, reduce_only=True)
+    """
+    reduce = target_fraction < current_fraction
+    return Signal(side, strength=target_fraction, reduce_only=reduce)
+
+
+def strength_to_delta(max_position: float, current_qty: float, side: str, strength: float) -> float:
+    """Translate ``strength`` into the position delta required.
+
+    Parameters
+    ----------
+    max_position:
+        Maximum absolute position permitted.
+    current_qty:
+        Current position quantity.
+    side:
+        ``"buy"`` or ``"sell"``.
+    strength:
+        Desired allocation fraction between 0 and 1.
+
+    Returns
+    -------
+    float
+        Signed quantity delta needed to reach the target allocation.
+
+    Examples
+    --------
+    >>> strength_to_delta(100, 30, 'buy', 0.5)
+    20.0
+    >>> strength_to_delta(100, 30, 'sell', 0.2)
+    -50.0
+    """
+    target = max_position if side == "buy" else -max_position if side == "sell" else 0.0
+    desired = target * strength
+    return desired - current_qty
+
+
+__all__ = ["target_signal", "strength_to_delta"]


### PR DESCRIPTION
## Summary
- Document signal `strength` as fraction of allowed equity and explain `reduce_only`
- Interpret signal strength as target allocation in `RiskManager.size`
- Add strategy sizing helpers to map strength to position deltas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68addac5ab4c832dad9ad1b91d5c6747