### PR TITLE
Track realized PnL and default exchange fees

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -214,9 +214,10 @@ class EventDrivenBacktestEngine:
         self.exchange_depth: Dict[str, float] = {}
         self.exchange_mode: Dict[str, str] = {}
         exchange_configs = exchange_configs or {}
+        default_fee = 0.001
         for exch, cfg in exchange_configs.items():
             self.exchange_latency[exch] = int(cfg.get("latency", latency))
-            self.exchange_fees[exch] = FeeModel(cfg.get("fee", 0.0))
+            self.exchange_fees[exch] = FeeModel(cfg.get("fee", default_fee))
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
             market_type = cfg.get("market_type")
             if market_type is None:
@@ -227,7 +228,7 @@ class EventDrivenBacktestEngine:
                         f"market_type must be specified for exchange '{exch}'"
                     )
             self.exchange_mode[exch] = str(market_type)
-        self.default_fee = FeeModel(0.0)
+        self.default_fee = FeeModel(default_fee)
         self.default_depth = float("inf")
 
         self.strategies: Dict[Tuple[str, str], object] = {}
@@ -434,7 +435,7 @@ class EventDrivenBacktestEngine:
                     cash -= trade_value + fee
                 else:
                     cash += trade_value - fee
-                svc.on_fill(order.symbol, order.side, fill_qty)
+                svc.on_fill(order.symbol, order.side, fill_qty, price)
                 order.filled_qty += fill_qty
                 order.remaining_qty -= fill_qty
                 order.total_cost += price * fill_qty

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,7 +34,8 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 8
+    assert df.shape[1] == 12
+    assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 
 def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
@@ -58,7 +59,8 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 8
+    assert df.shape[1] == 12
+    assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 
 class OneShotStrategy:
@@ -120,7 +122,8 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 8
+    assert df.shape[1] == 12
+    assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 
 def test_equity_loss_capped_by_risk_pct(tmp_path, monkeypatch):
@@ -152,4 +155,5 @@ def test_equity_loss_capped_by_risk_pct(tmp_path, monkeypatch):
     orders = res["orders"]
     notional = orders[0]["avg_price"] * orders[0]["filled"]
     loss = initial_equity - res["equity"]
-    assert loss <= notional * risk_pct + 1e-9
+    fee_total = notional * 0.002  # comisión de entrada y salida
+    assert loss <= notional * risk_pct + fee_total + 1e-9

--- a/tests/test_mtm_equity_curve.py
+++ b/tests/test_mtm_equity_curve.py
@@ -41,4 +41,6 @@ def test_equity_curve_marks_open_positions(tmp_path, monkeypatch):
     res = run_backtest_csv(
         data, strategies, latency=0, window=0, initial_equity=100
     )
-    assert res["equity_curve"] == pytest.approx([100.0, 100.0, 100.0, 110.0, 120.0])
+    assert res["equity_curve"] == pytest.approx(
+        [100.0, 100.0, 99.9, 109.9, 119.9]
+    )


### PR DESCRIPTION
## Summary
- track realized PnL in RiskManager and compute on position reductions
- use configurable per-exchange fees with a 0.1% default in the backtest engine
- expand tests to validate fee and realized PnL values in exported fills

## Testing
- `pytest tests/test_backtest_engine.py::test_fills_csv_export tests/test_backtest_engine.py::test_funding_payment tests/test_mtm_equity_curve.py::test_equity_curve_marks_open_positions tests/test_backtesting_integration.py::test_event_engine_runs tests/test_backtesting_integration.py::test_event_engine_single_symbol_cov tests/test_backtesting_integration.py::test_stop_loss_triggers_close tests/test_backtesting_integration.py::test_equity_loss_capped_by_risk_pct`
- `pytest` *(failed: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b07b43347c832d8910ab52eefc5304