### PR TITLE
feat: export fills to csv

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -144,11 +144,11 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `data`: ruta al CSV.
 - `--symbol`: par a evaluar.
 - `--strategy`: estrategia a utilizar.
+- `--fills-csv PATH`: exporta los fills a un CSV.
 
-Tras la ejecución se genera un archivo `fills.csv` en el directorio de resultados
-con las columnas `timestamp, side, price, qty, strategy, symbol, exchange, rpnl`.
-Desde este archivo puede reconstruirse el efectivo y la posición para validar el
-PnL final:
+Si se especifica `--fills-csv`, se genera un archivo con las columnas
+`timestamp, side, price, qty, strategy, symbol, exchange, rpnl`. Desde este
+archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
 ```python
 import pandas as pd
@@ -165,6 +165,7 @@ por el motor, permitiendo verificar el PnL obtenido.
 ## `backtest-cfg`
 Ejecuta un backtest basado en un archivo de configuración Hydra.
 - `config`: archivo YAML con los parámetros.
+- `--fills-csv PATH`: exporta los fills a un CSV.
 
 ## `backtest-db`
 Realiza un backtest usando datos almacenados en la base de datos.
@@ -173,11 +174,13 @@ Realiza un backtest usando datos almacenados en la base de datos.
 - `--strategy`: estrategia.
 - `--start` y `--end`: rango de fechas (YYYY-MM-DD).
 - `--timeframe`: periodo de las velas (`1m`).
+- `--fills-csv PATH`: exporta los fills a un CSV.
 
 ## `walk-forward`
 Optimiza una estrategia con técnica walk-forward usando una configuración
 Hydra.
 - `config`: archivo YAML con datos, estrategia y grilla de parámetros.
+- `--fills-csv PATH`: exporta los fills del periodo de prueba a un CSV.
 
 ## `report`
 Muestra un resumen de PnL desde TimescaleDB.

--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -84,7 +84,7 @@
       <div id="field-verbose-fills" style="display:flex;align-items:center">
         <label for="bt-verbose-fills" style="display:flex;align-items:center;gap:4px">
           <input id="bt-verbose-fills" type="checkbox"/>
-          Verbose fills
+          Exportar fills (CSV)
         </label>
       </div>
     </div>
@@ -385,7 +385,7 @@ async function runBacktest(){
     if(sl) cmd+=` --risk-pct ${sl}`;
   }
   const verbose=document.getElementById('bt-verbose-fills').checked;
-  if(verbose) cmd+=' --verbose-fills';
+  if(verbose) cmd+=' --fills-csv fills.csv';
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});
     const j=await r.json();

--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -42,6 +42,7 @@ def walk_forward_backtest(
     latency: int = 1,
     window: int = 120,
     verbose_fills: bool = False,
+    fills_csv: str | None = None,
 ) -> pd.DataFrame:
     """Run a basic walk-forward analysis and return metrics for each split."""
 
@@ -49,6 +50,9 @@ def walk_forward_backtest(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
+
+    if fills_csv:
+        verbose_fills = False
 
     records: List[Dict[str, Any]] = []
     split_no = 0
@@ -83,7 +87,7 @@ def walk_forward_backtest(
             verbose_fills=verbose_fills,
         )
         engine.strategies[(strategy_name, symbol)] = strat
-        test_res = engine.run()
+        test_res = engine.run(fills_csv=fills_csv)
         metrics = evaluate(test_res.get("equity_curve", []))
 
         rec = {"split": split_no, "params": best_params}

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -60,6 +60,28 @@ def test_pnl_with_and_without_slippage(tmp_path, monkeypatch):
     assert no_slip["equity"] >= with_slip["equity"]
 
 
+def test_fills_csv_export(tmp_path, monkeypatch):
+    csv_path = _make_csv(tmp_path)
+    monkeypatch.setitem(STRATEGIES, "dummy", DummyStrategy)
+    strategies = [("dummy", "SYM")]
+    data = {"SYM": str(csv_path)}
+    out = tmp_path / "fills.csv"
+    run_backtest_csv(data, strategies, latency=1, window=1, fills_csv=str(out))
+    assert out.exists()
+    df = pd.read_csv(out)
+    assert not df.empty
+    assert list(df.columns) == [
+        "timestamp",
+        "side",
+        "price",
+        "qty",
+        "strategy",
+        "symbol",
+        "exchange",
+        "rpnl",
+    ]
+
+
 def test_run_vectorbt_basic():
     vbt_local = pytest.importorskip("vectorbt")
     from tradingbot.backtest.vectorbt_engine import run_vectorbt


### PR DESCRIPTION
## Summary
- add optional `--fills-csv` flag across backtesting commands and web UI
- allow backtesting engine to write fills to CSV and skip verbose logs
- document and test CSV fill export

## Testing
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage tests/test_backtest_engine.py::test_fills_csv_export -q`


------
https://chatgpt.com/codex/tasks/task_e_68af76d5c208832dbf9d5b5a48363eb9