### PR TITLE
Refactor risk service to accept equity and remove stop_loss_pct

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -671,7 +671,7 @@ class BotConfig(BaseModel):
     leverage: int | None = None
     stop_loss: float | None = None
     take_profit: float | None = None
-    stop_loss_pct: float | None = None
+    risk_pct: float | None = None
     max_drawdown_pct: float | None = None
     testnet: bool | None = None
     dry_run: bool | None = None
@@ -727,8 +727,8 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         args.extend(["--stop-loss", str(cfg.stop_loss)])
     if cfg.take_profit is not None:
         args.extend(["--take-profit", str(cfg.take_profit)])
-    if cfg.stop_loss_pct is not None:
-        args.extend(["--stop-loss-pct", str(cfg.stop_loss_pct)])
+    if cfg.risk_pct is not None:
+        args.extend(["--risk-pct", str(cfg.risk_pct)])
     if cfg.max_drawdown_pct is not None:
         args.extend(["--max-drawdown-pct", str(cfg.max_drawdown_pct)])
     if cfg.testnet is not None:

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -81,13 +81,9 @@
         <label for="bt-trade-qty">Tamaño orden</label>
         <input id="bt-trade-qty" type="number" step="any"/>
       </div>
-      <div id="field-max-pos">
-        <label for="bt-max-pos">Posición máxima</label>
-        <input id="bt-max-pos" type="number" step="any"/>
-      </div>
-      <div id="field-stop-loss-pct">
-        <label for="bt-stop-loss-pct">Stop loss %</label>
-        <input id="bt-stop-loss-pct" type="number" step="any"/>
+      <div id="field-risk-pct">
+        <label for="bt-risk-pct">Risk %</label>
+        <input id="bt-risk-pct" type="number" step="any"/>
       </div>
       <div id="field-max-dd-pct">
         <label for="bt-max-drawdown-pct">Drawdown máx %</label>
@@ -288,7 +284,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-trade-qty','field-max-pos','field-stop-loss-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+  ['field-trade-qty','field-risk-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -345,13 +341,11 @@ async function runBacktest(){
   }
   if(mode!=='walk'){
     const tq=document.getElementById('bt-trade-qty').value.trim();
-    const mp=document.getElementById('bt-max-pos').value.trim();
-    const sl=document.getElementById('bt-stop-loss-pct').value.trim();
+  const sl=document.getElementById('bt-risk-pct').value.trim();
     const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
     if(tq) cmd+=` --trade-qty ${tq}`;
-    if(mp) cmd+=` --max-pos ${mp}`;
-    if(sl) cmd+=` --stop-loss-pct ${sl}`;
+  if(sl) cmd+=` --risk-pct ${sl}`;
     if(dd) cmd+=` --max-drawdown-pct ${dd}`;
     if(mn) cmd+=` --max-notional ${mn}`;
   }

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -94,8 +94,8 @@
       </div>
       <div id="strategy-params" style="display:contents"></div>
       <div>
-        <label for="bot-stop-loss-pct">Risk stop loss %</label>
-        <input id="bot-stop-loss-pct" type="number" step="0.0001" required/>
+        <label for="bot-risk-pct">Risk %</label>
+        <input id="bot-risk-pct" type="number" step="0.0001" required/>
       </div>
       <div>
         <label for="bot-max-drawdown-pct">Max drawdown %
