### PR TITLE
docs: clarify sizing with strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,20 @@ entorno real de Binance Futures.
 
 ## Gestión de riesgo
 
-Tanto la asignación como el stop‑loss se expresan como porcentajes del equity
-disponible:
+La exposición de cada operación se calcula con:
 
-- `equity_pct` indica la fracción de equity utilizada como notional por
-  señal: `notional = equity_total * equity_pct`.
-- `risk_pct` determina la pérdida máxima aceptada sobre esa asignación:
-  `max_loss = notional * risk_pct`.
+```
+notional = equity * strength
+```
 
-El parámetro `strength` de las señales escala el cambio propuesto en la
-posición. Por ejemplo, una señal con `strength = 1.5` piramida la entrada en un
-50 % adicional (`7.5 %` del equity si `equity_pct = 0.05`), mientras que
-`strength = 0.5` reduce la exposición a la mitad.
+`strength` representa la fracción del equity que se quiere asignar. Valores
+mayores a `1` piramidan la posición, mientras que valores entre `0` y `1`
+desescalan progresivamente; `0` cierra por completo. El stop‑loss local se
+expresa como porcentaje de esa asignación mediante `risk_pct`:
+
+```
+max_loss = notional * risk_pct
+```
 
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
 superan los límites configurados, detiene el bot o cierra las posiciones
@@ -91,9 +93,11 @@ backtest:
   initial_equity: 100
 
 risk:
-  equity_pct: 0.05   # usa el 5% del capital por operación
-  risk_pct: 0.02     # arriesga como máximo el 2% de la cuenta
+  risk_pct: 0.02     # stop-loss local al 2% de la asignación
 ```
+
+Las señales de la estrategia definen `strength` para indicar la fracción de
+equity a utilizar; por ejemplo, `strength = 0.05` emplea el 5 % del capital.
 
 ## Solución de problemas
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,8 +80,7 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--venue`: nombre del venue (ej. `binance_spot`, `okx_futures`).
 - `--symbol`: puede repetirse; símbolo a operar.
 - `--testnet`: usa endpoints de prueba.
-- `--equity-pct`: fracción del equity a asignar por señal.
-- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
+- `--risk-pct`: stop‑loss local como porcentaje de la asignación (`notional`).
 - `--leverage`: apalancamiento para futuros.
 - `--dry-run`: simula órdenes en testnet.
 - `--take-profit`: porcentaje de toma de ganancias.
@@ -97,8 +96,7 @@ Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 Ejecuta el bot contra un exchange real.
 - `--venue`: nombre del venue.
 - `--symbol`: puede repetirse.
-- `--equity-pct`: fracción del equity a asignar por señal.
-- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
+- `--risk-pct`: stop‑loss local como porcentaje de la asignación (`notional`).
 - `--leverage`: apalancamiento.
 - `--dry-run`: simula órdenes sin enviarlas.
 - `--i-know-what-im-doing`: confirmación necesaria para operar con dinero real.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -1,15 +1,17 @@
 # Gestión de riesgo
 
-## Cálculo de `equity_pct` y `risk_pct`
+## Cálculo del notional y `risk_pct`
 
-El capital asignado a cada operación se determina multiplicando la equity
-actual por `equity_pct`:
+La exposición de cada operación se determina a partir de la equity actual:
 
 ```
-notional = equity_total * equity_pct
+notional = equity * strength
 ```
 
-El stop‑loss se define como un porcentaje de esa asignación usando `risk_pct`:
+`strength` es la fracción del capital que se desea asignar. Valores mayores a
+`1` piramidan la posición; valores entre `0` y `1` desescalan y `0` cierra la
+exposición. El stop‑loss local se define como porcentaje de ese notional usando
+`risk_pct`:
 
 ```
 max_loss = notional * risk_pct
@@ -17,14 +19,6 @@ max_loss = notional * risk_pct
 
 A partir del notional se calcula la cantidad a comprar o vender en función del
 precio del activo.
-
-## Uso de `strength`
-
-Las estrategias pueden emitir señales con un atributo `strength` que escala el
-cambio propuesto en la posición. Un valor mayor a `1.0` permite piramidar
-agregando tamaño; valores entre `0` y `1` reducen exposición y `0` cierra la
-posición. Por ejemplo, con `equity_pct = 0.05` una señal con `strength = 1.5`
-usará el `7.5 %` del equity mientras que `strength = 0.5` solo el `2.5 %`.
 
 ## DailyGuard y drawdown global
 
@@ -45,6 +39,8 @@ backtest:
   initial_equity: 100
 
 risk:
-  equity_pct: 0.05
-  risk_pct: 0.02
+    risk_pct: 0.02
 ```
