### PR TITLE
Allow triangular arb strength to exceed 1

### DIFF
--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -102,7 +102,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                     if edge is None or edge.net < cfg.edge_threshold:
                         continue
 
-                    strength = max(0.0, min(edge.net, 1.0))
+                    strength = max(0.0, edge.net)
 
                     eq = broker.equity(
                         mark_prices={

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -113,7 +113,7 @@ class TriangularArb(Strategy):
             return None
         edge = compute_edge(prices, self.taker_fee_bps, self.buffer_bps)
         if edge and edge.net > self.min_edge:
-            strength = max(0.0, min(edge.net, 1.0))
+            strength = max(0.0, edge.net)
             if strength > 0:
                 side = "buy" if edge.direction == "b->m" else "sell"
                 return Signal(side, strength)

--- a/tests/test_arbitrage_triangular.py
+++ b/tests/test_arbitrage_triangular.py
@@ -31,3 +31,11 @@ def test_triangular_arb_with_fees():
     sig = strat.on_bar({"prices": prices})
     assert sig.side == "buy"
     assert sig.strength == pytest.approx(0.046853, rel=1e-3)
+
+
+def test_triangular_arb_strength_over_one():
+    strat = TriangularArb()
+    prices = {"bq": 100.0, "mq": 210.0, "mb": 0.5}
+    sig = strat.on_bar({"prices": prices})
+    assert sig.side == "buy"
+    assert sig.strength == pytest.approx(3.2)


### PR DESCRIPTION
## Summary
- Remove upper cap on signal strength for triangular arbitrage strategy
- Permit live triangular runner to operate with strength > 1
- Add regression test covering strength above one

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_arbitrage_triangular.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c4cfd78832dbc49119329684f89