### PR TITLE
Remove notional from monitoring panel configuration

### DIFF
--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -124,7 +124,6 @@ def strategy_schema(name: str) -> dict:
 _config: dict[str, object] = {
     "strategy": None,
     "pairs": [],
-    "notional": None,
     "params": {},
     "venue": "binance_spot",
     "risk_pct": 0.0,
@@ -254,7 +253,6 @@ class BotConfig(BaseModel):
 
     strategy: str | None = None
     pairs: list[str] | None = None
-    notional: float | None = None
     params: dict | None = None
     venue: str | None = None
     risk_pct: float | None = None
@@ -278,13 +276,11 @@ def update_config(cfg: BotConfig) -> dict:
 
     # Remove ``None`` values so partial updates work as expected and run a few
     # basic validations.  FastAPI/Pydantic already ensures types but we enforce
-    # simple domain rules such as positive notionals.
+    # simple domain rules.
     for key, value in list(data.items()):
         if value is None:
             data.pop(key)
             continue
-        if key == "notional" and value <= 0:
-            raise HTTPException(status_code=400, detail="notional must be positive")
         if key == "risk_pct" and value < 0:
             raise HTTPException(status_code=400, detail=f"{key} must be non-negative")
         if key == "leverage" and value <= 0:
@@ -341,8 +337,6 @@ async def bot_start() -> dict:
     ]
     for pair in _config.get("pairs") or []:
         args.extend(["--symbol", pair])
-    if _config.get("notional") is not None:
-        args.extend(["--notional", str(_config["notional"])])
     if _config.get("venue"):
         args.extend(["--venue", str(_config["venue"])])
     if _config.get("risk_pct") is not None:

--- a/tests/test_monitoring_panel.py
+++ b/tests/test_monitoring_panel.py
@@ -13,7 +13,6 @@ def test_config_roundtrip():
     payload = {
         "strategy": "mean_reversion",
         "pairs": ["BTC/USDT"],
-        "notional": 50,
         "venue": "binance_futures",
         "risk_pct": 0.005,
         "leverage": 3,
@@ -25,6 +24,7 @@ def test_config_roundtrip():
     post_cfg = post_resp.json()["config"]
     for key, value in payload.items():
         assert post_cfg[key] == value
+    assert "notional" not in post_cfg
 
     # Roundtrip: ensure the configuration persists
     get_resp = client.get("/config")
@@ -32,6 +32,7 @@ def test_config_roundtrip():
     get_cfg = get_resp.json()["config"]
     for key, value in payload.items():
         assert get_cfg[key] == value
+    assert "notional" not in get_cfg
 
 
 def test_start_stop(monkeypatch):


### PR DESCRIPTION
## Summary
- drop `notional` from monitoring panel's configuration and CLI invocation
- update panel configuration validation accordingly
- fix monitoring panel tests to reflect `notional` removal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae65533b84832dbfd954c4b8eccc4d