### PR TITLE
Refine position sizing utilities

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -296,7 +296,7 @@ class RiskManager:
         if self.vol_target <= 0 or symbol_vol <= 0:
             return 0.0
 
-        target_abs = vol_target(symbol_vol, self.vol_target, equity)
+        target_abs = vol_target(symbol_vol, equity, self.vol_target)
         sign = 1 if self.pos.qty >= 0 else -1
         target = sign * target_abs
         if equity <= 0 or self.vol_target <= 0 or price <= 0:

--- a/src/tradingbot/risk/position_sizing.py
+++ b/src/tradingbot/risk/position_sizing.py
@@ -8,24 +8,32 @@ strategies.
 from __future__ import annotations
 
 
-def vol_target(atr: float, vol_target: float, equity: float) -> float:
+def vol_target(atr: float, equity: float, vol_target: float) -> float:
     """Return target position size given a volatility estimate.
 
     Parameters
     ----------
     atr:
         Average true range or volatility estimate of the asset.
-    vol_target:
-        Fraction of current equity to allocate based on the desired
-        volatility target.
     equity:
         Current account equity.
+    vol_target:
+        Desired volatility target as a fraction of equity. ``0.02`` for
+        example would size the position such that one ATR move represents
+        a 2\% change in equity.
 
     Returns
     -------
     float
         Desired absolute position size.  If any argument is non-positive,
         ``0.0`` is returned.
+
+    Examples
+    --------
+    >>> vol_target(atr=2.0, equity=10.0, vol_target=1.0)
+    5.0
+    >>> vol_target(atr=1.0, equity=20.0, vol_target=0.5)
+    10.0
     """
     if atr <= 0 or vol_target <= 0 or equity <= 0:
         return 0.0
@@ -46,8 +54,7 @@ def delta_from_strength(
     ----------
     strength:
         Target exposure as a fraction of account equity. Positive values denote
-        long positions, negative values short. Values are clipped to
-        ``[-1, 1]``.
+        long positions, negative values short. No clipping is applied.
     equity:
         Current account equity.
     price:
@@ -69,9 +76,10 @@ def delta_from_strength(
     -10.0
     >>> delta_from_strength(-0.0, 10_000, 100, -40)
     40.0
+    >>> delta_from_strength(2.0, 10_000, 100, 0)
+    200.0
     """
 
-    strength = max(-1.0, min(1.0, strength))
     if price <= 0:
         return -current_qty
     target_qty = (equity * strength) / price

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -30,11 +30,11 @@ def test_risk_vol_sizing(synthetic_volatility):
 
 
 def test_vol_target_basic():
-    assert vol_target(atr=2.0, equity_pct=1.0, equity=10.0) == pytest.approx(5.0)
+    assert vol_target(atr=2.0, equity=10.0, vol_target=1.0) == pytest.approx(5.0)
 
 
 def test_vol_target_scales_linearly():
-    assert vol_target(atr=1.0, equity_pct=0.5, equity=20.0) == pytest.approx(10.0)
+    assert vol_target(atr=1.0, equity=20.0, vol_target=0.5) == pytest.approx(10.0)
 
 
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):


### PR DESCRIPTION
## Summary
- Reordered `vol_target` parameters to `(atr, equity, vol_target)` and expanded its docstring with examples
- Removed clipping from `delta_from_strength` and added illustrative example
- Updated risk manager and tests to use new API

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_risk_vol_sizing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae29dbe848832d9a666838b1852ec6