### PR TITLE
Export backtest fills and document PnL validation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,6 +145,23 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `--symbol`: par a evaluar.
 - `--strategy`: estrategia a utilizar.
 
+Tras la ejecución se genera un archivo `fills.csv` en el directorio de resultados
+con las columnas `timestamp, side, price, qty, strategy, symbol, exchange, rpnl`.
+Desde este archivo puede reconstruirse el efectivo y la posición para validar el
+PnL final:
+
+```python
+import pandas as pd
+
+fills = pd.read_csv("fills.csv")
+fills["signed_qty"] = fills["qty"].where(fills["side"] == "buy", -fills["qty"])
+fills["position"] = fills["signed_qty"].cumsum()
+fills["cash"] = (-fills["price"] * fills["signed_qty"]).cumsum() + INITIAL_EQUITY
+```
+
+La última fila de `cash` y `position` debe coincidir con los valores reportados
+por el motor, permitiendo verificar el PnL obtenido.
+
 ## `backtest-cfg`
 Ejecuta un backtest basado en un archivo de configuración Hydra.
 - `config`: archivo YAML con los parámetros.

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -367,6 +367,7 @@ class EventDrivenBacktestEngine:
                         order.strategy,
                         order.symbol,
                         order.exchange,
+                        getattr(svc.rm.pos, "realized_pnl", 0.0),
                     )
                 )
                 if self.verbose_fills:
@@ -413,10 +414,11 @@ class EventDrivenBacktestEngine:
                 symbol_vol = float(rets.std()) if not rets.empty else 0.0
                 if equity < 0:
                     continue
+                equity_for_order = max(equity, 1.0)
                 allowed, _reason, delta = svc.check_order(
                     symbol,
                     sig.side,
-                    equity,
+                    equity_for_order,
                     place_price,
                     strength=sig.strength,
                     symbol_vol=symbol_vol,
@@ -514,7 +516,7 @@ class EventDrivenBacktestEngine:
             equity = cash + mtm
             equity_curve.append(equity)
 
-            if equity <= 0:
+            if equity <= 0 and i > 0 and not order_queue:
                 log.warning(
                     "Equity depleted at bar %d; stopping backtest", i
                 )

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -929,6 +929,20 @@ def backtest(
         verbose_fills=verbose_fills,
     )
     result = eng.run()
+    fills_df = pd.DataFrame(
+        result["fills"],
+        columns=[
+            "timestamp",
+            "side",
+            "price",
+            "qty",
+            "strategy",
+            "symbol",
+            "exchange",
+            "rpnl",
+        ],
+    )
+    fills_df.to_csv("fills.csv", index=False)
     typer.echo(result)
     typer.echo(generate_report(result))
     sys.exit(0)
@@ -982,6 +996,20 @@ def backtest_cfg(
             verbose_fills=verbose_fills,
         )
         result = eng.run()
+        fills_df = pd.DataFrame(
+            result["fills"],
+            columns=[
+                "timestamp",
+                "side",
+                "price",
+                "qty",
+                "strategy",
+                "symbol",
+                "exchange",
+                "rpnl",
+            ],
+        )
+        fills_df.to_csv("fills.csv", index=False)
         typer.echo(OmegaConf.to_yaml(cfg))
         typer.echo(result)
         typer.echo(generate_report(result))
@@ -1061,6 +1089,20 @@ def backtest_db(
             verbose_fills=verbose_fills,
         )
         result = eng.run()
+        fills_df = pd.DataFrame(
+            result["fills"],
+            columns=[
+                "timestamp",
+                "side",
+                "price",
+                "qty",
+                "strategy",
+                "symbol",
+                "exchange",
+                "rpnl",
+            ],
+        )
+        fills_df.to_csv("fills.csv", index=False)
         typer.echo(result)
         typer.echo(generate_report(result))
         sys.exit(0)


### PR DESCRIPTION
## Summary
- include realized PnL with each fill and write fills.csv after running a backtest
- allow minimal sizing when equity is zero and avoid stopping early when orders are pending
- document how to reconstruct cash and position from fills.csv to verify final PnL

## Testing
- `pytest tests/test_backtest_engine.py tests/test_backtesting_integration.py tests/integration/test_recorded_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af63739f14832d948f4c6c15059ddf