### PR TITLE
Raise default min fill quantity to 1e-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ risk:
 
 El motor de backtesting ignora ejecuciones cuya cantidad sea menor a
 `min_fill_qty` para evitar registrar residuos irrelevantes. El umbral
-predeterminado es la constante `MIN_FILL_QTY = 1e-6`, pero puede ajustarse
-al crear `EventDrivenBacktestEngine`.
+predeterminado es la constante `MIN_FILL_QTY = 1e-3`, pero puede ajustarse
+al crear `EventDrivenBacktestEngine` o mediante los campos `backtest.min_fill_qty`
+y `exchange_configs.<exchange>.min_fill_qty` en la configuración YAML.
 
 ## Solución de problemas
 

--- a/data/examples/small_account.yaml
+++ b/data/examples/small_account.yaml
@@ -4,3 +4,4 @@ backtest:
   symbol: DOGE/USDT
   strategy: breakout_atr
   initial_equity: 100
+  min_fill_qty: 0.001

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -23,7 +23,7 @@ from ..data.features import returns, calc_ofi
 log = logging.getLogger(__name__)
 
 # Minimum quantity to record a fill. Fills below this threshold are ignored.
-MIN_FILL_QTY = 1e-6
+MIN_FILL_QTY = 1e-3
 
 
 def _validate_risk_pct(value: float) -> float:
@@ -168,7 +168,7 @@ class EventDrivenBacktestEngine:
     """Backtest engine supporting multiple symbols/strategies and order latency.
 
     Fills with quantity below ``min_fill_qty`` (defaults to
-    ``MIN_FILL_QTY`` = ``1e-6``) are ignored to avoid recording irrelevant
+    ``MIN_FILL_QTY`` = ``1e-3``) are ignored to avoid recording irrelevant
     residuals.
     """
 
@@ -220,6 +220,7 @@ class EventDrivenBacktestEngine:
         self.exchange_depth: Dict[str, float] = {}
         self.exchange_mode: Dict[str, str] = {}
         self.exchange_tick_size: Dict[str, float] = {}
+        self.exchange_min_fill_qty: Dict[str, float] = {}
         exchange_configs = exchange_configs or {}
         default_maker_bps = 10.0
         default_taker_bps = 10.0
@@ -230,6 +231,7 @@ class EventDrivenBacktestEngine:
             self.exchange_fees[exch] = FeeModel(maker_bps, taker_bps)
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
             self.exchange_tick_size[exch] = float(cfg.get("tick_size", 0.0))
+            self.exchange_min_fill_qty[exch] = float(cfg.get("min_fill_qty", self.min_fill_qty))
             market_type = cfg.get("market_type")
             if market_type is None:
                 if exch.endswith("_spot"):
@@ -415,7 +417,10 @@ class EventDrivenBacktestEngine:
                         max_affordable = cash / (price * (1 + rate))
                         fill_qty = min(fill_qty, max_affordable)
 
-                if fill_qty <= 0 or fill_qty < self.min_fill_qty:
+                min_fill_qty = self.exchange_min_fill_qty.get(
+                    order.exchange, self.min_fill_qty
+                )
+                if fill_qty <= 0 or fill_qty < min_fill_qty:
                     if not self.cancel_unfilled:
                         order.execute_index = i + 1
                         heapq.heappush(order_queue, order)
@@ -440,7 +445,7 @@ class EventDrivenBacktestEngine:
                             trade_value = fill_qty * price
                             fee = fee_model.calculate(trade_value, maker=maker)
 
-                if fill_qty <= 0 or fill_qty < self.min_fill_qty:
+                if fill_qty <= 0 or fill_qty < min_fill_qty:
                     if not self.cancel_unfilled:
                         order.execute_index = i + 1
                         heapq.heappush(order_queue, order)
