### PR TITLE
Refactor risk options to equity and risk percentages

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -669,8 +669,6 @@ class BotConfig(BaseModel):
     venue: str | None = None
     equity_pct: float | None = None
     leverage: int | None = None
-    stop_loss: float | None = None
-    take_profit: float | None = None
     risk_pct: float | None = None
     testnet: bool | None = None
     dry_run: bool | None = None
@@ -722,10 +720,6 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         args.extend(["--equity-pct", str(cfg.equity_pct)])
     if cfg.leverage is not None:
         args.extend(["--leverage", str(cfg.leverage)])
-    if cfg.stop_loss is not None:
-        args.extend(["--stop-loss", str(cfg.stop_loss)])
-    if cfg.take_profit is not None:
-        args.extend(["--take-profit", str(cfg.take_profit)])
     if cfg.risk_pct is not None:
         args.extend(["--risk-pct", str(cfg.risk_pct)])
     if cfg.testnet is not None:

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -59,11 +59,11 @@
           <option value="futures">Futuros</option>
         </select>
       </div>
-      <div id="field-trade-qty">
-        <label for="bot-trade-qty">Trade qty
-          <span class="help-icon" title="Cantidad fija de unidades base por operación">?</span>
+      <div id="field-equity-pct">
+        <label for="bot-equity-pct">Equity %
+          <span class="help-icon" title="Fracción del equity a usar">?</span>
         </label>
-        <input id="bot-trade-qty" type="number" step="0.0001"/>
+        <input id="bot-equity-pct" type="number" step="0.0001"/>
       </div>
       <div id="field-leverage">
         <label for="bot-leverage">Leverage</label>

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -626,8 +626,6 @@ def run_bot(
     equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
-    stop_loss: float = typer.Option(0.0, "--stop-loss", help="Strategy stop loss percentage"),
-    take_profit: float = typer.Option(0.0, "--take-profit", help="Strategy take profit percentage"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
 ) -> None:
     """Run the live trading bot with configurable venue and symbols."""
@@ -666,6 +664,8 @@ def paper_run(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
     config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
+    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
@@ -678,6 +678,8 @@ def paper_run(
             strategy_name=strategy,
             config_path=config,
             metrics_port=metrics_port,
+            equity_pct=equity_pct,
+            risk_pct=risk_pct,
         )
     )
 
@@ -691,7 +693,8 @@ def real_run(
         help=f"Trading venue ({_VENUE_CHOICES})",
     ),
     symbols: List[str] = typer.Option(["BTC/USDT"], "--symbol", help="Trading symbols"),
-    trade_qty: float = typer.Option(0.001, help="Order size"),
+    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
+    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Simulate orders without sending"),
     i_know_what_im_doing: bool = typer.Option(
@@ -715,7 +718,8 @@ def real_run(
             exchange=exchange,
             market=market,
             symbols=symbols,
-            trade_qty=trade_qty,
+            equity_pct=equity_pct,
+            risk_pct=risk_pct,
             leverage=leverage,
             dry_run=dry_run,
             i_know_what_im_doing=i_know_what_im_doing,
@@ -886,9 +890,7 @@ def backtest(
     symbol: str = "BTC/USDT",
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
-    equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -908,9 +910,7 @@ def backtest(
         {symbol: df},
         [(strategy, symbol)],
         initial_equity=capital,
-        trade_qty=trade_qty,
         equity_pct=equity_pct,
-        equity_actual=equity_actual,
         risk_pct=risk_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
@@ -924,9 +924,7 @@ def backtest(
 def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
-    equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -966,9 +964,7 @@ def backtest_cfg(
             {symbol: df},
             [(strategy, symbol)],
             initial_equity=capital,
-            trade_qty=trade_qty,
             equity_pct=equity_pct,
-            equity_actual=equity_actual,
             risk_pct=risk_pct,
             max_drawdown_pct=max_drawdown_pct,
             max_notional=max_notional,
@@ -999,9 +995,7 @@ def backtest_db(
     end: str = typer.Option(..., help="End date YYYY-MM-DD"),
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    trade_qty: float = typer.Option(1.0, "--trade-qty", help="Order size"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
-    equity_actual: float = typer.Option(0.0, "--equity-actual", help="Account equity"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
@@ -1049,9 +1043,7 @@ def backtest_db(
         {symbol: df},
         [(strategy, symbol)],
         initial_equity=capital,
-        trade_qty=trade_qty,
         equity_pct=equity_pct,
-        equity_actual=equity_actual,
         risk_pct=risk_pct,
         max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -42,6 +42,8 @@ async def run_paper(
     config_path: str | None = None,
     metrics_port: int = 8000,
     corr_threshold: float = 0.8,
+    equity_pct: float = 1.0,
+    risk_pct: float = 0.0,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
 
@@ -49,7 +51,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(equity_pct=1.0, risk_pct=0.0)
+    risk_core = RiskManager(equity_pct=equity_pct, risk_pct=risk_pct)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
     guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -38,8 +38,6 @@ def test_bot_endpoints(monkeypatch):
         "venue": "binance_spot",
         "equity_pct": 1.0,
         "leverage": 1,
-        "stop_loss": 0.02,
-        "take_profit": 0.05,
         "risk_pct": 0.03,
         "testnet": True,
         "dry_run": False,
@@ -50,8 +48,6 @@ def test_bot_endpoints(monkeypatch):
     pid = resp.json()["pid"]
     argv = list(calls["args"])
     assert "--venue" in argv and "binance_spot" in argv
-    assert "--stop-loss" in argv and "0.02" in argv
-    assert "--take-profit" in argv and "0.05" in argv
     assert "--equity-pct" in argv and "1.0" in argv
     assert "--risk-pct" in argv and "0.03" in argv
 


### PR DESCRIPTION
## Summary
- remove obsolete trade quantity and stop-loss options from CLI and API
- add `--equity-pct` and `--risk-pct` flags across CLI commands and API
- expose equity and risk percentage inputs in bots dashboard

## Testing
- `pytest tests/test_api_bots.py::test_bot_endpoints -q`
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0632a90c832d86e856bf626a1532