### PR TITLE
refactor: update position sizing signatures

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -301,7 +301,7 @@ class RiskManager:
         if self.vol_target <= 0 or symbol_vol <= 0:
             return 0.0
 
-        target_abs = vol_target(symbol_vol, self.vol_target, equity)
+        target_abs = vol_target(symbol_vol, equity, self.vol_target)
         sign = 1 if self.pos.qty >= 0 else -1
         target = sign * target_abs
         if equity <= 0 or self.vol_target <= 0 or price <= 0:

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -30,11 +30,11 @@ def test_risk_vol_sizing(synthetic_volatility):
 
 
 def test_vol_target_basic():
-    assert vol_target(atr=2.0, vol_target=1.0, equity=10.0) == pytest.approx(5.0)
+    assert vol_target(atr=2.0, equity=10.0, vol_target=1.0) == pytest.approx(5.0)
 
 
 def test_vol_target_scales_linearly():
-    assert vol_target(atr=1.0, vol_target=0.5, equity=20.0) == pytest.approx(10.0)
+    assert vol_target(atr=1.0, equity=20.0, vol_target=0.5) == pytest.approx(10.0)
 
 
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):


### PR DESCRIPTION
## Summary
- refactor vol_target to accept (atr, equity, vol_target) and document risk fraction
- remove clipping from delta_from_strength and clarify examples
- adapt risk manager and tests to new position sizing APIs

## Testing
- `pytest` *(killed: process out of memory)*
- `pytest tests/test_risk_vol_sizing.py tests/test_risk.py tests/test_risk_manager_limits.py` *(failed: AttributeError in tests/test_risk_manager_limits.py)*
- `pytest tests/test_risk_vol_sizing.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae2eda3180832db007635e55735bd7