### PR TITLE
Remove max_notional from backtest commands and engine

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -902,7 +902,6 @@ def backtest(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a simple vectorised backtest from a CSV file."""
     from pathlib import Path
@@ -920,7 +919,6 @@ def backtest(
         [(strategy, symbol)],
         initial_equity=capital,
         risk_pct=risk_pct,
-        max_notional=max_notional,
     )
     result = eng.run()
     typer.echo(result)
@@ -932,7 +930,6 @@ def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a backtest using a Hydra YAML configuration."""
 
@@ -970,7 +967,6 @@ def backtest_cfg(
             [(strategy, symbol)],
             initial_equity=capital,
             risk_pct=risk_pct,
-            max_notional=max_notional,
         )
         result = eng.run()
         typer.echo(OmegaConf.to_yaml(cfg))
@@ -999,7 +995,6 @@ def backtest_db(
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
     risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
-    max_notional: float = typer.Option(0.0, "--max-notional", help="Max order notional"),
 ) -> None:
     """Run a backtest using data stored in the database."""
 
@@ -1045,7 +1040,6 @@ def backtest_db(
         [(strategy, symbol)],
         initial_equity=capital,
         risk_pct=risk_pct,
-        max_notional=max_notional,
     )
     result = eng.run()
     typer.echo(result)


### PR DESCRIPTION
## Summary
- drop `max_notional` option from backtest CLI commands
- remove `max_notional` handling in `EventDrivenBacktestEngine` and relax portfolio caps
- allow order sizing with zero starting equity

## Testing
- `pytest -q` *(killed)*
- `pytest tests/test_backtest_engine.py tests/test_backtesting_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae5c4c139c832d9504ce958e132eba