### PR TITLE
Add parameter descriptions to strategies and expose tooltips

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -220,6 +220,14 @@ async function loadStrategyParams(name){
       const label=document.createElement('label');
       label.htmlFor=`bt-param-${p.name}`;
       label.textContent=p.name;
+      if(p.desc){
+        const span=document.createElement('span');
+        span.className='help-icon';
+        span.title=p.desc;
+        span.textContent='?';
+        label.appendChild(document.createTextNode(' '));
+        label.appendChild(span);
+      }
       const input=document.createElement('input');
       input.id=`bt-param-${p.name}`;
       input.dataset.name=p.name;

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -170,6 +170,14 @@ const api = (path) => `${location.origin}${path}`;
         const label=document.createElement('label');
         label.htmlFor=`param-${p.name}`;
         label.textContent=p.name;
+        if(p.desc){
+          const span=document.createElement('span');
+          span.className='help-icon';
+          span.title=p.desc;
+          span.textContent='?';
+          label.appendChild(document.createTextNode(' '));
+          label.appendChild(span);
+        }
         const input=document.createElement('input');
         input.id=`param-${p.name}`;
         input.dataset.name=p.name;


### PR DESCRIPTION
## Summary
- enrich `/strategies/{name}/schema` with parameter descriptions parsed from docstrings or `PARAM_INFO`
- include `desc` in schema responses and use it in front-end tooltips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1bb45031c832d8d317ec7d28a4d36