### PR TITLE
refactor tests to rely on equity strength sizing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,7 +118,6 @@ def risk_manager(equity_data):
     price = 100.0
 
     rm = RiskManager(risk_pct=risk_pct)
-    rm.equity_pct = 1.0
     # Atributos auxiliares para las pruebas
     rm.price = price
     rm.equity = float(equity_data.iloc[-1])

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -25,7 +25,6 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         latency=1,
         window=1,
         slippage=SlippageModel(volume_impact=0.0),
-        equity_pct=1.0,
         initial_equity=df["close"].iloc[0],
     )
     risk = engine.risk[("alwaysbuy", sym)]

--- a/tests/integration/test_stress_resilience.py
+++ b/tests/integration/test_stress_resilience.py
@@ -31,7 +31,6 @@ def test_engine_resilient_under_stress(monkeypatch):
         latency=1,
         window=1,
         slippage=SlippageModel(volume_impact=0.0),
-        equity_pct=1.0,
         risk_pct=0.0,
         initial_equity=1000.0,
     )
@@ -43,7 +42,6 @@ def test_engine_resilient_under_stress(monkeypatch):
         window=1,
         slippage=SlippageModel(volume_impact=0.0),
         stress=StressConfig(latency=2.0, spread=2.0),
-        equity_pct=1.0,
         risk_pct=0.0,
         initial_equity=1000.0,
     )

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -55,7 +55,6 @@ def test_risk_service_uses_correlation_service():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_pct=10000, total_cap_pct=20000))
     guard.refresh_usd_caps(1.0)
     rm = RiskManager(vol_target=0.02)
-    rm.equity_pct = 1.0
     corr = CorrelationService()
     svc = RiskService(rm, guard, corr_service=corr)
     now = datetime.now(timezone.utc)
@@ -95,7 +94,6 @@ def test_correlation_guard_groups_and_cap():
 
 def test_update_correlation_uses_guard_for_global_cap():
     rm = RiskManager()
