### PR TITLE
Add spot balance checks and oversize order tests

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -444,12 +444,14 @@ class EventDrivenBacktestEngine:
                     cash += trade_value - fee
                 svc.on_fill(order.symbol, order.side, fill_qty, price)
                 if mode == "spot":
-                    assert cash >= -1e-9, (
-                        f"cash became negative after {order.side} {order.symbol}: {cash}"
-                    )
-                    assert svc.rm.pos.qty >= -1e-9, (
-                        f"position went negative for {order.symbol}: {svc.rm.pos.qty}"
-                    )
+                    if cash < -1e-9:
+                        raise AssertionError(
+                            f"cash became negative after {order.side} {order.symbol}: {cash}"
+                        )
+                    if svc.rm.pos.qty < -1e-9:
+                        raise AssertionError(
+                            f"position went negative for {order.symbol}: {svc.rm.pos.qty}"
+                        )
                 order.filled_qty += fill_qty
                 order.remaining_qty -= fill_qty
                 order.total_cost += price * fill_qty

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -17,7 +17,8 @@ class BuyOnceStrategy:
         if self.done:
             return SimpleNamespace(side="flat", strength=0.0)
         self.done = True
-        return SimpleNamespace(side="buy", strength=1.0)
+        # send a buy order well beyond available cash
+        return SimpleNamespace(side="buy", strength=10.0)
 
 
 class SellOnceStrategy:
@@ -30,7 +31,8 @@ class SellOnceStrategy:
         if self.done:
             return SimpleNamespace(side="flat", strength=0.0)
         self.done = True
-        return SimpleNamespace(side="sell", strength=1.0)
+        # send a sell order well beyond held position
+        return SimpleNamespace(side="sell", strength=10.0)
 
 
 class SneakyFeeModel(FeeModel):
@@ -71,7 +73,7 @@ def _make_data():
     return {"SYM": df}
 
 
-def test_negative_cash_asserts(monkeypatch):
+def test_buy_order_exceeding_cash_triggers_assert(monkeypatch):
     monkeypatch.setitem(STRATEGIES, "buy_once", BuyOnceStrategy)
     data = _make_data()
     strategies = [("buy_once", "SYM")]
@@ -89,7 +91,7 @@ def test_negative_cash_asserts(monkeypatch):
         engine.run()
 
 
-def test_negative_position_asserts(monkeypatch):
+def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
     monkeypatch.setitem(STRATEGIES, "sell_once", SellOnceStrategy)
     data = _make_data()
     strategies = [("sell_once", "SYM")]


### PR DESCRIPTION
## Summary
- Ensure negative cash or positions in spot mode raise clear assertion errors
- Test oversize buy and sell orders that trigger these assertions

## Testing
- `pytest tests/test_spot_balance_assertions.py::test_buy_order_exceeding_cash_triggers_assert -q`
- `pytest tests/test_spot_balance_assertions.py::test_sell_order_exceeding_position_triggers_assert -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ab668e7c832d8be162449532dc1a