### PR TITLE
Refactor cross exchange runner to derive sizing from edge

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -176,7 +176,6 @@ Arbitraje entre un mercado spot y uno de futuros.
 - `spot`: nombre del adaptador spot.
 - `perp`: nombre del adaptador de futuros.
 - `--threshold`: diferencia mínima de precio para actuar.
-- `--notional`: monto por pata.
 
 ## `run-cross-arb`
 Versión que utiliza el `ExecutionRouter` para arbitraje spot/perp.

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1174,7 +1174,6 @@ def cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
 ) -> None:
     """Arbitraje entre spot y perp usando dos adapters."""
 
@@ -1210,7 +1209,6 @@ def cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
     )
     asyncio.run(run_cross_exchange_arbitrage(cfg))
 
@@ -1221,7 +1219,6 @@ def run_cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
 ) -> None:
     """Ejecuta el runner de arbitraje spot/perp con ``ExecutionRouter``."""
 
@@ -1255,7 +1252,6 @@ def run_cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
     )
     asyncio.run(run_cross_exchange(cfg))
 


### PR DESCRIPTION
## Summary
- drop `notional` option from `cross-arb` and `run-cross-arb`
- derive trade strength from edge and size using broker equity
- document updated CLI parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4c8e205c832dbfb5891a7d5a1f29