### PR TITLE
feat: add CLI timeout metrics

### DIFF
--- a/monitoring/grafana/dashboards/core.json
+++ b/monitoring/grafana/dashboards/core.json
@@ -98,6 +98,19 @@
       "datasource": "Prometheus",
       "id": 7,
       "gridPos": {"x": 16, "y": 16, "w": 8, "h": 8}
+    },
+    {
+      "type": "graph",
+      "title": "CLI timeouts",
+      "targets": [
+        {
+          "expr": "increase(cli_process_timeout_total[5m])",
+          "legendFormat": "timeouts"
+        }
+      ],
+      "datasource": "Prometheus",
+      "id": 8,
+      "gridPos": {"x": 0, "y": 24, "w": 12, "h": 8}
     }
   ],
   "templating": {

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -34,6 +34,17 @@ SYSTEM_DISCONNECTS = Counter(
     "Total number of system disconnections",
 )
 
+# CLI process completion metrics
+CLI_PROCESS_COMPLETED = Counter(
+    "cli_process_completed_total",
+    "CLI processes completed successfully",
+)
+
+CLI_PROCESS_TIMEOUT = Counter(
+    "cli_process_timeout_total",
+    "CLI processes terminated due to timeout",
+)
+
 # Process gauges
 PROCESS_CPU = Gauge(
     "process_cpu_percent",

--- a/monitoring/panel.py
+++ b/monitoring/panel.py
@@ -30,6 +30,8 @@ from .metrics import (
     PROCESS_MEMORY,
     PROCESS_UPTIME,
     update_process_metrics,
+    CLI_PROCESS_COMPLETED,
+    CLI_PROCESS_TIMEOUT,
 )
 from .strategies import (
     strategies_status,
@@ -530,6 +532,10 @@ async def run_cli(cmd: CLICommand) -> dict:
         stderr=asyncio.subprocess.PIPE,
     )
     out, err = await proc.communicate()
+    if proc.returncode == 0:
+        CLI_PROCESS_COMPLETED.inc()
+    else:
+        CLI_PROCESS_TIMEOUT.inc()
     return {
         "command": cmd.command,
         "stdout": out.decode(),


### PR DESCRIPTION
## Summary
- add Prometheus counters for CLI process outcomes
- track CLI process completion and timeouts in API and dashboard
- show CLI timeouts on core Grafana dashboard

## Testing
- `pytest` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68af59906e2c832d9d8c614df73cafe7