### PR TITLE
Add trend following strategy entry in backtest HTML

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -199,6 +199,10 @@ const strategies = {
     desc: "Analiza el flujo de órdenes agresivas vs. pasivas para estimar micro‑tendencias.",
     requires: ["trades", "book_delta"],
   },
+  trend_following: {
+    desc: "Seguimiento de tendencia con fuerza adaptativa",
+    requires: ["ohlcv"],
+  },
   cross_arbitrage: {
     desc: "Arbitraje del mismo par entre dos exchanges; compra donde esté barato y vende donde esté caro.",
     requires: ["prices"],


### PR DESCRIPTION
## Summary
- add trend_following strategy metadata to backtest panel

## Testing
- `pytest tests/test_smoke.py::test_smoke -q`
- Verified `trend_following` description rendering via Node script


------
https://chatgpt.com/codex/tasks/task_e_68af4b2105b8832d8b58f321463eb596