### PR TITLE
Annualise Sharpe ratio in backtest engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -206,7 +206,14 @@ class EventDrivenBacktestEngine:
 
     # ------------------------------------------------------------------
     def run(self) -> dict:
-        """Execute the backtest and return summary results."""
+        """Execute the backtest and return summary results.
+
+        Notes
+        -----
+        The reported Sharpe ratio is annualised assuming daily bars
+        (252 trading days per year). If using a different bar frequency,
+        adjust the square root factor accordingly.
+        """
         max_len = max(len(df) for df in self.data.values())
         log.info(
             "Ejecutando backtest con %d estrategias y %d barras",
@@ -461,9 +468,13 @@ class EventDrivenBacktestEngine:
         equity_curve.append(equity)
 
         equity_series = pd.Series(equity_curve)
-        # Compute simple Sharpe ratio from equity changes
+        # Compute annualised Sharpe ratio from equity changes assuming daily bars
         rets = equity_series.diff().dropna()
-        sharpe = float(rets.mean() / rets.std()) if not rets.empty and rets.std() else 0.0
+        sharpe = (
+            float((rets.mean() / rets.std()) * np.sqrt(252))
+            if not rets.empty and rets.std()
+            else 0.0
+        )
         # Maximum drawdown from the equity curve
         running_max = equity_series.cummax()
         drawdown = (equity_series - running_max) / running_max

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -189,3 +189,29 @@ def test_seed_reproducibility(tmp_path, monkeypatch):
     for eq in equities[1:]:
         assert abs(eq - base) <= abs(base) * 0.005
 
+
+def test_sharpe_is_annualised(tmp_path, monkeypatch):
+    rng = pd.date_range("2021-01-01", periods=10, freq="D")
+    price = np.linspace(100, 110, num=10)
+    df = pd.DataFrame(
+        {
+            "timestamp": rng.view("int64") // 10**9,
+            "open": price,
+            "high": price + 0.5,
+            "low": price - 0.5,
+            "close": price,
+            "volume": 1000,
+        }
+    )
+    path = tmp_path / "daily.csv"
+    df.to_csv(path, index=False)
+
+    monkeypatch.setitem(STRATEGIES, "dummy", DummyStrategy)
+    strategies = [("dummy", "SYM")]
+    data = {"SYM": str(path)}
+
+    res = run_backtest_csv(data, strategies, latency=1, window=1)
+    rets = pd.Series(res["equity_curve"]).diff().dropna()
+    expected = (rets.mean() / rets.std()) * np.sqrt(252)
+    assert res["sharpe"] == pytest.approx(expected)
+


### PR DESCRIPTION
## Summary
- annualise sharpe ratio in event-driven engine using `np.sqrt(252)`
- document daily bar assumption in engine documentation
- add regression test confirming sharpe ratio is annualised

## Testing
- `pytest tests/test_backtest_engine.py::test_sharpe_is_annualised -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef5c01f74832db6281df7f2b3fa35