### PR TITLE
Update last index on all exits

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -233,7 +233,8 @@ class EventDrivenBacktestEngine:
             for (strat, sym), svc in self.risk.items()
             if not self.data[sym].empty
         )
-        equity_curve.append(equity + mtm)
+        equity = cash + mtm
+        equity_curve.append(equity)
         last_index = max_len - 1
 
         for i in range(max_len):
@@ -481,6 +482,10 @@ class EventDrivenBacktestEngine:
             )
             equity = cash + mtm
             equity_curve.append(equity)
+
+            if i == max_len - 1:
+                last_index = i
+                break
 
         # Liquidate remaining positions
         for (strat_name, symbol), svc in self.risk.items():


### PR DESCRIPTION
## Summary
- compute initial equity before simulation loop
- record the last processed bar index when the main loop exits normally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af1b0b7638832d9d09bcbf79970411