### PR TITLE
Avoid duplicate equity entries in backtesting engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -457,8 +457,8 @@ class EventDrivenBacktestEngine:
                 last_price = float(self.data[symbol]["close"].iloc[-1])
                 equity += pos * last_price
 
-        # Final equity value
-        equity_curve.append(equity)
+        # Update final equity in the curve without duplicating the last value
+        equity_curve[-1] = equity
 
         equity_series = pd.Series(equity_curve)
         # Compute simple Sharpe ratio from equity changes


### PR DESCRIPTION
## Summary
- Prevent final equity from being appended twice
- Recompute returns and drawdown from deduplicated equity curve

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef5a1bd20832db0a84e5618a500a9