### PR TITLE
Handle stop loss without triggering kill switch

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Dict, Tuple
 
-from .manager import RiskManager
+from .manager import RiskManager, StopLossExceeded
 from .portfolio_guard import PortfolioGuard
 from .daily_guard import DailyGuard
 from .correlation_service import CorrelationService
@@ -97,7 +97,15 @@ class RiskService:
         if qty <= 0:
             return False, "zero_size", 0.0
 
-        if not self.rm.check_limits(price):
+        try:
+            limits_ok = self.rm.check_limits(price)
+        except StopLossExceeded:
+            self._persist("VIOLATION", symbol, "stop_loss", {})
+            # size to fully exit current position
+            exit_delta = -self.rm.pos.qty
+            return True, "stop_loss", exit_delta
+
+        if not limits_ok:
             self._persist("VIOLATION", symbol, "kill_switch", {})
             return False, "kill_switch", 0.0
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def test_size_scales_with_equity_and_strength():
-    from tradingbot.risk.manager import RiskManager
+    from tradingbot.risk.manager import RiskManager, StopLossExceeded
 
     price = 100.0
     equity_small = 10_000.0
@@ -20,7 +20,7 @@ def test_size_scales_with_equity_and_strength():
 
 
 def test_stop_loss_risk_pct():
-    from tradingbot.risk.manager import RiskManager
+    from tradingbot.risk.manager import RiskManager, StopLossExceeded
 
     equity = 10_000.0
     pos_pct = 0.10
@@ -32,8 +32,9 @@ def test_stop_loss_risk_pct():
     rm.set_position(qty)
 
     assert rm.check_limits(price)
-    assert not rm.check_limits(price * (1 - risk_pct))
-    assert rm.enabled is False
+    with pytest.raises(StopLossExceeded):
+        rm.check_limits(price * (1 - risk_pct))
+    assert rm.enabled is True
 
 
 def test_pyramiding_and_scaling(risk_manager):


### PR DESCRIPTION
## Summary
- add `StopLossExceeded` to signal per-position stop loss breaches without disabling risk manager
- propagate stop-loss events through `RiskService.check_order` to emit exit orders
- cover stop-loss behaviour with new tests

## Testing
- `pytest tests/test_risk_manager_limits.py::test_stop_loss_raises_exception tests/test_risk_manager_limits.py::test_risk_service_stop_loss_exit tests/test_risk.py::test_stop_loss_risk_pct`

------
https://chatgpt.com/codex/tasks/task_e_68ae232d3e24832d8f2259f990cdf258