### PR TITLE
Remove max-notional option from backtest UI

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -81,10 +81,6 @@
         <label for="bt-risk-pct">Risk %</label>
         <input id="bt-risk-pct" type="number" step="any"/>
       </div>
-      <div id="field-max-notional">
-        <label for="bt-max-notional">Notional máximo</label>
-        <input id="bt-max-notional" type="number" step="any"/>
-      </div>
     </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
@@ -276,7 +272,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-risk-pct','field-max-notional'].forEach(id=>{
+  ['field-risk-pct'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
 }
@@ -333,9 +329,7 @@ async function runBacktest(){
   }
   if(mode!=='walk'){
     const sl=document.getElementById('bt-risk-pct').value.trim();
-    const mn=document.getElementById('bt-max-notional').value.trim();
     if(sl) cmd+=` --risk-pct ${sl}`;
-    if(mn) cmd+=` --max-notional ${mn}`;
   }
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});


### PR DESCRIPTION
## Summary
- remove max notional field from backtest form
- drop handling of --max-notional flag in script

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c4b138c832d9252f6090818c60e