### PR TITLE
feat(api): add timeout support for streaming CLI

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,12 @@ Todos los comandos se ejecutan como:
 python -m tradingbot.cli <comando> [opciones]
 ```
 
+A través del endpoint de la API `/cli/start` es posible lanzar estos
+comandos en segundo plano. La petición acepta un parámetro opcional
+`timeout` (en segundos) que limita la duración máxima del proceso. Para
+backtests muy largos se recomienda establecer un `timeout` alto o `null`
+para deshabilitar el límite.
+
 A continuación se describen los comandos disponibles. Todas las estrategias
 emiten señales con un campo `strength`. El `RiskService` utiliza esa señal para
 dimensionar automáticamente la posición (`notional = equity * strength`).


### PR DESCRIPTION
## Summary
- allow /cli/start to accept and store optional timeout
- terminate streaming CLI jobs when timeout elapses
- document API timeout option for long-running backtests

## Testing
- `pytest -q` *(killed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68af598e7fc0832dbdcc0736e5df5d8a