### PR TITLE
Log fill side and realized PnL

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -345,6 +345,7 @@ class EventDrivenBacktestEngine:
                 fills.append(
                     (
                         bar.get("timestamp", i),
+                        order.side,
                         price,
                         fill_qty,
                         order.strategy,
@@ -354,11 +355,13 @@ class EventDrivenBacktestEngine:
                 )
                 if self.verbose_fills:
                     log.info(
-                        "Fill %s %s qty=%s price=%s",
+                        "Fill %s %s side=%s qty=%.8f price=%.2f rpnl=%.2f",
                         order.strategy,
                         order.symbol,
+                        order.side,
                         fill_qty,
                         price,
+                        getattr(svc.rm.pos, "realized_pnl", 0.0),
                     )
                 if order.remaining_qty > 1e-9 and not self.cancel_unfilled:
                     order.execute_index = i + 1

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -108,8 +108,8 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     assert len(res["orders"]) == 2
     assert res["orders"][0]["side"] == "buy"
     assert res["orders"][1]["side"] == "sell"
-    entry_price = res["fills"][0][1]
-    exit_price = res["fills"][1][1]
+    entry_price = res["fills"][0][2]
+    exit_price = res["fills"][1][2]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
 


### PR DESCRIPTION
## Summary
- Add order side and realized PnL logging for each fill
- Extend fill tuple with side and adjust tests accordingly

## Testing
- `pytest tests/test_backtesting_integration.py -q`
- `pytest tests/integration/test_recorded_flow.py -q`
- `pytest tests/test_backtest_engine.py -q` *(fails: segmentation fault)*
- `PYTHONPATH=src python backtest_fill_logging_snippet.py` *(manual run to inspect fill logs)*

------
https://chatgpt.com/codex/tasks/task_e_68af5ba6a4ec832d8eafbe71cfbc8fa4