### PR TITLE
Track equity each bar in backtest engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -409,7 +409,7 @@ class EventDrivenBacktestEngine:
                     funding_total += cash
 
             # Track equity after processing each bar
-        equity_curve.append(equity)
+            equity_curve.append(equity)
 
         # Liquidate remaining positions
         for (strat_name, symbol), svc in self.risk.items():


### PR DESCRIPTION
## Summary
- fix equity curve tracking to record equity after each bar

## Testing
- `pytest tests/test_backtest_engine.py -q`
- `PYTHONPATH=src python - <<'PY'...`

------
https://chatgpt.com/codex/tasks/task_e_68ae7cf42238832d84ebc5b6573122db