### PR TITLE
Ensure SSE end events on CLI errors and UI timeout fallback

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -636,6 +636,9 @@ async def cli_stream(job_id: str):
         try:
             async for chunk in _stream_process(proc):
                 yield chunk
+        except Exception as exc:
+            # Surface the error to the client before finishing the stream.
+            yield f"event: error\ndata: {exc}\n\n"
         finally:
             # Remove job and always emit an ``end`` event so that the client
             # knows the stream is finished even if many lines were produced.

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -127,7 +127,20 @@ const END_FALLBACK_MS=60000;
 
 function startEndFallback(){
   if(endTimer){clearTimeout(endTimer);}
-  endTimer=setTimeout(()=>{hideWorking();},END_FALLBACK_MS);
+  endTimer=setTimeout(()=>{
+    endTimer=null;
+    const runBtn=document.getElementById('bt-run');
+    const stopBtn=document.getElementById('bt-stop');
+    const out=document.getElementById('bt-output');
+    appendOutput(out,'[timeout]');
+    appendSummary(out.textContent);
+    if(evt){evt.close();}
+    currentJob=null;
+    stopBtn.disabled=true;
+    runBtn.disabled=false;
+    runBtn.textContent='Ejecutar';
+    hideWorking();
+  },END_FALLBACK_MS);
 }
 
 const strategies = {


### PR DESCRIPTION
## Summary
- guarantee `cli_stream` always emits an `end` event, even when the process errors
- enhance `startEndFallback` in backtest UI to re-enable **Ejecutar** and show a timeout message

## Testing
- `pytest -q`
- `python` script simulating `_stream_process` failure to confirm `error` and `end` events are sent
- `node` jsdom script triggering `startEndFallback` to ensure button resets and timeout message is displayed


------
https://chatgpt.com/codex/tasks/task_e_68ae7be19ba0832d9bfa4e68c8a336ee