### PR TITLE
docs: update risk management examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ entorno real de Binance Futures.
 
 Las señales incluyen un parámetro `strength` que dimensiona la orden según
 `notional = equity * strength`. Un `strength = 1.0` usa todo el capital
-disponible, valores mayores piramidan la posición y menores la reducen. El
-gestor de riesgo aplica un stop‑loss local con `risk_pct`, cerrando la posición
-si la pérdida latente supera `notional * risk_pct`. Para limitar la exposición
-global puede emplearse `PortfolioGuard`, configurando `total_cap_pct` y
-`per_symbol_cap_pct`.
+disponible; valores mayores piramidan la posición y menores la reducen. El
+gestor de riesgo limita la pérdida con `risk_pct` y permite dimensionar según
+la volatilidad mediante `vol_target`. Para limitar la exposición global puede
+emplearse `PortfolioGuard`, dejando `total_cap_pct` y `per_symbol_cap_pct` en
+`null` para deshabilitar estos límites.
 
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
 superan los límites configurados, detiene el bot o cierra las posiciones
@@ -84,6 +84,12 @@ backtest:
   symbol: DOGE/USDT
   strategy: breakout_atr
   initial_equity: 100
+
+risk:
+  risk_pct: 0.02
+  vol_target: 0.01
+  total_cap_pct: null
+  per_symbol_cap_pct: null
 
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,8 +9,18 @@ python -m tradingbot.cli <comando> [opciones]
 A continuación se describen los comandos disponibles. Todas las estrategias
 emiten señales con un campo `strength` que se traduce en `notional = equity * strength`.
 Valores mayores a `1.0` piramidan la exposición, menores la desescalan. El
-parámetro `risk_pct` define un stop‑loss local: la posición se cierra si la
-pérdida supera `notional * risk_pct`.
+parámetro `risk_pct` establece la pérdida máxima permitida y `vol_target`
+dimensiona la posición según la volatilidad.
+
+Ejemplo de configuración de riesgo:
+
+```yaml
+risk:
+  risk_pct: 0.02
+  vol_target: 0.01
+  total_cap_pct: null
+  per_symbol_cap_pct: null
+```
 
 ## `ingest`
 Recibe datos de mercado en vivo y opcionalmente los almacena.
@@ -84,7 +94,7 @@ Ejecuta el bot en modo en vivo (testnet o real).
 - `--venue`: nombre del venue (ej. `binance_spot`, `okx_futures`).
 - `--symbol`: puede repetirse; símbolo a operar.
 - `--testnet`: usa endpoints de prueba.
-- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
+- `--risk-pct`: porcentaje de pérdida máxima del equity asignado.
 - `--leverage`: apalancamiento para futuros.
 - `--dry-run`: simula órdenes en testnet.
 - `--take-profit`: porcentaje de toma de ganancias.
@@ -100,7 +110,7 @@ Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 Ejecuta el bot contra un exchange real.
 - `--venue`: nombre del venue.
 - `--symbol`: puede repetirse.
-- `--risk-pct`: stop‑loss como porcentaje del equity asignado.
+- `--risk-pct`: porcentaje de pérdida máxima del equity asignado.
 - `--leverage`: apalancamiento.
 - `--dry-run`: simula órdenes sin enviarlas.
 - `--i-know-what-im-doing`: confirmación necesaria para operar con dinero real.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -6,12 +6,12 @@ Cada señal trae un `strength` que define el tamaño según la fórmula
 `notional = equity * strength`. Un valor de `1.0` utiliza todo el capital
 disponible, valores mayores piramidan la posición y menores la reducen.
 Por ejemplo, `strength = 1.5` incrementa la exposición un 50 %, mientras que
-`strength = 0.5` la reduce a la mitad. El campo `risk_pct` actúa como
-stop‑loss local: la posición se cierra si la pérdida supera `notional * risk_pct`.
+`strength = 0.5` la reduce a la mitad. El campo `risk_pct` establece la pérdida
+máxima permitida y `vol_target` dimensiona la posición según la volatilidad.
 
 ## PortfolioGuard
 
-Para limitar el uso de capital se puede emplear `PortfolioGuard`, que permite fijar límites globales (`total_cap_pct`) o por símbolo (`per_symbol_cap_pct`).
+Para limitar el uso de capital se puede emplear `PortfolioGuard`, que permite fijar límites globales (`total_cap_pct`) o por símbolo (`per_symbol_cap_pct`). Estos valores pueden establecerse en `null` para deshabilitar los límites.
 
 ## DailyGuard y drawdown global
 
@@ -27,4 +27,10 @@ backtest:
   symbol: DOGE/USDT
   strategy: breakout_atr
   initial_equity: 100
+
+risk:
+  risk_pct: 0.02
+  vol_target: 0.01
+  total_cap_pct: null
+  per_symbol_cap_pct: null
 ```

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -34,3 +34,9 @@ ingestion:
   open_interest:
     binance_futures:
       BTC/USDT: 60
+
+risk:
+  risk_pct: 0.02
+  vol_target: 0.01
+  total_cap_pct: null
+  per_symbol_cap_pct: null


### PR DESCRIPTION
## Summary
- add risk configuration example with `risk_pct` and `vol_target`
- clarify PortfolioGuard limits and remove fixed parameter references
- document `risk_pct` as max loss in CLI docs

## Testing
- `pytest` *(interrupted: KeyboardInterrupt)*
- `pytest tests/test_risk_vol_sizing.py::test_vol_target_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae40e3dcb8832db76b413254d065c5