### PR TITLE
Add equity and risk percentage options for risk management

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -81,9 +81,13 @@
         <label for="bt-trade-qty">Tamaño orden</label>
         <input id="bt-trade-qty" type="number" step="any"/>
       </div>
-      <div id="field-max-pos">
-        <label for="bt-max-pos">Posición máxima</label>
-        <input id="bt-max-pos" type="number" step="any"/>
+      <div id="field-equity-pct">
+        <label for="bt-equity-pct">Equity %</label>
+        <input id="bt-equity-pct" type="number" step="any"/>
+      </div>
+      <div id="field-risk-pct">
+        <label for="bt-risk-pct">Riesgo %</label>
+        <input id="bt-risk-pct" type="number" step="any"/>
       </div>
       <div id="field-stop-loss-pct">
         <label for="bt-stop-loss-pct">Stop loss %</label>
@@ -288,7 +292,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-trade-qty','field-max-pos','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+  ['field-trade-qty','field-equity-pct','field-risk-pct','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -345,12 +349,14 @@ async function runBacktest(){
   }
   if(mode!=='walk'){
     const tq=document.getElementById('bt-trade-qty').value.trim();
-    const mp=document.getElementById('bt-max-pos').value.trim();
+    const eqp=document.getElementById('bt-equity-pct').value.trim();
+    const rp=document.getElementById('bt-risk-pct').value.trim();
     const sl=document.getElementById('bt-stop-loss-pct').value.trim();
     const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
     if(tq) cmd+=` --trade-qty ${tq}`;
-    if(mp) cmd+=` --max-pos ${mp}`;
+    if(eqp) cmd+=` --equity-pct ${eqp}`;
+    if(rp) cmd+=` --risk-pct ${rp}`;
     if(sl) cmd+=` --stop-loss-pct ${sl}`;
     if(dd) cmd+=` --max-drawdown-pct ${dd}`;
     if(mn) cmd+=` --max-notional ${mn}`;

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -150,6 +150,8 @@ class EventDrivenBacktestEngine:
         max_drawdown_pct: float = 0.0,
         stop_loss_pct: float = 0.0,
         max_notional: float = 0.0,
+        equity_pct: float = 0.0,
+        risk_pct: float = 0.0,
     ) -> None:
         self.data = data
         self.latency = int(latency)
@@ -176,6 +178,8 @@ class EventDrivenBacktestEngine:
         self._max_drawdown_pct = float(max_drawdown_pct)
         self._stop_loss_pct = float(stop_loss_pct)
         self._max_notional = float(max_notional)
+        self._equity_pct = float(equity_pct)
+        self._risk_pct = float(risk_pct)
 
         # Exchange specific configurations
         self.exchange_latency: Dict[str, int] = {}
@@ -212,6 +216,8 @@ class EventDrivenBacktestEngine:
                 max_pos=self._max_pos,
                 stop_loss_pct=self._stop_loss_pct,
                 max_drawdown_pct=self._max_drawdown_pct,
+                equity_pct=self._equity_pct,
+                risk_pct=self._risk_pct,
                 limits=limits,
             )
             self.strategy_exchange[key] = exchange

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -745,12 +745,15 @@ def run_daemon(config: str = "config/config.yaml") -> None:
 
         adapter = BinanceSpotWSAdapter()
         bus = EventBus()
-        risk = RiskManager(bus=bus)
+        r_cfg = getattr(cfg, "risk", {})
+        eq_pct = getattr(r_cfg, "equity_pct", 0.0)
+        r_pct = getattr(r_cfg, "risk_pct", 0.0)
+        risk = RiskManager(bus=bus, equity_pct=eq_pct, risk_pct=r_pct)
         strat = BreakoutATR()
         router = ExecutionRouter(adapters=[adapter])
 
