### PR TITLE
Parse backtest summary with regex

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -218,34 +218,40 @@ let strategyInfo = strategies;
 
 function appendSummary(text){
   try{
-    let eq=null,pnl=null,fills=null,dd=null;
-    const m=text.match(/Backtest finalizado:\s*equity\s*([0-9\.e+-]+),\s*pnl\s*([0-9\.e+-]+),\s*fills\s*(\d+),\s*drawdown\s*([0-9\.e+-]+)%/);
+    let eq=null,pnl=null,fills=null,dd=null,slip=null;
+    const re=/Backtest finalizado: equity (\S+), pnl (\S+), fills (\d+), drawdown (\S+)%/;
+    const m=text.match(re);
     if(m){
       eq=parseFloat(m[1]);
       pnl=parseFloat(m[2]);
       fills=parseInt(m[3],10);
       dd=parseFloat(m[4]);
     }else{
-      const eqMatch=text.match(/'equity':\s*([0-9\.e+-]+)/);
-      const pnlMatch=text.match(/'pnl':\s*([0-9\.e+-]+)/);
-      const ddMatch=text.match(/'max_drawdown':\s*([0-9\.e+-]+)/);
+      const eqMatch=text.match(/'equity':\s*(\S+)/);
+      const pnlMatch=text.match(/'pnl':\s*(\S+)/);
+      const ddMatch=text.match(/'max_drawdown':\s*(\S+)/);
       const fillsMatch=text.match(/'fills':\s*\[(.*)\]/s);
+      const slipMatch=text.match(/'slippage':\s*(\S+)/);
       eq=eqMatch?parseFloat(eqMatch[1]):null;
       pnl=pnlMatch?parseFloat(pnlMatch[1]):null;
       dd=ddMatch?parseFloat(ddMatch[1])*100:null;
+      slip=slipMatch?parseFloat(slipMatch[1]):null;
       if(fillsMatch){
         fills=(fillsMatch[1].match(/\(/g)||[]).length;
       }
     }
+    const out=document.getElementById('bt-output');
     const lines=[
       '',
-      `equity final ≈ ${eq!=null?eq.toFixed(2):'N/A'}`,
-      `pnl total ≈ ${pnl!=null?pnl.toFixed(2):'N/A'}`,
+      `equity final ≈ ${eq!=null&&!isNaN(eq)?eq.toFixed(2):(m?m[1]:'N/A')}`,
+      `pnl total ≈ ${pnl!=null&&!isNaN(pnl)?pnl.toFixed(2):(m?m[2]:'N/A')}`,
       `${fills!=null?fills:'N/A'} fills (operaciones ejecutadas)`,
-      `drawdown máximo ≈ ${dd!=null?dd.toFixed(2):'N/A'}%`,
-      ''
+      `drawdown máximo ≈ ${dd!=null&&!isNaN(dd)?dd.toFixed(2):(m?m[4]:'N/A')}%`,
     ];
-    const out=document.getElementById('bt-output');
+    if(slip!=null&&!isNaN(slip)){
+      lines.push(`slippage medio ≈ ${slip.toFixed(2)}`);
+    }
+    lines.push('');
     lines.forEach(l=>appendOutput(out,l));
   }catch(e){/* ignore parsing errors */}
 }


### PR DESCRIPTION
## Summary
- Extract equity, pnl, fills and drawdown from the final backtest line using regex
- Retain fallback parsing and optionally report average slippage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8b2454d0832da82218a6d9ac6439