### PR TITLE
feat: dynamic strategy parameter loading

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -57,6 +57,10 @@
         <label for="bt-strategy">Estrategia</label>
         <select id="bt-strategy"></select>
       </div>
+      <div id="field-strategy-config">
+        <label for="bt-strategy-config">Config estrategia</label>
+        <input id="bt-strategy-config" placeholder="config.yaml"/>
+      </div>
       <div id="field-capital">
         <label for="bt-capital">Capital inicial</label>
         <input id="bt-capital" type="number" step="any" placeholder=""/>
@@ -87,6 +91,7 @@
           Exportar fills (CSV)
         </label>
       </div>
+      <div id="bt-strategy-params" style="display:contents"></div>
     </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
@@ -204,6 +209,32 @@ const dataInfo = {
   features: "Indicadores y estadísticas usados por un modelo de ML.",
 };
 
+async function loadStrategyParams(name){
+  const container=document.getElementById('bt-strategy-params');
+  container.innerHTML='';
+  try{
+    const r=await fetch(api(`/strategies/${name}/schema`));
+    const j=await r.json();
+    (j.params||[]).forEach(p=>{
+      const div=document.createElement('div');
+      const label=document.createElement('label');
+      label.htmlFor=`bt-param-${p.name}`;
+      label.textContent=p.name;
+      const input=document.createElement('input');
+      input.id=`bt-param-${p.name}`;
+      input.dataset.name=p.name;
+      input.dataset.type=p.type||'';
+      const type=(p.type||'').toLowerCase();
+      if(type.includes('int')||type.includes('float')||type.includes('number')){
+        input.type='number'; input.step='0.0001';
+      }else{ input.type='text'; }
+      if(p.default!==undefined && p.default!==null) input.value=p.default;
+      div.appendChild(label); div.appendChild(input);
+      container.appendChild(div);
+    });
+  }catch(e){}
+}
+
 let strategyInfo = {};
 
 async function loadStrategyInfo(){
@@ -288,6 +319,7 @@ async function loadStrategies(){
       o.value=s;o.textContent=s;sel.appendChild(o);
     });
     updateStrategyInfo();
+    loadStrategyParams(sel.value);
   }catch(e){console.error(e);}
 }
 
