### PR TITLE
feat: add trade cooldown to Breakout ATR strategy

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -10,7 +10,9 @@ local basado en `notional * risk_pct`.
 
 ### Breakout con ATR (`breakout_atr`)
 Compra cuando el precio supera el canal superior calculado con el indicador
-ATR y vende cuando cae por debajo del canal inferior.
+ATR y vende cuando cae por debajo del canal inferior. El parámetro
+`min_bars_between_trades` limita la emisión de señales opuestas hasta que
+transcurra un mínimo de velas.
 
 ### Breakout por Volumen (`breakout_vol`)
 Detecta rupturas de precio acompañadas de incrementos de volumen.

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -5,6 +5,8 @@ exchanges:
 strategies:
   default: breakout_atr
   params:
+    breakout_atr:
+      min_bars_between_trades: 1
     mean_rev_ofi:
       ofi_window: 20
       zscore_threshold: 1.0

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -3,6 +3,7 @@ import pandas as pd
 from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import keltner_channels
 
+
 class BreakoutATR(Strategy):
     name = "breakout_atr"
 
@@ -11,6 +12,7 @@ class BreakoutATR(Strategy):
         ema_n: int = 20,
         atr_n: int = 14,
         mult: float = 1.5,
+        min_bars_between_trades: int = 1,
         *,
         config_path: str | None = None,
     ):
@@ -18,17 +20,41 @@ class BreakoutATR(Strategy):
         self.ema_n = int(params.get("ema_n", ema_n))
         self.atr_n = int(params.get("atr_n", atr_n))
         self.mult = float(params.get("mult", mult))
+        mbbt = params.get("min_bars_between_trades", min_bars_between_trades)
+        self.min_bars_between_trades = max(int(mbbt), 1)
+        self._last_trade_idx: int | None = None
+        self._last_trade_side: str | None = None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
-        # bar should include a small rolling window (as dict of lists) or a pandas row with context
-        df: pd.DataFrame = bar["window"]  # expects columns: open, high, low, close, volume
+        # bar should include a small rolling window (as dict of lists)
+        # or a pandas row with context
+        df: pd.DataFrame = bar["window"]
+        # expects columns: open, high, low, close, volume
         if len(df) < max(self.ema_n, self.atr_n) + 2:
             return None
         upper, lower = keltner_channels(df, self.ema_n, self.atr_n, self.mult)
         last_close = df["close"].iloc[-1]
+        current_idx = len(df) - 1
+
+        sig: Signal
         if last_close > upper.iloc[-1]:
-            return Signal("buy", 1.0)
-        if last_close < lower.iloc[-1]:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            sig = Signal("buy", 1.0)
+        elif last_close < lower.iloc[-1]:
+            sig = Signal("sell", 1.0)
+        else:
+            sig = Signal("flat", 0.0)
+
+        if sig.side in {"buy", "sell"}:
+            if (
+                self._last_trade_idx is not None
+                and self._last_trade_side is not None
+                and sig.side != self._last_trade_side
+                and current_idx - self._last_trade_idx
+                < self.min_bars_between_trades
+            ):
+                return Signal("flat", 0.0)
+            self._last_trade_idx = current_idx
+            self._last_trade_side = sig.side
+
+        return sig

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -12,7 +12,20 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     sig_buy = strat.on_bar({"window": breakout_df_buy})
     assert sig_buy.side == "buy"
 
-    sig_sell = strat.on_bar({"window": breakout_df_sell})
+    # ensure at least one bar passes before opposite signal
+    row = {
+        "open": 4,
+        "high": 5,
+        "low": 3.5,
+        "close": -20.0,
+        "volume": 1,
+    }
+    df_wait = pd.concat(
+        [breakout_df_sell, pd.DataFrame([row])],
+        ignore_index=True,
+    )
+
+    sig_sell = strat.on_bar({"window": df_wait})
     assert sig_sell.side == "sell"
 
 


### PR DESCRIPTION
## Summary
- add `min_bars_between_trades` parameter to BreakoutATR and block opposite signals until enough bars pass
- expose `min_bars_between_trades` in default YAML config and document usage
- adjust strategy tests for new cooldown behavior

## Testing
- `flake8 src/tradingbot/strategies/breakout_atr.py tests/test_strategies.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1b398f4832dbccb2516dc86a40f