### PR TITLE
feat(api): include strategy parameter descriptions

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -180,10 +180,10 @@ const api = (path) => `${location.origin}${path}`;
         const label=document.createElement('label');
         label.htmlFor=`param-${p.name}`;
         label.textContent=p.name;
-        if(p.description){
+        if(p.desc){
           const help=document.createElement('span');
           help.className='help-icon';
-          help.title=p.description;
+          help.title=p.desc;
           help.textContent='?';
           label.appendChild(document.createTextNode(' '));
           label.appendChild(help);


### PR DESCRIPTION
## Summary
- extract parameter descriptions from strategy docstrings and optional `PARAM_INFO` mappings
- expose `desc` field in strategy schema and consume it in bot UI tooltips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1bffefbf8832dba535dcacc08a22e