### PR TITLE
Load backtest venue config from YAML

### DIFF
--- a/src/tradingbot/backtest/exchange_config.yaml
+++ b/src/tradingbot/backtest/exchange_config.yaml
@@ -1,0 +1,28 @@
+binance_spot:
+  market_type: spot
+  fee: 0.001
+  depth: 10
+binance_futures:
+  market_type: perp
+  fee: 0.0005
+  depth: 10
+okx_spot:
+  market_type: spot
+  fee: 0.001
+  depth: 5
+okx_futures:
+  market_type: perp
+  fee: 0.0005
+  depth: 5
+bybit_spot:
+  market_type: spot
+  fee: 0.001
+  depth: 5
+bybit_futures:
+  market_type: perp
+  fee: 0.0005
+  depth: 5
+deribit_futures:
+  market_type: perp
+  fee: 0.0005
+  depth: 5

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1118,27 +1118,16 @@ def backtest_db(
         log.info("Serie con %d barras; estrategia: %s", len(df), strategy)
         if fills_csv:
             verbose_fills = False
-        from ..config import settings
+        import yaml
+        from importlib import resources
 
-        depth_map = {
-            "binance_spot": 10,
-            "binance_futures": 10,
-            "okx_spot": 5,
-            "okx_futures": 5,
-            "bybit_spot": 5,
-            "bybit_futures": 5,
-            "deribit_futures": 5,
-        }
-        fee_attr = f"{venue}_taker_fee_bps"
-        default_fee_bps = 10.0 if venue.endswith("_spot") else 5.0
-        fee_bps = getattr(settings, fee_attr, default_fee_bps)
-        exchange_cfg = {
-            venue: {
-                "market_type": "spot" if venue.endswith("_spot") else "perp",
-                "fee": fee_bps / 10000.0,
-                "depth": depth_map.get(venue, 5),
-            }
-        }
+        cfg_path = resources.files("tradingbot.backtest").joinpath("exchange_config.yaml")
+        exchange_cfg_all = yaml.safe_load(cfg_path.read_text())
+        venue_cfg = exchange_cfg_all.get(venue, {})
+        if not venue_cfg:
+            typer.echo(f"missing config for {venue}")
+            raise typer.Exit()
+        exchange_cfg = {venue: venue_cfg}
         eng = EventDrivenBacktestEngine(
             {symbol: df},
             [(strategy, symbol, venue)],


### PR DESCRIPTION
## Summary
- load backtest venue parameters from a YAML config
- pass exchange config to backtest engine
- test that spot venues disallow shorts and use configured fees

## Testing
- `pytest tests/test_backtest_db_cli.py -q`
- `pytest tests/test_api_backtest_db_stream.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f2a3568832d9f7bbee3602fe364