### PR TITLE
Configure custom Prometheus metrics path for monitoring jobs

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -12,12 +12,14 @@ alerting:
 
 scrape_configs:
   - job_name: api
+    metrics_path: /metrics/prometheus
     basic_auth:
       username: monitor
       password: securepassword
     static_configs:
       - targets: ["api:8000"]
   - job_name: status
+    metrics_path: /metrics/prometheus
     basic_auth:
       username: monitor
       password: securepassword


### PR DESCRIPTION
## Summary
- specify `/metrics/prometheus` as `metrics_path` for `api` and `status` scrape jobs

## Testing
- `pytest` *(fails: process hangs early, see log)*
- `docker compose restart prometheus` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68af180d8338832db8be784a48c620dd