### PR TITLE
Refactor tri-arb sizing to risk-based strength

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1151,7 +1151,6 @@ def train_ml(
 @app.command("tri-arb")
 def tri_arb(
     route: str = typer.Argument(..., help="Ruta BASE-MID-QUOTE, ej. BTC-ETH-USDT"),
-    notional: float = typer.Option(100.0, help="Notional en la divisa quote"),
 ) -> None:
     """Ejecutar arbitrage triangular simple en Binance."""
 
@@ -1164,7 +1163,7 @@ def tri_arb(
     except ValueError as exc:  # pragma: no cover - validated por typer
         raise typer.BadParameter("Formato de ruta inválido, usa BASE-MID-QUOTE") from exc
 
-    cfg = TriConfig(route=TriRoute(base, mid, quote), notional_quote=notional)
+    cfg = TriConfig(route=TriRoute(base, mid, quote))
     asyncio.run(run_triangular_binance(cfg))
 
 

--- a/src/tradingbot/storage/quest.py
+++ b/src/tradingbot/storage/quest.py
@@ -291,7 +291,7 @@ def insert_tri_signal(
     quote: str,
     direction: str,
     edge: float,
-    notional_quote: float,
+    notional: float,
     taker_fee_bps: float,
     buffer_bps: float,
     bq: float,
@@ -304,24 +304,24 @@ def insert_tri_signal(
             text(
                 """
                 INSERT INTO tri_signals (exchange, base, mid, quote, direction, edge, notional_quote, taker_fee_bps, buffer_bps, bq, mq, mb)
-                VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional_quote, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
-                """
-            ),
-            dict(
-                exchange=exchange,
-                base=base,
-                mid=mid,
-                quote=quote,
-                direction=direction,
-                edge=edge,
-                notional_quote=notional_quote,
-                taker_fee_bps=taker_fee_bps,
-                buffer_bps=buffer_bps,
-                bq=bq,
-                mq=mq,
-                mb=mb,
-            ),
-        )
+                VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
+            """
+        ),
+        dict(
+            exchange=exchange,
+            base=base,
+            mid=mid,
+            quote=quote,
+            direction=direction,
+            edge=edge,
+            notional=notional,
+            taker_fee_bps=taker_fee_bps,
+            buffer_bps=buffer_bps,
+            bq=bq,
+            mq=mq,
+            mb=mb,
+        ),
+    )
 
 
 def insert_cross_signal(

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -263,12 +263,12 @@ def insert_order(engine, *, strategy: str, exchange: str, symbol: str, side: str
             VALUES (:strategy, :exchange, :symbol, :side, :type, :qty, :px, :status, :ext_order_id, :notes)
         '''), dict(strategy=strategy, exchange=exchange, symbol=normalize(symbol), side=side, type=type_, qty=qty, px=px, status=status, ext_order_id=ext_order_id, notes=notes))
 
-def insert_tri_signal(engine, *, exchange: str, base: str, mid: str, quote: str, direction: str, edge: float, notional_quote: float, taker_fee_bps: float, buffer_bps: float, bq: float, mq: float, mb: float):
+def insert_tri_signal(engine, *, exchange: str, base: str, mid: str, quote: str, direction: str, edge: float, notional: float, taker_fee_bps: float, buffer_bps: float, bq: float, mq: float, mb: float):
     with engine.begin() as conn:
         conn.execute(text('''
             INSERT INTO market.tri_signals (exchange, base, mid, quote, direction, edge, notional_quote, taker_fee_bps, buffer_bps, bq, mq, mb)
-            VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional_quote, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
-        '''), dict(exchange=exchange, base=base, mid=mid, quote=quote, direction=direction, edge=edge, notional_quote=notional_quote, taker_fee_bps=taker_fee_bps, buffer_bps=buffer_bps, bq=bq, mq=mq, mb=mb))
+            VALUES (:exchange, :base, :mid, :quote, :direction, :edge, :notional, :taker_fee_bps, :buffer_bps, :bq, :mq, :mb)
+        '''), dict(exchange=exchange, base=base, mid=mid, quote=quote, direction=direction, edge=edge, notional=notional, taker_fee_bps=taker_fee_bps, buffer_bps=buffer_bps, bq=bq, mq=mq, mb=mb))
 
 
 def insert_cross_signal(engine, *, symbol: str, spot_exchange: str, perp_exchange: str,


### PR DESCRIPTION
## Summary
- derive trade strength from cycle edge and size each leg via `RiskService.check_order`
- drop fixed `--notional` option and log/persist executed notional for triangular arb
- update Timescale/QuestDB persistence for new notional field and remove unused helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c8eb0e8832d888b97dc27af0d9f