### PR TITLE
Handle stop-loss without halting entire system

### DIFF
--- a/tests/test_execution_router_stop_loss.py
+++ b/tests/test_execution_router_stop_loss.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.order_types import Order
+from tradingbot.risk.manager import RiskManager
+
+
+class DummyAdapter:
+    name = "dummy"
+
+    async def place_order(self, **kwargs):
+        return {"status": "filled", **kwargs}
+
+
+@pytest.mark.asyncio
+async def test_router_closes_position_on_stop_loss():
+    adapter = DummyAdapter()
+    rm = RiskManager(risk_pct=0.05)
+    rm.set_position(1.0)
+    rm.check_limits(100.0)
+    router = ExecutionRouter(adapter, risk_manager=rm)
+    order = Order(symbol="XYZ", side="buy", type_="market", qty=1.0, price=90.0)
+    res = await router.execute(order)
+    assert res["status"] == "stop_loss"
+    assert res["exit"]["reduce_only"] is True
+    assert res["exit"]["side"] == "sell"
+    assert rm.enabled


### PR DESCRIPTION
## Summary
- propagate StopLossExceeded from risk checks
- router reacts to StopLossExceeded by submitting a reduce-only exit order and resetting positions
- test coverage for router stop-loss handling

## Testing
- `pytest tests/test_execution_router_stop_loss.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ae29734d58832d9fc853b0ebe00ece