-        corr_thr = getattr(getattr(cfg, "risk", {}), "correlation_threshold", 0.8)
-        ret_win = getattr(getattr(cfg, "risk", {}), "returns_window", 100)
+        corr_thr = getattr(r_cfg, "correlation_threshold", 0.8)
+        ret_win = getattr(r_cfg, "returns_window", 100)
         bal_cfg = getattr(cfg, "balance", {})
         bal_assets = getattr(bal_cfg, "assets", [])
         bal_thr = getattr(bal_cfg, "threshold", 0.0)
@@ -881,7 +884,8 @@ def backtest(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Equity allocation %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk per trade %"),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -902,7 +906,8 @@ def backtest(
         [(strategy, symbol)],
         initial_equity=capital,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        equity_pct=equity_pct,
+        risk_pct=risk_pct,
         stop_loss_pct=stop_loss_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
@@ -917,7 +922,8 @@ def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Equity allocation %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk per trade %"),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -958,7 +964,8 @@ def backtest_cfg(
             [(strategy, symbol)],
             initial_equity=capital,
             trade_qty=trade_qty,
-            max_pos=max_pos,
+            equity_pct=equity_pct,
+            risk_pct=risk_pct,
             stop_loss_pct=stop_loss_pct,
             max_drawdown_pct=max_drawdown_pct,
             max_notional=max_notional,
@@ -990,7 +997,8 @@ def backtest_db(
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
-    max_pos: float = typer.Option(1.0, "--max-pos", help="Max position size"),
+    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Equity allocation %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk per trade %"),
     stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -1039,7 +1047,8 @@ def backtest_db(
         [(strategy, symbol)],
         initial_equity=capital,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        equity_pct=equity_pct,
+        risk_pct=risk_pct,
         stop_loss_pct=stop_loss_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -24,6 +24,9 @@ storage:
 risk:
   correlation_threshold: 0.8
   returns_window: 100
+  equity_pct: 0.0
+  risk_pct: 0.0
+  pyramid_pct_step: null
 balance:
   enabled: false
   threshold: 0.0

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -57,6 +57,9 @@ class RiskConfig:
 
     correlation_threshold: float = 0.8
     returns_window: int = 100
+    equity_pct: float = 0.0
+    risk_pct: float = 0.0
+    pyramid_pct_step: float | None = None
 
 
 @dataclass

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -94,6 +94,8 @@ async def run_live_binance(
     daily_max_loss_usdt: float = 100.0,
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
+    equity_pct: float = 0.0,
+    risk_pct: float = 0.0,
     *,
     config_path: str | None = None,
 ):
@@ -103,7 +105,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_pos=1.0, equity_pct=equity_pct, risk_pct=risk_pct)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -27,7 +27,8 @@ except Exception:  # pragma: no cover
 log = logging.getLogger(__name__)
 
 
-async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = None) -> None:
+async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = None,
+                            equity_pct: float = 0.0, risk_pct: float = 0.0) -> None:
     """Run cross exchange arbitrage using ``ExecutionRouter``.
 
     Parameters
@@ -40,7 +41,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     bus = EventBus()
     if risk is None:
         risk = RiskService(
-            RiskManager(),
+            RiskManager(equity_pct=equity_pct, risk_pct=risk_pct),
             PortfolioGuard(GuardConfig(venue="cross")),
             daily=None,
         )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -41,6 +41,8 @@ async def run_paper(
     *,
     config_path: str | None = None,
     metrics_port: int = 8000,
+    equity_pct: float = 0.0,
+    risk_pct: float = 0.0,
     corr_threshold: float = 0.8,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
@@ -49,7 +51,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_pos=1.0, equity_pct=equity_pct, risk_pct=risk_pct)
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -97,6 +97,8 @@ async def _run_symbol(
     daily_max_drawdown_pct: float,
     max_consecutive_losses: int,
     corr_threshold: float,
+    equity_pct: float,
+    risk_pct: float,
     config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
@@ -108,7 +110,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_pos=1.0, equity_pct=equity_pct, risk_pct=risk_pct)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_usdt=total_cap_usdt,
@@ -201,6 +203,8 @@ async def run_live_real(
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
+    equity_pct: float = 0.0,
+    risk_pct: float = 0.0,
     config_path: str | None = None,
 ) -> None:
     """Run a simple live loop on a real crypto exchange."""
@@ -232,6 +236,8 @@ async def run_live_real(
             daily_max_drawdown_pct,
             max_consecutive_losses,
             corr_threshold,
+            equity_pct,
+            risk_pct,
             config_path=config_path,
         )
         for c in cfgs

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -54,6 +54,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
                       soft_cap_pct: float, soft_cap_grace_sec: int,
                       daily_max_loss_usdt: float, daily_max_drawdown_pct: float,
                       max_consecutive_losses: int, corr_threshold: float,
+                      equity_pct: float, risk_pct: float,
                       config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     ws_kwargs: Dict[str, Any] = {"testnet": True}
@@ -74,7 +75,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(max_pos=1.0, equity_pct=equity_pct, risk_pct=risk_pct)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,
@@ -159,6 +160,8 @@ async def run_live_testnet(
     daily_max_drawdown_pct: float = 0.05,
     max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
+    equity_pct: float = 0.0,
+    risk_pct: float = 0.0,
     *,
     config_path: str | None = None,
 ) -> None:
@@ -182,6 +185,8 @@ async def run_live_testnet(
             daily_max_drawdown_pct,
             max_consecutive_losses,
             corr_threshold,
+            equity_pct,
+            risk_pct,
             config_path=config_path,
         )
         for c in cfgs

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -41,7 +41,8 @@ class TriConfig:
     edge_threshold: float = 0.001
     persist_pg: bool = False  # <-- nuevo flag
 
-async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None):
+async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None,
+                                 equity_pct: float = 0.0, risk_pct: float = 0.0):
     syms = make_symbols(cfg.route)
     streams = [_stream_name(syms.bq), _stream_name(syms.mq), _stream_name(syms.mb)]
     url = BINANCE_WS + "/".join(streams)
@@ -51,7 +52,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
     fills = 0
     if risk is None:
         risk = RiskService(
-            RiskManager(),
+            RiskManager(equity_pct=equity_pct, risk_pct=risk_pct),
             PortfolioGuard(GuardConfig(venue="binance")),
         )
 

--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -55,6 +55,9 @@ class RiskManager:
         *,
         daily_loss_limit: float = 0.0,
         daily_drawdown_pct: float = 0.0,
+        equity_pct: float = 0.0,
+        risk_pct: float = 0.0,
+        pyramid_pct_step: float | None = None,
         limits: RiskLimits | None = None,
         bus: EventBus | None = None,
     ):
@@ -79,6 +82,10 @@ class RiskManager:
         self.daily_drawdown_pct = abs(daily_drawdown_pct)
         self.daily_pnl: float = 0.0
         self._daily_peak: float = 0.0
+
+        self.equity_pct = abs(equity_pct)
+        self.risk_pct = abs(risk_pct)
+        self.pyramid_pct_step = pyramid_pct_step
 
         self.enabled = True
         self.last_kill_reason: str | None = None

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -87,7 +87,7 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
     engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None
     if cfg.persist_pg and not _CAN_PG:
         log.warning("Persistencia habilitada pero Timescale no disponible.")
-    risk = RiskManager()
+    risk = RiskManager(equity_pct=0.0, risk_pct=0.0)
 
     async def maybe_trade() -> None:
         if last["spot"] is None or last["perp"] is None:

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -32,7 +32,7 @@ class DummyStrat:
 
 
 class DummyRisk:
-    def size(self, side, strength):
+    def size(self, side, strength, **k):
         return 1.0
 
     def check_limits(self, price):
@@ -41,13 +41,28 @@ class DummyRisk:
     def add_fill(self, side, qty):
         pass
 
+    def update_correlation(self, pairs, threshold):
+        return []
+
+    def update_position(self, *a, **k):
+        pass
+
 
 class DummyPG:
+    def __init__(self):
+        self.st = type("S", (), {"venue_positions": {}})()
+
     def mark_price(self, symbol, px):
         pass
 
     def soft_cap_decision(self, *a):
         return ("allow", "", None)
+
+    def volatility(self, symbol):
+        return 0.0
+
+    def update_position_on_order(self, *a, **k):
+        pass
 
 
 class DummyDG:
@@ -86,11 +101,12 @@ class DummyExec:
 @pytest.mark.asyncio
 async def test_bybit_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
-    monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "BreakoutATR", lambda *a, **k: DummyStrat())
+    monkeypatch.setattr(rt, "RiskManager", lambda max_pos, **k: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
+    monkeypatch.setattr(rt, "_CAN_PG", False)
 
     monkeypatch.setitem(
         rt.ADAPTERS,
@@ -112,6 +128,9 @@ async def test_bybit_futures_order(monkeypatch):
         daily_max_loss_usdt=100.0,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
+        corr_threshold=0.8,
+        equity_pct=0.0,
+        risk_pct=0.0,
     )
 
     inst = DummyExec.last_instance
@@ -146,11 +165,12 @@ async def test_run_real(monkeypatch):
     import tradingbot.live.runner_real as rr
     rr = importlib.reload(rr)
     monkeypatch.setattr(rr, "BarAggregator", DummyAgg)
-    monkeypatch.setattr(rr, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rr, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rr, "BreakoutATR", lambda *a, **k: DummyStrat())
+    monkeypatch.setattr(rr, "RiskManager", lambda max_pos, **k: DummyRisk())
     monkeypatch.setattr(rr, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rr, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rr, "PaperAdapter", DummyBroker)
+    monkeypatch.setattr(rr, "_CAN_PG", False)
     monkeypatch.setitem(
         rr.ADAPTERS,
         ("binance", "spot"),
@@ -171,6 +191,9 @@ async def test_run_real(monkeypatch):
         daily_max_loss_usdt=100.0,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
+        corr_threshold=0.8,
+        equity_pct=0.0,
+        risk_pct=0.0,
     )
 
     inst = DummyExecReal.last_instance
@@ -199,11 +222,12 @@ class DummyExec2(DummyExec):
 @pytest.mark.asyncio
 async def test_okx_futures_order(monkeypatch):
     monkeypatch.setattr(rt, "BarAggregator", DummyAgg)
-    monkeypatch.setattr(rt, "BreakoutATR", lambda: DummyStrat())
-    monkeypatch.setattr(rt, "RiskManager", lambda max_pos: DummyRisk())
+    monkeypatch.setattr(rt, "BreakoutATR", lambda *a, **k: DummyStrat())
+    monkeypatch.setattr(rt, "RiskManager", lambda max_pos, **k: DummyRisk())
     monkeypatch.setattr(rt, "PortfolioGuard", lambda config: DummyPG())
     monkeypatch.setattr(rt, "DailyGuard", lambda limits, venue: DummyDG())
     monkeypatch.setattr(rt, "PaperAdapter", DummyBroker)
+    monkeypatch.setattr(rt, "_CAN_PG", False)
 
     monkeypatch.setitem(
         rt.ADAPTERS,
@@ -225,6 +249,9 @@ async def test_okx_futures_order(monkeypatch):
         daily_max_loss_usdt=100.0,
         daily_max_drawdown_pct=0.05,
         max_consecutive_losses=3,
+        corr_threshold=0.8,
+        equity_pct=0.0,
+        risk_pct=0.0,
     )
 
     inst = DummyExec2.last_instance


### PR DESCRIPTION
## Summary
- add `equity_pct`, `risk_pct` and optional `pyramid_pct_step` to risk configuration
- replace `--max-pos` with `--equity-pct`/`--risk-pct` in backtest CLI and propagate to engines and runners
- update risk manager and examples to accept the new percentage-based settings

## Testing
- `pytest` *(fails: process killed)*
- `pytest tests/test_live_runner.py::test_bybit_futures_order -q`

------
https://chatgpt.com/codex/tasks/task_e_68adda3e0df0832d8e12634e738f07c3