### PR TITLE
Add TP/SL and duration tracking to order flow and depth imbalance strategies

### DIFF
--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -15,9 +15,22 @@ class DepthImbalance(Strategy):
 
     name = "depth_imbalance"
 
-    def __init__(self, window: int = 3, threshold: float = 0.2):
+    def __init__(
+        self,
+        window: int = 3,
+        threshold: float = 0.2,
+        tp: float | None = None,
+        sl: float | None = None,
+        max_duration: pd.Timedelta | int | float | str | None = None,
+    ):
         self.window = window
         self.threshold = threshold
+        self.tp = tp
+        self.sl = sl
+        self.max_duration = pd.Timedelta(max_duration) if max_duration else None
+        self.pos_side: str | None = None
+        self.entry_price: float | None = None
+        self.entry_time: pd.Timestamp | None = None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -25,10 +38,51 @@ class DepthImbalance(Strategy):
         needed = {"bid_qty", "ask_qty"}
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
+
+        price = bar.get("close")
+        now = pd.Timestamp(bar.get("ts") or bar.get("timestamp") or pd.Timestamp.utcnow())
+
+        if self.pos_side and self.entry_price is not None:
+            pnl = (
+                price - self.entry_price
+                if self.pos_side == "buy"
+                else self.entry_price - price
+            ) if price is not None else None
+            pct = pnl / self.entry_price if pnl is not None else None
+            if pct is not None:
+                if self.tp is not None and pct >= self.tp:
+                    side = self.pos_side
+                    self.pos_side = None
+                    self.entry_price = None
+                    self.entry_time = None
+                    return Signal(side, 0.0)
+                if self.sl is not None and pct <= -self.sl:
+                    side = self.pos_side
+                    self.pos_side = None
+                    self.entry_price = None
+                    self.entry_time = None
+                    return Signal(side, 0.0)
+            if (
+                self.max_duration is not None
+                and self.entry_time is not None
+                and now - self.entry_time >= self.max_duration
+            ):
+                side = self.pos_side
+                self.pos_side = None
+                self.entry_price = None
+                self.entry_time = None
+                return Signal(side, 0.0)
+
         di_series = depth_imbalance(df[list(needed)])
         di_mean = di_series.iloc[-self.window :].mean()
         if di_mean > self.threshold:
+            self.pos_side = "buy"
+            self.entry_price = price
+            self.entry_time = now
             return Signal("buy", 1.0)
         if di_mean < -self.threshold:
+            self.pos_side = "sell"
+            self.entry_price = price
+            self.entry_time = now
             return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        return None

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -12,10 +12,24 @@ class OrderFlow(Strategy):
 
     name = "order_flow"
 
-    def __init__(self, window: int = 3, buy_threshold: float = 1.0, sell_threshold: float = 1.0):
+    def __init__(
+        self,
+        window: int = 3,
+        buy_threshold: float = 1.0,
+        sell_threshold: float = 1.0,
+        tp: float | None = None,
+        sl: float | None = None,
+        max_duration: pd.Timedelta | int | float | str | None = None,
+    ):
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
+        self.tp = tp
+        self.sl = sl
+        self.max_duration = pd.Timedelta(max_duration) if max_duration else None
+        self.pos_side: str | None = None
+        self.entry_price: float | None = None
+        self.entry_time: pd.Timestamp | None = None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -23,10 +37,51 @@ class OrderFlow(Strategy):
         needed = {"bid_qty", "ask_qty"}
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
+
+        price = bar.get("close")
+        now = pd.Timestamp(bar.get("ts") or bar.get("timestamp") or pd.Timestamp.utcnow())
+
+        if self.pos_side and self.entry_price is not None:
+            pnl = (
+                price - self.entry_price
+                if self.pos_side == "buy"
+                else self.entry_price - price
+            ) if price is not None else None
+            pct = pnl / self.entry_price if pnl is not None else None
+            if pct is not None:
+                if self.tp is not None and pct >= self.tp:
+                    side = self.pos_side
+                    self.pos_side = None
+                    self.entry_price = None
+                    self.entry_time = None
+                    return Signal(side, 0.0)
+                if self.sl is not None and pct <= -self.sl:
+                    side = self.pos_side
+                    self.pos_side = None
+                    self.entry_price = None
+                    self.entry_time = None
+                    return Signal(side, 0.0)
+            if (
+                self.max_duration is not None
+                and self.entry_time is not None
+                and now - self.entry_time >= self.max_duration
+            ):
+                side = self.pos_side
+                self.pos_side = None
+                self.entry_price = None
+                self.entry_time = None
+                return Signal(side, 0.0)
+
         ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
         if ofi_mean > self.buy_threshold:
+            self.pos_side = "buy"
+            self.entry_price = price
+            self.entry_time = now
             return Signal("buy", 1.0)
         if ofi_mean < -self.sell_threshold:
+            self.pos_side = "sell"
+            self.entry_price = price
+            self.entry_time = now
             return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        return None


### PR DESCRIPTION
## Summary
- Replace flat signals with `None` in order flow and depth imbalance strategies
- Add optional TP/SL and max duration parameters with position tracking
- Track current side and entry price for closing logic

## Testing
- `pytest tests/test_strategies.py -q`
- `pytest tests/test_strategies.py::test_order_flow_signals tests/test_depth_imbalance.py::test_depth_imbalance_strategy_buy tests/test_depth_imbalance.py::test_depth_imbalance_strategy_sell -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad5498b4832dbe39db2ba6116ba9