### PR TITLE
Add TP/SL thresholds to composite signals

### DIFF
--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -10,4 +10,6 @@ class Order:
     post_only: bool = False
     time_in_force: str | None = None
     iceberg_qty: float | None = None
+    take_profit: float | None = None
+    stop_loss: float | None = None
     reduce_only: bool = False

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -158,6 +158,8 @@ class PaperAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
+        take_profit: float | None = None,
+        stop_loss: float | None = None,
         reduce_only: bool = False,
     ) -> dict:
         order_id = self._next_order_id()

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -216,6 +216,10 @@ class ExecutionRouter:
                 or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
             ):
                 kwargs["iceberg_qty"] = order.iceberg_qty
+        if order.take_profit is not None:
+            kwargs["take_profit"] = order.take_profit
+        if order.stop_loss is not None:
+            kwargs["stop_loss"] = order.stop_loss
 
         try:
             res = await adapter.place_order(**kwargs)

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -531,6 +531,8 @@ class TradeBotDaemon:
             side="buy" if delta > 0 else "sell",
             type_="market",
             qty=abs(delta),
+            take_profit=getattr(signal, "take_profit", None),
+            stop_loss=getattr(signal, "stop_loss", None),
             reduce_only=getattr(signal, "reduce_only", False),
         )
         res = await self.router.execute(order)

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -189,7 +189,14 @@ async def run_live_binance(
 
         side = "buy" if delta > 0 else "sell"
         prev_rpnl = broker.state.realized_pnl
-        resp = await broker.place_order(symbol, side, "market", abs(delta))
+        resp = await broker.place_order(
+            symbol,
+            side,
+            "market",
+            abs(delta),
+            take_profit=getattr(signal, "take_profit", None),
+            stop_loss=getattr(signal, "stop_loss", None),
+        )
         fills += 1
         log.info("FILL live %s", resp)
         risk.on_fill(symbol, side, abs(delta), venue="binance")

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -106,6 +106,8 @@ async def run_paper(
                 side=side,
                 type_="market",
                 qty=abs(delta),
+                take_profit=getattr(signal, "take_profit", None),
+                stop_loss=getattr(signal, "stop_loss", None),
                 reduce_only=signal.reduce_only,
             )
             await router.execute(order)

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -179,10 +179,23 @@ async def _run_symbol(
         side = "buy" if delta > 0 else "sell"
         qty = abs(delta)
         if dry_run:
-            resp = await broker.place_order(cfg.symbol, side, "market", qty)
+            resp = await broker.place_order(
+                cfg.symbol,
+                side,
+                "market",
+                qty,
+                take_profit=getattr(sig, "take_profit", None),
+                stop_loss=getattr(sig, "stop_loss", None),
+            )
         else:
             resp = await exec_adapter.place_order(
-                cfg.symbol, side, "market", qty, mark_price=closed.c
+                cfg.symbol,
+                side,
+                "market",
+                qty,
+                mark_price=closed.c,
+                take_profit=getattr(sig, "take_profit", None),
+                stop_loss=getattr(sig, "stop_loss", None),
             )
         log.info("LIVE FILL %s", resp)
         risk.on_fill(cfg.symbol, side, qty, venue=venue if not dry_run else "paper")

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -141,10 +141,23 @@ async def _run_symbol(exchange: str, market: str, cfg: _SymbolConfig, leverage: 
         side = "buy" if delta > 0 else "sell"
         qty = abs(delta)
         if market == "futures" and dry_run:
-            resp = await broker.place_order(cfg.symbol, side, "market", qty)
+            resp = await broker.place_order(
+                cfg.symbol,
+                side,
+                "market",
+                qty,
+                take_profit=getattr(sig, "take_profit", None),
+                stop_loss=getattr(sig, "stop_loss", None),
+            )
         else:
             resp = await exec_adapter.place_order(
-                cfg.symbol, side, "market", qty, mark_price=closed.c
+                cfg.symbol,
+                side,
+                "market",
+                qty,
+                mark_price=closed.c,
+                take_profit=getattr(sig, "take_profit", None),
+                stop_loss=getattr(sig, "stop_loss", None),
             )
         log.info("LIVE FILL %s", resp)
         risk.on_fill(cfg.symbol, side, qty, venue=venue if not dry_run else "paper")

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -16,13 +16,16 @@ class Signal:
     ``strength`` defines sizing through ``notional = equity * strength``. A
     value of ``1.0`` uses the full account equity, values above ``1.0`` pyramid
     exposure and values between ``0`` and ``1`` scale it down. ``0`` or
-    negative values close the position. ``risk_pct`` acts as a local stop‑loss
-    calculated as ``notional * risk_pct``.
+    negative values close the position. Optional ``take_profit`` and
+    ``stop_loss`` levels express absolute prices for OCO orders. ``risk_pct``
+    acts as a local stop‑loss calculated as ``notional * risk_pct``.
     """
 
     side: str  # 'buy' | 'sell' | 'flat'
     strength: float = 1.0  # fraction of the base equity allocation
     reduce_only: bool = False
+    take_profit: float | None = None  # optional TP price level
+    stop_loss: float | None = None  # optional SL price level
 
 class Strategy(ABC):
     name: str

--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -10,8 +10,31 @@ class CompositeSignals(Strategy):
 
     name = "composite_signals"
 
-    def __init__(self, strategies: Sequence[tuple[Type[Strategy], dict]]):
+    def __init__(
+        self,
+        strategies: Sequence[tuple[Type[Strategy], dict]],
+        *,
+        tp_pct: float = 0.0,
+        sl_pct: float = 0.0,
+    ):
         self.sub_strategies = [cls(**params) for cls, params in strategies]
+        self.tp_pct = float(tp_pct)
+        self.sl_pct = float(sl_pct)
+
+    def _levels(self, side: str, price: float | None) -> dict[str, float | None]:
+        tp = sl = None
+        if price is not None:
+            if side == "buy":
+                if self.tp_pct > 0:
+                    tp = price * (1 + self.tp_pct)
+                if self.sl_pct > 0:
+                    sl = price * (1 - self.sl_pct)
+            else:  # sell
+                if self.tp_pct > 0:
+                    tp = price * (1 - self.tp_pct)
+                if self.sl_pct > 0:
+                    sl = price * (1 + self.sl_pct)
+        return {"take_profit": tp, "stop_loss": sl}
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -25,12 +48,17 @@ class CompositeSignals(Strategy):
                 buys += 1
             elif sig.side == "sell":
                 sells += 1
+        price = bar.get("close") or bar.get("price")
         if buys >= 2 and buys > sells:
-            return Signal("buy", 1.0)
+            levels = self._levels("buy", price)
+            return Signal("buy", 1.0, **levels)
         if sells >= 2 and sells > buys:
-            return Signal("sell", 1.0)
+            levels = self._levels("sell", price)
+            return Signal("sell", 1.0, **levels)
         if buys > len(self.sub_strategies) / 2:
-            return Signal("buy", 1.0)
+            levels = self._levels("buy", price)
+            return Signal("buy", 1.0, **levels)
         if sells > len(self.sub_strategies) / 2:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            levels = self._levels("sell", price)
+            return Signal("sell", 1.0, **levels)
+        return None

--- a/tests/test_composite_signals.py
+++ b/tests/test_composite_signals.py
@@ -1,0 +1,37 @@
+import pytest
+import pytest
+
+from tradingbot.strategies.base import Strategy, Signal
+from tradingbot.strategies.composite_signals import CompositeSignals
+
+
+class BuyStrat(Strategy):
+    name = "buy"
+
+    def on_bar(self, bar):
+        return Signal("buy", 1.0)
+
+
+class SellStrat(Strategy):
+    name = "sell"
+
+    def on_bar(self, bar):
+        return Signal("sell", 1.0)
+
+
+def test_no_consensus_returns_none():
+    cs = CompositeSignals([(BuyStrat, {}), (SellStrat, {})])
+    assert cs.on_bar({"close": 100}) is None
+
+
+def test_tp_sl_applied_on_consensus():
+    cs = CompositeSignals(
+        [(BuyStrat, {}), (BuyStrat, {}), (SellStrat, {})],
+        tp_pct=0.05,
+        sl_pct=0.02,
+    )
+    sig = cs.on_bar({"close": 100})
+    assert sig is not None
+    assert sig.side == "buy"
+    assert pytest.approx(sig.take_profit, rel=1e-9) == 105.0
+    assert pytest.approx(sig.stop_loss, rel=1e-9) == 98.0

--- a/tests/test_router_orders.py
+++ b/tests/test_router_orders.py
@@ -47,6 +47,7 @@ async def test_best_venue_selection():
         {"type_": "limit", "price": 100.0, "time_in_force": "IOC"},
         {"type_": "limit", "price": 100.0, "time_in_force": "FOK"},
         {"type_": "limit", "price": 100.0, "iceberg_qty": 0.1},
+        {"type_": "limit", "price": 100.0, "take_profit": 110.0, "stop_loss": 90.0},
         {"type_": "market", "reduce_only": True},
     ],
 )


### PR DESCRIPTION
## Summary
- allow Signal objects to carry optional take-profit and stop-loss levels
- composite strategy now requires majority consensus and attaches configurable TP/SL levels
- propagate TP/SL through order and runner pipeline

## Testing
- `pytest tests/test_router_orders.py tests/test_composite_signals.py tests/test_execution_flags.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1ad1f1914832d8a3a4c55f0fef2eb