### PR TITLE
feat: configurable minimum order size

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -98,7 +98,7 @@ class RiskService:
         )
         qty = abs(delta)
 
-        if qty <= 0:
+        if qty < self.rm.min_order_qty:
             return False, "zero_size", 0.0
 
         try:

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -157,3 +157,16 @@ def test_long_only_prevents_shorts():
     rm.set_position(1.0)
     allowed, _, delta = rm.check_order("SYM", "sell", equity=100.0, price=100.0)
     assert allowed and delta == pytest.approx(-1.0)
+
+
+def test_min_order_qty_blocks_small_orders():
+    from tradingbot.risk.manager import RiskManager
+
+    rm = RiskManager(min_order_qty=0.01)
+    # Strength yields a delta of 0.001 which is below the threshold
+    allowed, reason, delta = rm.check_order(
+        "SYM", "buy", equity=100.0, price=100.0, strength=0.001
+    )
+    assert not allowed
+    assert reason == "zero_size"
+    assert delta == 0.0


### PR DESCRIPTION
## Summary
- add `min_order_qty` threshold to EventDrivenBacktestEngine and pass through risk service
- enforce minimum order quantity in RiskManager and RiskService
- cover new behaviour with test for small order rejection

## Testing
- `pytest tests/test_risk.py::test_min_order_qty_blocks_small_orders -q`
- `pytest tests/test_backtest_engine.py::test_fills_csv_export -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5734d5c832db64efa7324130af3