### PR TITLE
Track realized PnL and fees in backtests

### DIFF
--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -82,6 +82,8 @@ def test_fills_csv_export(tmp_path, monkeypatch):
         "equity_after",
         "realized_pnl",
     ]
+    assert (df["fee"].abs() > 0).any()
+    assert (df["realized_pnl"].abs() > 0).any()
 
 
 def test_spot_long_only_enforced(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add realized PnL tracking to RiskManager positions
- support per-exchange fees with 0.001 default in backtest engine and pass prices to fills
- verify fills.csv records fee and realized_pnl

## Testing
- `pytest tests/test_backtest_engine.py::test_fills_csv_export -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b07902294c832d88db415009eeb944