### PR TITLE
Enforce spot balance accounting and enhanced fill exports

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -147,16 +147,14 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `--fills-csv PATH`: exporta los fills a un CSV.
 
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
-`timestamp, side, price, qty, strategy, symbol, exchange, rpnl`. Desde este
-archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
+`timestamp, side, price, qty, strategy, symbol, exchange, fee, cash_after, base_after, equity_after, realized_pnl`.
+Desde este archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
 ```python
 import pandas as pd
 
 fills = pd.read_csv("fills.csv")
-fills["signed_qty"] = fills["qty"].where(fills["side"] == "buy", -fills["qty"])
-fills["position"] = fills["signed_qty"].cumsum()
-fills["cash"] = (-fills["price"] * fills["signed_qty"]).cumsum() + INITIAL_EQUITY
+# `base_after`, `cash_after` y `equity_after` ya contienen los balances tras cada fill.
 ```
 
 La última fila de `cash` y `position` debe coincidir con los valores reportados

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -103,7 +103,7 @@ async def run_live_binance(
     """
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
-    risk_core = RiskManager(risk_pct=risk_pct)
+    risk_core = RiskManager(risk_pct=risk_pct, allow_short=False)
     strat = BreakoutATR(config_path=config_path)
     guard = PortfolioGuard(GuardConfig(
         total_cap_pct=total_cap_pct,

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -50,7 +50,7 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(risk_pct=risk_pct)
+    risk_core = RiskManager(risk_pct=risk_pct, allow_short=False)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
     guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -107,7 +107,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(risk_pct=cfg.risk_pct)
+    risk_core = RiskManager(risk_pct=cfg.risk_pct, allow_short=(market != "spot"))
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -74,7 +74,7 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
             exec_adapter = exec_cls()
     agg = BarAggregator()
     strat = BreakoutATR(config_path=config_path)
-    risk_core = RiskManager(risk_pct=cfg.risk_pct)
+    risk_core = RiskManager(risk_pct=cfg.risk_pct, allow_short=(market != "spot"))
     guard = PortfolioGuard(GuardConfig(
         total_cap_pct=total_cap_pct,
         per_symbol_cap_pct=per_symbol_cap_pct,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,9 @@ def mock_adapter(mock_trades):
 
 @pytest.fixture
 def paper_adapter():
-    return PaperAdapter()
+    pa = PaperAdapter()
+    pa.state.cash = 1_000_000.0
+    return pa
 
 
 @pytest.fixture

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -148,3 +148,12 @@ def test_covariance_limit_triggers_kill():
     assert ok is False
     assert rm.enabled is False
     assert rm.last_kill_reason == "covariance_limit"
+
+
+def test_long_only_prevents_shorts():
+    from tradingbot.risk.manager import RiskManager
+
+    rm = RiskManager(allow_short=False)
+    rm.set_position(1.0)
+    allowed, _, delta = rm.check_order("SYM", "sell", equity=100.0, price=100.0)
+    assert allowed and delta == pytest.approx(-1.0)


### PR DESCRIPTION
## Summary
- prevent shorting on spot venues and cap order notional by risk_pct
- enforce cash/base balances in backtests and paper trading
- export fee and balance fields on fill CSVs for reconciliation

## Testing
- `pytest tests/test_backtest_engine.py::test_fills_csv_export tests/test_backtest_engine.py::test_spot_long_only_enforced tests/test_risk.py::test_long_only_prevents_shorts tests/test_execution.py::test_paper_adapter_execution -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe1d38f9c832dbbd8aed4be9ff73c