@@ -296,6 +328,7 @@ function updateBtFields(){
   document.getElementById('field-data').style.display=mode==='csv'?'':'none';
   document.getElementById('field-symbol').style.display=(mode==='csv'||mode==='db')?'':'none';
   document.getElementById('field-strategy').style.display=(mode==='csv'||mode==='db')?'':'none';
+  document.getElementById('field-strategy-config').style.display=(mode==='csv'||mode==='db')?'':'none';
   document.getElementById('field-config').style.display=(mode==='cfg'||mode==='walk')?'':'none';
   document.getElementById('field-venue').style.display=mode==='db'?'':'none';
   document.getElementById('bt-venue').style.display=mode==='db'?'':'none';
@@ -305,6 +338,7 @@ function updateBtFields(){
   ['field-risk-pct'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
+  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'contents':'none';
 }
 
 function updateStrategyInfo(){
@@ -361,6 +395,17 @@ async function runBacktest(){
     const sl=document.getElementById('bt-risk-pct').value.trim();
     if(sl) cmd+=` --risk-pct ${sl}`;
   }
+  const stratCfg=document.getElementById('bt-strategy-config').value.trim();
+  if(stratCfg) cmd+=` --config ${stratCfg}`;
+  const paramEls=document.querySelectorAll('#bt-strategy-params input');
+  paramEls.forEach(el=>{
+    if(!el.value) return;
+    const t=(el.dataset.type||'').toLowerCase();
+    let v=el.value;
+    if(t.includes('int')) v=parseInt(v,10);
+    else if(t.includes('float')||t.includes('number')) v=parseFloat(v);
+    cmd+=` --param ${el.dataset.name}=${v}`;
+  });
   const verbose=document.getElementById('bt-verbose-fills').checked;
   if(verbose) cmd+=' --fills-csv fills.csv';
   try{
@@ -453,11 +498,15 @@ document.getElementById('bt-clear').addEventListener('click',()=>{
   hideWorking();
 });
 document.getElementById('cli-run').addEventListener('click',runCli);
-document.getElementById('bt-strategy').addEventListener('change',updateStrategyInfo);
+document.getElementById('bt-strategy').addEventListener('change',()=>{
+  updateStrategyInfo();
+  loadStrategyParams(document.getElementById('bt-strategy').value);
+});
 updateBtFields();
 loadStrategies();
 loadExchanges();
 loadStrategyInfo();
+loadStrategyParams(document.getElementById('bt-strategy').value);
 </script>
 </body>
 </html>

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -80,6 +80,10 @@
         <label for="bot-threshold">Threshold</label>
         <input id="bot-threshold" type="number" step="0.0001" value="0.001"/>
       </div>
+      <div>
+        <label for="bot-config">Config YAML</label>
+        <input id="bot-config" placeholder="config.yaml"/>
+      </div>
       <div id="strategy-params" style="display:contents"></div>
       <div>
         <label for="bot-risk-pct">Risk %</label>
@@ -218,6 +222,7 @@ async function startBot(){
   const env = document.getElementById('bot-env').value;
   const testnet = env === 'testnet';
   const dry_run = env === 'paper';
+  const config = document.getElementById('bot-config').value;
     const spot = document.getElementById('bot-spot').value;
     const perp = document.getElementById('bot-perp').value;
     const threshold = document.getElementById('bot-threshold').value;
@@ -232,6 +237,7 @@ async function startBot(){
       params[el.dataset.name]=v;
     });
     const payload = {strategy, pairs, exchange, market, testnet, dry_run};
+    if(config) payload.config = config;
     if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);
     if(daily_max_drawdown_pct) payload.daily_max_drawdown_pct = Number(daily_max_drawdown_pct);

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -43,6 +43,7 @@ async def run_paper(
     metrics_port: int = 8000,
     corr_threshold: float = 0.8,
     risk_pct: float = 0.0,
+    params: dict | None = None,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
 
@@ -67,7 +68,8 @@ async def run_paper(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    strat = strat_cls(config_path=config_path) if config_path else strat_cls()
+    params = params or {}
+    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
 
     server = await _start_metrics(metrics_port)
 

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from .runner import BarAggregator
 from ..config import settings
-from ..strategies.breakout_atr import BreakoutATR
+from ..strategies import STRATEGIES
 from ..risk.manager import RiskManager, load_positions
 from ..risk.daily_guard import DailyGuard, GuardLimits
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
@@ -96,6 +96,8 @@ async def _run_symbol(
     daily_max_loss_pct: float,
     daily_max_drawdown_pct: float,
     corr_threshold: float,
+    strategy_name: str,
+    params: dict | None = None,
     config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
@@ -106,7 +108,11 @@ async def _run_symbol(
     ws = ws_cls()
     exec_adapter = exec_cls(**exec_kwargs)
     agg = BarAggregator()
-    strat = BreakoutATR(config_path=config_path)
+    strat_cls = STRATEGIES.get(strategy_name)
+    if strat_cls is None:
+        raise ValueError(f"unknown strategy: {strategy_name}")
+    params = params or {}
+    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
     risk_core = RiskManager(risk_pct=cfg.risk_pct, allow_short=(market != "spot"))
     guard = PortfolioGuard(
         GuardConfig(
@@ -204,7 +210,9 @@ async def run_live_real(
     daily_max_loss_pct: float = 0.05,
     daily_max_drawdown_pct: float = 0.05,
     corr_threshold: float = 0.8,
+    strategy_name: str = "breakout_atr",
     config_path: str | None = None,
+    params: dict | None = None,
 ) -> None:
     """Run a simple live loop on a real crypto exchange."""
 
@@ -234,6 +242,8 @@ async def run_live_real(
             daily_max_loss_pct,
             daily_max_drawdown_pct,
             corr_threshold,
+            strategy_name=strategy_name,
+            params=params,
             config_path=config_path,
         )
         for c in cfgs


### PR DESCRIPTION
## Summary
- add CLI support for `--config` and `--param` to backtests and bot runner
- allow dashboard backtest and bot forms to send strategy configs and parameters
- generalise live runners to instantiate strategies with YAML/parameter overrides

## Testing
- `pytest` *(killed: process out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1adc59744832d840e6cf5169b36e2