### PR TITLE
Validate risk_pct inputs and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ la volatilidad mediante `vol_target`. Para limitar la exposición global puede
 emplearse `PortfolioGuard`, dejando `total_cap_pct` y `per_symbol_cap_pct` en
 `null` para deshabilitar estos límites.
 
+El parámetro `risk_pct` debe indicarse como una fracción entre 0 y 1. Si se
+provee un valor entre 1 y 100 se interpreta como porcentaje y se divide entre
+100. Valores negativos o superiores a 100 generan un error.
+
+Ejemplos:
+
+```bash
+python -m tradingbot.cli backtest data.csv --symbol BTC/USDT --risk-pct 0.02
+# equivalente a:
+python -m tradingbot.cli backtest data.csv --symbol BTC/USDT --risk-pct 2
+```
+
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se
 superan los límites configurados, detiene el bot o cierra las posiciones
 abiertas.

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -9,6 +9,16 @@ Por ejemplo, `strength = 1.5` incrementa la exposición un 50 %, mientras que
 `strength = 0.5` la reduce a la mitad. El campo `risk_pct` establece la pérdida
 máxima permitida y `vol_target` dimensiona la posición según la volatilidad.
 
+El parámetro `risk_pct` debe estar entre 0 y 1. Los valores entre 1 y 100 se
+interpretan como porcentajes y se convierten dividiéndolos entre 100. Valores
+negativos o mayores a 100 provocan un error.
+
+Ejemplo desde el CLI:
+
+```bash
+python -m tradingbot.cli backtest data.csv --risk-pct 2   # 2 % de riesgo
+```
+
 ## PortfolioGuard
 
 Para limitar el uso de capital se puede emplear `PortfolioGuard`, que permite fijar límites globales (`total_cap_pct`) o por símbolo (`per_symbol_cap_pct`). Estos valores pueden establecerse en `null` para deshabilitar los límites.

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -26,6 +26,24 @@ log = logging.getLogger(__name__)
 MIN_FILL_QTY = 1e-6
 
 
+def _validate_risk_pct(value: float) -> float:
+    """Ensure ``risk_pct`` is a fraction in [0, 1].
+
+    Values greater than 1 and up to 100 are interpreted as percentages and
+    converted by dividing by 100. Values outside these ranges raise a
+    :class:`ValueError`.
+    """
+
+    val = float(value)
+    if val < 0:
+        raise ValueError("risk_pct must be non-negative")
+    if val > 1:
+        if val <= 100:
+            return val / 100
+        raise ValueError("risk_pct must be between 0 and 1")
+    return val
+
+
 @dataclass(order=True)
 class Order:
     """Representation of a pending order in the backtest queue."""
@@ -188,7 +206,7 @@ class EventDrivenBacktestEngine:
             self.slippage.spread_mult *= self.stress.spread
 
         self.initial_equity = float(initial_equity)
-        self._risk_pct = float(risk_pct)
+        self._risk_pct = _validate_risk_pct(risk_pct)
 
         # Exchange specific configurations
         self.exchange_latency: Dict[str, int] = {}

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -150,6 +150,24 @@ def _validate_backtest_venue(value: str) -> str:
     return _validate_venue(value)
 
 
+def _parse_risk_pct(value: float) -> float:
+    """Validate and normalise risk percentage values.
+
+    Accepts values in [0, 1]. If a value between 1 and 100 is provided it is
+    assumed to be a percentage and is divided by 100. Values outside these
+    ranges raise a :class:`typer.BadParameter` error.
+    """
+
+    val = float(value)
+    if val < 0:
+        raise typer.BadParameter("risk-pct must be non-negative")
+    if val > 1:
+        if val <= 100:
+            return val / 100
+        raise typer.BadParameter("risk-pct must be between 0 and 1")
+    return val
+
+
 def get_supported_kinds(adapter_cls: type[adapters.ExchangeAdapter]) -> list[str]:
     """Return a sorted list of stream kinds supported by ``adapter_cls``.
 
@@ -629,7 +647,12 @@ def run_bot(
     testnet: bool = typer.Option(True, help="Use testnet endpoints"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk manager loss percentage (0-1 or 0-100)",
+    ),
     daily_max_loss_pct: float = typer.Option(
         0.05, "--daily-max-loss-pct", help="Daily loss limit as fraction of equity"
     ),
@@ -675,7 +698,12 @@ def paper_run(
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
     config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk manager loss percentage (0-1 or 0-100)",
+    ),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
@@ -702,7 +730,12 @@ def real_run(
         help=f"Trading venue ({_VENUE_CHOICES})",
     ),
     symbols: List[str] = typer.Option(["BTC/USDT"], "--symbol", help="Trading symbols"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk manager loss percentage"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk manager loss percentage (0-1 or 0-100)",
+    ),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Simulate orders without sending"),
     daily_max_loss_pct: float = typer.Option(
@@ -905,7 +938,12 @@ def backtest(
     symbol: str = "BTC/USDT",
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk stop loss % (0-1 or 0-100)",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -943,7 +981,12 @@ def backtest(
 def backtest_cfg(
     config: str,
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk stop loss % (0-1 or 0-100)",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -1020,7 +1063,12 @@ def backtest_db(
     end: str = typer.Option(..., help="End date YYYY-MM-DD"),
     timeframe: str = typer.Option("1m", help="Bar timeframe"),
     capital: float = typer.Option(0.0, help="Capital inicial"),
-    risk_pct: float = typer.Option(0.0, "--risk-pct", help="Risk stop loss %"),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk stop loss % (0-1 or 0-100)",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),

--- a/tests/test_risk_pct_validation.py
+++ b/tests/test_risk_pct_validation.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+
+
+@pytest.fixture
+def dummy_data():
+    return {"BTC/USDT": pd.DataFrame({
+        "open": [1.0],
+        "high": [1.0],
+        "low": [1.0],
+        "close": [1.0],
+        "volume": [1.0],
+    })}
+
+
+def test_engine_normalizes_percentage(dummy_data):
+    eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=5)
+    assert eng._risk_pct == pytest.approx(0.05)
+
+
+def test_engine_rejects_invalid_risk_pct(dummy_data):
+    with pytest.raises(ValueError):
+        EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=-0.1)
+    with pytest.raises(ValueError):
+        EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=150)


### PR DESCRIPTION
## Summary
- normalize `--risk-pct` CLI values and reject invalid percentages
- ensure backtesting engine converts or rejects out-of-range `risk_pct`
- document correct `risk_pct` usage and add coverage tests

## Testing
- `pytest`
- `pytest tests/test_risk_pct_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb5280658832da079cfa627f4d781