### PR TITLE
Split exchange fee into maker/taker fields

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,18 +33,20 @@ risk:
 
 Las configuraciones específicas de cada venue se declaran en `config/config.yaml`
  bajo la clave `exchange_configs`. Cada entrada define el tipo de mercado,
- la comisión y el tamaño mínimo de tick a aplicar durante los backtests y al
+ las comisiones maker/taker y el tamaño mínimo de tick a aplicar durante los backtests y al
  utilizar la CLI:
 
 ```yaml
 exchange_configs:
   binance_spot:
     market_type: spot
-    fee: 0.001
+    maker_fee_bps: 10.0
+    taker_fee_bps: 10.0
     tick_size: 0.01
   okx_spot:
     market_type: spot
-    fee: 0.001
+    maker_fee_bps: 10.0
+    taker_fee_bps: 10.0
     tick_size: 0.1
 ```
 

--- a/docs/venues.md
+++ b/docs/venues.md
@@ -23,14 +23,15 @@ como SOL, XRP, MATIC, DOT, ADA, DOGE, LTC y TRX.
 
 ## Exchange configuration
 
-Per-venue settings such as fees or tick sizes can be defined in
+Per-venue settings such as maker/taker fees or tick sizes can be defined in
 `config/config.yaml` under an ``exchange_configs`` section:
 
 ```yaml
 exchange_configs:
   binance_spot:
     market_type: spot
-    fee: 0.001
+    maker_fee_bps: 10.0
+    taker_fee_bps: 10.0
     tick_size: 0.01
 ```
 

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -225,8 +225,8 @@ class EventDrivenBacktestEngine:
         default_taker_bps = 10.0
         for exch, cfg in exchange_configs.items():
             self.exchange_latency[exch] = int(cfg.get("latency", latency))
-            maker_bps = float(cfg.get("maker_fee_bps", cfg.get("fee", default_maker_bps)))
-            taker_bps = float(cfg.get("taker_fee_bps", cfg.get("fee", default_taker_bps)))
+            maker_bps = float(cfg.get("maker_fee_bps", default_maker_bps))
+            taker_bps = float(cfg.get("taker_fee_bps", cfg.get("maker_fee_bps", default_taker_bps)))
             self.exchange_fees[exch] = FeeModel(maker_bps, taker_bps)
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
             self.exchange_tick_size[exch] = float(cfg.get("tick_size", 0.0))

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -44,13 +44,16 @@ risk:
 exchange_configs:
   binance_spot:
     market_type: spot
-    fee: 0.001
+    maker_fee_bps: 10.0
+    taker_fee_bps: 10.0
     tick_size: 0.01
   binance_futures:
     market_type: perp
-    fee: 0.0005
+    maker_fee_bps: 5.0
+    taker_fee_bps: 5.0
     tick_size: 0.01
   okx_spot:
     market_type: spot
-    fee: 0.001
+    maker_fee_bps: 10.0
+    taker_fee_bps: 10.0
     tick_size: 0.1

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -74,7 +74,8 @@ class ExchangeVenueConfig:
     """Per-venue configuration such as fees and tick sizes."""
 
     market_type: str = "spot"
-    fee: float = 0.001
+    maker_fee_bps: float = 10.0
+    taker_fee_bps: float = 10.0
     tick_size: float = 0.0
 
 

--- a/tests/test_backtest_db_cli.py
+++ b/tests/test_backtest_db_cli.py
@@ -1,4 +1,6 @@
 from types import SimpleNamespace
+
+import pytest
 from omegaconf import OmegaConf
 
 from tradingbot.cli import main as cli_main
@@ -59,7 +61,12 @@ def test_backtest_db_futures_config(monkeypatch):
     eng = _run_backtest(monkeypatch, "binance_futures")
     cfg = _load_cfg()["binance_futures"]
     assert eng.exchange_mode["binance_futures"] == cfg["market_type"]
-    assert eng.exchange_fees["binance_futures"].fee == cfg["fee"]
+    assert eng.exchange_fees["binance_futures"].maker_fee == pytest.approx(
+        cfg["maker_fee_bps"] / 10000.0
+    )
+    assert eng.exchange_fees["binance_futures"].taker_fee == pytest.approx(
+        cfg["taker_fee_bps"] / 10000.0
+    )
     assert eng.exchange_tick_size["binance_futures"] == cfg["tick_size"]
     rm = eng.risk[("dummy", "BTC/USDT")].rm
     assert rm.allow_short is True
@@ -69,7 +76,12 @@ def test_backtest_db_spot_config(monkeypatch):
     eng = _run_backtest(monkeypatch, "binance_spot")
     cfg = _load_cfg()["binance_spot"]
     assert eng.exchange_mode["binance_spot"] == cfg["market_type"]
-    assert eng.exchange_fees["binance_spot"].fee == cfg["fee"]
+    assert eng.exchange_fees["binance_spot"].maker_fee == pytest.approx(
+        cfg["maker_fee_bps"] / 10000.0
+    )
+    assert eng.exchange_fees["binance_spot"].taker_fee == pytest.approx(
+        cfg["taker_fee_bps"] / 10000.0
+    )
     assert eng.exchange_tick_size["binance_spot"] == cfg["tick_size"]
     rm = eng.risk[("dummy", "BTC/USDT")].rm
     assert rm.allow_short is False

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -288,7 +288,13 @@ def test_spot_venue_config_applied(tmp_path, monkeypatch):
         {"SYM": df},
         [("buyonce", "SYM", "spot_venue")],
         initial_equity=1000.0,
-        exchange_configs={"spot_venue": {"market_type": "spot", "fee": 0.001}},
+        exchange_configs={
+            "spot_venue": {
+                "market_type": "spot",
+                "maker_fee_bps": 10,
+                "taker_fee_bps": 10,
+            }
+        },
         latency=1,
         window=1,
         verbose_fills=True,


### PR DESCRIPTION
## Summary
- replace single `fee` field with `maker_fee_bps` and `taker_fee_bps` in exchange configs
- adjust config dataclass and backtest engine to use the new fields
- update tests and docs for maker/taker fee format

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_backtest_engine.py::test_spot_venue_config_applied tests/test_backtest_db_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e2b058e4832d9bd6a32a25b78786