### PR TITLE
Refactor arb sizing to use signal strength

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -158,7 +158,6 @@ Entrena un modelo basado en `MLStrategy` y lo guarda en disco.
 ## `tri-arb`
 Ejecuta un arbitraje triangular simple en Binance.
 - `route`: cadena `BASE-MID-QUOTE` que define los tres pares.
-- `--notional`: monto a utilizar en la divisa de salida.
 
 ## `cross-arb`
 Arbitraje entre un mercado spot y uno de futuros.
@@ -166,7 +165,6 @@ Arbitraje entre un mercado spot y uno de futuros.
 - `spot`: nombre del adaptador spot.
 - `perp`: nombre del adaptador de futuros.
 - `--threshold`: diferencia mínima de precio para actuar.
-- `--notional`: monto por pata.
 
 ## `run-cross-arb`
 Versión que utiliza el `ExecutionRouter` para arbitraje spot/perp.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -53,8 +53,12 @@ mercados.
 
 ### Arbitraje Triangular (`arbitrage_triangular`)
 Opera tres pares de divisas al mismo tiempo para explotar desequilibrios en
-las tasas de cambio.
+las tasas de cambio. La señal emitida utiliza ``strength = edge`` (limitado a
+``[0, 1]``) y ``RiskService.check_order`` dimensiona cada pata según el equity
+actual.
 
 ### Arbitraje entre Exchanges (`cross_exchange_arbitrage`)
 Compara el precio entre un mercado spot y uno de futuros (perpetuo) y opera
-cuando la diferencia supera un umbral.
+cuando la diferencia supera un umbral. La fuerza de la señal se basa en el
+``edge`` detectado (``strength = |edge|``) y el tamaño final de la operación lo
+calcula ``RiskService.check_order`` sin necesidad de un notional fijo.

--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -699,8 +699,6 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
         ]
         if cfg.threshold is not None:
             args.extend(["--threshold", str(cfg.threshold)])
-        if cfg.notional is not None:
-            args.extend(["--notional", str(cfg.notional)])
         return args
 
     args = [
@@ -713,8 +711,6 @@ def _build_bot_args(cfg: BotConfig) -> list[str]:
     ]
     for pair in cfg.pairs or []:
         args.extend(["--symbol", normalize_symbol(pair)])
-    if cfg.notional is not None:
-        args.extend(["--notional", str(cfg.notional)])
     if cfg.venue:
         args.extend(["--venue", cfg.venue])
     if cfg.leverage is not None:

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1151,7 +1151,6 @@ def train_ml(
 @app.command("tri-arb")
 def tri_arb(
     route: str = typer.Argument(..., help="Ruta BASE-MID-QUOTE, ej. BTC-ETH-USDT"),
-    notional: float = typer.Option(100.0, help="Notional en la divisa quote"),
 ) -> None:
     """Ejecutar arbitrage triangular simple en Binance."""
 
@@ -1164,7 +1163,7 @@ def tri_arb(
     except ValueError as exc:  # pragma: no cover - validated por typer
         raise typer.BadParameter("Formato de ruta inválido, usa BASE-MID-QUOTE") from exc
 
-    cfg = TriConfig(route=TriRoute(base, mid, quote), notional_quote=notional)
+    cfg = TriConfig(route=TriRoute(base, mid, quote))
     asyncio.run(run_triangular_binance(cfg))
 
 
@@ -1174,7 +1173,6 @@ def cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
 ) -> None:
     """Arbitraje entre spot y perp usando dos adapters."""
 
@@ -1210,7 +1208,6 @@ def cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
     )
     asyncio.run(run_cross_exchange_arbitrage(cfg))
 
@@ -1221,7 +1218,6 @@ def run_cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
 ) -> None:
     """Ejecuta el runner de arbitraje spot/perp con ``ExecutionRouter``."""
 
@@ -1255,7 +1251,6 @@ def run_cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
     )
     asyncio.run(run_cross_exchange(cfg))
 

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Dict
-import time
 
 from .base import Strategy, Signal, record_signal_metrics
 