+
+Las señales deben indicar `strength` para asignar capital; por ejemplo,
+`strength = 0.05` utiliza el 5 % del equity disponible.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -3,6 +3,12 @@
 Las estrategias definen cómo se toman decisiones de compra o venta. A
 continuación se presenta un resumen en lenguaje sencillo.
 
+Todas las estrategias emiten señales con un campo `strength` que especifica la
+fracción de equity a utilizar (`notional = equity * strength`). Valores mayores
+a `1` permiten piramidar posiciones; valores entre `0` y `1` desescalan la
+exposición. El stop‑loss local se controla con `risk_pct`, aplicado sobre ese
+notional.
+
 ### Breakout con ATR (`breakout_atr`)
 Compra cuando el precio supera el canal superior calculado con el indicador
 ATR y vende cuando cae por debajo del canal inferior.

--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -43,7 +43,8 @@ class RiskManager:
     Añade límites de pérdida y drawdown y un *kill switch* mediante ``enabled``.
     ``check_limits`` debe invocarse con el precio de mercado actual antes de
     enviar cualquier orden.  Si los límites se violan, ``enabled`` se vuelve
-    ``False`` y no se deben continuar enviando órdenes.
+    ``False`` y no se deben continuar enviando órdenes.  El stop‑loss local se
+    define con ``risk_pct`` aplicado sobre ``notional = equity * strength``.
     """
 
     def __init__(

--- a/src/tradingbot/risk/position_sizing.py
+++ b/src/tradingbot/risk/position_sizing.py
@@ -1,8 +1,8 @@
 """Helpers for position sizing based on volatility targets.
 
-This module now also provides utilities to translate signal strength into
-actual position deltas, ensuring consistent pyramiding and reduction across
-strategies.
+Incluye utilidades para traducir ``strength`` en cambios de posición usando
+``notional = equity * strength``. Esto permite piramidación, desescalado y
+compatibilidad entre estrategias.
 """
 
 from __future__ import annotations
@@ -16,7 +16,8 @@ def vol_target(atr: float, equity_pct: float, equity: float) -> float:
     atr:
         Average true range or volatility estimate of the asset.
     equity_pct:
-        Fraction of current equity to allocate.
+        Fracción base de equity reservada para el activo; la asignación final
+        la determina ``notional = equity * strength``.
     equity:
         Current account equity.
 
@@ -45,11 +46,11 @@ def delta_from_strength(
     Parameters
     ----------
     strength:
-        Target exposure as a fraction of ``equity_pct``. Positive values denote
-        long positions, negative values short. Values are clipped to
-        ``[-1, 1]``.
+        Fracción de equity deseada para la posición. ``notional = equity *
+        strength``. Valores positivos denotan largos; negativos, cortos. Se
+        limita a ``[-1, 1]``.
     equity_pct:
-        Fraction of current equity allocated to the asset.
+        Límite máximo de equity permitido para el activo.
     equity:
         Current account equity.
     price:

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -13,13 +13,11 @@ from ..storage import timescale
 class Signal:
     """Simple trading signal.
 
-    ``strength`` scales position sizing as a fraction of account equity.
-    A value of ``1.0`` requests the full allocation defined by the risk
-    manager's ``equity_pct`` while ``1.5`` would pyramid exposure to
-    ``150%`` of that base size. Values between ``0`` and ``1`` reduce the
-    position proportionally and ``0`` or negative values close it. The
-    risk manager also interprets ``risk_pct`` as a stop‑loss expressed as a
-    percentage of equity.
+    ``strength`` indica la fracción de equity a utilizar y determina el notional
+    mediante ``notional = equity * strength``. Valores mayores a ``1`` permiten
+    piramidar posiciones; valores entre ``0`` y ``1`` desescalan la exposición.
+    ``0`` o negativos cierran la posición. El gestor de riesgo aplica
+    ``risk_pct`` como un stop‑loss local sobre ese notional.
     """
 
     side: str  # 'buy' | 'sell' | 'flat'


### PR DESCRIPTION
## Summary
- document position sizing using `notional = equity * strength`
- note pyramiding/desescalado and local `risk_pct` stop-loss
- drop `--equity-pct` option from CLI docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae2325d06c832d8cf38c92f42f1b22