### PR TITLE
Halt backtest on zero equity and cap drawdown at 100%

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -339,6 +339,12 @@ class EventDrivenBacktestEngine:
                     order.execute_index = i + 1
                     heapq.heappush(order_queue, order)
 
+            if equity <= 0 and fills:
+                log.warning(
+                    "Equity depleted at bar %d; stopping backtest", i
+                )
+                equity_curve.append(equity)
+                break
 
             # Generate new orders from strategies
             for (strat_name, symbol), strat in self.strategies.items():
@@ -468,6 +474,7 @@ class EventDrivenBacktestEngine:
         running_max = equity_series.cummax()
         drawdown = (equity_series - running_max) / running_max
         max_drawdown = -float(drawdown.min()) if not drawdown.empty else 0.0
+        max_drawdown = min(max_drawdown, 1.0)
 
         pnl = equity - self.initial_equity
 

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pandas as pd
 import pytest
@@ -148,6 +149,19 @@ def test_l2_queue_partial_and_cancel(tmp_path, monkeypatch):
     assert len(res["fills"]) == 0
 
 
+class HalfShotStrategy:
+    name = "halfshot"
+
+    def __init__(self) -> None:
+        self.sent = False
+
+    def on_bar(self, bar):
+        if self.sent:
+            return None
+        self.sent = True
+        return SimpleNamespace(side="buy", strength=0.5)
+
+
 def test_funding_payment(tmp_path, monkeypatch):
     rng = pd.date_range("2021-01-01", periods=3, freq="H")
     df = pd.DataFrame(
@@ -164,13 +178,51 @@ def test_funding_payment(tmp_path, monkeypatch):
     path = tmp_path / "fund.csv"
     df.to_csv(path, index=False)
 
-    monkeypatch.setitem(STRATEGIES, "oneshot", OneShotStrategy)
-    strategies = [("oneshot", "SYM")]
+    monkeypatch.setitem(STRATEGIES, "halfshot", HalfShotStrategy)
+    strategies = [("halfshot", "SYM")]
     data = {"SYM": str(path)}
 
-    res = run_backtest_csv(data, strategies, latency=1, window=1)
+    res = run_backtest_csv(
+        data, strategies, latency=1, window=1, initial_equity=200.0
+    )
     assert pytest.approx(res["funding"], rel=1e-9) == 1.0
-    assert pytest.approx(res["equity"], rel=1e-9) == -1.0
+    assert pytest.approx(res["equity"], rel=1e-9) == 199.0
+
+
+class AlwaysBuyStrategy:
+    name = "always"
+
+    def on_bar(self, bar):
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+def test_stop_on_equity_depletion(tmp_path, monkeypatch, caplog):
+    rng = pd.date_range("2021-01-01", periods=5, freq="T")
+    df = pd.DataFrame(
+        {
+            "timestamp": rng.view("int64") // 10**9,
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "volume": 1000,
+        }
+    )
+    path = tmp_path / "deplete.csv"
+    df.to_csv(path, index=False)
+
+    monkeypatch.setitem(STRATEGIES, "always", AlwaysBuyStrategy)
+    strategies = [("always", "SYM")]
+    data = {"SYM": str(path)}
+
+    caplog.set_level(logging.WARNING)
+    res = run_backtest_csv(
+        data, strategies, latency=1, window=1, initial_equity=1.0
+    )
+
+    assert len(res["fills"]) == 1
+    assert res["max_drawdown"] <= 1.0
+    assert any("Equity depleted" in m for m in caplog.messages)
 
 
 def test_seed_reproducibility(tmp_path, monkeypatch):

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -68,6 +68,19 @@ class OneShotStrategy:
         return SimpleNamespace(side="buy", strength=1.0)
 
 
+class HalfShotStrategy:
+    name = "halfshot"
+
+    def __init__(self) -> None:
+        self.sent = False
+
+    def on_bar(self, bar):
+        if self.sent:
+            return None
+        self.sent = True
+        return SimpleNamespace(side="buy", strength=0.5)
+
+
 def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     rng = pd.date_range("2021-01-01", periods=5, freq="min")
     price = [100.0, 100.0, 100.0, 80.0, 80.0]
@@ -82,10 +95,10 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
         }
     )
     data = {"SYM": df}
-    monkeypatch.setitem(STRATEGIES, "oneshot", OneShotStrategy)
+    monkeypatch.setitem(STRATEGIES, "halfshot", HalfShotStrategy)
     engine = EventDrivenBacktestEngine(
         data,
-        [("oneshot", "SYM")],
+        [("halfshot", "SYM")],
         latency=1,
         window=1,
         risk_pct=0.1,


### PR DESCRIPTION
## Summary
- Stop EventDrivenBacktestEngine when account equity drops to zero and cap reported drawdown to 100%
- Update tests to reflect new behaviour and cover equity depletion scenario

## Testing
- `pytest tests/test_backtest_engine.py -q`
- `pytest tests/test_backtesting_integration.py::test_stop_loss_triggers_close tests/test_latency_integration.py::test_heterogeneous_latency -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef5aeeba8832db60ac047762f02ba