-    rm.equity_pct = 1.0
     pairs = {
         ("BTC", "ETH"): 0.9,
         ("ETH", "SOL"): 0.85,

--- a/tests/test_daemon_integration.py
+++ b/tests/test_daemon_integration.py
@@ -52,7 +52,6 @@ async def test_daemon_processes_trades():
     router = DummyRouter()
     bus = EventBus()
     risk = RiskManager(bus=bus)
-    risk.equity_pct = 1.0
     daemon = TradeBotDaemon({"feed": adapter}, [AlwaysBuy()], risk, router, ["BTCUSDT"])
     daemon.equity = 5.0
     task = asyncio.create_task(daemon.run())
@@ -80,7 +79,6 @@ async def test_daemon_adjusts_size_for_correlation():
             return {"status": "filled"}
 
     risk = DummyRisk()
-    risk.equity_pct = 1.0
     router = DummyRouter()
     daemon = TradeBotDaemon({}, [], risk, router, ["AAA"], returns_window=10)
     daemon.equity = 4.0
@@ -101,7 +99,6 @@ async def test_daemon_emits_event_on_high_correlation():
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
     risk = RiskManager(bus=bus)
-    risk.equity_pct = 1.0
     router = ExecutionRouter(PaperAdapter())
     daemon = TradeBotDaemon({}, [], risk, router, ["AAA", "BBB"], returns_window=5)
     daemon.equity = 2.0

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -116,7 +116,7 @@ async def test_bybit_futures_order(monkeypatch):
         rt,
         "_SymbolConfig",
         lambda symbol, risk_pct: types.SimpleNamespace(
-            symbol=symbol, risk_pct=risk_pct, equity_pct=1.0
+            symbol=symbol, risk_pct=risk_pct
         ),
     )
     monkeypatch.setitem(
@@ -183,7 +183,7 @@ async def test_run_real(monkeypatch):
         rr,
         "_SymbolConfig",
         lambda symbol, risk_pct: types.SimpleNamespace(
-            symbol=symbol, risk_pct=risk_pct, equity_pct=1.0
+            symbol=symbol, risk_pct=risk_pct
         ),
     )
     monkeypatch.setitem(
@@ -245,7 +245,7 @@ async def test_okx_futures_order(monkeypatch):
         rt,
         "_SymbolConfig",
         lambda symbol, risk_pct: types.SimpleNamespace(
-            symbol=symbol, risk_pct=risk_pct, equity_pct=1.0
+            symbol=symbol, risk_pct=risk_pct
         ),
     )
     monkeypatch.setitem(

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -21,7 +21,6 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.oco_orders" (venue, symbol, side, qty, entry_price, sl_price, tp_price, status) VALUES ("paper", "BTCUSDT", "long", 1.5, 10000, 9500, 10500, "active");'))
 
     rm = RiskManager()
-    rm.equity_pct = 1.0
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper"))
     guard.refresh_usd_caps(1e6)
     risk = RiskService(rm, guard)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -9,9 +9,7 @@ def test_size_scales_with_equity_and_strength():
     equity_small = 10_000.0
     equity_big = 20_000.0
     rm_small = RiskManager()
-    rm_small.equity_pct = 1.0
     rm_big = RiskManager()
-    rm_big.equity_pct = 1.0
 
     expected_small = equity_small * 0.5 / price
     expected_big = equity_big * 0.5 / price
@@ -29,7 +27,6 @@ def test_stop_loss_risk_pct():
 
     qty = equity * 0.10 / price
     rm = RiskManager(risk_pct=risk_pct)
-    rm.equity_pct = 1.0
     rm.set_position(qty)
 
     assert rm.check_limits(price)
@@ -65,7 +62,6 @@ def test_size_with_volatility_event():
     from tradingbot.utils.metrics import RISK_EVENTS
 
     rm = RiskManager(vol_target=0.02)
-    rm.equity_pct = 1.0
     before = RISK_EVENTS.labels(event_type="volatility_sizing")._value.get()
     delta = rm.size_with_volatility(0.04, price=1.0, equity=10)
     after = RISK_EVENTS.labels(event_type="volatility_sizing")._value.get()
@@ -78,7 +74,6 @@ def test_update_correlation_limits_exposure():
     from tradingbot.utils.metrics import RISK_EVENTS
 
     rm = RiskManager()
-    rm.equity_pct = 1.0
     pairs = {("BTC", "ETH"): 0.9}
     before = RISK_EVENTS.labels(event_type="correlation_limit")._value.get()
     exceeded = rm.update_correlation(pairs, 0.8)
@@ -92,7 +87,6 @@ def test_kill_switch_disables():
     from tradingbot.utils.metrics import RISK_EVENTS
 
     rm = RiskManager()
-    rm.equity_pct = 1.0
     before = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
     rm.kill_switch("manual")
     after = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
@@ -110,7 +104,6 @@ async def test_daily_loss_limit_via_bus():
     events = []
     bus.subscribe("risk:halted", lambda e: events.append(e))
     rm = RiskManager(daily_loss_limit=50, bus=bus)
-    rm.equity_pct = 1.0
     await bus.publish("pnl", {"delta": -60})
     await asyncio.sleep(0)
     assert rm.enabled is False
@@ -145,7 +138,6 @@ def test_covariance_limit_triggers_kill():
     from tradingbot.risk.manager import RiskManager
 
     rm = RiskManager()
-    rm.equity_pct = 1.0
     positions = {"BTC": 1.0, "ETH": 1.0}
     cov = {
         ("BTC", "BTC"): 0.04,

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -7,7 +7,6 @@ from tradingbot.risk.manager import RiskManager
 
 def test_covariance_and_aggregation():
     rm = RiskManager()
-    rm.equity_pct = 1.0
     returns = {"A": [0.1, 0.2, 0.15], "B": [0.05, 0.07, 0.06]}
     cov = rm.covariance_matrix(returns)
     assert pytest.approx(cov[("A", "A")]) == np.var(returns["A"], ddof=1)
@@ -21,7 +20,6 @@ def test_covariance_and_aggregation():
 
 def test_adjust_size_and_portfolio_risk():
     rm = RiskManager()
-    rm.equity_pct = 1.0
     corr = {("A", "B"): 0.9}
     size = rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
     assert size == pytest.approx(1.0)

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -26,7 +26,6 @@ async def test_risk_service_correlation_limits_and_sizing():
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
     rm = RiskManager(bus=bus)
-    rm.equity_pct = 1.0
     guard = PortfolioGuard(
         GuardConfig(total_cap_pct=50.0, per_symbol_cap_pct=50.0, venue="test")
     )

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -14,7 +14,6 @@ from tradingbot.risk.position_sizing import vol_target
 def test_risk_vol_sizing(synthetic_volatility):
     equity = 1.0
     rm = RiskManager(vol_target=0.02)
-    rm.equity_pct = 1.0
     price = 1.0
     base = rm.size("buy", price, equity, strength=0.1)
     delta = rm.size(
@@ -40,7 +39,6 @@ def test_vol_target_scales_linearly():
 def test_risk_vol_sizing_with_correlation(synthetic_volatility):
     equity = 1.0
     rm = RiskManager(vol_target=0.02)
-    rm.equity_pct = 1.0
     corr = {("BTC", "ETH"): 0.9}
     price = 1.0
     base = rm.size(
@@ -67,7 +65,6 @@ def test_risk_vol_sizing_with_correlation(synthetic_volatility):
 def test_risk_service_uses_guard_volatility():
     guard = PortfolioGuard(GuardConfig(per_symbol_cap_pct=10000, total_cap_pct=20000))
     rm = RiskManager(vol_target=0.02)
-    rm.equity_pct = 1.0
     rm_guard_equity = 1.0
     guard.refresh_usd_caps(rm_guard_equity)
     svc = RiskService(rm, guard)


### PR DESCRIPTION
## Summary
- remove obsolete `equity_pct` assignments from tests
- update RiskManager fixtures and live runner configs to use current `risk_pct` API
- size expectations now follow `notional = equity * strength`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a0beef4832d8910a14890126be3