@@ -220,7 +220,7 @@ async function startBot(){
   const market = document.getElementById('bot-market').value;
   const trade_qty = document.getElementById('bot-trade-qty').value;
   const leverage = document.getElementById('bot-leverage').value;
-  const stop_loss_pct = document.getElementById('bot-stop-loss-pct').value;
+  const risk_pct = document.getElementById('bot-risk-pct').value;
   const max_drawdown_pct = document.getElementById('bot-max-drawdown-pct').value;
   const env = document.getElementById('bot-env').value;
   const testnet = env === 'testnet';
@@ -242,7 +242,7 @@ async function startBot(){
     if(notional) payload.notional = Number(notional);
     if(trade_qty) payload.trade_qty = Number(trade_qty);
     if(leverage) payload.leverage = Number(leverage);
-    if(stop_loss_pct) payload.stop_loss_pct = Number(stop_loss_pct);
+    if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(max_drawdown_pct) payload.max_drawdown_pct = Number(max_drawdown_pct);
   if(strategy==='cross_arbitrage'){
     payload.spot = spot;

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -628,7 +628,7 @@ def run_bot(
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
     stop_loss: float = typer.Option(0.0, "--stop-loss", help="Strategy stop loss percentage"),
     take_profit: float = typer.Option(0.0, "--take-profit", help="Strategy take profit percentage"),
-    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk manager stop loss percentage"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk manager max drawdown percentage"),
 ) -> None:
     """Run the live trading bot with configurable venue and symbols."""
@@ -883,7 +883,7 @@ def backtest(
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
-    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -905,7 +905,7 @@ def backtest(
         trade_qty=trade_qty,
         equity_pct=equity_pct,
         equity_actual=equity_actual,
-        stop_loss_pct=stop_loss_pct,
+        risk_pct=risk_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
     )
@@ -921,7 +921,7 @@ def backtest_cfg(
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
-    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -963,7 +963,7 @@ def backtest_cfg(
             trade_qty=trade_qty,
             equity_pct=equity_pct,
             equity_actual=equity_actual,
-            stop_loss_pct=stop_loss_pct,
+            risk_pct=risk_pct,
             max_drawdown_pct=max_drawdown_pct,
             max_notional=max_notional,
         )
@@ -996,7 +996,7 @@ def backtest_db(
     trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
-    stop_loss_pct: float = typer.Option(0.0, "--stop-loss-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -1046,7 +1046,7 @@ def backtest_db(
         trade_qty=trade_qty,
         equity_pct=equity_pct,
         equity_actual=equity_actual,
-        stop_loss_pct=stop_loss_pct,
+        risk_pct=risk_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
     )

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -171,9 +171,11 @@ async def run_live_binance(
         if signal is None:
             continue
 
+        eq = broker.equity(mark_prices={symbol: px})
         allowed, reason, delta = risk.check_order(
             symbol,
             signal.side,
+            eq,
             closed.c,
             strength=signal.strength,
             symbol_vol=float(bar.get("volatility", 0.0) or 0.0),

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -65,17 +65,20 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         qty = cfg.notional / last["spot"]
         spot_side = "buy" if edge > 0 else "sell"
         perp_side = "sell" if edge > 0 else "buy"
+        equity = cfg.notional
         ok1, _r1, delta1 = risk.check_order(
             cfg.symbol,
             spot_side,
+            equity,
             last["spot"],
-            strength=qty,
+            strength=1.0,
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
+            equity,
             last["perp"],
-            strength=qty,
+            strength=1.0,
         )
         if not (ok1 and ok2):
             return

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -88,9 +88,11 @@ async def run_paper(
             signal = strat.on_bar({"window": df})
             if signal is None:
                 continue
+            eq = broker.equity(mark_prices={symbol: closed.c})
             allowed, _reason, delta = risk.check_order(
                 symbol,
                 signal.side,
+                eq,
                 closed.c,
                 strength=signal.strength,
                 corr_threshold=corr_threshold,

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -163,9 +163,11 @@ async def _run_symbol(
         sig = strat.on_bar({"window": df})
         if sig is None:
             continue
+        eq = broker.equity(mark_prices={cfg.symbol: px})
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
+            eq,
             closed.c,
             strength=sig.strength,
             corr_threshold=corr_threshold,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -125,9 +125,11 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         sig = strat.on_bar({"window": df})
         if sig is None:
             continue
+        eq = broker.equity(mark_prices={cfg.symbol: px})
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
+            eq,
             closed.c,
             strength=sig.strength,
             corr_threshold=corr_threshold,

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -129,23 +129,33 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                     )
 
                     # Ejecutar 3 patas en PAPER
+                    eq = broker.equity(
+                        mark_prices={
+                            f"{cfg.route.base}/{cfg.route.quote}": last["bq"],
+                            f"{cfg.route.mid}/{cfg.route.base}": last["mb"],
+                            f"{cfg.route.mid}/{cfg.route.quote}": last["mq"],
+                        }
+                    )
                     if edge.direction == "b->m":
                         checks = [
                             risk.check_order(
                                 f"{cfg.route.base}/{cfg.route.quote}",
                                 "buy",
+                                eq,
                                 last["bq"],
                                 strength=q["base_qty"],
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.base}",
                                 "buy",
+                                eq,
                                 last["mb"],
                                 strength=q["mid_qty"],
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.quote}",
                                 "sell",
+                                eq,
                                 last["mq"],
                                 strength=q["mid_qty"],
                             ),
@@ -180,18 +190,21 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.quote}",
                                 "buy",
+                                eq,
                                 last["mq"],
                                 strength=q["mid_qty"],
                             ),
                             risk.check_order(
                                 f"{cfg.route.mid}/{cfg.route.base}",
                                 "sell",
+                                eq,
                                 last["mb"],
                                 strength=q["mid_qty"],
                             ),
                             risk.check_order(
                                 f"{cfg.route.base}/{cfg.route.quote}",
                                 "sell",
+                                eq,
                                 last["bq"],
                                 strength=q["base_qty"],
                             ),

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -60,6 +60,7 @@ class RiskService:
         self,
         symbol: str,
         side: str,
+        equity: float,
         price: float,
         strength: float = 1.0,
         *,
@@ -72,6 +73,8 @@ class RiskService:
         proposed after volatility and correlation adjustments.
         """
 
+        self.guard.refresh_usd_caps(equity)
+
         if symbol_vol is None or symbol_vol <= 0:
             symbol_vol = self.guard.volatility(symbol)
 
@@ -82,7 +85,7 @@ class RiskService:
         delta = self.rm.size(
             side,
             price,
-            self.guard.equity,
+            equity,
             strength,
             symbol=symbol,
             symbol_vol=symbol_vol or 0.0,

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -40,7 +40,7 @@ def test_bot_endpoints(monkeypatch):
         "leverage": 1,
         "stop_loss": 0.02,
         "take_profit": 0.05,
-        "stop_loss_pct": 0.03,
+        "risk_pct": 0.03,
         "max_drawdown_pct": 0.1,
         "testnet": True,
         "dry_run": False,
@@ -53,7 +53,7 @@ def test_bot_endpoints(monkeypatch):
     assert "--venue" in argv and "binance_spot" in argv
     assert "--stop-loss" in argv and "0.02" in argv
     assert "--take-profit" in argv and "0.05" in argv
-    assert "--stop-loss-pct" in argv and "0.03" in argv
+    assert "--risk-pct" in argv and "0.03" in argv
     assert "--max-drawdown-pct" in argv and "0.1" in argv
 
     lst = client.get("/bots", auth=("admin", "admin"))
@@ -97,7 +97,7 @@ def test_cross_arbitrage_start(monkeypatch):
         "threshold": 0.001,
         "stop_loss": 0.02,
         "take_profit": 0.05,
-        "stop_loss_pct": 0.03,
+        "risk_pct": 0.03,
         "max_drawdown_pct": 0.1,
     }
 

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -73,7 +73,7 @@ def test_risk_service_uses_correlation_service():
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
     symbol_vol = guard.volatility("BTC")
     base = rm.size("buy", price_btc, guard.equity, symbol="BTC", symbol_vol=symbol_vol)
-    allowed, _, delta = svc.check_order("BTC", "buy", price=price_btc, corr_threshold=0.8)
+    allowed, _, delta = svc.check_order("BTC", "buy", 1.0, price_btc, corr_threshold=0.8)
     assert allowed
     assert delta == pytest.approx(base * 0.5)
 

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -39,7 +39,7 @@ class DummyRisk:
     def mark_price(self, symbol, price):
         pass
 
-    def check_order(self, symbol, side, price, strength=1.0, **_):
+    def check_order(self, symbol, side, equity, price, strength=1.0, **_):
         return True, "", 1.0
 
     def on_fill(self, symbol, side, qty, venue=None):

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -73,7 +73,7 @@ def test_risk_service_updates_and_persists(monkeypatch):
     svc.update_position("ex2", "BTC", -0.4)
     agg = svc.aggregate_positions()
     assert agg["BTC"] == pytest.approx(0.6)
-    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, strength=1.0)
+    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, 1.0, strength=1.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
 

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -41,7 +41,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     assert events and events[0]["reason"] == "correlation"
 
     allowed, _, delta = svc.check_order(
-        "AAA", "buy", 100.0, corr_threshold=0.8
+        "AAA", "buy", 200.0, 100.0, corr_threshold=0.8
     )
     assert allowed
     assert delta == pytest.approx(0.5)

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -55,7 +55,7 @@ def test_risk_service_uses_guard_volatility():
     guard.refresh_usd_caps(rm_guard_equity)
     svc = RiskService(rm, guard)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
-    allowed, _, delta = svc.check_order("BTC", "buy", price=1.0)
+    allowed, _, delta = svc.check_order("BTC", "buy", 1.0, 1.0)
     vol = np.std([0.01, -0.02, 0.03]) * np.sqrt(365)
     budget = rm_guard_equity * rm.equity_pct
     expected = budget / 1.0 + budget / vol


### PR DESCRIPTION
## Summary
- pass explicit equity and price to `RiskService.check_order`
- replace stop_loss_pct/max_pos options with risk_pct throughout API and CLI
- update runners and tests to supply account equity when checking orders

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3856ec4832d8a38c8cafff5eeb0