### PR TITLE
Avoid division by zero in drawdown calculation

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -466,7 +466,7 @@ class EventDrivenBacktestEngine:
         sharpe = float(rets.mean() / rets.std()) if not rets.empty and rets.std() else 0.0
         # Maximum drawdown from the equity curve
         running_max = equity_series.cummax()
-        drawdown = (equity_series - running_max) / running_max
+        drawdown = (equity_series - running_max) / running_max.clip(lower=1e-9)
         max_drawdown = -float(drawdown.min()) if not drawdown.empty else 0.0
 
         pnl = equity - self.initial_equity

--- a/src/tradingbot/reporting/metrics.py
+++ b/src/tradingbot/reporting/metrics.py
@@ -47,7 +47,7 @@ def max_drawdown(equity_curve: Sequence[float]) -> float:
         return 0.0
     series = pd.Series(list(equity_curve), dtype="float64")
     running_max = series.cummax()
-    drawdown = (series - running_max) / running_max
+    drawdown = (series - running_max) / running_max.clip(lower=1e-9)
     return float(drawdown.min()) if not drawdown.empty else 0.0
 
 

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pandas as pd
 import pytest
@@ -188,4 +189,23 @@ def test_seed_reproducibility(tmp_path, monkeypatch):
     base = equities[0]
     for eq in equities[1:]:
         assert abs(eq - base) <= abs(base) * 0.005
+
+
+def test_max_drawdown_zero_initial_equity(tmp_path, monkeypatch):
+    csv_path = _make_csv(tmp_path)
+
+    class NoTradeStrategy:
+        name = "no_trade"
+
+        def on_bar(self, bar):
+            return None
+
+    monkeypatch.setitem(STRATEGIES, "no_trade", NoTradeStrategy)
+    strategies = [("no_trade", "SYM")]
+    data = {"SYM": str(csv_path)}
+
+    res = run_backtest_csv(data, strategies, latency=1, window=1, initial_equity=0.0)
+
+    assert res["max_drawdown"] == 0.0
+    assert not math.isnan(res["max_drawdown"])
 


### PR DESCRIPTION
## Summary
- Clip running max in backtest engine and reporting metrics to prevent division by zero
- Test backtest with zero initial equity to ensure max_drawdown is 0 and not NaN

## Testing
- `pytest tests/test_backtest_engine.py::test_max_drawdown_zero_initial_equity -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef5b7b518832dab2acb7c8778db1a