### PR TITLE
Add basic auth to Prometheus scrape configs

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -12,8 +12,14 @@ alerting:
 
 scrape_configs:
   - job_name: api
+    basic_auth:
+      username: monitor
+      password: securepassword
     static_configs:
       - targets: ["api:8000"]
   - job_name: status
+    basic_auth:
+      username: monitor
+      password: securepassword
     static_configs:
       - targets: ["status:8001"]


### PR DESCRIPTION
## Summary
- secure Prometheus scrape targets with HTTP basic auth credentials

## Testing
- `pytest` *(fails: KeyboardInterrupt)*
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fd472b0832d8c0f5a892943716a