### PR TITLE
Refactor daily guard to equity percentages

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -91,9 +91,8 @@ async def run_live_binance(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
-    max_consecutive_losses: int = 3,
     *,
     config_path: str | None = None,
 ):
@@ -113,9 +112,8 @@ async def run_live_binance(
         soft_cap_grace_sec=soft_cap_grace_sec,
     ))
     dguard = DailyGuard(GuardLimits(
-        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_loss_pct=daily_max_loss_pct,
         daily_max_drawdown_pct=daily_max_drawdown_pct,
-        max_consecutive_losses=max_consecutive_losses,
         halt_action="close_all",
     ), venue="binance")
     pg_engine = get_engine() if (persist_pg and _CAN_PG) else None

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -93,9 +93,8 @@ async def _run_symbol(
     per_symbol_cap_usdt: float,
     soft_cap_pct: float,
     soft_cap_grace_sec: int,
-    daily_max_loss_usdt: float,
+    daily_max_loss_pct: float,
     daily_max_drawdown_pct: float,
-    max_consecutive_losses: int,
     corr_threshold: float,
     config_path: str | None = None,
 ) -> None:
@@ -120,9 +119,8 @@ async def _run_symbol(
     )
     dguard = DailyGuard(
         GuardLimits(
-            daily_max_loss_usdt=daily_max_loss_usdt,
+            daily_max_loss_pct=daily_max_loss_pct,
             daily_max_drawdown_pct=daily_max_drawdown_pct,
-            max_consecutive_losses=max_consecutive_losses,
             halt_action="close_all",
         ),
         venue=venue,
@@ -197,9 +195,8 @@ async def run_live_real(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
-    max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
     config_path: str | None = None,
 ) -> None:
@@ -228,9 +225,8 @@ async def run_live_real(
             per_symbol_cap_usdt,
             soft_cap_pct,
             soft_cap_grace_sec,
-            daily_max_loss_usdt,
+            daily_max_loss_pct,
             daily_max_drawdown_pct,
-            max_consecutive_losses,
             corr_threshold,
             config_path=config_path,
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -52,8 +52,8 @@ class _SymbolConfig:
 async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: int,
                       dry_run: bool, total_cap_usdt: float, per_symbol_cap_usdt: float,
                       soft_cap_pct: float, soft_cap_grace_sec: int,
-                      daily_max_loss_usdt: float, daily_max_drawdown_pct: float,
-                      max_consecutive_losses: int, corr_threshold: float,
+                      daily_max_loss_pct: float, daily_max_drawdown_pct: float,
+                      corr_threshold: float,
                       config_path: str | None = None) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     ws_kwargs: Dict[str, Any] = {"testnet": True}
@@ -83,9 +83,8 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         soft_cap_grace_sec=soft_cap_grace_sec,
     ))
     dguard = DailyGuard(GuardLimits(
-        daily_max_loss_usdt=daily_max_loss_usdt,
+        daily_max_loss_pct=daily_max_loss_pct,
         daily_max_drawdown_pct=daily_max_drawdown_pct,
-        max_consecutive_losses=max_consecutive_losses,
         halt_action="close_all",
     ), venue=venue)
     corr = CorrelationService()
@@ -155,9 +154,8 @@ async def run_live_testnet(
     per_symbol_cap_usdt: float = 500.0,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
-    daily_max_loss_usdt: float = 100.0,
+    daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
-    max_consecutive_losses: int = 3,
     corr_threshold: float = 0.8,
     *,
     config_path: str | None = None,
@@ -178,9 +176,8 @@ async def run_live_testnet(
             per_symbol_cap_usdt,
             soft_cap_pct,
             soft_cap_grace_sec,
-            daily_max_loss_usdt,
+            daily_max_loss_pct,
             daily_max_drawdown_pct,
-            max_consecutive_losses,
             corr_threshold,
             config_path=config_path,
         )

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -110,7 +110,8 @@ async def test_daily_guard_halts_on_loss():
 
     broker = PaperAdapter()
     symbol = "BTC/USDT"
-    guard = DailyGuard(GuardLimits(daily_max_loss_usdt=5.0), venue="paper")
+    guard = DailyGuard(GuardLimits(daily_max_loss_pct=0.05), venue="paper")
+    broker.state.cash = 100.0
 
     broker.update_last_price(symbol, 100.0)
     guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 100.0}))
@@ -122,7 +123,7 @@ async def test_daily_guard_halts_on_loss():
     delta = (sell["price"] - buy["price"]) * 1
     guard.on_realized_delta(delta)
     halted, reason = guard.check_halt()
-    assert halted and reason == "daily_max_loss"
+    assert halted and reason == "daily_loss"
 
 
 def test_covariance_limit_triggers_kill():

--- a/tests/test_risk_daily_guard.py
+++ b/tests/test_risk_daily_guard.py
@@ -19,7 +19,7 @@ async def test_daily_guard_close_and_persist(monkeypatch):
     broker.update_last_price(symbol, 100.0)
 
     guard = DailyGuard(
-        GuardLimits(daily_max_drawdown_pct=0.05, halt_action="close_all"),
+        GuardLimits(daily_max_loss_pct=1.0, daily_max_drawdown_pct=0.05, halt_action="close_all"),
         venue="paper",
         storage_engine="eng",
     )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -302,7 +302,7 @@ def test_insert_risk_event_timescale():
         engine,
         venue="binance",
         symbol="",
-        kind="daily_max_loss",
+        kind="daily_loss",
         message="",
         details="{}",
     )
@@ -312,7 +312,7 @@ def test_insert_risk_event_timescale():
             text("SELECT venue, kind FROM market.risk_events")
         ).fetchone()
 
-    assert row == ("binance", "daily_max_loss")
+    assert row == ("binance", "daily_loss")
 
 
 def test_insert_trade_timescale_ts():


### PR DESCRIPTION
## Summary
- simplify DailyGuard to enforce only global daily loss and drawdown limits based on total equity
- expose configurable percentage thresholds and remove per-symbol loss/consecutive loss logic
- update live runners and tests to use new GuardLimits API

## Testing
- `pytest tests/test_risk.py::test_daily_guard_halts_on_loss -q`
- `pytest tests/test_risk_daily_guard.py::test_daily_guard_close_and_persist -q`
- `pytest tests/test_live_runner.py::test_bybit_futures_order -q`
- `pytest tests/test_live_runner.py::test_run_real tests/test_live_runner.py::test_okx_futures_order -q`
- `pytest tests/test_storage.py::test_insert_risk_event_timescale -q`


------
https://chatgpt.com/codex/tasks/task_e_68adda414c78832d927fdad6271d0733