### PR TITLE
Use equity-based sizing for cross arbitrage tests

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1151,7 +1151,8 @@ def train_ml(
 @app.command("tri-arb")
 def tri_arb(
     route: str = typer.Argument(..., help="Ruta BASE-MID-QUOTE, ej. BTC-ETH-USDT"),
-    notional: float = typer.Option(100.0, help="Notional en la divisa quote"),
+    strength: float = typer.Option(1.0, help="Fracción del equity a utilizar"),
+    equity: float = typer.Option(100.0, help="Equity simulado en la divisa quote"),
 ) -> None:
     """Ejecutar arbitrage triangular simple en Binance."""
 
@@ -1164,7 +1165,7 @@ def tri_arb(
     except ValueError as exc:  # pragma: no cover - validated por typer
         raise typer.BadParameter("Formato de ruta inválido, usa BASE-MID-QUOTE") from exc
 
-    cfg = TriConfig(route=TriRoute(base, mid, quote), notional_quote=notional)
+    cfg = TriConfig(route=TriRoute(base, mid, quote), strength=strength, equity=equity)
     asyncio.run(run_triangular_binance(cfg))
 
 
@@ -1174,7 +1175,8 @@ def cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
+    strength: float = typer.Option(1.0, help="Fracción del equity a utilizar"),
+    equity: float = typer.Option(100.0, help="Equity simulado en la divisa quote"),
 ) -> None:
     """Arbitraje entre spot y perp usando dos adapters."""
 
@@ -1210,7 +1212,8 @@ def cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
+        strength=strength,
+        equity=equity,
     )
     asyncio.run(run_cross_exchange_arbitrage(cfg))
 
@@ -1221,7 +1224,8 @@ def run_cross_arb(
     spot: str = typer.Argument(..., help="Adapter spot, ej. binance_spot"),
     perp: str = typer.Argument(..., help="Adapter perp, ej. binance_futures"),
     threshold: float = typer.Option(0.001, help="Umbral de premium (decimales)"),
-    notional: float = typer.Option(100.0, help="Notional por pata en moneda quote"),
+    strength: float = typer.Option(1.0, help="Fracción del equity a utilizar"),
+    equity: float = typer.Option(100.0, help="Equity simulado en la divisa quote"),
 ) -> None:
     """Ejecuta el runner de arbitraje spot/perp con ``ExecutionRouter``."""
 
@@ -1255,7 +1259,8 @@ def run_cross_arb(
         spot=adapters[spot](),
         perp=adapters[perp](),
         threshold=threshold,
-        notional=notional,
+        strength=strength,
+        equity=equity,
     )
     asyncio.run(run_cross_exchange(cfg))
 

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -332,7 +332,7 @@ class TradeBotDaemon:
                 edge = (last["perp"] - last["spot"]) / last["spot"]
                 if abs(edge) < cfg.threshold:
                     return
-                qty = cfg.notional / last["spot"]
+                qty = (cfg.equity * cfg.strength) / last["spot"]
                 if edge > 0:
                     spot_side, perp_side = "buy", "sell"
                 else:

--- a/tests/fixtures/market.py
+++ b/tests/fixtures/market.py
@@ -56,6 +56,7 @@ class DummyMarketAdapter:
         price: float | None = None,
         post_only: bool = False,
         time_in_force: str | None = None,
+        **_: any,
     ) -> dict:
         self.orders.append({"symbol": symbol, "side": side, "qty": qty})
         return {"status": "filled", "price": self.state.last_px[symbol]}

--- a/tests/test_cross_exchange_runner.py
+++ b/tests/test_cross_exchange_runner.py
@@ -37,20 +37,26 @@ async def test_cross_exchange_runner_persists_and_executes(
         fake_insert_order,
     )
 
+    monkeypatch.setattr(
+        "tradingbot.live.runner_cross_exchange._CAN_PG", False
+    )
+
     cfg = CrossArbConfig(
         symbol="BTC/USDT",
         spot=spot,
         perp=perp,
         threshold=0.001,
-        notional=100.0,
+        strength=1.0,
+        equity=100.0,
     )
 
     await run_cross_exchange(cfg)
 
+    expected = 100.0 / 101.0
     assert spot.orders == [
-        {"symbol": "BTC/USDT", "side": "buy", "qty": pytest.approx(1.0)}
+        {"symbol": "BTC/USDT", "side": "buy", "qty": pytest.approx(expected)}
     ]
     assert perp.orders == [
-        {"symbol": "BTC/USDT", "side": "sell", "qty": pytest.approx(1.0)}
+        {"symbol": "BTC/USDT", "side": "sell", "qty": pytest.approx(expected)}
     ]
     assert len(inserted) == 2


### PR DESCRIPTION
## Summary
- support `strength` and simulated `equity` in `CrossArbConfig` and `TriConfig`
- adapt cross exchange runner and strategy to size using `equity * strength`
- update CLI commands, fixtures, and tests to the new sizing model

## Testing
- `pytest tests/test_cross_exchange_arbitrage.py -q`
- `pytest tests/test_cross_exchange_runner.py -q`
- `pytest tests/test_cross_exchange_arbitrage_rebalance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4c908984832d949f0a4411365b11