### PR TITLE
Use equity percentage in backtest form

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -77,9 +77,9 @@
         <label for="bt-end">Fin</label>
         <input id="bt-end" type="date"/>
       </div>
-      <div id="field-trade-qty">
-        <label for="bt-trade-qty">Tamaño orden</label>
-        <input id="bt-trade-qty" type="number" step="any"/>
+      <div id="field-equity-pct">
+        <label for="bt-equity-pct">Equity %</label>
+        <input id="bt-equity-pct" type="number" step="any"/>
       </div>
       <div id="field-risk-pct">
         <label for="bt-risk-pct">Risk %</label>
@@ -284,7 +284,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-trade-qty','field-risk-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+  ['field-equity-pct','field-risk-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -340,11 +340,11 @@ async function runBacktest(){
     cmd+=` --capital ${capital}`;
   }
   if(mode!=='walk'){
-    const tq=document.getElementById('bt-trade-qty').value.trim();
+    const eq=document.getElementById('bt-equity-pct').value.trim();
   const sl=document.getElementById('bt-risk-pct').value.trim();
     const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
-    if(tq) cmd+=` --trade-qty ${tq}`;
+    if(eq) cmd+=` --equity-pct ${eq}`;
   if(sl) cmd+=` --risk-pct ${sl}`;
     if(dd) cmd+=` --max-drawdown-pct ${dd}`;
     if(mn) cmd+=` --max-notional ${mn}`;


### PR DESCRIPTION
## Summary
- Replace trade quantity field with equity percentage
- Adjust field toggling and CLI command to use `--equity-pct`

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d65761c832dbd2519a7951808f1