### PR TITLE
Filter micro fills in backtest logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ risk:
 
 ```
 
+El motor de backtesting ignora ejecuciones cuya cantidad sea menor a
+`min_fill_qty` (por defecto `1e-6`) para evitar registrar residuos irrelevantes.
+Este parámetro puede ajustarse al crear `EventDrivenBacktestEngine`.
+
 ## Solución de problemas
 
 Si se muestra el mensaje `System clock offset`, indica que el reloj del


### PR DESCRIPTION
## Summary
- Add configurable `min_fill_qty` to skip tiny fills in the backtest engine
- Format fill quantity with fixed decimal precision in verbose logging
- Document `min_fill_qty` threshold in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af5bb19a70832d996b88f92cff71ca