### PR TITLE
feat: add equity-based risk sizing

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -146,7 +146,8 @@ class EventDrivenBacktestEngine:
         seed: int | None = None,
         initial_equity: float = 0.0,
         trade_qty: float = 1.0,
-        max_pos: float = 1.0,
+        equity_pct: float | None = None,
+        risk_pct: float = 1.0,
         max_drawdown_pct: float = 0.0,
         stop_loss_pct: float = 0.0,
         max_notional: float = 0.0,
@@ -172,7 +173,8 @@ class EventDrivenBacktestEngine:
 
         self.initial_equity = float(initial_equity)
         self.trade_qty = float(trade_qty)
-        self._max_pos = float(max_pos)
+        self.equity_pct = float(equity_pct)
+        self.risk_pct = float(risk_pct)
         self._max_drawdown_pct = float(max_drawdown_pct)
         self._stop_loss_pct = float(stop_loss_pct)
         self._max_notional = float(max_notional)
@@ -209,7 +211,8 @@ class EventDrivenBacktestEngine:
                 else None
             )
             self.risk[key] = RiskManager(
-                max_pos=self._max_pos,
+                equity_pct=self.equity_pct,
+                risk_pct=self.risk_pct,
                 stop_loss_pct=self._stop_loss_pct,
                 max_drawdown_pct=self._max_drawdown_pct,
                 limits=limits,
@@ -364,6 +367,7 @@ class EventDrivenBacktestEngine:
                 place_price = float(df["close"].iloc[i])
                 if not risk.check_limits(place_price):
                     continue
+                risk.update_equity(equity, place_price)
                 delta = risk.size(sig.side, sig.strength)
                 rets = returns(window_df).dropna()
                 symbol_vol = float(rets.std()) if not rets.empty else 0.0
@@ -490,7 +494,8 @@ def run_backtest_csv(
     stress: StressConfig | None = None,
     seed: int | None = None,
     trade_qty: float = 1.0,
-    max_pos: float = 1.0,
+    equity_pct: float = 1.0,
+    risk_pct: float = 1.0,
     max_drawdown_pct: float = 0.0,
     stop_loss_pct: float = 0.0,
     max_notional: float = 0.0,
@@ -511,7 +516,8 @@ def run_backtest_csv(
         stress=stress,
         seed=seed,
         trade_qty=trade_qty,
-        max_pos=max_pos,
+        equity_pct=equity_pct,
+        risk_pct=risk_pct,
         max_drawdown_pct=max_drawdown_pct,
         stop_loss_pct=stop_loss_pct,
         max_notional=max_notional,
@@ -538,7 +544,8 @@ def run_backtest_mlflow(
     seed: int | None = None,
     experiment: str = "backtest",
     trade_qty: float = 1.0,
-    max_pos: float = 1.0,
+    equity_pct: float = 1.0,
+    risk_pct: float = 1.0,
     max_drawdown_pct: float = 0.0,
     stop_loss_pct: float = 0.0,
     max_notional: float = 0.0,
@@ -572,7 +579,8 @@ def run_backtest_mlflow(
             stress=stress,
             seed=seed,
             trade_qty=trade_qty,
-            max_pos=max_pos,
+            equity_pct=equity_pct,
+            risk_pct=risk_pct,
             max_drawdown_pct=max_drawdown_pct,
             stop_loss_pct=stop_loss_pct,
             max_notional=max_notional,

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -103,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(equity_pct=1.0, risk_pct=0.1)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
@@ -177,6 +177,7 @@ async def run_live_binance(
             signal.side,
             closed.c,
             strength=signal.strength,
+            equity=broker.equity(mark_prices={symbol: closed.c}),
             symbol_vol=float(bar.get("volatility", 0.0) or 0.0),
             corr_threshold=0.8,
         )

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -40,7 +40,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     bus = EventBus()
     if risk is None:
         risk = RiskService(
-            RiskManager(),
+            RiskManager(equity_pct=1.0, risk_pct=0.1),
             PortfolioGuard(GuardConfig(venue="cross")),
             daily=None,
         )
@@ -70,12 +70,14 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
             spot_side,
             last["spot"],
             strength=qty,
+            equity=cfg.spot.equity(mark_prices={cfg.symbol: last["spot"]}),
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
             last["perp"],
             strength=qty,
+            equity=cfg.perp.equity(mark_prices={cfg.symbol: last["perp"]}),
         )
         if not (ok1 and ok2):
             return

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -49,7 +49,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(equity_pct=1.0, risk_pct=0.1)
     guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)
@@ -92,6 +92,7 @@ async def run_paper(
                 signal.side,
                 closed.c,
                 strength=signal.strength,
+                equity=broker.equity(mark_prices={symbol: closed.c}),
                 corr_threshold=corr_threshold,
             )
             if not allowed or abs(delta) <= 0:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -108,7 +108,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(equity_pct=1.0, risk_pct=0.1)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_usdt=total_cap_usdt,
@@ -166,6 +166,7 @@ async def _run_symbol(
             sig.side,
             closed.c,
             strength=sig.strength,
+            equity=broker.equity(mark_prices={cfg.symbol: closed.c}),
             corr_threshold=corr_threshold,
         )
         if not allowed or abs(delta) <= 0:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -74,7 +74,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(max_pos=1.0)
+    risk_core = RiskManager(equity_pct=1.0, risk_pct=0.1)
     guard = PortfolioGuard(GuardConfig(
         total_cap_usdt=total_cap_usdt,
         per_symbol_cap_usdt=per_symbol_cap_usdt,
@@ -127,6 +127,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             sig.side,
             closed.c,
             strength=sig.strength,
+            equity=broker.equity(mark_prices={cfg.symbol: closed.c}),
             corr_threshold=corr_threshold,
         )
         if not allowed or abs(delta) <= 0:

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -63,6 +63,7 @@ class RiskService:
         price: float,
         strength: float = 1.0,
         *,
+        equity: float | None = None,
         symbol_vol: float | None = None,
         corr_threshold: float = 0.0,
     ) -> tuple[bool, str, float]:
@@ -71,6 +72,9 @@ class RiskService:
         Returns ``(allowed, reason, delta)`` where ``delta`` is the signed size
         proposed after volatility and correlation adjustments.
         """
+
+        if equity is not None:
+            self.rm.update_equity(equity, price)
 
         if symbol_vol is None or symbol_vol <= 0:
             symbol_vol = self.guard.volatility(symbol)


### PR DESCRIPTION
## Summary
- derive max position from account equity using `RiskManager(equity_pct, risk_pct)`
- pass current equity into `RiskService.check_order`
- update live runners and backtest engine for equity-based sizing

## Testing
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q` *(fails: assert 0 == 1)*
- `pytest tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress -q` *(fails: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68adda4602ac832dbdebb9e1194d46f8