### PR TITLE
Remove obsolete equity percentage field from backtest page

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -276,7 +276,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-equity-pct','field-risk-pct','field-max-notional'].forEach(id=>{
+  ['field-risk-pct','field-max-notional'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }


### PR DESCRIPTION
## Summary
- stop toggling nonexistent `field-equity-pct` input in backtest UI

## Testing
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q` *(fails: EventDrivenBacktestEngine.__init__() got an unexpected keyword argument 'equity_pct')*


------
https://chatgpt.com/codex/tasks/task_e_68ae3a0b08f4832dbb15c8e60bdebcd1