### PR TITLE
Add trailing stop and volatility-based sizing to scalping strategies

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -15,21 +15,34 @@ class BreakoutVol(Strategy):
     Parameters
     ----------
     lookback : int, optional
-        Window size for the rolling statistics, default ``20``.
+        Window size for the rolling statistics, default ``10``.
     mult : float, optional
         Multiplier applied to the standard deviation, default ``2``.
+    tp_bps : float, optional
+        Take profit in basis points, default ``10``.
+    sl_bps : float, optional
+        Stop loss in basis points, default ``15``.
+    trailing_stop_bps : float, optional
+        Distance from the best price in basis points to trigger a trailing stop,
+        default ``10``.
+    volatility_factor : float, optional
+        Multiplier applied to recent volatility (in bps) to size positions,
+        default ``0.02``.
     """
 
     name = "breakout_vol"
 
     def __init__(self, **kwargs):
-        self.lookback = kwargs.get("lookback", 20)
+        self.lookback = kwargs.get("lookback", 10)
         self.mult = kwargs.get("mult", 1.5)
-        self.tp_bps = kwargs.get("tp_bps", 30.0)
-        self.sl_bps = kwargs.get("sl_bps", 40.0)
-        self.max_hold_bars = kwargs.get("max_hold_bars", 20)
+        self.tp_bps = kwargs.get("tp_bps", 10.0)
+        self.sl_bps = kwargs.get("sl_bps", 15.0)
+        self.max_hold_bars = kwargs.get("max_hold_bars", 10)
+        self.trailing_stop_bps = kwargs.get("trailing_stop_bps", 10.0)
+        self.volatility_factor = kwargs.get("volatility_factor", 0.02)
         self.pos_side: int = 0
         self.entry_price: float | None = None
+        self.favorable_price: float | None = None
         self.hold_bars: int = 0
 
     @record_signal_metrics
@@ -44,30 +57,48 @@ class BreakoutVol(Strategy):
         upper = mean + self.mult * std
         lower = mean - self.mult * std
 
+        returns = closes.pct_change().dropna()
+        vol = returns.rolling(self.lookback).std().iloc[-1] if len(returns) >= self.lookback else 0.0
+        vol_bps = vol * 10000
+        size = max(0.0, min(1.0, vol_bps * self.volatility_factor))
+
         if self.pos_side == 0:
             if last > upper:
                 self.pos_side = 1
                 self.entry_price = last
+                self.favorable_price = last
                 self.hold_bars = 0
-                return Signal("buy", 1.0)
+                return Signal("buy", size)
             if last < lower:
                 self.pos_side = -1
                 self.entry_price = last
+                self.favorable_price = last
                 self.hold_bars = 0
-                return Signal("sell", 1.0)
+                return Signal("sell", size)
             return None
 
         self.hold_bars += 1
-        assert self.entry_price is not None
+        assert self.entry_price is not None and self.favorable_price is not None
+        if self.pos_side > 0:
+            self.favorable_price = max(self.favorable_price, last)
+        else:
+            self.favorable_price = min(self.favorable_price, last)
+
         pnl_bps = (last - self.entry_price) / self.entry_price * 10000 * self.pos_side
+        trail_hit = False
+        if self.trailing_stop_bps is not None:
+            best_pnl = (last - self.favorable_price) / self.favorable_price * 10000 * self.pos_side
+            trail_hit = best_pnl <= -self.trailing_stop_bps
         if (
             pnl_bps >= self.tp_bps
             or pnl_bps <= -self.sl_bps
             or self.hold_bars >= self.max_hold_bars
+            or trail_hit
         ):
             side = "sell" if self.pos_side > 0 else "buy"
             self.pos_side = 0
             self.entry_price = None
+            self.favorable_price = None
             self.hold_bars = 0
             return Signal(side, 1.0)
         return None

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -14,26 +14,34 @@ class ScalpPingPongConfig:
     Parameters
     ----------
     lookback : int, optional
-        Window length for the z-score calculation, by default ``30``.
+        Window length for the z-score calculation, by default ``15``.
     z_threshold : float, optional
         Absolute z-score value required to open a trade, by default ``0.2``.
     exit_z : float, optional
         Threshold below which the position is exited for mean reversion,
         by default ``0.05``.
     tp_bps : float, optional
-        Take profit in basis points, by default ``30``.
+        Take profit in basis points, by default ``10``.
     sl_bps : float, optional
-        Stop loss in basis points, by default ``40``.
+        Stop loss in basis points, by default ``15``.
     max_hold_bars : int, optional
-        Maximum number of bars to hold a trade, by default ``15``.
+        Maximum number of bars to hold a trade, by default ``8``.
+    trailing_stop_bps : float, optional
+        Distance from the best price in basis points to trigger a trailing stop,
+        default ``10``.
+    volatility_factor : float, optional
+        Multiplier applied to recent volatility (in bps) to size positions,
+        default ``0.02``.
     """
 
