### PR TITLE
Add exchange-specific configuration mapping

### DIFF
--- a/docs/venues.md
+++ b/docs/venues.md
@@ -21,3 +21,19 @@ target and the primary connection method used by each adapter.
 Deribit ofrece perpetuos no solo de BTC y ETH sino también de varios altcoins
 como SOL, XRP, MATIC, DOT, ADA, DOGE, LTC y TRX.
 
+## Exchange configuration
+
+Per-venue settings such as fees or tick sizes can be defined in
+`config/config.yaml` under an ``exchange_configs`` section:
+
+```yaml
+exchange_configs:
+  binance_spot:
+    market_type: spot
+    fee: 0.001
+    tick_size: 0.01
+```
+
+Venues without an explicit entry fall back to automatic ``_spot``/``_perp``
+inference for the market type.
+

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -213,12 +213,14 @@ class EventDrivenBacktestEngine:
         self.exchange_fees: Dict[str, FeeModel] = {}
         self.exchange_depth: Dict[str, float] = {}
         self.exchange_mode: Dict[str, str] = {}
+        self.exchange_tick_size: Dict[str, float] = {}
         exchange_configs = exchange_configs or {}
         default_fee = 0.001
         for exch, cfg in exchange_configs.items():
             self.exchange_latency[exch] = int(cfg.get("latency", latency))
             self.exchange_fees[exch] = FeeModel(cfg.get("fee", default_fee))
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
+            self.exchange_tick_size[exch] = float(cfg.get("tick_size", 0.0))
             market_type = cfg.get("market_type")
             if market_type is None:
                 market_type = "spot" if exch.endswith("_spot") else "perp"

--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -43,6 +43,7 @@ def walk_forward_backtest(
     window: int = 120,
     verbose_fills: bool = False,
     fills_csv: str | None = None,
+    exchange_configs: Dict[str, Dict[str, float]] | None = None,
 ) -> pd.DataFrame:
     """Run a basic walk-forward analysis and return metrics for each split."""
 
@@ -70,6 +71,7 @@ def walk_forward_backtest(
                 latency=latency,
                 window=window,
                 verbose_fills=verbose_fills,
+                exchange_configs=exchange_configs,
             )
             engine.strategies[(strategy_name, symbol)] = strat
             res = engine.run()
@@ -85,6 +87,7 @@ def walk_forward_backtest(
             latency=latency,
             window=window,
             verbose_fills=verbose_fills,
+            exchange_configs=exchange_configs,
         )
         engine.strategies[(strategy_name, symbol)] = strat
         test_res = engine.run(fills_csv=fills_csv)

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1028,12 +1028,16 @@ def backtest_cfg(
         log.info("Iniciando backtest CSV: %s %s", symbol, data)
         df = pd.read_csv(data)
         log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
+        exchange_cfg = OmegaConf.to_container(
+            getattr(cfg, "exchange_configs", {}), resolve=True
+        )
         eng = EventDrivenBacktestEngine(
             {symbol: df},
             [(strategy, symbol)],
             initial_equity=capital,
             risk_pct=risk_pct,
             verbose_fills=verbose_fills,
+            exchange_configs=exchange_cfg,
         )
         result = eng.run(fills_csv=fills_csv)
         typer.echo(OmegaConf.to_yaml(cfg))
@@ -1186,6 +1190,9 @@ def walk_forward_cfg(
         from ..backtesting.walk_forward import walk_forward_backtest
 
         wf_cfg = cfg.walk_forward
+        exchange_cfg = OmegaConf.to_container(
+            getattr(cfg, "exchange_configs", {}), resolve=True
+        )
         df = walk_forward_backtest(
             wf_cfg.data,
             wf_cfg.symbol,
@@ -1197,6 +1204,7 @@ def walk_forward_cfg(
             window=getattr(wf_cfg, "window", 120),
             verbose_fills=verbose_fills,
             fills_csv=fills_csv,
+            exchange_configs=exchange_cfg,
         )
 
         reports_dir = Path("reports")

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -40,3 +40,13 @@ risk:
   vol_target: 0.01
   total_cap_pct: null
   per_symbol_cap_pct: null
+
+exchange_configs:
+  binance_spot:
+    market_type: spot
+    fee: 0.001
+    tick_size: 0.01
+  okx_spot:
+    market_type: spot
+    fee: 0.001
+    tick_size: 0.1

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -70,6 +70,15 @@ class BalanceConfig:
 
 
 @dataclass
+class ExchangeVenueConfig:
+    """Per-venue configuration such as fees and tick sizes."""
+
+    market_type: str = "spot"
+    fee: float = 0.001
+    tick_size: float = 0.0
+
+
+@dataclass
 class AppConfig:
     """Top level application configuration."""
 
@@ -79,6 +88,7 @@ class AppConfig:
     storage: StorageConfig = field(default_factory=StorageConfig)
     risk: RiskConfig = field(default_factory=RiskConfig)
     balance: BalanceConfig = field(default_factory=BalanceConfig)
+    exchange_configs: Dict[str, ExchangeVenueConfig] = field(default_factory=dict)
 
 
 # Register configuration so Hydra validates the structure


### PR DESCRIPTION
## Summary
- extend project config with `exchange_configs` including market type, fees and tick sizes
- support loading exchange configs in Hydra, CLI backtests and walk-forward
- document exchange configuration and automatic `_spot`/`_perp` inference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b09f2d1f54832daaf5fb12644b77bf