### PR TITLE
Refactor strategies to use stateful exits

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -23,6 +23,56 @@ class Strategy(ABC):
         ...
 
 
+class StatefulStrategy(Strategy):
+    """Strategy base class with simple position tracking and exits."""
+
+    def __init__(
+        self,
+        *,
+        tp_pct: float = 0.0,
+        sl_pct: float = 0.0,
+        max_hold_bars: int = 0,
+    ) -> None:
+        self.tp_pct = float(tp_pct)
+        self.sl_pct = float(sl_pct)
+        self.max_hold_bars = int(max_hold_bars)
+        self.pos_side: str | None = None
+        self.entry_price: float | None = None
+        self.hold_bars: int = 0
+
+    def check_exit(self, price: float) -> Signal | None:
+        """Check exit conditions and return an opposing signal if met."""
+
+        if self.pos_side is None or self.entry_price is None:
+            return None
+        self.hold_bars += 1
+        if self.pos_side == "buy":
+            hit_tp = self.tp_pct > 0 and price >= self.entry_price * (1 + self.tp_pct)
+            hit_sl = self.sl_pct > 0 and price <= self.entry_price * (1 - self.sl_pct)
+            timed_out = self.max_hold_bars > 0 and self.hold_bars >= self.max_hold_bars
+            if hit_tp or hit_sl or timed_out:
+                self.pos_side = None
+                self.entry_price = None
+                self.hold_bars = 0
+                return Signal("sell", 1.0)
+        else:
+            hit_tp = self.tp_pct > 0 and price <= self.entry_price * (1 - self.tp_pct)
+            hit_sl = self.sl_pct > 0 and price >= self.entry_price * (1 + self.sl_pct)
+            timed_out = self.max_hold_bars > 0 and self.hold_bars >= self.max_hold_bars
+            if hit_tp or hit_sl or timed_out:
+                self.pos_side = None
+                self.entry_price = None
+                self.hold_bars = 0
+                return Signal("buy", 1.0)
+        return None
+
+    def open_position(self, side: str, price: float) -> Signal:
+        self.pos_side = side
+        self.entry_price = price
+        self.hold_bars = 0
+        return Signal(side, 1.0)
+
+
 def load_params(path: str | None) -> dict[str, Any]:
     """Load strategy parameters from a YAML file.
 
@@ -86,4 +136,10 @@ def record_signal_metrics(fn):
     return wrapper
 
 
-__all__ = ["Signal", "Strategy", "load_params", "record_signal_metrics"]
+__all__ = [
+    "Signal",
+    "Strategy",
+    "StatefulStrategy",
+    "load_params",
+    "record_signal_metrics",
+]

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -1,8 +1,8 @@
 import pandas as pd
-from .base import Strategy, Signal, record_signal_metrics
+from .base import StatefulStrategy, Signal, record_signal_metrics
 from ..data.features import rsi, calc_ofi
 
-class Momentum(Strategy):
+class Momentum(StatefulStrategy):
     """Simple momentum strategy using the Relative Strength Index (RSI).
 
     Parameters are provided via ``**kwargs`` so the class can be easily
@@ -19,25 +19,40 @@ class Momentum(Strategy):
 
     name = "momentum"
 
-    def __init__(self, **kwargs):
-        self.rsi_n = kwargs.get("rsi_n", 14)
-        self.threshold = kwargs.get("rsi_threshold", 60.0)
+    def __init__(
+        self,
+        *,
+        rsi_n: int = 14,
+        rsi_threshold: float = 60.0,
+        tp_pct: float = 0.0,
+        sl_pct: float = 0.0,
+        max_hold_bars: int = 0,
+    ) -> None:
+        super().__init__(tp_pct=tp_pct, sl_pct=sl_pct, max_hold_bars=max_hold_bars)
+        self.rsi_n = rsi_n
+        self.threshold = rsi_threshold
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.rsi_n + 1:
             return None
+        price = float(df["close"].iloc[-1]) if "close" in df.columns else None
+        if price is not None:
+            exit_sig = self.check_exit(price)
+            if exit_sig:
+                return exit_sig
         rsi_series = rsi(df, self.rsi_n)
         last_rsi = rsi_series.iloc[-1]
         ofi_val = 0.0
         if {"bid_qty", "ask_qty"}.issubset(df.columns):
             ofi_val = calc_ofi(df[["bid_qty", "ask_qty"]]).iloc[-1]
