### PR TITLE
Clean up obsolete max drawdown option in backtest CLI

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -85,10 +85,6 @@
         <label for="bt-risk-pct">Risk %</label>
         <input id="bt-risk-pct" type="number" step="any"/>
       </div>
-      <div id="field-max-dd-pct">
-        <label for="bt-max-drawdown-pct">Drawdown máx %</label>
-        <input id="bt-max-drawdown-pct" type="number" step="any"/>
-      </div>
       <div id="field-max-notional">
         <label for="bt-max-notional">Notional máximo</label>
         <input id="bt-max-notional" type="number" step="any"/>
@@ -284,7 +280,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-trade-qty','field-risk-pct','field-max-dd-pct','field-max-notional'].forEach(id=>{
+  ['field-trade-qty','field-risk-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -342,11 +338,9 @@ async function runBacktest(){
   if(mode!=='walk'){
     const tq=document.getElementById('bt-trade-qty').value.trim();
   const sl=document.getElementById('bt-risk-pct').value.trim();
-    const dd=document.getElementById('bt-max-drawdown-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
     if(tq) cmd+=` --trade-qty ${tq}`;
   if(sl) cmd+=` --risk-pct ${sl}`;
-    if(dd) cmd+=` --max-drawdown-pct ${dd}`;
     if(mn) cmd+=` --max-notional ${mn}`;
   }
   try{

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -892,7 +892,6 @@ def backtest(
     capital: float = typer.Option(0.0, help="Capital inicial"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a simple vectorised backtest from a CSV file."""
@@ -912,7 +911,6 @@ def backtest(
         initial_equity=capital,
         equity_pct=equity_pct,
         risk_pct=risk_pct,
-        max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
     )
     result = eng.run()
@@ -926,7 +924,6 @@ def backtest_cfg(
     capital: float = typer.Option(0.0, help="Capital inicial"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a backtest using a Hydra YAML configuration."""
@@ -966,7 +963,6 @@ def backtest_cfg(
             initial_equity=capital,
             equity_pct=equity_pct,
             risk_pct=risk_pct,
-            max_drawdown_pct=max_drawdown_pct,
             max_notional=max_notional,
         )
         result = eng.run()
@@ -997,7 +993,6 @@ def backtest_db(
     capital: float = typer.Option(0.0, help="Capital inicial"),
     equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_drawdown_pct: float = typer.Option(0.0, "--max-drawdown-pct", help="Risk max drawdown %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a backtest using data stored in the database."""
@@ -1045,7 +1040,6 @@ def backtest_db(
         initial_equity=capital,
         equity_pct=equity_pct,
         risk_pct=risk_pct,
-        max_drawdown_pct=max_drawdown_pct,
         max_notional=max_notional,
     )
     result = eng.run()


### PR DESCRIPTION
## Summary
- drop `--max-drawdown-pct` option from `backtest`, `backtest-cfg` and `backtest-db` commands
- remove drawdown field from web backtest helper

## Testing
- `pytest tests/test_backtest_engine.py -q` *(fails: assert 0 > 0)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0d6c4b30832d928b860517bf4fef