@@ -81,68 +80,6 @@ def compute_edge(
         return TriEdge(direction="b->m", gross=edge_bm, net=edge_bm, prices=prices)
     else:
         return TriEdge(direction="m->b", gross=edge_mb, net=edge_mb, prices=prices)
-
-def compute_qtys_for_route(
-    direction: str,
-    notional_quote: float,
-    prices: Dict[str, float],
-    taker_fee_bps: float,
-    buffer_bps: float,
-    latency_s: float = 0.0,
-    max_notional: Optional[float] = None,
-    max_leg_qty: Optional[float] = None,
-) -> Dict[str, float]:
-    """Compute approximate quantities for each leg of the route.
-
-    Parameters
-    ----------
-    direction:
-        ``"b->m"`` for QUOTE→BASE→MID→QUOTE or ``"m->b"`` for
-        QUOTE→MID→BASE→QUOTE.
-    notional_quote:
-        Initial notional in quote currency to deploy.
-    prices:
-        Mapping of prices for the legs (``bq``, ``mq``, ``mb``).
-    taker_fee_bps:
-        Taker fee in basis points per leg.
-    buffer_bps:
-        Safety buffer in basis points per leg.
-    latency_s:
-        Optional latency in seconds to simulate before computing quantities.
-    max_notional:
-        Cap the total notional deployed. ``None`` disables the cap.
-    max_leg_qty:
-        Maximum quantity allowed for each leg. ``None`` disables the cap.
-
-    Returns
-    -------
-    Dict[str, float]
-        Approximate quantities for ``base_qty``, ``mid_qty`` and
-        resulting ``quote_out``.
-    """
-    if latency_s:
-        time.sleep(latency_s)
-    if max_notional is not None:
-        notional_quote = min(notional_quote, max_notional)
-
-    f = 1 - taker_fee_bps/10000.0
-    buf = 1 - buffer_bps/10000.0
-    bq, mq, mb = prices["bq"], prices["mq"], prices["mb"]
-
-    if direction == "b->m":
-        base_qty = (notional_quote * f * buf) / bq
-        base_qty = min(base_qty, max_leg_qty) if max_leg_qty is not None else base_qty
-        mid_qty = (base_qty * f * buf) / mb
-        mid_qty = min(mid_qty, max_leg_qty) if max_leg_qty is not None else mid_qty
-        quote_out = mid_qty * mq * f * buf
-        return {"base_qty": base_qty, "mid_qty": mid_qty, "quote_out": quote_out}
-    else:
-        mid_qty = (notional_quote * f * buf) / mq
-        mid_qty = min(mid_qty, max_leg_qty) if max_leg_qty is not None else mid_qty
-        base_qty = (mid_qty * f * buf) / mb
-        base_qty = min(base_qty, max_leg_qty) if max_leg_qty is not None else base_qty
-        quote_out = base_qty * bq * f * buf
-        return {"base_qty": base_qty, "mid_qty": mid_qty, "quote_out": quote_out}
 
 
 class TriangularArb(Strategy):

--- a/tests/fixtures/market.py
+++ b/tests/fixtures/market.py
@@ -56,6 +56,7 @@ class DummyMarketAdapter:
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        **kwargs,
     ) -> dict:
         self.orders.append({"symbol": symbol, "side": side, "qty": qty})
         return {"status": "filled", "price": self.state.last_px[symbol]}

--- a/tests/test_cross_exchange_arbitrage_rebalance.py
+++ b/tests/test_cross_exchange_arbitrage_rebalance.py
@@ -61,7 +61,6 @@ async def test_rebalance_called_and_snapshots_persisted(monkeypatch):
         spot=spot,
         perp=perp,
         threshold=0.001,
-        notional=100.0,
         persist_pg=True,
         rebalance_assets=("USDT",),
         rebalance_threshold=1.0,
@@ -74,5 +73,5 @@ async def test_rebalance_called_and_snapshots_persisted(monkeypatch):
     venues = {c[0] for c in snapshots}
     assert venues == {"spot", "perp"}
     pos = {v: p for v, _, p, _, _ in snapshots}
-    assert pos["spot"] == pytest.approx(1.0)
-    assert pos["perp"] == pytest.approx(-1.0)
+    assert pos["spot"] == pytest.approx(0.01, rel=1e-3)
+    assert pos["perp"] == pytest.approx(-0.01, rel=1e-3)

--- a/tests/test_cross_exchange_runner.py
+++ b/tests/test_cross_exchange_runner.py
@@ -42,7 +42,6 @@ async def test_cross_exchange_runner_persists_and_executes(
         spot=spot,
         perp=perp,
         threshold=0.001,
-        notional=100.0,
     )
 
     await run_cross_exchange(cfg)


### PR DESCRIPTION
## Summary
- Remove fixed notionals from arbitrage configs and rely on signal `strength` for sizing
- Delegate trade quantity to `RiskService.check_order` in cross-exchange and triangular runners
- Update docs and CLI to document strength-based sizing instead of fixed notional

## Testing
- `pytest tests/test_cross_exchange_arbitrage.py -q`
- `pytest tests/test_cross_exchange_arbitrage_rebalance.py tests/test_cross_exchange_runner.py tests/test_arbitrage_triangular.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a0f0cdc832d97f4c8ea485c9791