@@ -783,6 +788,7 @@ def run_backtest_csv(
     initial_equity: float = 1000.0,
     verbose_fills: bool = False,
     fills_csv: str | None = None,
+    min_fill_qty: float = MIN_FILL_QTY,
 ) -> dict:
     """Convenience wrapper to run the engine from CSV files."""
 
@@ -804,6 +810,7 @@ def run_backtest_csv(
         risk_pct=risk_pct,
         initial_equity=initial_equity,
         verbose_fills=verbose_fills,
+        min_fill_qty=min_fill_qty,
     )
     return engine.run(fills_csv=fills_csv)
 
@@ -830,6 +837,7 @@ def run_backtest_mlflow(
     initial_equity: float = 1000.0,
     verbose_fills: bool = False,
     fills_csv: str | None = None,
+    min_fill_qty: float = MIN_FILL_QTY,
 ) -> dict:
     """Run the backtest and log results to an MLflow run.
 
@@ -863,6 +871,7 @@ def run_backtest_mlflow(
             initial_equity=initial_equity,
             verbose_fills=verbose_fills,
             fills_csv=fills_csv,
+            min_fill_qty=min_fill_qty,
         )
         log_backtest_metrics(result)
         return result

--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
 
 import pandas as pd
 
-from .engine import EventDrivenBacktestEngine
+from .engine import EventDrivenBacktestEngine, MIN_FILL_QTY
 from ..strategies import STRATEGIES
 from ..reporting.metrics import evaluate
 
@@ -44,6 +44,7 @@ def walk_forward_backtest(
     verbose_fills: bool = False,
     fills_csv: str | None = None,
     exchange_configs: Dict[str, Dict[str, float]] | None = None,
+    min_fill_qty: float = MIN_FILL_QTY,
 ) -> pd.DataFrame:
     """Run a basic walk-forward analysis and return metrics for each split."""
 
@@ -72,6 +73,7 @@ def walk_forward_backtest(
                 window=window,
                 verbose_fills=verbose_fills,
                 exchange_configs=exchange_configs,
+                min_fill_qty=min_fill_qty,
             )
             engine.strategies[(strategy_name, symbol)] = strat
             res = engine.run()
@@ -88,6 +90,7 @@ def walk_forward_backtest(
             window=window,
             verbose_fills=verbose_fills,
             exchange_configs=exchange_configs,
+            min_fill_qty=min_fill_qty,
         )
         engine.strategies[(strategy_name, symbol)] = strat
         test_res = engine.run(fills_csv=fills_csv)

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -17,6 +17,7 @@ backtest:
   strategy: breakout_atr
   latency: 1
   window: 120
+  min_fill_qty: 0.001
 
 storage:
   backend: sqlite
@@ -47,13 +48,16 @@ exchange_configs:
     maker_fee_bps: 10.0
     taker_fee_bps: 10.0
     tick_size: 0.01
+    min_fill_qty: 0.001
   binance_futures:
     market_type: perp
     maker_fee_bps: 5.0
     taker_fee_bps: 5.0
     tick_size: 0.01
+    min_fill_qty: 0.001
   okx_spot:
     market_type: spot
     maker_fee_bps: 10.0
     taker_fee_bps: 10.0
     tick_size: 0.1
+    min_fill_qty: 0.001

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -41,6 +41,7 @@ class BacktestConfig:
     strategy: str = "breakout_atr"
     latency: int = 1
     window: int = 120
+    min_fill_qty: float = 1e-3
 
 
 @dataclass
@@ -77,6 +78,7 @@ class ExchangeVenueConfig:
     maker_fee_bps: float = 10.0
     taker_fee_bps: float = 10.0
     tick_size: float = 0.0
+    min_fill_qty: float = 1e-3
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Bump `MIN_FILL_QTY` to `1e-3` and allow per-exchange override
- Expose `min_fill_qty` through configs and CLI/backtest utilities
- Document new defaults and configuration options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0f1ae9ad0832d8731bcd35f67c886