### PR TITLE
Update OKX spot fee configuration and docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,7 +34,8 @@ risk:
 Las configuraciones específicas de cada venue se declaran en `config/config.yaml`
  bajo la clave `exchange_configs`. Cada entrada define el tipo de mercado,
  las comisiones maker/taker y el tamaño mínimo de tick a aplicar durante los backtests y al
- utilizar la CLI:
+ utilizar la CLI. Se pueden definir entradas adicionales con el sufijo `_testnet`
+ para ajustar tarifas en entornos de prueba:
 
 ```yaml
 exchange_configs:
@@ -45,7 +46,12 @@ exchange_configs:
     tick_size: 0.01
   okx_spot:
     market_type: spot
-    maker_fee_bps: 10.0
+    maker_fee_bps: 8.0
+    taker_fee_bps: 10.0
+    tick_size: 0.1
+  okx_spot_testnet:
+    market_type: spot
+    maker_fee_bps: 8.0
     taker_fee_bps: 10.0
     tick_size: 0.1
 ```

--- a/docs/venues.md
+++ b/docs/venues.md
@@ -24,7 +24,8 @@ como SOL, XRP, MATIC, DOT, ADA, DOGE, LTC y TRX.
 ## Exchange configuration
 
 Per-venue settings such as maker/taker fees or tick sizes can be defined in
-`config/config.yaml` under an ``exchange_configs`` section:
+`config/config.yaml` under an ``exchange_configs`` section. Entries with a
+``_testnet`` suffix allow overriding fees for test environments:
 
 ```yaml
 exchange_configs:
@@ -33,6 +34,16 @@ exchange_configs:
     maker_fee_bps: 10.0
     taker_fee_bps: 10.0
     tick_size: 0.01
+  okx_spot:
+    market_type: spot
+    maker_fee_bps: 8.0
+    taker_fee_bps: 10.0
+    tick_size: 0.1
+  okx_spot_testnet:
+    market_type: spot
+    maker_fee_bps: 8.0
+    taker_fee_bps: 10.0
+    tick_size: 0.1
 ```
 
 Venues without an explicit entry fall back to automatic ``_spot``/``_perp``

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -54,6 +54,11 @@ exchange_configs:
     tick_size: 0.01
   okx_spot:
     market_type: spot
-    maker_fee_bps: 10.0
+    maker_fee_bps: 8.0
+    taker_fee_bps: 10.0
+    tick_size: 0.1
+  okx_spot_testnet:
+    market_type: spot
+    maker_fee_bps: 8.0
     taker_fee_bps: 10.0
     tick_size: 0.1


### PR DESCRIPTION
## Summary
- set OKX spot maker fee to 8 bps and taker fee to 10 bps
- add okx_spot_testnet entry for testnet fee overrides
- document updated default fees and testnet configuration examples

## Testing
- ⚠️ `pytest -q` (terminated with KeyboardInterrupt after running tests)
- ✅ `pytest tests/test_execution_router_extra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1a7cbf4832da9a06a1cb6fa010a