### PR TITLE
feat: set API credentials in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - PG_USER=postgres
       - PG_PASSWORD=postgres
       - PG_DB=trading
+      - API_USER=monitor
+      - API_PASS=securepassword
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- add API_USER and API_PASS to api service environment in docker compose

## Testing
- `docker compose up -d` *(fails: command not found)*
- `pytest` *(fails: Fatal Python error: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68af1808b3a4832dac7e60be404a78ce