### PR TITLE
Add stateful exits and volatility thresholds to LiquidityEvents

### DIFF
--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -13,13 +13,50 @@ class LiquidityEvents(Strategy):
     results in a sell signal.  If no vaciado is detected, the strategy checks
     for large gaps between the first and second level of the book and trades in
     the direction of the gap.
+
+    The strategy maintains an internal state and exits positions based on take
+    profit, stop loss or maximum holding period.  Thresholds for detecting
+    vacuums and gaps can be dynamically adjusted according to recent price
+    volatility to increase the frequency of events during turbulent markets.
     """
 
     name = "liquidity_events"
 
-    def __init__(self, vacuum_threshold: float = 0.5, gap_threshold: float = 1.0):
+    def __init__(
+        self,
+        vacuum_threshold: float = 0.5,
+        gap_threshold: float = 1.0,
+        tp_pct: float = 0.01,
+        sl_pct: float = 0.005,
+        max_hold: int = 30,
+        vol_window: int = 20,
+        dynamic_thresholds: bool = True,
+    ):
         self.vacuum_threshold = vacuum_threshold
         self.gap_threshold = gap_threshold
+        self.tp_pct = tp_pct
+        self.sl_pct = sl_pct
+        self.max_hold = max_hold
+        self.vol_window = vol_window
+        self.dynamic_thresholds = dynamic_thresholds
+
+        self.position: str | None = None
+        self.entry_price: float = 0.0
+        self.bars_in_position: int = 0
+
+    def _mid_prices(self, df: pd.DataFrame) -> pd.Series:
+        bid = df["bid_px"].apply(lambda x: x[0])
+        ask = df["ask_px"].apply(lambda x: x[0])
+        return (bid + ask) / 2
+
+    def _vol_adjust(self, series: pd.Series, base: float) -> float:
+        if not self.dynamic_thresholds:
+            return base
+        returns = series.pct_change().fillna(0)
+        vol = returns.rolling(self.vol_window).std().iloc[-1]
+        if pd.isna(vol):
+            vol = 0.0
+        return base / (1 + vol)
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -28,15 +65,54 @@ class LiquidityEvents(Strategy):
         if not needed.issubset(df.columns) or len(df) < 2:
             return None
 
-        vac = book_vacuum(df[list({"bid_qty", "ask_qty"})], self.vacuum_threshold).iloc[-1]
+        mid = self._mid_prices(df)
+        last_price = mid.iloc[-1]
+
+        # Handle open positions
+        if self.position == "long":
+            self.bars_in_position += 1
+            if (
+                last_price >= self.entry_price * (1 + self.tp_pct)
+                or last_price <= self.entry_price * (1 - self.sl_pct)
+                or self.bars_in_position >= self.max_hold
+            ):
+                self.position = None
+                return Signal("sell", 1.0, reduce_only=True)
+            return None
+        if self.position == "short":
+            self.bars_in_position += 1
+            if (
+                last_price <= self.entry_price * (1 - self.tp_pct)
+                or last_price >= self.entry_price * (1 + self.sl_pct)
+                or self.bars_in_position >= self.max_hold
+            ):
+                self.position = None
+                return Signal("buy", 1.0, reduce_only=True)
+            return None
+
+        vac_thresh = self._vol_adjust(mid, self.vacuum_threshold)
+        vac = book_vacuum(df[["bid_qty", "ask_qty"]], vac_thresh).iloc[-1]
         if vac > 0:
+            self.position = "long"
+            self.entry_price = last_price
+            self.bars_in_position = 0
             return Signal("buy", 1.0)
         if vac < 0:
+            self.position = "short"
+            self.entry_price = last_price
+            self.bars_in_position = 0
             return Signal("sell", 1.0)
 
-        gap = liquidity_gap(df[list({"bid_px", "ask_px"})], self.gap_threshold).iloc[-1]
+        gap_thresh = self._vol_adjust(mid, self.gap_threshold)
+        gap = liquidity_gap(df[["bid_px", "ask_px"]], gap_thresh).iloc[-1]
         if gap > 0:
+            self.position = "long"
+            self.entry_price = last_price
+            self.bars_in_position = 0
             return Signal("buy", 1.0)
         if gap < 0:
+            self.position = "short"
+            self.entry_price = last_price
+            self.bars_in_position = 0
             return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        return None

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -26,7 +26,7 @@ def test_liquidity_events_strategy_buy_vacuum():
         "bid_px": [[100, 99], [100, 99]],
         "ask_px": [[101, 102], [101, 102]],
     })
-    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2)
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, dynamic_thresholds=False)
     sig = strat.on_bar({"window": df})
     assert sig is not None and sig.side == "buy"
 
@@ -38,6 +38,97 @@ def test_liquidity_events_strategy_sell_gap():
         "bid_px": [[100, 99], [100, 90]],
         "ask_px": [[101, 102], [101, 102]],
     })
-    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=5)
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=5, dynamic_thresholds=False)
     sig = strat.on_bar({"window": df})
     assert sig is not None and sig.side == "sell"
+
+
+def test_liquidity_events_no_signal_returns_none():
+    df = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 10],
+        "bid_px": [[100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, dynamic_thresholds=False)
+    sig = strat.on_bar({"window": df})
+    assert sig is None
+
+
+def test_take_profit_exit():
+    df_entry = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 4],
+        "bid_px": [[100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.01, sl_pct=0.01, max_hold=10, dynamic_thresholds=False)
+    sig = strat.on_bar({"window": df_entry})
+    assert sig is not None and sig.side == "buy"
+
+    df_exit = pd.DataFrame({
+        "bid_qty": [10, 10, 10],
+        "ask_qty": [10, 4, 10],
+        "bid_px": [[100, 99], [100, 99], [102, 101]],
+        "ask_px": [[101, 102], [101, 102], [103, 104]],
+    })
+    sig_exit = strat.on_bar({"window": df_exit})
+    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
+
+
+def test_stop_loss_exit():
+    df_entry = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 4],
+        "bid_px": [[100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.05, sl_pct=0.01, max_hold=10, dynamic_thresholds=False)
+    sig = strat.on_bar({"window": df_entry})
+    assert sig is not None and sig.side == "buy"
+
+    df_exit = pd.DataFrame({
+        "bid_qty": [10, 10, 10],
+        "ask_qty": [10, 4, 10],
+        "bid_px": [[100, 99], [100, 99], [99, 98]],
+        "ask_px": [[101, 102], [101, 102], [99.8, 100]],
+    })
+    sig_exit = strat.on_bar({"window": df_exit})
+    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
+
+
+def test_time_exit():
+    df_entry = pd.DataFrame({
+        "bid_qty": [10, 10],
+        "ask_qty": [10, 4],
+        "bid_px": [[100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102]],
+    })
+    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.05, sl_pct=0.05, max_hold=1, dynamic_thresholds=False)
+    sig = strat.on_bar({"window": df_entry})
+    assert sig is not None and sig.side == "buy"
+
+    df_exit = pd.DataFrame({
+        "bid_qty": [10, 10, 10],
+        "ask_qty": [10, 4, 10],
+        "bid_px": [[100, 99], [100, 99], [100, 99]],
+        "ask_px": [[101, 102], [101, 102], [101, 102]],
+    })
+    sig_exit = strat.on_bar({"window": df_exit})
+    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
+
+
+def test_dynamic_thresholds_increase_events():
+    df = pd.DataFrame({
+        "bid_qty": [10, 10, 10, 10],
+        "ask_qty": [10, 10, 10, 10],
+        "bid_px": [[100, 99], [200, 199], [50, 49], [50, 48.5]],
+        "ask_px": [[101, 102], [201, 202], [51, 52], [51, 52]],
+    })
+    strat_dyn = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, vol_window=3, dynamic_thresholds=True)
+    sig_dyn = strat_dyn.on_bar({"window": df})
+    assert sig_dyn is not None and sig_dyn.side == "sell"
+
+    strat_static = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, dynamic_thresholds=False)
+    sig_static = strat_static.on_bar({"window": df})
+    assert sig_static is None


### PR DESCRIPTION
## Summary
- remove flat signal and add stateful trade management with TP/SL/time exits
- allow dynamic event thresholds that scale with volatility to increase signal frequency
- expand liquidity event tests to cover exits and volatility-based behavior

## Testing
- `pytest tests/test_liquidity_events.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1ad20e06c832dab67ebca9a5085f0