### PR TITLE
feat: add trade identifiers and reason propagation

### DIFF
--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -13,3 +13,5 @@ class Order:
     take_profit: float | None = None
     stop_loss: float | None = None
     reduce_only: bool = False
+    reason: str | None = None
+    slip_bps: float | None = None


### PR DESCRIPTION
## Summary
- add reason and slip support to orders
- ensure router outputs unique order_id/trade_id and adjusted fill_price
- track trade identifiers in paper adapter and log reason

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bedd816c832da058dbf1c969c181