### PR TITLE
Fetch strategy info dynamically in backtest page

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -227,7 +227,19 @@ const dataInfo = {
   features: "Indicadores y estadísticas usados por un modelo de ML.",
 };
 
-let strategyInfo = strategies;
+let strategyInfo = {};
+
+async function loadStrategyInfo(){
+  try{
+    const r=await fetch(api('/strategies/info'));
+    const j=await r.json();
+    strategyInfo={...strategies,...j};
+  }catch(e){
+    console.error(e);
+    strategyInfo=strategies;
+  }
+  updateStrategyInfo();
+}
 
 function appendSummary(text){
   try{
@@ -450,6 +462,7 @@ document.getElementById('bt-strategy').addEventListener('change',updateStrategyI
 updateBtFields();
 loadStrategies();
 loadExchanges();
+loadStrategyInfo();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load strategy metadata from `/strategies/info` to sync UI with backend
- Keep fallback info and ensure `trend_following` is available in strategy list

## Testing
- `pytest -q` *(killed: out-of-memory)*
- `pytest tests/test_strategies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5099de44832d9c15329effcb3448