### PR TITLE
Add detailed fill metadata and realized PnL calculation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,7 +178,7 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `--fills-csv PATH`: exporta los fills a un CSV.
 
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
-`timestamp, side, price, qty, strategy, symbol, exchange, fee, cash_after, base_after, equity_after, realized_pnl`.
+`timestamp, bar_index, order_id, trade_id, roundtrip_id, reason, side, price, qty, strategy, symbol, exchange, fee_type, fee, slip_bps, cash_after, base_after, equity_after, realized_pnl`.
 Desde este archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
 ```python

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -36,6 +36,11 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         result["fills"],
         columns=[
             "timestamp",
+            "bar_index",
+            "order_id",
+            "trade_id",
+            "roundtrip_id",
+            "reason",
             "side",
             "price",
             "qty",
@@ -44,19 +49,22 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
             "exchange",
             "fee_type",
             "fee",
+            "slip_bps",
             "cash_after",
             "base_after",
             "equity_after",
             "realized_pnl",
         ],
     )
-    assert len(result["fills"][0]) == 13
+    assert len(result["fills"][0]) == 19
     assert (fills["cash_after"] >= -1e-9).all()
     assert (fills["base_after"] >= -1e-9).all()
     assert risk.rm.pos.qty == pytest.approx(0.0)
-    assert risk.rm.pos.realized_pnl == pytest.approx(
-        fills["realized_pnl"].iloc[-1]
-    )
+    row = fills.iloc[0]
+    place_price = row.price / (1 + row.slip_bps / 10000)
+    slip_cash = (row.price - place_price) * row.qty
+    expected = risk.rm.pos.realized_pnl - row.fee - slip_cash
+    assert row.realized_pnl == pytest.approx(expected)
     final_price = df["close"].iloc[-1]
     expected_equity = fills["cash_after"].iloc[-1] + fills["base_after"].iloc[-1] * final_price
     assert result["equity"] == pytest.approx(expected_equity)

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -75,6 +75,11 @@ def test_fills_csv_export(tmp_path, monkeypatch):
     assert not df.empty
     assert list(df.columns) == [
         "timestamp",
+        "bar_index",
+        "order_id",
+        "trade_id",
+        "roundtrip_id",
+        "reason",
         "side",
         "price",
         "qty",
@@ -83,6 +88,7 @@ def test_fills_csv_export(tmp_path, monkeypatch):
         "exchange",
         "fee_type",
         "fee",
+        "slip_bps",
         "cash_after",
         "base_after",
         "equity_after",
@@ -91,12 +97,15 @@ def test_fills_csv_export(tmp_path, monkeypatch):
     # Comprobar cálculo de fee
     expected_fee = df["price"] * df["qty"] * 0.001
     assert np.allclose(df["fee"], expected_fee)
-    # Comprobar que realized_pnl coincide con RiskManager
+    # Comprobar realized_pnl por fill
     rm = RiskManager()
+    prev_rpnl = 0.0
     rpnl = []
     for row in df.itertuples():
         rm.add_fill(row.side, row.qty, row.price)
-        rpnl.append(rm.pos.realized_pnl)
+        delta = rm.pos.realized_pnl - prev_rpnl
+        rpnl.append(delta - row.fee)  # sin slippage en este test
+        prev_rpnl = rm.pos.realized_pnl
     assert np.allclose(df["realized_pnl"], rpnl)
 
 
@@ -141,6 +150,11 @@ def test_spot_long_only_enforced(tmp_path, monkeypatch):
         res["fills"],
         columns=[
             "timestamp",
+            "bar_index",
+            "order_id",
+            "trade_id",
+            "roundtrip_id",
+            "reason",
             "side",
             "price",
             "qty",
@@ -149,6 +163,7 @@ def test_spot_long_only_enforced(tmp_path, monkeypatch):
             "exchange",
             "fee_type",
             "fee",
+            "slip_bps",
             "cash_after",
             "base_after",
             "equity_after",
@@ -243,6 +258,11 @@ def test_spot_balances_never_negative(tmp_path, monkeypatch):
         res["fills"],
         columns=[
             "timestamp",
+            "bar_index",
+            "order_id",
+            "trade_id",
+            "roundtrip_id",
+            "reason",
             "side",
             "price",
             "qty",
@@ -251,6 +271,7 @@ def test_spot_balances_never_negative(tmp_path, monkeypatch):
             "exchange",
             "fee_type",
             "fee",
+            "slip_bps",
             "cash_after",
             "base_after",
             "equity_after",
@@ -308,6 +329,11 @@ def test_spot_venue_config_applied(tmp_path, monkeypatch):
         res["fills"],
         columns=[
             "timestamp",
+            "bar_index",
+            "order_id",
+            "trade_id",
+            "roundtrip_id",
+            "reason",
             "side",
             "price",
             "qty",
@@ -316,6 +342,7 @@ def test_spot_venue_config_applied(tmp_path, monkeypatch):
             "exchange",
             "fee_type",
             "fee",
+            "slip_bps",
             "cash_after",
             "base_after",
             "equity_after",

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,7 +34,7 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 12
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 
@@ -59,7 +59,7 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 12
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 
@@ -122,7 +122,7 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 12
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl"}.issubset(df.columns)
 
 


### PR DESCRIPTION
## Summary
- extend fills tuple with bar index, identifiers, reason and slippage info
- compute per-fill realized PnL accounting for fees and slippage
- export new fields (and slippage-adjusted price) to CSV

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1bedebaa4832d9e7db803e6540b79