### PR TITLE
Add configurable min order quantity threshold

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -98,7 +98,7 @@ class RiskService:
         )
         qty = abs(delta)
 
-        if qty <= 0:
+        if qty < self.rm.min_order_qty:
             return False, "zero_size", 0.0
 
         try:


### PR DESCRIPTION
## Summary
- add `min_order_qty` parameter to EventDrivenBacktestEngine and propagate to RiskManager
- ensure RiskManager and RiskService drop orders below `min_order_qty`
- trigger kill switch in RiskManager when portfolio variance exceeds limit

## Testing
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage -q`
- `pytest tests/test_risk.py tests/test_risk_manager_extra.py tests/test_backtest_engine.py -q` *(fails: size_with_volatility_event expected 10 got 5; ValueError for missing market_type)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f1ab8d0c832d87e3a0797d1ed3c0