### PR TITLE
feat: drop notional from bot API

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -661,11 +661,14 @@ async def cli_stop(job_id: str):
 
 
 class BotConfig(BaseModel):
-    """Configuration for launching a trading bot."""
+    """Configuration for launching a trading bot.
+
+    Strategies size their orders through a ``strength`` value, so explicit
+    ``notional`` budgets are no longer required.
+    """
 
     strategy: str
     pairs: list[str] | None = None
-    notional: float | None = None
     venue: str | None = None
     leverage: int | None = None
     risk_pct: float | None = None
@@ -699,8 +702,7 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         ]
         if cfg.threshold is not None:
             args.extend(["--threshold", str(cfg.threshold)])
-        if cfg.notional is not None:
-            args.extend(["--notional", str(cfg.notional)])
+        # sizing is derived from strength in strategy signals
         return args
 
     args = [
@@ -713,8 +715,6 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
     ]
     for pair in cfg.pairs or []:
         args.extend(["--symbol", normalize_symbol(pair)])
-    if cfg.notional is not None:
-        args.extend(["--notional", str(cfg.notional)])
     if cfg.venue:
         args.extend(["--venue", cfg.venue])
     if cfg.leverage is not None:

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -38,12 +38,6 @@
         <label for="bot-pairs">Pares (coma)</label>
         <input id="bot-pairs" placeholder="BTC/USDT,ETH/USDT"/>
       </div>
-      <div>
-        <label for="bot-notional">Notional (USDT)
-          <span class="help-icon" title="Monto en USDT por operación">?</span>
-        </label>
-        <input id="bot-notional" type="number" step="0.01"/>
-      </div>
       <div id="field-exchange">
         <label for="bot-exchange">Exchange</label>
         <select id="bot-exchange">
@@ -215,7 +209,6 @@ const api = (path) => `${location.origin}${path}`;
 async function startBot(){
   const strategy = document.getElementById('bot-strategy').value;
   const pairs = document.getElementById('bot-pairs').value.split(',').map(s=>s.trim()).filter(Boolean);
-  const notional = document.getElementById('bot-notional').value;
   const exchange = document.getElementById('bot-exchange').value;
   const market = document.getElementById('bot-market').value;
   const risk_pct = document.getElementById('bot-risk-pct').value;
@@ -239,7 +232,6 @@ async function startBot(){
       params[el.dataset.name]=v;
     });
     const payload = {strategy, pairs, exchange, market, testnet, dry_run};
-    if(notional) payload.notional = Number(notional);
     if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);
     if(daily_max_drawdown_pct) payload.daily_max_drawdown_pct = Number(daily_max_drawdown_pct);

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -86,7 +86,6 @@ def test_cross_arbitrage_start(monkeypatch):
         "pairs": ["BTC/USDT"],
         "spot": "binance_spot",
         "perp": "binance_futures",
-        "notional": 25.0,
         "threshold": 0.001,
     }
 
@@ -96,4 +95,5 @@ def test_cross_arbitrage_start(monkeypatch):
     argv = list(calls["args"])
     assert "run-cross-arb" in argv
     assert "binance_spot" in argv and "binance_futures" in argv
+    assert "--notional" not in argv
 


### PR DESCRIPTION
## Summary
- remove notional field from bots dashboard
- ignore notional in BotConfig and launch args
- update bot API test to ensure notional isn't sent

## Testing
- `pytest` *(fails: tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk - TypeError: EventDriven..., tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress - TypeError: run_backtest_csv() got an...)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a113864832dac750b8cb57476bf