### PR TITLE
Use stop-bar price when equity depletes

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -234,6 +234,7 @@ class EventDrivenBacktestEngine:
             if not self.data[sym].empty
         )
         equity_curve.append(equity + mtm)
+        last_index = max_len - 1
 
         for i in range(max_len):
             if i and i % 1000 == 0:
@@ -356,6 +357,7 @@ class EventDrivenBacktestEngine:
                     "Equity depleted at bar %d; stopping backtest", i
                 )
                 equity_curve.append(equity)
+                last_index = i
                 break
 
             # Generate new orders from strategies
@@ -477,7 +479,9 @@ class EventDrivenBacktestEngine:
         for (strat_name, symbol), svc in self.risk.items():
             pos = svc.rm.pos.qty
             if abs(pos) > 1e-9:
-                last_price = float(self.data[symbol]["close"].iloc[-1])
+                df = self.data[symbol]
+                price_idx = min(last_index, len(df) - 1)
+                last_price = float(df["close"].iloc[price_idx])
                 equity += pos * last_price
                 svc.rm.set_position(0.0)
 


### PR DESCRIPTION
## Summary
- Capture the bar index when equity falls below zero
- Liquidate remaining positions at the recorded bar's close price
- Update final equity curve to reflect liquidation at the stop bar

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af1430a980832dab21cb0f7a70617a