### PR TITLE
Derive spot/perp mode in backtests and wire venue through CLI

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -221,13 +221,18 @@ class EventDrivenBacktestEngine:
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
             market_type = cfg.get("market_type")
             if market_type is None:
-                if exch.endswith("_spot"):
-                    market_type = "spot"
-                else:
-                    raise ValueError(
-                        f"market_type must be specified for exchange '{exch}'"
-                    )
+                market_type = "spot" if exch.endswith("_spot") else "perp"
             self.exchange_mode[exch] = str(market_type)
+        # Auto-derive market type for exchanges without explicit configs
+        for strat_info in strategies:
+            if len(strat_info) == 2:
+                exchange = "default"
+            else:
+                exchange = strat_info[2]
+            if exchange not in self.exchange_mode:
+                self.exchange_mode[exchange] = (
+                    "spot" if exchange.endswith("_spot") else "perp"
+                )
         self.default_fee = FeeModel(default_fee)
         self.default_depth = float("inf")
 

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1118,12 +1118,14 @@ def backtest_db(
         log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
         if fills_csv:
             verbose_fills = False
+        exchange_cfg = {venue: {}}
         eng = EventDrivenBacktestEngine(
             {symbol: df},
-            [(strategy, symbol)],
+            [(strategy, symbol, venue)],
             initial_equity=capital,
             risk_pct=risk_pct,
             verbose_fills=verbose_fills,
+            exchange_configs=exchange_cfg,
         )
         result = eng.run(fills_csv=fills_csv)
         typer.echo(result)


### PR DESCRIPTION
## Summary
- Auto-detect market type for exchanges lacking explicit config
- Pass CLI venue and exchange config to event-driven backtest engine so spot backtests enforce balance limits

## Testing
- `pytest` *(fails: tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk)*

------
https://chatgpt.com/codex/tasks/task_e_68b0880a8e5c832db54ab125335300cd