### PR TITLE
Initialize equity curve in backtest and report positive drawdown

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -221,6 +221,7 @@ class EventDrivenBacktestEngine:
         slippage_total = 0.0
         funding_total = 0.0
         equity_curve: List[float] = []
+        equity_curve.append(equity)
 
         for i in range(max_len):
             if i and i % 1000 == 0:
@@ -465,7 +466,7 @@ class EventDrivenBacktestEngine:
         # Maximum drawdown from the equity curve
         running_max = equity_series.cummax()
         drawdown = (equity_series - running_max) / running_max
-        max_drawdown = float(drawdown.min()) if not drawdown.empty else 0.0
+        max_drawdown = -float(drawdown.min()) if not drawdown.empty else 0.0
 
         pnl = equity - self.initial_equity
 


### PR DESCRIPTION
## Summary
- Initialize equity curve with starting equity before loop
- Track equity after each bar and report max drawdown as a positive value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8b16160c832db97d119398bca309