### PR TITLE
feat: adapt signal strength based on position performance

### DIFF
--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -2,6 +2,7 @@ from .breakout_atr import BreakoutATR
 from .breakout_vol import BreakoutVol
 from .momentum import Momentum
 from .mean_reversion import MeanReversion
+from .trend_following import TrendFollowing
 from .arbitrage_triangular import TriangularArb
 from .cash_and_carry import CashAndCarry
 from .order_flow import OrderFlow
@@ -16,6 +17,7 @@ STRATEGIES = {
     BreakoutATR.name: BreakoutATR,
     BreakoutVol.name: BreakoutVol,
     Momentum.name: Momentum,
+    TrendFollowing.name: TrendFollowing,
     MeanReversion.name: MeanReversion,
     TriangularArb.name: TriangularArb,
     CashAndCarry.name: CashAndCarry,
@@ -42,6 +44,10 @@ STRATEGY_INFO: dict[str, dict] = {
     },
     "momentum": {
         "desc": "Sigue la tendencia con RSI",
+        "requires": ["ohlcv"],
+    },
+    "trend_following": {
+        "desc": "Seguimiento de tendencia con fuerza adaptativa",
         "requires": ["ohlcv"],
     },
     "mean_reversion": {
@@ -87,6 +93,7 @@ __all__ = [
     "BreakoutVol",
     "Momentum",
     "MeanReversion",
+    "TrendFollowing",
     "TriangularArb",
     "CashAndCarry",
     "OrderFlow",

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -1,0 +1,64 @@
+import pandas as pd
+from .base import Strategy, Signal, record_signal_metrics
+from ..data.features import rsi, calc_ofi
+
+
+class TrendFollowing(Strategy):
+    """RSI based trend following strategy with adaptive strength.
+
+    Signals are generated when the RSI crosses extreme levels.  The returned
+    ``strength`` scales up if an existing position is profitable and the new
+    signal aligns with it.  Adverse moves reduce the strength and may turn it
+    negative to indicate that the position should be reduced or flipped.
+    """
+
+    name = "trend_following"
+
+    def __init__(self, **kwargs):
+        self.rsi_n = kwargs.get("rsi_n", 14)
+        self.threshold = kwargs.get("rsi_threshold", 60.0)
+        self._pos_side: str | None = None
+        self._entry_price: float | None = None
+
+    def _calc_strength(self, side: str, price: float) -> float:
+        if side == "flat":
+            self._pos_side = None
+            self._entry_price = None
+            return 0.0
+        strength = 1.0
+        if self._pos_side and self._entry_price:
+            pnl = (price - self._entry_price) / self._entry_price
+            if self._pos_side == "sell":
+                pnl = -pnl
+            if side == self._pos_side:
+                strength += pnl
+            else:
+                strength = -pnl
+        if strength > 0:
+            self._pos_side = side
+            self._entry_price = price
+        else:
+            self._pos_side = None
+            self._entry_price = None
+        return strength
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.rsi_n + 1:
+            return None
+        rsi_series = rsi(df, self.rsi_n)
+        last_rsi = rsi_series.iloc[-1]
+        ofi_val = 0.0
+        if {"bid_qty", "ask_qty"}.issubset(df.columns):
+            ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
+        price_col = "close" if "close" in df.columns else "price"
+        price = float(df[price_col].iloc[-1])
+        if last_rsi > self.threshold and ofi_val >= 0:
+            strength = self._calc_strength("buy", price)
+            return Signal("buy", strength)
+        if last_rsi < 100 - self.threshold and ofi_val <= 0:
+            strength = self._calc_strength("sell", price)
+            return Signal("sell", strength)
+        strength = self._calc_strength("flat", price)
+        return Signal("flat", strength)


### PR DESCRIPTION
## Summary
- scale mean reversion signals using entry price to reward profitable positions and punish losers
- extend cross-exchange arbitrage to size trades with a dynamic strength factor
- add adaptive RSI trend-following strategy and register it in the strategy catalog

## Testing
- `pytest tests/test_mean_reversion.py::test_mean_reversion_on_bar_signals -q`
- `pytest tests/test_cross_exchange_arbitrage.py::test_cross_exchange_arbitrage_executes_hedged_orders -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae40e326b4832dacf6de30290a4f36