-    lookback: int = 30
+    lookback: int = 15
     z_threshold: float = 0.2
     exit_z: float = 0.05
-    tp_bps: float = 30.0
-    sl_bps: float = 40.0
-    max_hold_bars: int = 15
+    tp_bps: float = 10.0
+    sl_bps: float = 15.0
+    max_hold_bars: int = 8
+    trailing_stop_bps: float | None = 10.0
+    volatility_factor: float = 0.02
 
 
 class ScalpPingPong(Strategy):
@@ -46,6 +54,7 @@ class ScalpPingPong(Strategy):
         self.pos_side: int = 0  # 0 flat, +1 long, -1 short
         self.entry_price: float | None = None
         self.hold_bars: int = 0
+        self.favorable_price: float | None = None
 
     def _calc_zscore(self, closes: pd.Series) -> float:
         returns = closes.pct_change().dropna()
@@ -64,35 +73,56 @@ class ScalpPingPong(Strategy):
         if len(df) < self.cfg.lookback + 1:
             return None
         closes = df["close"]
+        returns = closes.pct_change().dropna()
         z = self._calc_zscore(closes)
         price = float(closes.iloc[-1])
+
+        vol = returns.rolling(self.cfg.lookback).std().iloc[-1] if len(returns) >= self.cfg.lookback else 0.0
+        vol_bps = vol * 10000
+        vol_size = max(0.0, min(1.0, vol_bps * self.cfg.volatility_factor))
 
         if self.pos_side == 0:
             if z <= -self.cfg.z_threshold:
                 self.pos_side = 1
                 self.entry_price = price
+                self.favorable_price = price
                 self.hold_bars = 0
                 strength = min(1.0, abs(z) / self.cfg.z_threshold)
-                return Signal("buy", strength)
+                size = min(1.0, strength * vol_size)
+                if size > 0:
+                    return Signal("buy", size)
             if z >= self.cfg.z_threshold:
                 self.pos_side = -1
                 self.entry_price = price
+                self.favorable_price = price
                 self.hold_bars = 0
                 strength = min(1.0, abs(z) / self.cfg.z_threshold)
-                return Signal("sell", strength)
+                size = min(1.0, strength * vol_size)
+                if size > 0:
+                    return Signal("sell", size)
             return None
 
         self.hold_bars += 1
-        assert self.entry_price is not None
+        assert self.entry_price is not None and self.favorable_price is not None
+        if self.pos_side > 0:
+            self.favorable_price = max(self.favorable_price, price)
+        else:
+            self.favorable_price = min(self.favorable_price, price)
+
         pnl_bps = (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
         exit_z = abs(z) < self.cfg.exit_z
         exit_tp = pnl_bps >= self.cfg.tp_bps
         exit_sl = pnl_bps <= -self.cfg.sl_bps
         exit_time = self.hold_bars >= self.cfg.max_hold_bars
-        if exit_z or exit_tp or exit_sl or exit_time:
+        exit_trail = False
+        if self.cfg.trailing_stop_bps is not None:
+            best_pnl = (price - self.favorable_price) / self.favorable_price * 10000 * self.pos_side
+            exit_trail = best_pnl <= -self.cfg.trailing_stop_bps
+        if exit_z or exit_tp or exit_sl or exit_time or exit_trail:
             side = "sell" if self.pos_side > 0 else "buy"
             self.pos_side = 0
             self.entry_price = None
+            self.favorable_price = None
             self.hold_bars = 0
             return Signal(side, 1.0)
         return None


### PR DESCRIPTION
## Summary
- reduce windows and tp/sl thresholds in breakout and scalp strategies for quicker trades
- add trailing stop support and volatility-proportional position sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad1a64e8832da7500150b2545679