### PR TITLE
Document minimum fill quantity threshold and format fill logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ risk:
 ```
 
 El motor de backtesting ignora ejecuciones cuya cantidad sea menor a
-`min_fill_qty` (por defecto `1e-6`) para evitar registrar residuos irrelevantes.
-Este parámetro puede ajustarse al crear `EventDrivenBacktestEngine`.
+`min_fill_qty` para evitar registrar residuos irrelevantes. El umbral
+predeterminado es la constante `MIN_FILL_QTY = 1e-6`, pero puede ajustarse
+al crear `EventDrivenBacktestEngine`.
 
 ## Solución de problemas
 

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -136,7 +136,9 @@ class StressConfig:
 class EventDrivenBacktestEngine:
     """Backtest engine supporting multiple symbols/strategies and order latency.
 
-    Fills with quantity below ``min_fill_qty`` (default ``1e-6``) are ignored.
+    Fills with quantity below ``min_fill_qty`` (defaults to
+    ``MIN_FILL_QTY`` = ``1e-6``) are ignored to avoid recording irrelevant
+    residuals.
     """
 
     def __init__(
@@ -371,11 +373,11 @@ class EventDrivenBacktestEngine:
                 )
                 if self.verbose_fills:
                     log.info(
-                        "Fill %s %s side=%s qty=%.8f price=%.2f rpnl=%.2f",
+                        "Fill %s %s side=%s qty=%s price=%.2f rpnl=%.2f",
                         order.strategy,
                         order.symbol,
                         order.side,
-                        fill_qty,
+                        f"{fill_qty:.8f}",
                         price,
                         getattr(svc.rm.pos, "realized_pnl", 0.0),
                     )


### PR DESCRIPTION
## Summary
- Document minimum fill quantity threshold and ignore tiny fills
- Format fill quantity logs with fixed decimal precision
- Note `MIN_FILL_QTY` default in backtesting guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af63705db4832da1e917778764a2ad