### PR TITLE
Recalculate entry price when scaling positions

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -199,9 +199,16 @@ class RiskService:
 
     # ------------------------------------------------------------------
     # Fill / PnL updates
-    def on_fill(self, symbol: str, side: str, qty: float, venue: str | None = None) -> None:
+    def on_fill(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        price: float | None = None,
+        venue: str | None = None,
+    ) -> None:
         """Update internal position books after a fill."""
-        self.rm.add_fill(side, qty)
+        self.rm.add_fill(side, qty, price=price)
         self.guard.update_position_on_order(symbol, side, qty, venue=venue)
         if venue is not None:
             book = self.guard.st.venue_positions.get(venue, {})

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -45,7 +45,7 @@ class DummyRisk:
     def check_order(self, symbol, side, equity, price, strength=1.0, **_):
         return True, "", 1.0
 
-    def on_fill(self, symbol, side, qty, venue=None):
+    def on_fill(self, symbol, side, qty, price=None, venue=None):
         pass
 
 

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -32,6 +32,24 @@ def test_stop_loss_sets_reason():
     assert rm.pos.qty == pytest.approx(1.0)
 
 
+def test_stop_loss_multiple_fills_weighted_average():
+    from tradingbot.risk.exceptions import StopLossExceeded
+
+    rm = RiskManager(risk_pct=0.1)
+    rm.add_fill("buy", 1, price=100)
+    rm.add_fill("buy", 1, price=120)
+    # Precio de entrada promedio = 110
+    assert rm._entry_price == pytest.approx(110.0)
+    assert rm.pos.qty == pytest.approx(2.0)
+
+    # Precio no dispara el stop todavía
+    assert rm.check_limits(105)
+
+    # Caída por debajo del umbral de stop-loss
+    with pytest.raises(StopLossExceeded):
+        rm.check_limits(98)
+
+
 def test_manual_kill_switch_records_reason():
     rm = RiskManager()
     rm.kill_switch("manual")


### PR DESCRIPTION
## Summary
- Recompute position entry price as quantity-weighted average in RiskManager.add_fill
- Feed fill prices through event and service layers to maintain accurate stop-loss basis
- Add regression test ensuring stop-loss triggers correctly after multiple fills at different prices

## Testing
- `pytest tests/test_risk_manager_limits.py::test_stop_loss_multiple_fills_weighted_average -q`
- `pytest tests/test_risk.py -q` *(fails: test_size_with_volatility_event, test_covariance_limit_triggers_kill)*

------
https://chatgpt.com/codex/tasks/task_e_68afb52d470c832d8d10d3684cf77af8