### PR TITLE
feat: enhance mean reversion strategy

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -5,12 +5,12 @@ from ..data.features import rsi
 class MeanReversion(Strategy):
     """RSI based mean reversion strategy with adaptive strength.
 
-    Besides generating ``buy``/``sell``/``flat`` signals based on RSI levels,
+    Besides generating ``buy``/``sell`` signals based on RSI levels,
     the strategy adjusts the ``strength`` of those signals according to the
-    performance of the current position: if price has moved in favour of the
-    open trade the strength is increased (pyramiding), while adverse moves
-    reduce it and can even flip it negative to suggest position reduction or
-    reversal.
+    performance of the current position or the distance of RSI from the
+    threshold levels. The same tracking logic used in
+    :class:`ScalpPingPong` is applied to handle take profit, stop loss and
+    maximum holding time.
 
     Parameters are accepted through ``**kwargs`` for easy configuration.
 
@@ -24,6 +24,14 @@ class MeanReversion(Strategy):
     lower : float, optional
         Lower RSI level below which a ``buy`` signal is triggered, by default
         ``30``.
+    tp_bps : float, optional
+        Take profit in basis points, by default ``30``.
+    sl_bps : float, optional
+        Stop loss in basis points, by default ``40``.
+    max_hold_bars : int, optional
+        Maximum number of bars to hold a trade, by default ``15``.
+    scale_by : {"pnl", "rsi"}, optional
+        Method used to scale signal ``strength``, by default ``"pnl"``.
     """
 
     name = "mean_reversion"
@@ -32,18 +40,19 @@ class MeanReversion(Strategy):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.upper = kwargs.get("upper", 60.0)
         self.lower = kwargs.get("lower", 40.0)
+        self.tp_bps = kwargs.get("tp_bps", 30.0)
+        self.sl_bps = kwargs.get("sl_bps", 40.0)
+        self.max_hold_bars = kwargs.get("max_hold_bars", 15)
+        self.scale_by = kwargs.get("scale_by", "pnl")
         # Track current position to adapt strength
         self._pos_side: str | None = None
         self._entry_price: float | None = None
+        self._hold_bars: int = 0
 
-    def _calc_strength(self, side: str, price: float) -> float:
-        """Return adaptive strength based on open position performance."""
-        if side == "flat":
-            self._pos_side = None
-            self._entry_price = None
-            return 0.0
+    def _calc_strength(self, side: str, price: float, last_rsi: float) -> float:
+        """Return adaptive strength based on PnL or RSI distance."""
         strength = 1.0
-        if self._pos_side and self._entry_price:
+        if self.scale_by == "pnl" and self._pos_side and self._entry_price:
             # positive when current position is in profit
             pnl = (price - self._entry_price) / self._entry_price
             if self._pos_side == "sell":
@@ -52,12 +61,11 @@ class MeanReversion(Strategy):
                 strength += pnl
             else:
                 strength = -pnl
-        if strength > 0:
-            self._pos_side = side
-            self._entry_price = price
-        else:
-            self._pos_side = None
-            self._entry_price = None
+        elif self.scale_by == "rsi":
+            if side == "buy":
+                strength = min(1.0, (self.lower - last_rsi) / self.lower)
+            else:
+                strength = min(1.0, (last_rsi - self.upper) / (100 - self.upper))
         return strength
 
     @record_signal_metrics
@@ -69,14 +77,45 @@ class MeanReversion(Strategy):
         last_rsi = rsi_series.iloc[-1]
         price_col = "close" if "close" in df.columns else "price"
         price = float(df[price_col].iloc[-1])
-        if last_rsi > self.upper:
-            strength = self._calc_strength("sell", price)
-            return Signal("sell", strength)
-        if last_rsi < self.lower:
-            strength = self._calc_strength("buy", price)
+
+        if self._pos_side is None:
+            if last_rsi > self.upper:
+                strength = self._calc_strength("sell", price, last_rsi)
+                self._pos_side = "sell"
+                self._entry_price = price
+                self._hold_bars = 0
+                return Signal("sell", strength)
+            if last_rsi < self.lower:
+                strength = self._calc_strength("buy", price, last_rsi)
+                self._pos_side = "buy"
+                self._entry_price = price
+                self._hold_bars = 0
+                return Signal("buy", strength)
+            return None
+
+        self._hold_bars += 1
+        assert self._entry_price is not None
+        pnl_bps = (price - self._entry_price) / self._entry_price * 10000
+        if self._pos_side == "sell":
+            pnl_bps = -pnl_bps
+        exit_rsi = self.lower < last_rsi < self.upper
+        exit_tp = pnl_bps >= self.tp_bps
+        exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self._hold_bars >= self.max_hold_bars
+        if exit_rsi or exit_tp or exit_sl or exit_time:
+            side = "sell" if self._pos_side == "buy" else "buy"
+            self._pos_side = None
+            self._entry_price = None
+            self._hold_bars = 0
+            return Signal(side, 1.0)
+
+        if self._pos_side == "buy" and last_rsi < self.lower:
+            strength = self._calc_strength("buy", price, last_rsi)
             return Signal("buy", strength)
-        strength = self._calc_strength("flat", price)
-        return Signal("flat", strength)
+        if self._pos_side == "sell" and last_rsi > self.upper:
+            strength = self._calc_strength("sell", price, last_rsi)
+            return Signal("sell", strength)
+        return None
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- remove automatic flat signal in mean reversion strategy
- add tp/sl/max_hold parameters with ScalpPingPong-style tracking
- allow strength scaling by PnL or RSI distance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1ad57c53c832d99473cad919608ce