### PR TITLE
Refactor portfolio guard to use equity-based caps

### DIFF
--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -546,12 +546,15 @@ class TradeBotDaemon:
         """Adjust portfolio guard limits from external controller."""
         if not self.guard:
             return
-        tot = evt.get("total_cap_usdt")
-        per = evt.get("per_symbol_cap_usdt")
+        tot = evt.get("total_cap_pct")
+        per = evt.get("per_symbol_cap_pct")
         if tot is not None:
-            self.guard.cfg.total_cap_usdt = float(tot)
+            self.guard.cfg.total_cap_pct = float(tot)
         if per is not None:
-            self.guard.cfg.per_symbol_cap_usdt = float(per)
+            self.guard.cfg.per_symbol_cap_pct = float(per)
+        eq = evt.get("equity")
+        if eq is not None:
+            self.guard.refresh_usd_caps(float(eq))
 
     # ------------------------------------------------------------------
     async def _on_halt(self, _evt: dict) -> None:

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -87,8 +87,8 @@ async def run_live_binance(
     symbol: str = "BTC/USDT",
     fee_bps: float = 1.5,
     persist_pg: bool = False,
-    total_cap_usdt: float = 1000.0,
-    per_symbol_cap_usdt: float = 500.0,
+    total_cap_pct: float = 1.0,
+    per_symbol_cap_pct: float = 0.5,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
     daily_max_loss_pct: float = 0.05,
@@ -105,8 +105,8 @@ async def run_live_binance(
     risk_core = RiskManager(equity_pct=1.0)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
-        total_cap_usdt=total_cap_usdt,
-        per_symbol_cap_usdt=per_symbol_cap_usdt,
+        total_cap_pct=total_cap_pct,
+        per_symbol_cap_pct=per_symbol_cap_pct,
         venue="binance",
         soft_cap_pct=soft_cap_pct,
         soft_cap_grace_sec=soft_cap_grace_sec,
@@ -118,6 +118,7 @@ async def run_live_binance(
     ), venue="binance")
     pg_engine = get_engine() if (persist_pg and _CAN_PG) else None
     risk = RiskService(risk_core, guard, dguard, engine=pg_engine)
+    guard.refresh_usd_caps(broker.equity({}))
     oco_book = OcoBook()
     if pg_engine is not None:
         pos_map = load_positions(pg_engine, guard.cfg.venue)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -50,7 +50,8 @@ async def run_paper(
     router = ExecutionRouter([broker])
 
     risk_core = RiskManager(equity_pct=1.0)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="paper"))
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
+    guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, corr_service=corr)
     engine = get_engine() if _CAN_PG else None

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -89,8 +89,8 @@ async def _run_symbol(
     cfg: _SymbolConfig,
     leverage: int,
     dry_run: bool,
-    total_cap_usdt: float,
-    per_symbol_cap_usdt: float,
+    total_cap_pct: float,
+    per_symbol_cap_pct: float,
     soft_cap_pct: float,
     soft_cap_grace_sec: int,
     daily_max_loss_pct: float,
@@ -110,8 +110,8 @@ async def _run_symbol(
     risk_core = RiskManager(equity_pct=1.0)
     guard = PortfolioGuard(
         GuardConfig(
-            total_cap_usdt=total_cap_usdt,
-            per_symbol_cap_usdt=per_symbol_cap_usdt,
+            total_cap_pct=total_cap_pct,
+            per_symbol_cap_pct=per_symbol_cap_pct,
             venue=venue,
             soft_cap_pct=soft_cap_pct,
             soft_cap_grace_sec=soft_cap_grace_sec,
@@ -128,6 +128,10 @@ async def _run_symbol(
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, dguard, corr_service=corr)
     broker = PaperAdapter(fee_bps=1.5)
+    try:
+        guard.refresh_usd_caps(broker.equity({}))
+    except Exception:
+        guard.refresh_usd_caps(0.0)
     engine = get_engine() if _CAN_PG else None
     oco_book = OcoBook()
     if engine is not None:
@@ -191,8 +195,8 @@ async def run_live_real(
     dry_run: bool = False,
     *,
     i_know_what_im_doing: bool,
-    total_cap_usdt: float = 1000.0,
-    per_symbol_cap_usdt: float = 500.0,
+    total_cap_pct: float = 1.0,
+    per_symbol_cap_pct: float = 0.5,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
     daily_max_loss_pct: float = 0.05,
@@ -221,8 +225,8 @@ async def run_live_real(
             c,
             leverage,
             dry_run,
-            total_cap_usdt,
-            per_symbol_cap_usdt,
+            total_cap_pct,
+            per_symbol_cap_pct,
             soft_cap_pct,
             soft_cap_grace_sec,
             daily_max_loss_pct,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -50,7 +50,7 @@ class _SymbolConfig:
     trade_qty: float
 
 async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: int,
-                      dry_run: bool, total_cap_usdt: float, per_symbol_cap_usdt: float,
+                      dry_run: bool, total_cap_pct: float, per_symbol_cap_pct: float,
                       soft_cap_pct: float, soft_cap_grace_sec: int,
                       daily_max_loss_pct: float, daily_max_drawdown_pct: float,
                       corr_threshold: float,
@@ -76,8 +76,8 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
     strat = BreakoutATR(config_path=config_path)
     risk_core = RiskManager(equity_pct=1.0)
     guard = PortfolioGuard(GuardConfig(
-        total_cap_usdt=total_cap_usdt,
-        per_symbol_cap_usdt=per_symbol_cap_usdt,
+        total_cap_pct=total_cap_pct,
+        per_symbol_cap_pct=per_symbol_cap_pct,
         venue=venue,
         soft_cap_pct=soft_cap_pct,
         soft_cap_grace_sec=soft_cap_grace_sec,
@@ -90,6 +90,10 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
     corr = CorrelationService()
     risk = RiskService(risk_core, guard, dguard, corr_service=corr)
     broker = PaperAdapter(fee_bps=1.5)
+    try:
+        guard.refresh_usd_caps(broker.equity({}))
+    except Exception:
+        guard.refresh_usd_caps(0.0)
     engine = get_engine() if _CAN_PG else None
     oco_book = OcoBook()
     if engine is not None:
@@ -150,8 +154,8 @@ async def run_live_testnet(
     trade_qty: float = 0.001,
     leverage: int = 1,
     dry_run: bool = False,
-    total_cap_usdt: float = 1000.0,
-    per_symbol_cap_usdt: float = 500.0,
+    total_cap_pct: float = 1.0,
+    per_symbol_cap_pct: float = 0.5,
     soft_cap_pct: float = 0.10,
     soft_cap_grace_sec: int = 30,
     daily_max_loss_pct: float = 0.05,
@@ -172,8 +176,8 @@ async def run_live_testnet(
             c,
             leverage,
             dry_run,
-            total_cap_usdt,
-            per_symbol_cap_usdt,
+            total_cap_pct,
+            per_symbol_cap_pct,
             soft_cap_pct,
             soft_cap_grace_sec,
             daily_max_loss_pct,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,13 +132,11 @@ def portfolio_guard():
     per_symbol_pct = 0.20  # 20% por símbolo
 
     cfg = GuardConfig(
-        total_cap_usdt=equity * total_pct,
-        per_symbol_cap_usdt=equity * per_symbol_pct,
+        total_cap_pct=total_pct,
+        per_symbol_cap_pct=per_symbol_pct,
         venue="test",
     )
 
     guard = PortfolioGuard(cfg)
-    guard.equity = equity
-    guard.total_pct = total_pct
-    guard.per_symbol_pct = per_symbol_pct
+    guard.refresh_usd_caps(equity)
     return guard

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -52,8 +52,8 @@ def test_correlation_service_window_rolls():
 
 
 def test_risk_service_uses_correlation_service():
-    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
-    guard.equity = 1.0
+    guard = PortfolioGuard(GuardConfig(per_symbol_cap_pct=10000, total_cap_pct=20000))
+    guard.refresh_usd_caps(1.0)
     rm = RiskManager(equity_pct=0.1, vol_target=0.02)
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -65,6 +65,9 @@ class DummyPG:
     def update_position_on_order(self, symbol, side, qty, venue=None):
         pass
 
+    def refresh_usd_caps(self, equity):
+        self.equity = equity
+
 
 class DummyDG:
     def on_mark(self, *a, **k):
@@ -122,8 +125,8 @@ async def test_bybit_futures_order(monkeypatch):
         cfg,
         leverage=5,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_pct=0.05,
@@ -182,8 +185,8 @@ async def test_run_real(monkeypatch):
         cfg,
         leverage=1,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_pct=0.05,
@@ -237,8 +240,8 @@ async def test_okx_futures_order(monkeypatch):
         cfg,
         leverage=7,
         dry_run=False,
-        total_cap_usdt=1000.0,
-        per_symbol_cap_usdt=500.0,
+        total_cap_pct=1.0,
+        per_symbol_cap_pct=0.5,
         soft_cap_pct=0.1,
         soft_cap_grace_sec=30,
         daily_max_loss_pct=0.05,

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -21,7 +21,8 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.oco_orders" (venue, symbol, side, qty, entry_price, sl_price, tp_price, status) VALUES ("paper", "BTCUSDT", "long", 1.5, 10000, 9500, 10500, "active");'))
 
     rm = RiskManager(equity_pct=1.0)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1e6, per_symbol_cap_usdt=1e6, venue="paper"))
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper"))
+    guard.refresh_usd_caps(1e6)
     risk = RiskService(rm, guard)
 
     # Rehydrate

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -63,7 +63,8 @@ def test_daily_loss_limit_triggers_kill_switch():
 
 def test_risk_service_updates_and_persists(monkeypatch):
     rm = RiskManager(equity_pct=1.0)
-    guard = PortfolioGuard(GuardConfig(total_cap_usdt=1.0, per_symbol_cap_usdt=1.0, venue="X"))
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
+    guard.refresh_usd_caps(1.0)
     daily = DailyGuard(GuardLimits(), venue="X")
     events: list = []
     monkeypatch.setattr(timescale, "insert_risk_event", lambda engine, **kw: events.append(kw))

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -27,9 +27,9 @@ async def test_risk_service_correlation_limits_and_sizing():
     bus.subscribe("risk:paused", lambda e: events.append(e))
     rm = RiskManager(equity_pct=1.0, bus=bus)
     guard = PortfolioGuard(
-        GuardConfig(total_cap_usdt=1000.0, per_symbol_cap_usdt=500.0, venue="test")
+        GuardConfig(total_cap_pct=5.0, per_symbol_cap_pct=2.5, venue="test")
     )
-    guard.equity = 200.0
+    guard.refresh_usd_caps(200.0)
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)
 

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -49,10 +49,10 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
 
 
 def test_risk_service_uses_guard_volatility():
-    guard = PortfolioGuard(GuardConfig(per_symbol_cap_usdt=10000, total_cap_usdt=20000))
+    guard = PortfolioGuard(GuardConfig(per_symbol_cap_pct=10000, total_cap_pct=20000))
     rm = RiskManager(equity_pct=0.1, vol_target=0.02)
     rm_guard_equity = 1.0
-    guard.equity = rm_guard_equity
+    guard.refresh_usd_caps(rm_guard_equity)
     svc = RiskService(rm, guard)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
     allowed, _, delta = svc.check_order("BTC", "buy", price=1.0)


### PR DESCRIPTION
## Summary
- convert GuardConfig to percentage-based capital limits
- add method to refresh USD caps from latest equity
- update hard/soft cap logic and runners to use refreshed limits

## Testing
- `pytest tests/test_risk_service_correlation.py::test_risk_service_correlation_limits_and_sizing -q`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68adefcc1938832d9f246fc884cb30d9