### PR TITLE
feat: support daily guard limits

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -670,6 +670,8 @@ class BotConfig(BaseModel):
     equity_pct: float | None = None
     leverage: int | None = None
     risk_pct: float | None = None
+    daily_max_loss_pct: float | None = None
+    daily_max_drawdown_pct: float | None = None
     testnet: bool | None = None
     dry_run: bool | None = None
     spot: str | None = None
@@ -722,6 +724,10 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         args.extend(["--leverage", str(cfg.leverage)])
     if cfg.risk_pct is not None:
         args.extend(["--risk-pct", str(cfg.risk_pct)])
+    if cfg.daily_max_loss_pct is not None:
+        args.extend(["--daily-max-loss-pct", str(cfg.daily_max_loss_pct)])
+    if cfg.daily_max_drawdown_pct is not None:
+        args.extend(["--daily-max-drawdown-pct", str(cfg.daily_max_drawdown_pct)])
     if cfg.testnet is not None:
         args.append("--testnet" if cfg.testnet else "--no-testnet")
     if cfg.dry_run is not None:

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -98,10 +98,16 @@
         <input id="bot-risk-pct" type="number" step="0.0001" required/>
       </div>
       <div>
-        <label for="bot-max-drawdown-pct">Max drawdown %
-          <span class="help-icon" title="Pérdida máxima permitida antes de detener el bot">?</span>
+        <label for="bot-daily-max-loss-pct">Daily max loss %
+          <span class="help-icon" title="Pérdida diaria máxima permitida (porcentaje del equity)">?</span>
         </label>
-        <input id="bot-max-drawdown-pct" type="number" step="0.0001" required/>
+        <input id="bot-daily-max-loss-pct" type="number" step="0.0001"/>
+      </div>
+      <div>
+        <label for="bot-daily-max-drawdown-pct">Daily max drawdown %
+          <span class="help-icon" title="Drawdown diario máximo relativo al pico intradía">?</span>
+        </label>
+        <input id="bot-daily-max-drawdown-pct" type="number" step="0.0001"/>
       </div>
       <div>
         <label for="bot-env">Entorno</label>
@@ -220,6 +226,8 @@ async function startBot(){
   const market = document.getElementById('bot-market').value;
   const equity_pct = document.getElementById('bot-equity-pct').value;
   const risk_pct = document.getElementById('bot-risk-pct').value;
+  const daily_max_loss_pct = document.getElementById('bot-daily-max-loss-pct').value;
+  const daily_max_drawdown_pct = document.getElementById('bot-daily-max-drawdown-pct').value;
   const leverage = document.getElementById('bot-leverage').value;
   const env = document.getElementById('bot-env').value;
   const testnet = env === 'testnet';
@@ -241,6 +249,8 @@ async function startBot(){
     if(notional) payload.notional = Number(notional);
     if(equity_pct) payload.equity_pct = Number(equity_pct);
     if(risk_pct) payload.risk_pct = Number(risk_pct);
+    if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);
+    if(daily_max_drawdown_pct) payload.daily_max_drawdown_pct = Number(daily_max_drawdown_pct);
     if(leverage) payload.leverage = Number(leverage);
   if(strategy==='cross_arbitrage'){
     payload.spot = spot;

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -627,6 +627,12 @@ def run_bot(
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
+    daily_max_loss_pct: float = typer.Option(
+        0.05, "--daily-max-loss-pct", help="Daily loss limit as fraction of equity"
+    ),
+    daily_max_drawdown_pct: float = typer.Option(
+        0.05, "--daily-max-drawdown-pct", help="Intraday max drawdown limit"
+    ),
 ) -> None:
     """Run the live trading bot with configurable venue and symbols."""
 
@@ -644,6 +650,8 @@ def run_bot(
                 risk_pct=risk_pct,
                 leverage=leverage,
                 dry_run=dry_run,
+                daily_max_loss_pct=daily_max_loss_pct,
+                daily_max_drawdown_pct=daily_max_drawdown_pct,
             )
         )
     else:
@@ -654,6 +662,8 @@ def run_bot(
                 symbol=symbols[0],
                 equity_pct=equity_pct,
                 risk_pct=risk_pct,
+                daily_max_loss_pct=daily_max_loss_pct,
+                daily_max_drawdown_pct=daily_max_drawdown_pct,
             )
         )
 
@@ -697,6 +707,12 @@ def real_run(
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Simulate orders without sending"),
+    daily_max_loss_pct: float = typer.Option(
+        0.05, "--daily-max-loss-pct", help="Daily loss limit as fraction of equity"
+    ),
+    daily_max_drawdown_pct: float = typer.Option(
+        0.05, "--daily-max-drawdown-pct", help="Intraday max drawdown limit"
+    ),
     i_know_what_im_doing: bool = typer.Option(
         False,
         "--i-know-what-im-doing",
@@ -722,6 +738,8 @@ def real_run(
             risk_pct=risk_pct,
             leverage=leverage,
             dry_run=dry_run,
+            daily_max_loss_pct=daily_max_loss_pct,
+            daily_max_drawdown_pct=daily_max_drawdown_pct,
             i_know_what_im_doing=i_know_what_im_doing,
         )
     )


### PR DESCRIPTION
## Summary
- add daily loss and drawdown inputs to bots dashboard
- plumb DailyGuard params through API and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae1ae070d4832d9269da573d909c68