### PR TITLE
Auto-refresh trading fees for adapters

### DIFF
--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -94,6 +94,8 @@ class BinanceFuturesAdapter(ExchangeAdapter):
             self._configure_lock = None
             self._position_mode_configured = False
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params: Dict[str, Any] = {}
         if symbol:

--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -82,6 +82,8 @@ class BinanceSpotAdapter(ExchangeAdapter):
 
         self.name = "binance_spot_testnet" if testnet else "binance_spot"
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params: Dict[str, Any] = {}
         if symbol:

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -77,6 +77,8 @@ class BybitFuturesAdapter(ExchangeAdapter):
             )
         )
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params = {"category": "linear"}
         if symbol:

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -69,6 +69,8 @@ class BybitSpotAdapter(ExchangeAdapter):
             )
         )
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params = {"category": "spot"}
         if symbol:

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -82,6 +82,8 @@ class OKXFuturesAdapter(ExchangeAdapter):
             )
         )
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params = {"instType": "SWAP"}
         if symbol:

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -74,6 +74,8 @@ class OKXSpotAdapter(ExchangeAdapter):
             )
         )
 
+        self._start_fee_updater()
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params = {"instType": "SPOT"}
         if symbol:


### PR DESCRIPTION
## Summary
- add background fee updater to `ExchangeAdapter`
- schedule initial and periodic fee updates in all venue adapters

## Testing
- `pytest` *(fails: hung during tests/test_adapters.py::test_ws_adapter_reconnect)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e2b286e8832da4538c3395bd066a