### PR TITLE
Normalize risk_pct for 1-100 inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ emplearse `PortfolioGuard`, dejando `total_cap_pct` y `per_symbol_cap_pct` en
 `null` para deshabilitar estos límites.
 
 El parámetro `risk_pct` debe indicarse como una fracción entre 0 y 1. Si se
-provee un valor entre 1 y 100 se interpreta como porcentaje y se divide entre
-100. Valores negativos o superiores a 100 generan un error.
+provee un valor de 1 a 100 se interpreta como porcentaje y se divide entre
+100 (por ejemplo, `risk_pct=1` equivale a `0.01`). Valores negativos o
+superiores a 100 generan un error.
 
 Ejemplos:
 
@@ -82,6 +83,7 @@ Ejemplos:
 python -m tradingbot.cli backtest data.csv --symbol BTC/USDT --risk-pct 0.02
 # equivalente a:
 python -m tradingbot.cli backtest data.csv --symbol BTC/USDT --risk-pct 2
+# y "--risk-pct 1" equivale a 0.01 (1 % de riesgo)
 ```
 
 `DailyGuard` supervisa las pérdidas intradía y el drawdown global. Si se

--- a/docs/risk.md
+++ b/docs/risk.md
@@ -9,14 +9,16 @@ Por ejemplo, `strength = 1.5` incrementa la exposición un 50 %, mientras que
 `strength = 0.5` la reduce a la mitad. El campo `risk_pct` establece la pérdida
 máxima permitida y `vol_target` dimensiona la posición según la volatilidad.
 
-El parámetro `risk_pct` debe estar entre 0 y 1. Los valores entre 1 y 100 se
-interpretan como porcentajes y se convierten dividiéndolos entre 100. Valores
-negativos o mayores a 100 provocan un error.
+El parámetro `risk_pct` debe estar entre 0 y 1. Los valores de 1 a 100 se
+interpretan como porcentajes y se convierten dividiéndolos entre 100 (por
+ejemplo, un valor de 1 se normaliza a 0.01). Valores negativos o mayores a 100
+provocan un error.
 
 Ejemplo desde el CLI:
 
 ```bash
 python -m tradingbot.cli backtest data.csv --risk-pct 2   # 2 % de riesgo
+# también puede usarse "--risk-pct 1" para un 1 % de riesgo
 ```
 
 ## PortfolioGuard

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -37,7 +37,7 @@ def _validate_risk_pct(value: float) -> float:
     val = float(value)
     if val < 0:
         raise ValueError("risk_pct must be non-negative")
-    if val > 1:
+    if val >= 1:
         if val <= 100:
             return val / 100
         raise ValueError("risk_pct must be between 0 and 1")

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -161,7 +161,7 @@ def _parse_risk_pct(value: float) -> float:
     val = float(value)
     if val < 0:
         raise typer.BadParameter("risk-pct must be non-negative")
-    if val > 1:
+    if val >= 1:
         if val <= 100:
             return val / 100
         raise typer.BadParameter("risk-pct must be between 0 and 1")

--- a/tests/test_risk_pct_validation.py
+++ b/tests/test_risk_pct_validation.py
@@ -18,6 +18,8 @@ def dummy_data():
 def test_engine_normalizes_percentage(dummy_data):
     eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=5)
     assert eng._risk_pct == pytest.approx(0.05)
+    eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=1)
+    assert eng._risk_pct == pytest.approx(0.01)
 
 
 def test_engine_rejects_invalid_risk_pct(dummy_data):


### PR DESCRIPTION
## Summary
- allow `risk_pct` values from 1 to 100 to be interpreted as percentages by using `>= 1` in normalization
- document that `risk_pct=1` is interpreted as `0.01` and provide usage examples
- test `risk_pct=1` normalization in backtesting engine

## Testing
- `pytest tests/test_risk_pct_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68afbcdf6b3c832d8e73dc23b8487c24