### PR TITLE
Refactor strategy signals to use stateful exits

### DIFF
--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Sequence, Type
 
+import pandas as pd
+
 from .base import Strategy, Signal, record_signal_metrics
 
 
@@ -10,8 +12,21 @@ class CompositeSignals(Strategy):
 
     name = "composite_signals"
 
-    def __init__(self, strategies: Sequence[tuple[Type[Strategy], dict]]):
+    def __init__(
+        self,
+        strategies: Sequence[tuple[Type[Strategy], dict]],
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+    ):
         self.sub_strategies = [cls(**params) for cls, params in strategies]
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -25,12 +40,51 @@ class CompositeSignals(Strategy):
                 buys += 1
             elif sig.side == "sell":
                 sells += 1
+        buy = False
+        sell = False
         if buys >= 2 and buys > sells:
-            return Signal("buy", 1.0)
-        if sells >= 2 and sells > buys:
-            return Signal("sell", 1.0)
-        if buys > len(self.sub_strategies) / 2:
-            return Signal("buy", 1.0)
-        if sells > len(self.sub_strategies) / 2:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+            buy = True
+        elif sells >= 2 and sells > buys:
+            sell = True
+        elif buys > len(self.sub_strategies) / 2:
+            buy = True
+        elif sells > len(self.sub_strategies) / 2:
+            sell = True
+
+        df = bar.get("window")
+        price = None
+        if isinstance(df, pd.DataFrame):
+            col = "close" if "close" in df.columns else "price"
+            if col in df.columns:
+                price = float(df[col].iloc[-1])
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        exit_tp = exit_sl = False
+        if price is not None and self.entry_price is not None:
+            pnl_bps = (
+                (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            )
+            exit_tp = pnl_bps >= self.tp_bps
+            exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -15,9 +15,23 @@ class DepthImbalance(Strategy):
 
     name = "depth_imbalance"
 
-    def __init__(self, window: int = 3, threshold: float = 0.2):
+    def __init__(
+        self,
+        window: int = 3,
+        threshold: float = 0.2,
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+    ):
         self.window = window
         self.threshold = threshold
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -27,8 +41,39 @@ class DepthImbalance(Strategy):
             return None
         di_series = depth_imbalance(df[list(needed)])
         di_mean = di_series.iloc[-self.window :].mean()
-        if di_mean > self.threshold:
-            return Signal("buy", 1.0)
-        if di_mean < -self.threshold:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        buy = di_mean > self.threshold
+        sell = di_mean < -self.threshold
+        price = None
+        if {"close"}.issubset(df.columns):
+            price = float(df["close"].iloc[-1])
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        exit_tp = exit_sl = False
+        if price is not None and self.entry_price is not None:
+            pnl_bps = (
+                (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            )
+            exit_tp = pnl_bps >= self.tp_bps
+            exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -17,9 +17,23 @@ class LiquidityEvents(Strategy):
 
     name = "liquidity_events"
 
-    def __init__(self, vacuum_threshold: float = 0.5, gap_threshold: float = 1.0):
+    def __init__(
+        self,
+        vacuum_threshold: float = 0.5,
+        gap_threshold: float = 1.0,
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+    ):
         self.vacuum_threshold = vacuum_threshold
         self.gap_threshold = gap_threshold
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -29,14 +43,40 @@ class LiquidityEvents(Strategy):
             return None
 
         vac = book_vacuum(df[list({"bid_qty", "ask_qty"})], self.vacuum_threshold).iloc[-1]
-        if vac > 0:
-            return Signal("buy", 1.0)
-        if vac < 0:
-            return Signal("sell", 1.0)
-
         gap = liquidity_gap(df[list({"bid_px", "ask_px"})], self.gap_threshold).iloc[-1]
-        if gap > 0:
-            return Signal("buy", 1.0)
-        if gap < 0:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        buy = vac > 0 or gap > 0
+        sell = vac < 0 or gap < 0
+        price = None
+        if {"close"}.issubset(df.columns):
+            price = float(df["close"].iloc[-1])
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        exit_tp = exit_sl = False
+        if price is not None and self.entry_price is not None:
+            pnl_bps = (
+                (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            )
+            exit_tp = pnl_bps >= self.tp_bps
+            exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -28,37 +28,23 @@ class MeanReversion(Strategy):
 
     name = "mean_reversion"
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+        **kwargs,
+    ):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.upper = kwargs.get("upper", 60.0)
         self.lower = kwargs.get("lower", 40.0)
-        # Track current position to adapt strength
-        self._pos_side: str | None = None
-        self._entry_price: float | None = None
-
-    def _calc_strength(self, side: str, price: float) -> float:
-        """Return adaptive strength based on open position performance."""
-        if side == "flat":
-            self._pos_side = None
-            self._entry_price = None
-            return 0.0
-        strength = 1.0
-        if self._pos_side and self._entry_price:
-            # positive when current position is in profit
-            pnl = (price - self._entry_price) / self._entry_price
-            if self._pos_side == "sell":
-                pnl = -pnl
-            if side == self._pos_side:
-                strength += pnl
-            else:
-                strength = -pnl
-        if strength > 0:
-            self._pos_side = side
-            self._entry_price = price
-        else:
-            self._pos_side = None
-            self._entry_price = None
-        return strength
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -69,14 +55,39 @@ class MeanReversion(Strategy):
         last_rsi = rsi_series.iloc[-1]
         price_col = "close" if "close" in df.columns else "price"
         price = float(df[price_col].iloc[-1])
-        if last_rsi > self.upper:
-            strength = self._calc_strength("sell", price)
-            return Signal("sell", strength)
-        if last_rsi < self.lower:
-            strength = self._calc_strength("buy", price)
-            return Signal("buy", strength)
-        strength = self._calc_strength("flat", price)
-        return Signal("flat", strength)
+        buy = last_rsi < self.lower
+        sell = last_rsi > self.upper
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        exit_tp = exit_sl = False
+        if self.entry_price is not None:
+            pnl_bps = (
+                (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            )
+            exit_tp = pnl_bps >= self.tp_bps
+            exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -12,10 +12,25 @@ class OrderFlow(Strategy):
 
     name = "order_flow"
 
-    def __init__(self, window: int = 3, buy_threshold: float = 1.0, sell_threshold: float = 1.0):
+    def __init__(
+        self,
+        window: int = 3,
+        buy_threshold: float = 1.0,
+        sell_threshold: float = 1.0,
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+    ):
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -25,8 +40,39 @@ class OrderFlow(Strategy):
             return None
         ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
-        if ofi_mean > self.buy_threshold:
-            return Signal("buy", 1.0)
-        if ofi_mean < -self.sell_threshold:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        buy = ofi_mean > self.buy_threshold
+        sell = ofi_mean < -self.sell_threshold
+        price = None
+        if {"close"}.issubset(df.columns):
+            price = float(df["close"].iloc[-1])
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        exit_tp = exit_sl = False
+        if price is not None and self.entry_price is not None:
+            pnl_bps = (
+                (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            )
+            exit_tp = pnl_bps >= self.tp_bps
+            exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -14,33 +14,22 @@ class TrendFollowing(Strategy):
 
     name = "trend_following"
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        *,
+        tp_bps: float = 30.0,
+        sl_bps: float = 40.0,
+        max_hold_bars: int = 20,
+        **kwargs,
+    ):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.threshold = kwargs.get("rsi_threshold", 60.0)
-        self._pos_side: str | None = None
-        self._entry_price: float | None = None
-
-    def _calc_strength(self, side: str, price: float) -> float:
-        if side == "flat":
-            self._pos_side = None
-            self._entry_price = None
-            return 0.0
-        strength = 1.0
-        if self._pos_side and self._entry_price:
-            pnl = (price - self._entry_price) / self._entry_price
-            if self._pos_side == "sell":
-                pnl = -pnl
-            if side == self._pos_side:
-                strength += pnl
-            else:
-                strength = -pnl
-        if strength > 0:
-            self._pos_side = side
-            self._entry_price = price
-        else:
-            self._pos_side = None
-            self._entry_price = None
-        return strength
+        self.tp_bps = float(tp_bps)
+        self.sl_bps = float(sl_bps)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: int = 0
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -54,11 +43,36 @@ class TrendFollowing(Strategy):
             ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
         price_col = "close" if "close" in df.columns else "price"
         price = float(df[price_col].iloc[-1])
-        if last_rsi > self.threshold and ofi_val >= 0:
-            strength = self._calc_strength("buy", price)
-            return Signal("buy", strength)
-        if last_rsi < 100 - self.threshold and ofi_val <= 0:
-            strength = self._calc_strength("sell", price)
-            return Signal("sell", strength)
-        strength = self._calc_strength("flat", price)
-        return Signal("flat", strength)
+        buy = last_rsi > self.threshold and ofi_val >= 0
+        sell = last_rsi < 100 - self.threshold and ofi_val <= 0
+
+        if self.pos_side == 0:
+            if buy:
+                self.pos_side = 1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+            if sell:
+                self.pos_side = -1
+                self.entry_price = price
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+            return None
+
+        self.hold_bars += 1
+        exit_signal = (sell and self.pos_side > 0) or (buy and self.pos_side < 0)
+        pnl_bps = (
+            (price - self.entry_price) / self.entry_price * 10000 * self.pos_side
+            if self.entry_price is not None
+            else 0.0
+        )
+        exit_tp = pnl_bps >= self.tp_bps
+        exit_sl = pnl_bps <= -self.sl_bps
+        exit_time = self.hold_bars >= self.max_hold_bars
+        if exit_signal or exit_tp or exit_sl or exit_time:
+            side = "sell" if self.pos_side > 0 else "buy"
+            self.pos_side = 0
+            self.entry_price = None
+            self.hold_bars = 0
+            return Signal(side, 1.0)
+        return None

--- a/tests/test_triple_barrier.py
+++ b/tests/test_triple_barrier.py
@@ -46,8 +46,7 @@ def test_triple_barrier_meta_filtering():
     for i in range(len(prices)):
         signal = strat.on_bar({"window": prices.iloc[: i + 1]})
     assert meta_model.fit_called
-    assert signal is not None
-    assert signal.side == "flat"
+    assert signal is None
 
     # allow trades by setting meta model to return 1
     meta_model2 = DummyModel(value=1)
@@ -58,6 +57,8 @@ def test_triple_barrier_meta_filtering():
     strat2.model = primary_model2
     signal = None
     for i in range(len(prices)):
-        signal = strat2.on_bar({"window": prices.iloc[: i + 1]})
+        sig = strat2.on_bar({"window": prices.iloc[: i + 1]})
+        if signal is None and sig is not None:
+            signal = sig
     assert signal is not None
     assert signal.side == "buy"


### PR DESCRIPTION
## Summary
- Track position side, entry price and bar duration across multiple strategies and drop implicit `flat` signals
- Add TP/SL/time-based exit logic to momentum, mean reversion, order-flow and related strategies
- Update triple barrier tests to expect `None` when meta filter blocks trades

## Testing
- `pytest tests/test_triple_barrier.py tests/test_strategies.py tests/test_mean_reversion.py tests/test_liquidity_events.py tests/test_depth_imbalance.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1ad5a9aa4832d9eed1779b70f323e