### PR TITLE
Clarify equity-based allocation and risk docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ entorno real de Binance Futures.
 
 ## Gestión de riesgo
 
-El tamaño de cada operación se calcula a partir del capital disponible:
+Tanto la asignación como el stop‑loss se expresan como porcentajes del equity
+disponible:
 
 - `equity_pct` indica la fracción de equity utilizada como notional por
   señal: `notional = equity_total * equity_pct`.
-- `risk_pct` define la pérdida máxima aceptada sobre ese notional:
+- `risk_pct` determina la pérdida máxima aceptada sobre esa asignación:
   `max_loss = notional * risk_pct`.
 
 El parámetro `strength` de las señales escala el cambio propuesto en la
-posición. Valores mayores a `1.0` permiten piramidar entradas mientras que
-valores menores reducen exposición.
+posición. Por ejemplo, una señal con `strength = 1.5` piramida la entrada en un
+50 % adicional (`7.5 %` del equity si `equity_pct = 0.05`), mientras que
+`strength = 0.5` reduce la exposición a la mitad.
 
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
 superan los límites configurados, detiene el bot o cierra las posiciones

--- a/data/examples/backtest.yaml
+++ b/data/examples/backtest.yaml
@@ -4,5 +4,8 @@ strategies:
   - [breakout_atr, BTC/USDT]
 latency: 1
 window: 120
+risk:
+  equity_pct: 0.05
+  risk_pct: 0.02
 mlflow:
   run_name: example_backtest

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,10 +80,11 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--venue`: nombre del venue (ej. `binance_spot`, `okx_futures`).
 - `--symbol`: puede repetirse; símbolo a operar.
 - `--testnet`: usa endpoints de prueba.
-- `--trade-qty`: tamaño de la orden.
+- `--equity-pct`: fracción del equity a asignar por señal.
+- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
 - `--leverage`: apalancamiento para futuros.
 - `--dry-run`: simula órdenes en testnet.
-- `--stop-loss` y `--take-profit`: porcentajes de la estrategia.
+- `--take-profit`: porcentaje de toma de ganancias.
 
 ## `paper-run`
 Corre una estrategia en modo paper (sin dinero real) y expone métricas.
@@ -96,7 +97,8 @@ Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 Ejecuta el bot contra un exchange real.
 - `--venue`: nombre del venue.
 - `--symbol`: puede repetirse.
-- `--trade-qty`: tamaño de la orden.
+- `--equity-pct`: fracción del equity a asignar por señal.
+- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
 - `--leverage`: apalancamiento.
 - `--dry-run`: simula órdenes sin enviarlas.
 - `--i-know-what-im-doing`: confirmación necesaria para operar con dinero real.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -9,7 +9,7 @@ actual por `equity_pct`:
 notional = equity_total * equity_pct
 ```
 
-El riesgo máximo permitido sobre esa operación se controla con `risk_pct`:
+El stop‑loss se define como un porcentaje de esa asignación usando `risk_pct`:
 
 ```
 max_loss = notional * risk_pct
@@ -23,7 +23,8 @@ precio del activo.
 Las estrategias pueden emitir señales con un atributo `strength` que escala el
 cambio propuesto en la posición. Un valor mayor a `1.0` permite piramidar
 agregando tamaño; valores entre `0` y `1` reducen exposición y `0` cierra la
-posición.
+posición. Por ejemplo, con `equity_pct = 0.05` una señal con `strength = 1.5`
+usará el `7.5 %` del equity mientras que `strength = 0.5` solo el `2.5 %`.
 
 ## DailyGuard y drawdown global
 

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -13,14 +13,17 @@ from ..storage import timescale
 class Signal:
     """Simple trading signal.
 
-    ``strength`` expresses the desired exposure as a fraction of the
-    maximum position size allowed by the risk manager.  ``1.0`` requests the
-    full allocation while ``0`` or a negative value signals that any existing
-    position should be closed.
+    ``strength`` scales position sizing as a fraction of account equity.
+    A value of ``1.0`` requests the full allocation defined by the risk
+    manager's ``equity_pct`` while ``1.5`` would pyramid exposure to
+    ``150%`` of that base size. Values between ``0`` and ``1`` reduce the
+    position proportionally and ``0`` or negative values close it. The
+    risk manager also interprets ``risk_pct`` as a stop‑loss expressed as a
+    percentage of equity.
     """
 
     side: str  # 'buy' | 'sell' | 'flat'
-    strength: float = 1.0  # fraction of the max permitted allocation
+    strength: float = 1.0  # fraction of the base equity allocation
     reduce_only: bool = False
 
 class Strategy(ABC):


### PR DESCRIPTION
## Summary
- Document that both allocation and stop loss are expressed as equity percentages
- Replace CLI docs with `--equity-pct`/`--risk-pct` options and add examples of pyramiding via `strength`
- Update sample configs to use `equity_pct` and `risk_pct`

## Testing
- `pytest tests/test_risk.py -q` *(fails: assert -2.5 == 5.0 ± 5.0e-06)*

------
https://chatgpt.com/codex/tasks/task_e_68ae06359db4832d9301b19224f76a7f