### PR TITLE
Allow volatility sizing to exceed equity

### DIFF
--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -293,7 +293,9 @@ class RiskManager:
         """Dimensiona la posición basada en un objetivo de volatilidad.
 
         Devuelve el delta necesario para alcanzar el objetivo usando
-        :func:`delta_from_strength` para mantener piramidado consistente.
+        :func:`delta_from_strength` para mantener piramidado consistente. El
+        delta resultante puede exceder el 100 % del equity si ``vol_target`` lo
+        requiere.
         """
         if self.vol_target <= 0 or symbol_vol <= 0:
             return 0.0
@@ -305,7 +307,6 @@ class RiskManager:
             strength = 0.0
         else:
             strength = target * price / equity
-        strength = max(-1.0, min(1.0, strength))
         RISK_EVENTS.labels(event_type="volatility_sizing").inc()
         return delta_from_strength(strength, equity, price, self.pos.qty)
 


### PR DESCRIPTION
## Summary
- Allow volatility sizing to exceed 100% equity by removing strength clamp
- Document that volatility-based sizing may return deltas above equity

## Testing
- `pytest tests/test_risk_manager_extra.py tests/test_risk_manager_limits.py tests/test_rehydrate.py` *(fails: AttributeError: 'RiskManager' object has no attribute 'reset')*
- `python -m py_compile src/tradingbot/risk/manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c4e4f94832d9d3cb7235d341682