### PR TITLE
Set default paper trading fees and use them in PaperAdapter

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     binance_futures_market: str = "USDT-M"  # informativo
 
     # Fees (bps) configurable por entorno
-    paper_maker_fee_bps: float = 0.0
-    paper_taker_fee_bps: float | None = None
+    paper_maker_fee_bps: float = 10.0
+    paper_taker_fee_bps: float = 10.0
 
     # Binance Spot
     binance_spot_maker_fee_bps: float = 10.0

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -39,17 +39,16 @@ class PaperAdapter(ExchangeAdapter):
         fee_bps: float | None = None,
     ):
         self.state = PaperState()
-        mf = maker_fee_bps
-        if mf is None:
-            mf = fee_bps if fee_bps is not None else settings.paper_maker_fee_bps
-        self.maker_fee_bps = float(mf)
-        default_taker = (
-            settings.paper_taker_fee_bps
-            if settings.paper_taker_fee_bps is not None
-            else self.maker_fee_bps
+        mf = (
+            maker_fee_bps
+            if maker_fee_bps is not None
+            else (fee_bps if fee_bps is not None else settings.paper_maker_fee_bps)
         )
+        self.maker_fee_bps = float(mf)
         self.taker_fee_bps = float(
-            taker_fee_bps if taker_fee_bps is not None else default_taker
+            taker_fee_bps
+            if taker_fee_bps is not None
+            else settings.paper_taker_fee_bps
         )
 
     def update_last_price(self, symbol: str, px: float):

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -11,6 +11,7 @@ from tradingbot.execution.paper import PaperAdapter
 class TimedPaperAdapter(PaperAdapter):
     def __init__(self):
         super().__init__()
+        self.state.cash = 1_000_000.0
         self.call_times: list[float] = []
 
     async def place_order(self, *args, **kwargs):  # type: ignore[override]
@@ -46,6 +47,14 @@ async def test_paper_stream_updates_price(paper_adapter):
     res = await paper_adapter.place_order("BTCUSDT", "buy", "market", 0.5)
     assert res["status"] == "filled"
     assert res["price"] == 100.0
+
+
+def test_paper_adapter_uses_config_fees():
+    from tradingbot.config import settings
+
+    adapter = PaperAdapter()
+    assert adapter.maker_fee_bps == settings.paper_maker_fee_bps
+    assert adapter.taker_fee_bps == settings.paper_taker_fee_bps
 
 
 @pytest.mark.asyncio
@@ -98,6 +107,8 @@ async def test_pov_participates():
 
 
 class DummyExecAdapter:
+    name = "dummy"
+
     def __init__(self):
         self.args = None
 


### PR DESCRIPTION
## Summary
- set default paper maker/taker fees to 10 bps
- initialize PaperAdapter with configured fees
- test that PaperAdapter picks up config fee defaults

## Testing
- `pytest tests/test_execution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e2b1b94c832da07015d318dcdfa3