### PR TITLE
Ensure CLI stream sends end event

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -395,16 +395,22 @@ async function runBacktest(){
     resetEndFallback();
     evt=new EventSource(api(`/cli/stream/${j.id}`));
     evt.onmessage=(e)=>{resetEndFallback();appendOutput(outEl,e.data);};
-    evt.addEventListener('end',(e)=>{
-      if(endTimer){clearTimeout(endTimer);endTimer=null;} // clear fallback timer
+    const finish=(msg)=>{
+      if(endTimer){clearTimeout(endTimer);endTimer=null;}
       stopBtn.disabled=true;
       runBtn.disabled=false;
       runBtn.textContent='Ejecutar';
       currentJob=null;
-      evt.close();
+      if(evt){evt.close();}
       hideWorking();
       appendSummary(outEl.textContent);
-      appendOutput(outEl,`Proceso finalizado (código ${e.data}).`);
+      appendOutput(outEl,msg);
+    };
+    evt.addEventListener('status',(e)=>{
+      finish(`Proceso finalizado (${e.data}).`);
+    });
+    evt.addEventListener('end',(e)=>{
+      finish(`Proceso finalizado (código ${e.data}).`);
     });
     evt.onerror=()=>{
       if(endTimer){clearTimeout(endTimer);endTimer=null;}


### PR DESCRIPTION
## Summary
- Always emit `end` event after CLI processes finish and include optional `status: finished`
- Frontend listens for `status`/`end` events to close SSE connection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af966f97b0832da922f2cdcb59d49c