-        if last_rsi > self.threshold and ofi_val >= 0:
-            return Signal("buy", 1.0)
-        if last_rsi < 100 - self.threshold and ofi_val <= 0:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        if self.pos_side is None:
+            if last_rsi > self.threshold and ofi_val >= 0 and price is not None:
+                return self.open_position("buy", price)
+            if last_rsi < 100 - self.threshold and ofi_val <= 0 and price is not None:
+                return self.open_position("sell", price)
+        return None
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -1,9 +1,9 @@
 import pandas as pd
-from .base import Strategy, Signal, record_signal_metrics
+from .base import StatefulStrategy, Signal, record_signal_metrics
 from ..data.features import calc_ofi
 
 
-class OrderFlow(Strategy):
+class OrderFlow(StatefulStrategy):
     """Order Flow Imbalance strategy.
 
     Calculates the mean Order Flow Imbalance (OFI) over a rolling window and
@@ -12,7 +12,17 @@ class OrderFlow(Strategy):
 
     name = "order_flow"
 
-    def __init__(self, window: int = 3, buy_threshold: float = 1.0, sell_threshold: float = 1.0):
+    def __init__(
+        self,
+        window: int = 3,
+        buy_threshold: float = 1.0,
+        sell_threshold: float = 1.0,
+        *,
+        tp_pct: float = 0.0,
+        sl_pct: float = 0.0,
+        max_hold_bars: int = 0,
+    ) -> None:
+        super().__init__(tp_pct=tp_pct, sl_pct=sl_pct, max_hold_bars=max_hold_bars)
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
@@ -23,10 +33,15 @@ class OrderFlow(Strategy):
         needed = {"bid_qty", "ask_qty"}
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
+        price = float(df.get("close", df[list(needed)].mean(axis=1).iloc[-1]))
+        exit_sig = self.check_exit(price)
+        if exit_sig:
+            return exit_sig
         ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
-        if ofi_mean > self.buy_threshold:
-            return Signal("buy", 1.0)
-        if ofi_mean < -self.sell_threshold:
-            return Signal("sell", 1.0)
-        return Signal("flat", 0.0)
+        if self.pos_side is None:
+            if ofi_mean > self.buy_threshold:
+                return self.open_position("buy", price)
+            if ofi_mean < -self.sell_threshold:
+                return self.open_position("sell", price)
+        return None

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -6,9 +6,10 @@ def test_mean_reversion_on_bar_signals():
     df_up = pd.DataFrame({"close": list(range(1, 21))})
     strat = MeanReversion(rsi_n=5, upper=70, lower=30)
     sig_buy = strat.on_bar({"window": df_down})
-    sig_sell = strat.on_bar({"window": df_up})
-    assert sig_buy.side == "buy"
-    assert sig_sell.side == "sell"
+    strat2 = MeanReversion(rsi_n=5, upper=70, lower=30)
+    sig_sell = strat2.on_bar({"window": df_up})
+    assert sig_buy and sig_buy.side == "buy"
+    assert sig_sell and sig_sell.side == "sell"
 
 def test_mean_reversion_generate_signals():
     df = pd.DataFrame({"price": [1, 2, 3, 4, 3, 2, 1, 2, 3]})

--- a/tests/test_triple_barrier.py
+++ b/tests/test_triple_barrier.py
@@ -46,8 +46,7 @@ def test_triple_barrier_meta_filtering():
     for i in range(len(prices)):
         signal = strat.on_bar({"window": prices.iloc[: i + 1]})
     assert meta_model.fit_called
-    assert signal is not None
-    assert signal.side == "flat"
+    assert signal is None
 
     # allow trades by setting meta model to return 1
     meta_model2 = DummyModel(value=1)
@@ -58,6 +57,8 @@ def test_triple_barrier_meta_filtering():
     strat2.model = primary_model2
     signal = None
     for i in range(len(prices)):
-        signal = strat2.on_bar({"window": prices.iloc[: i + 1]})
+        sig = strat2.on_bar({"window": prices.iloc[: i + 1]})
+        if sig is not None:
+            signal = sig
     assert signal is not None
     assert signal.side == "buy"


### PR DESCRIPTION
## Summary
- add `StatefulStrategy` base with position tracking and TP/SL/timeout exit logic
- refactor momentum, mean reversion, OFI mean reversion, order flow, depth imbalance, liquidity events, triple barrier, and ML strategies to inherit stateful base and return `None` instead of flat signals
- update tests to reflect absence of implicit flat signals

## Testing
- `pytest tests/test_mean_reversion.py tests/test_depth_imbalance.py tests/test_liquidity_events.py tests/test_triple_barrier.py tests/test_basic_strategies.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1b4d05604832db405f74eeb4027b5