### PR TITLE
Track open PnL in backtest equity and tests

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -221,7 +221,7 @@ class EventDrivenBacktestEngine:
             max_len,
         )
 
-        equity = self.initial_equity
+        cash = self.initial_equity
         fills: List[tuple] = []
         order_queue: List[Order] = []
         orders: List[Order] = []
@@ -233,7 +233,8 @@ class EventDrivenBacktestEngine:
             for (strat, sym), svc in self.risk.items()
             if not self.data[sym].empty
         )
-        equity_curve.append(equity + mtm)
+        equity = cash + mtm
+        equity_curve.append(equity)
 
         for i in range(max_len):
             if i and i % 1000 == 0:
@@ -321,13 +322,13 @@ class EventDrivenBacktestEngine:
                 )
                 slippage_total += slip * fill_qty
 
-                cash = fill_qty * price
+                trade_value = fill_qty * price
                 fee_model = self.exchange_fees.get(order.exchange, self.default_fee)
-                fee = fee_model.calculate(cash)
+                fee = fee_model.calculate(trade_value)
                 if order.side == "buy":
-                    equity -= cash + fee
+                    cash -= trade_value + fee
                 else:
-                    equity += cash - fee
+                    cash += trade_value - fee
                 svc = self.risk[(order.strategy, order.symbol)]
                 svc.on_fill(order.symbol, order.side, fill_qty)
                 order.filled_qty += fill_qty
@@ -351,6 +352,12 @@ class EventDrivenBacktestEngine:
                     order.execute_index = i + 1
                     heapq.heappush(order_queue, order)
 
+            mtm = sum(
+                svc.rm.pos.qty * self.data[sym]["close"].iloc[i]
+                for (strat, sym), svc in self.risk.items()
+                if i < len(self.data[sym])
+            )
+            equity = cash + mtm
             if equity <= 0 and fills:
                 log.warning(
                     "Equity depleted at bar %d; stopping backtest", i
@@ -425,9 +432,9 @@ class EventDrivenBacktestEngine:
                 if rate:
                     price = float(bar.get("close", 0.0))
                     pos = svc.rm.pos.qty
-                    cash = pos * price * rate
-                    equity -= cash
-                    funding_total += cash
+                    funding_cash = pos * price * rate
+                    cash -= funding_cash
+                    funding_total += funding_cash
 
             # Re-check risk limits after funding adjustments
             for (strat_name, symbol), svc in self.risk.items():
@@ -471,16 +478,18 @@ class EventDrivenBacktestEngine:
                 for (strat, sym), svc in self.risk.items()
                 if i < len(self.data[sym])
             )
-            equity_curve.append(equity + mtm)
+            equity = cash + mtm
+            equity_curve.append(equity)
 
         # Liquidate remaining positions
         for (strat_name, symbol), svc in self.risk.items():
             pos = svc.rm.pos.qty
             if abs(pos) > 1e-9:
                 last_price = float(self.data[symbol]["close"].iloc[-1])
-                equity += pos * last_price
+                cash += pos * last_price
                 svc.rm.set_position(0.0)
 
+        equity = cash
         # Update final equity in the curve without duplicating the last value
         equity_curve[-1] = equity
 

--- a/tests/test_mtm_equity_curve.py
+++ b/tests/test_mtm_equity_curve.py
@@ -39,6 +39,6 @@ def test_equity_curve_marks_open_positions(tmp_path, monkeypatch):
     data = {"SYM": str(path)}
 
     res = run_backtest_csv(
-        data, strategies, latency=0, window=0, initial_equity=0
+        data, strategies, latency=0, window=0, initial_equity=100
     )
-    assert res["equity_curve"] == pytest.approx([0.0, 0.0, 0.0, 10.0, 20.0, 20.0])
+    assert res["equity_curve"] == pytest.approx([100.0, 100.0, 100.0, 110.0, 120.0])


### PR DESCRIPTION
## Summary
- Recalculate backtest equity each bar as cash plus mark-to-market value
- Stop engine only when total equity (cash + mtm) is depleted
- Build equity curve from total equity and update tests for new behaviour

## Testing
- `pytest tests/test_backtest_engine.py tests/test_mtm_equity_curve.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11b4f354832d8fe1e71094df9359