### PR TITLE
refactor: drop equity_pct flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,6 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--venue`: nombre del venue (ej. `binance_spot`, `okx_futures`).
 - `--symbol`: puede repetirse; símbolo a operar.
 - `--testnet`: usa endpoints de prueba.
-- `--equity-pct`: fracción del equity a asignar por señal.
 - `--risk-pct`: stop‑loss como porcentaje del equity asignado.
 - `--leverage`: apalancamiento para futuros.
 - `--dry-run`: simula órdenes en testnet.
@@ -97,7 +96,6 @@ Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 Ejecuta el bot contra un exchange real.
 - `--venue`: nombre del venue.
 - `--symbol`: puede repetirse.
-- `--equity-pct`: fracción del equity a asignar por señal.
 - `--risk-pct`: stop‑loss como porcentaje del equity asignado.
 - `--leverage`: apalancamiento.
 - `--dry-run`: simula órdenes sin enviarlas.

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -127,7 +127,6 @@ _config: dict[str, object] = {
     "notional": None,
     "params": {},
     "venue": "binance_spot",
-    "equity_pct": 0.0,
     "risk_pct": 0.0,
     "leverage": 1,
     "testnet": True,
@@ -258,7 +257,6 @@ class BotConfig(BaseModel):
     notional: float | None = None
     params: dict | None = None
     venue: str | None = None
-    equity_pct: float | None = None
     risk_pct: float | None = None
     leverage: int | None = None
     testnet: bool | None = None
@@ -287,7 +285,7 @@ def update_config(cfg: BotConfig) -> dict:
             continue
         if key == "notional" and value <= 0:
             raise HTTPException(status_code=400, detail="notional must be positive")
-        if key in {"equity_pct", "risk_pct"} and value < 0:
+        if key == "risk_pct" and value < 0:
             raise HTTPException(status_code=400, detail=f"{key} must be non-negative")
         if key == "leverage" and value <= 0:
             raise HTTPException(status_code=400, detail="leverage must be positive")
@@ -347,8 +345,6 @@ async def bot_start() -> dict:
         args.extend(["--notional", str(_config["notional"])])
     if _config.get("venue"):
         args.extend(["--venue", str(_config["venue"])])
-    if _config.get("equity_pct") is not None:
-        args.extend(["--equity-pct", str(_config["equity_pct"])])
     if _config.get("risk_pct") is not None:
         args.extend(["--risk-pct", str(_config["risk_pct"])])
     if _config.get("leverage") is not None:

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -667,7 +667,6 @@ class BotConfig(BaseModel):
     pairs: list[str] | None = None
     notional: float | None = None
     venue: str | None = None
-    equity_pct: float | None = None
     leverage: int | None = None
     risk_pct: float | None = None
     testnet: bool | None = None
@@ -716,8 +715,6 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         args.extend(["--notional", str(cfg.notional)])
     if cfg.venue:
         args.extend(["--venue", cfg.venue])
-    if cfg.equity_pct is not None:
-        args.extend(["--equity-pct", str(cfg.equity_pct)])
     if cfg.leverage is not None:
         args.extend(["--leverage", str(cfg.leverage)])
     if cfg.risk_pct is not None:

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -77,10 +77,6 @@
         <label for="bt-end">Fin</label>
         <input id="bt-end" type="date"/>
       </div>
-      <div id="field-equity-pct">
-        <label for="bt-equity-pct">Equity %</label>
-        <input id="bt-equity-pct" type="number" step="any"/>
-      </div>
       <div id="field-risk-pct">
         <label for="bt-risk-pct">Risk %</label>
         <input id="bt-risk-pct" type="number" step="any"/>
@@ -336,10 +332,8 @@ async function runBacktest(){
     cmd+=` --capital ${capital}`;
   }
   if(mode!=='walk'){
-    const eq=document.getElementById('bt-equity-pct').value.trim();
     const sl=document.getElementById('bt-risk-pct').value.trim();
     const mn=document.getElementById('bt-max-notional').value.trim();
-    if(eq) cmd+=` --equity-pct ${eq}`;
     if(sl) cmd+=` --risk-pct ${sl}`;
     if(mn) cmd+=` --max-notional ${mn}`;
   }

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -59,12 +59,6 @@
           <option value="futures">Futuros</option>
         </select>
       </div>
-      <div id="field-equity-pct">
-        <label for="bot-equity-pct">Equity %
-          <span class="help-icon" title="Fracción del equity a usar">?</span>
-        </label>
-        <input id="bot-equity-pct" type="number" step="0.0001"/>
-      </div>
       <div id="field-leverage">
         <label for="bot-leverage">Leverage</label>
         <input id="bot-leverage" type="number" step="1"/>
@@ -202,7 +196,7 @@ const api = (path) => `${location.origin}${path}`;
   async function updateForm(){
     const strat=document.getElementById('bot-strategy').value;
     const cross=strat==='cross_arbitrage';
-    ['field-exchange','field-market','field-equity-pct','field-risk-pct'].forEach(id=>{
+    ['field-exchange','field-market','field-risk-pct'].forEach(id=>{
       document.getElementById(id).style.display = cross ? 'none' : '';
     });
     ['field-spot','field-perp','field-threshold'].forEach(id=>{
@@ -218,7 +212,6 @@ async function startBot(){
   const notional = document.getElementById('bot-notional').value;
   const exchange = document.getElementById('bot-exchange').value;
   const market = document.getElementById('bot-market').value;
-  const equity_pct = document.getElementById('bot-equity-pct').value;
   const risk_pct = document.getElementById('bot-risk-pct').value;
   const leverage = document.getElementById('bot-leverage').value;
   const env = document.getElementById('bot-env').value;
@@ -239,7 +232,6 @@ async function startBot(){
     });
     const payload = {strategy, pairs, exchange, market, testnet, dry_run};
     if(notional) payload.notional = Number(notional);
-    if(equity_pct) payload.equity_pct = Number(equity_pct);
     if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(leverage) payload.leverage = Number(leverage);
   if(strategy==='cross_arbitrage'){

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -149,7 +149,6 @@ class EventDrivenBacktestEngine:
         initial_equity: float = 0.0,
         risk_pct: float = 0.0,
         max_notional: float = 0.0,
-        equity_pct: float = 0.0,
     ) -> None:
         self.data = data
         self.latency = int(latency)
@@ -171,7 +170,6 @@ class EventDrivenBacktestEngine:
             self.slippage.spread_mult *= self.stress.spread
 
         self.initial_equity = float(initial_equity)
-        self._equity_pct = float(equity_pct)
         self._risk_pct = float(risk_pct)
         self._max_notional = float(max_notional)
 
@@ -207,7 +205,6 @@ class EventDrivenBacktestEngine:
                 else None
             )
             rm = RiskManager(
-                equity_pct=self._equity_pct,
                 risk_pct=self._risk_pct,
                 limits=limits,
             )
@@ -495,7 +492,6 @@ def run_backtest_csv(
     seed: int | None = None,
     risk_pct: float = 0.0,
     max_notional: float = 0.0,
-    equity_pct: float = 0.0,
     initial_equity: float = 0.0,
 ) -> dict:
     """Convenience wrapper to run the engine from CSV files."""
@@ -515,7 +511,6 @@ def run_backtest_csv(
         seed=seed,
         risk_pct=risk_pct,
         max_notional=max_notional,
-        equity_pct=equity_pct,
         initial_equity=initial_equity,
     )
     return engine.run()
@@ -541,7 +536,6 @@ def run_backtest_mlflow(
     experiment: str = "backtest",
     risk_pct: float = 0.0,
     max_notional: float = 0.0,
-    equity_pct: float = 0.0,
     initial_equity: float = 0.0,
 ) -> dict:
     """Run the backtest and log results to an MLflow run.
@@ -574,7 +568,6 @@ def run_backtest_mlflow(
             seed=seed,
             risk_pct=risk_pct,
             max_notional=max_notional,
-            equity_pct=equity_pct,
             initial_equity=initial_equity,
         )
         log_backtest_metrics(result)

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -623,7 +623,6 @@ def run_bot(
     ),
     symbols: List[str] = typer.Option(["BTC/USDT"], "--symbol", help="Trading symbols"),
     testnet: bool = typer.Option(True, help="Use testnet endpoints"),
-    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
@@ -640,7 +639,6 @@ def run_bot(
                 exchange=exchange,
                 market=market,
                 symbols=symbols,
-                equity_pct=equity_pct,
                 risk_pct=risk_pct,
                 leverage=leverage,
                 dry_run=dry_run,
@@ -652,7 +650,6 @@ def run_bot(
         asyncio.run(
             run_live_binance(
                 symbol=symbols[0],
-                equity_pct=equity_pct,
                 risk_pct=risk_pct,
             )
         )
@@ -664,7 +661,6 @@ def paper_run(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
     config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
-    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
@@ -678,7 +674,6 @@ def paper_run(
             strategy_name=strategy,
             config_path=config,
             metrics_port=metrics_port,
-            equity_pct=equity_pct,
             risk_pct=risk_pct,
         )
     )
@@ -693,7 +688,6 @@ def real_run(
         help=f"Trading venue ({_VENUE_CHOICES})",
     ),
     symbols: List[str] = typer.Option(["BTC/USDT"], "--symbol", help="Trading symbols"),
-    equity_pct: float = typer.Option(1.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Simulate orders without sending"),
@@ -718,7 +712,6 @@ def real_run(
             exchange=exchange,
             market=market,
             symbols=symbols,
-            equity_pct=equity_pct,
             risk_pct=risk_pct,
             leverage=leverage,
             dry_run=dry_run,
@@ -755,7 +748,7 @@ def run_daemon(config: str = "config/config.yaml") -> None:
 
         adapter = BinanceSpotWSAdapter()
         bus = EventBus()
-        risk = RiskManager(equity_pct=1.0, risk_pct=0.0, bus=bus)
+        risk = RiskManager(risk_pct=0.0, bus=bus)
         strat = BreakoutATR()
         router = ExecutionRouter(adapters=[adapter])
 
@@ -890,7 +883,6 @@ def backtest(
     symbol: str = "BTC/USDT",
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -909,7 +901,6 @@ def backtest(
         {symbol: df},
         [(strategy, symbol)],
         initial_equity=capital,
-        equity_pct=equity_pct,
         risk_pct=risk_pct,
         max_notional=max_notional,
     )
@@ -922,7 +913,6 @@ def backtest(
 def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -961,7 +951,6 @@ def backtest_cfg(
             {symbol: df},
             [(strategy, symbol)],
             initial_equity=capital,
-            equity_pct=equity_pct,
             risk_pct=risk_pct,
             max_notional=max_notional,
         )
@@ -991,7 +980,6 @@ def backtest_db(
     end: str = typer.Option(..., help="End date YYYY-MM-DD"),
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    equity_pct: float = typer.Option(0.0, "--equity-pct", help="Fraction of equity to use"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
     max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
@@ -1038,7 +1026,6 @@ def backtest_db(
         {symbol: df},
         [(strategy, symbol)],
         initial_equity=capital,
-        equity_pct=equity_pct,
         risk_pct=risk_pct,
         max_notional=max_notional,
     )

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -87,7 +87,6 @@ async def run_live_binance(
     symbol: str = "BTC/USDT",
     fee_bps: float = 1.5,
     persist_pg: bool = False,
-    equity_pct: float = 1.0,
     risk_pct: float = 0.0,
     total_cap_pct: float = 1.0,
     per_symbol_cap_pct: float = 0.5,
@@ -104,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(equity_pct=equity_pct, risk_pct=risk_pct)
+    risk_core = RiskManager(risk_pct=risk_pct)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_pct=total_cap_pct,

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -40,7 +40,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     bus = EventBus()
     if risk is None:
         risk = RiskService(
-            RiskManager(equity_pct=1.0, risk_pct=0.0),
+            RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="cross")),
             daily=None,
         )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -42,7 +42,6 @@ async def run_paper(
     config_path: str | None = None,
     metrics_port: int = 8000,
     corr_threshold: float = 0.8,
-    equity_pct: float = 1.0,
     risk_pct: float = 0.0,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
@@ -51,7 +50,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(equity_pct=equity_pct, risk_pct=risk_pct)
+    risk_core = RiskManager(risk_pct=risk_pct)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
     guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -80,7 +80,6 @@ def _get_keys(exchange: str) -> Tuple[str | None, str | None]:
 @dataclass
 class _SymbolConfig:
     symbol: str
-    equity_pct: float
     risk_pct: float
 
 
@@ -108,7 +107,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(equity_pct=cfg.equity_pct, risk_pct=cfg.risk_pct)
+    risk_core = RiskManager(risk_pct=cfg.risk_pct)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,
@@ -193,7 +192,6 @@ async def run_live_real(
     exchange: str = "binance",
     market: str = "spot",
     symbols: List[str] | None = None,
-    equity_pct: float = 1.0,
     risk_pct: float = 0.0,
     leverage: int = 1,
     dry_run: bool = False,
@@ -219,7 +217,7 @@ async def run_live_real(
         raise ValueError(f"Unsupported combination {exchange} {market}")
     symbols = symbols or ["BTC/USDT"]
     cfgs = [
-        _SymbolConfig(symbol=s.upper().replace("-", "/"), equity_pct=equity_pct, risk_pct=risk_pct)
+        _SymbolConfig(symbol=s.upper().replace("-", "/"), risk_pct=risk_pct)
         for s in symbols
     ]
     tasks = [

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -47,7 +47,6 @@ ADAPTERS: Dict[Tuple[str, str], AdapterTuple] = {
 @dataclass
 class _SymbolConfig:
     symbol: str
-    equity_pct: float
     risk_pct: float
 
 async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: int,
@@ -75,7 +74,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(equity_pct=cfg.equity_pct, risk_pct=cfg.risk_pct)
+    risk_core = RiskManager(risk_pct=cfg.risk_pct)
     guard = PortfolioGuard(GuardConfig(
         total_cap_pct=total_cap_pct,
         per_symbol_cap_pct=per_symbol_cap_pct,
@@ -154,7 +153,6 @@ async def run_live_testnet(
     exchange: str = "binance",
     market: str = "spot",
     symbols: List[str] | None = None,
-    equity_pct: float = 1.0,
     risk_pct: float = 0.0,
     leverage: int = 1,
     dry_run: bool = False,
@@ -173,7 +171,7 @@ async def run_live_testnet(
         raise ValueError(f"Unsupported combination {exchange} {market}")
     symbols = symbols or ["BTC/USDT"]
     cfgs = [
-        _SymbolConfig(symbol=s.upper().replace("-", "/"), equity_pct=equity_pct, risk_pct=risk_pct)
+        _SymbolConfig(symbol=s.upper().replace("-", "/"), risk_pct=risk_pct)
         for s in symbols
     ]
     tasks = [

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -51,7 +51,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
     fills = 0
     if risk is None:
         risk = RiskService(
-            RiskManager(equity_pct=1.0, risk_pct=0.0),
+            RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="binance")),
         )
 

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -87,7 +87,7 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
     engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None
     if cfg.persist_pg and not _CAN_PG:
         log.warning("Persistencia habilitada pero Timescale no disponible.")
-    risk = RiskManager(equity_pct=1.0, risk_pct=0.0)
+    risk = RiskManager(risk_pct=0.0)
 
     async def maybe_trade() -> None:
         if last["spot"] is None or last["perp"] is None:

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -36,7 +36,6 @@ def test_bot_endpoints(monkeypatch):
         "strategy": "dummy",
         "pairs": ["BTC/USDT"],
         "venue": "binance_spot",
-        "equity_pct": 1.0,
         "leverage": 1,
         "risk_pct": 0.03,
         "testnet": True,
@@ -48,7 +47,6 @@ def test_bot_endpoints(monkeypatch):
     pid = resp.json()["pid"]
     argv = list(calls["args"])
     assert "--venue" in argv and "binance_spot" in argv
-    assert "--equity-pct" in argv and "1.0" in argv
     assert "--risk-pct" in argv and "0.03" in argv
 
     lst = client.get("/bots", auth=("admin", "admin"))

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -15,7 +15,6 @@ def test_config_roundtrip():
         "pairs": ["BTC/USDT"],
         "notional": 50,
         "venue": "binance_futures",
-        "equity_pct": 0.01,
         "risk_pct": 0.005,
         "leverage": 3,
         "testnet": True,
@@ -42,7 +41,6 @@ def test_start_stop(monkeypatch):
         json={
             "strategy": "dummy",
             "venue": "binance_spot",
-            "equity_pct": 0.001,
             "risk_pct": 0.0,
             "leverage": 1,
             "testnet": True,
@@ -77,7 +75,6 @@ def test_start_stop(monkeypatch):
     assert calls
     argv = list(calls["args"])
     assert "--venue" in argv and argv[argv.index("--venue") + 1] == "binance_spot"
-    assert "--equity-pct" in argv and argv[argv.index("--equity-pct") + 1] == "0.001"
     assert "--risk-pct" in argv and argv[argv.index("--risk-pct") + 1] == "0.0"
     assert "--leverage" in argv and argv[argv.index("--leverage") + 1] == "1"
     assert "--testnet" in argv


### PR DESCRIPTION
## Summary
- remove `equity_pct` options from runners, CLI and API
- update monitoring panel and HTML templates accordingly
- adjust tests after configuration changes

## Testing
- `pytest tests/test_api_bots.py tests/test_monitoring_panel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae2320a6f0832db51992643135ebc2