### PR TITLE
Clarify strength-based sizing and local stop-loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ entorno real de Binance Futures.
 
 ## Gestión de riesgo
 
-La asignación de capital depende únicamente del parámetro `strength` de las
-señales: `strength = 1.0` usa todo el capital disponible, valores mayores
-piramidan la exposición y menores la reducen. Para limitar la exposición se
-puede emplear `PortfolioGuard`, configurando `total_cap_pct` para la exposición
-global y `per_symbol_cap_pct` para cada símbolo.
+Las señales incluyen un parámetro `strength` que dimensiona la orden según
+`notional = equity * strength`. Un `strength = 1.0` usa todo el capital
+disponible, valores mayores piramidan la posición y menores la reducen. El
+gestor de riesgo aplica un stop‑loss local con `risk_pct`, cerrando la posición
+si la pérdida latente supera `notional * risk_pct`. Para limitar la exposición
+global puede emplearse `PortfolioGuard`, configurando `total_cap_pct` y
+`per_symbol_cap_pct`.
 
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
 superan los límites configurados, detiene el bot o cierra las posiciones

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,7 +6,11 @@ Todos los comandos se ejecutan como:
 python -m tradingbot.cli <comando> [opciones]
 ```
 
-A continuación se describen los comandos disponibles.
+A continuación se describen los comandos disponibles. Todas las estrategias
+emiten señales con un campo `strength` que se traduce en `notional = equity * strength`.
+Valores mayores a `1.0` piramidan la exposición, menores la desescalan. El
+parámetro `risk_pct` define un stop‑loss local: la posición se cierra si la
+pérdida supera `notional * risk_pct`.
 
 ## `ingest`
 Recibe datos de mercado en vivo y opcionalmente los almacena.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -2,7 +2,12 @@
 
 ## Asignación por señal
 
-La cantidad operada por cada señal se determina únicamente por su atributo `strength`. Un valor de `1.0` utiliza todo el capital disponible; valores mayores piramidan la posición y menores reducen la exposición. Por ejemplo, una señal con `strength = 1.5` incrementa la posición un 50 %, mientras que `strength = 0.5` la reduce a la mitad.
+Cada señal trae un `strength` que define el tamaño según la fórmula
+`notional = equity * strength`. Un valor de `1.0` utiliza todo el capital
+disponible, valores mayores piramidan la posición y menores la reducen.
+Por ejemplo, `strength = 1.5` incrementa la exposición un 50 %, mientras que
+`strength = 0.5` la reduce a la mitad. El campo `risk_pct` actúa como
+stop‑loss local: la posición se cierra si la pérdida supera `notional * risk_pct`.
 
 ## PortfolioGuard
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -3,6 +3,11 @@
 Las estrategias definen cómo se toman decisiones de compra o venta. A
 continuación se presenta un resumen en lenguaje sencillo.
 
+Todas las señales incluyen un campo `strength` que dimensiona las órdenes
+mediante `notional = equity * strength`. Valores superiores a `1.0` piramidan
+la posición y menores la desescalan. Además, `risk_pct` define un stop‑loss
+local basado en `notional * risk_pct`.
+
 ### Breakout con ATR (`breakout_atr`)
 Compra cuando el precio supera el canal superior calculado con el indicador
 ATR y vende cuando cae por debajo del canal inferior.

--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -234,9 +234,10 @@ class RiskManager:
     ) -> float:
         """Compute position delta for a strength-based signal.
 
-        ``equity`` es el equity actual de la cuenta utilizado para dimensionar
-        la posición. ``price`` es el precio del activo. ``strength`` representa
-        la fracción de equity deseada.
+        El tamaño se obtiene con ``notional = equity * strength``. ``price`` es
+        el precio del activo y ``equity`` el capital actual. Valores de
+        ``strength`` mayores a ``1`` piramidan la posición y menores la
+        reducen. El stop‑loss local se calcula aparte como ``notional * risk_pct``.
         """
 
         signed_strength = strength if signal_side == "buy" else -strength

--- a/src/tradingbot/risk/position_sizing.py
+++ b/src/tradingbot/risk/position_sizing.py
@@ -1,8 +1,9 @@
 """Helpers for position sizing based on volatility targets.
 
-This module now also provides utilities to translate signal strength into
-actual position deltas, ensuring consistent pyramiding and reduction across
-strategies.
+This module also provides utilities to translate signal strength into actual
+position deltas via ``notional = equity * strength``, ensuring consistent
+pyramiding and reduction across strategies. Local stop‑losses use ``risk_pct``
+as ``notional * risk_pct``.
 """
 
 from __future__ import annotations
@@ -41,6 +42,11 @@ def delta_from_strength(
     current_qty: float,
 ) -> float:
     """Translate a signal ``strength`` into a position delta.
+
+    ``strength`` controls notional through ``notional = equity * strength``.
+    Values above ``1.0`` pyramid exposure, values between ``0`` and ``1`` scale
+    it down and negatives close or flip the position. A separate ``risk_pct``
+    can later apply a local stop‑loss as ``notional * risk_pct``.
 
     Parameters
     ----------

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -13,13 +13,11 @@ from ..storage import timescale
 class Signal:
     """Simple trading signal.
 
-    ``strength`` scales position sizing as a fraction of account equity.
-    A value of ``1.0`` requests the full allocation defined by the risk
-    manager's ``equity_pct`` while ``1.5`` would pyramid exposure to
-    ``150%`` of that base size. Values between ``0`` and ``1`` reduce the
-    position proportionally and ``0`` or negative values close it. The
-    risk manager also interprets ``risk_pct`` as a stop‑loss expressed as a
-    percentage of equity.
+    ``strength`` defines sizing through ``notional = equity * strength``. A
+    value of ``1.0`` uses the full account equity, values above ``1.0`` pyramid
+    exposure and values between ``0`` and ``1`` scale it down. ``0`` or
+    negative values close the position. ``risk_pct`` acts as a local stop‑loss
+    calculated as ``notional * risk_pct``.
     """
 
     side: str  # 'buy' | 'sell' | 'flat'


### PR DESCRIPTION
## Summary
- describe position sizing as `notional = equity * strength`
- document pyramiding, scaling down, and `risk_pct` stop-loss across docs
- update strategy and risk comments to reference new sizing formula

## Testing
- `pytest` *(fails: EventDriven... TypeError, run_backtest_csv got an ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae29883818832d87740dfa424009ec