### PR TITLE
Handle DataFrame correlation & covariance in RiskService

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -286,22 +286,9 @@ class EventDrivenBacktestEngine:
             ):
                 corr_df = rolling_corr.loc[i]
                 cov_df = rolling_cov.loc[i]
-                corr_pairs: Dict[tuple[str, str], float] = {}
-                syms = list(corr_df.columns)
-                for a_idx, a in enumerate(syms):
-                    for b in syms[a_idx + 1 :]:
-                        val = corr_df.at[a, b]
-                        if not pd.isna(val):
-                            corr_pairs[(a, b)] = float(val)
-                cov_matrix = {
-                    (a, b): float(val)
-                    for (a, b), val in cov_df.stack().dropna().items()
-                }
                 for svc in self.risk.values():
-                    if corr_pairs:
-                        svc.rm.update_correlation(corr_pairs, 0.8)
-                    if cov_matrix:
-                        svc.rm.update_covariance(cov_matrix, 0.8)
+                    svc.update_correlation(corr_df, 0.8)
+                    svc.update_covariance(cov_df, 0.8)
             # Execute queued orders for this index
             while order_queue and order_queue[0].execute_index <= i:
                 order = heapq.heappop(order_queue)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -79,7 +79,7 @@ async def run_paper(
             qty = float(t.get("qty", 0.0))
             broker.update_last_price(symbol, px)
             risk.mark_price(symbol, px)
-            risk.update_correlation(corr_threshold)
+            risk.update_correlation(corr._returns.corr(), corr_threshold)
             closed = agg.on_trade(ts, px, qty)
             if closed is None:
                 continue

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -149,7 +149,7 @@ async def _run_symbol(
         qty: float = float(t.get("qty") or 0.0)
         broker.update_last_price(cfg.symbol, px)
         risk.mark_price(cfg.symbol, px)
-        risk.update_correlation(corr_threshold)
+        risk.update_correlation(corr._returns.corr(), corr_threshold)
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, 0.0)
         if halted:
             log.error("[HALT] motivo=%s", reason)

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -111,7 +111,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         qty: float = float(t.get("qty") or 0.0)
         broker.update_last_price(cfg.symbol, px)
         risk.mark_price(cfg.symbol, px)
-        risk.update_correlation(corr_threshold)
+        risk.update_correlation(corr._returns.corr(), corr_threshold)
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, 0.0)
         if halted:
             log.error("[HALT] motivo=%s", reason)

--- a/src/tradingbot/risk/manager.py
+++ b/src/tradingbot/risk/manager.py
@@ -419,6 +419,13 @@ class RiskManager:
             # dispatch asynchronously without awaiting
             asyncio.create_task(self.bus.publish("risk:halted", {"reason": reason}))
 
+    def reset(self) -> None:
+        """Reinicia el gestor habilitando límites nuevamente."""
+        self.enabled = True
+        self.last_kill_reason = None
+        self.close_all_positions()
+        KILL_SWITCH_ACTIVE.set(0)
+
     # ------------------------------------------------------------------
     # Daily PnL / Drawdown tracking
     def update_pnl(self, delta: float, *, venue: str | None = None) -> None:


### PR DESCRIPTION
## Summary
- Extend RiskService with DataFrame-aware `update_correlation` and new `update_covariance` that internally filter significant pairs
- Simplify backtesting engine to forward raw correlation/covariance frames to RiskService
- Add RiskManager `reset` helper and tests for new correlation/covariance limits

## Testing
- `pytest tests/test_risk_service_correlation.py::test_risk_service_covariance_limit tests/test_paper_runner.py::test_run_paper tests/test_risk_manager_limits.py::test_reset_clears_kill_switch -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8d7a7fd8832d8fe6e72ddf076160