### PR TITLE
feat(backtest): track roundtrip identifiers in fills

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,7 +178,7 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `--fills-csv PATH`: exporta los fills a un CSV.
 
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
-`timestamp, side, price, qty, strategy, symbol, exchange, fee, cash_after, base_after, equity_after, realized_pnl`.
+`timestamp, side, price, qty, strategy, symbol, exchange, fee_type, fee, cash_after, base_after, equity_after, realized_pnl, trade_id, roundtrip_id`.
 Desde este archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
 ```python

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -48,9 +48,11 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
             "base_after",
             "equity_after",
             "realized_pnl",
+            "trade_id",
+            "roundtrip_id",
         ],
     )
-    assert len(result["fills"][0]) == 13
+    assert len(result["fills"][0]) == 15
     assert (fills["cash_after"] >= -1e-9).all()
     assert (fills["base_after"] >= -1e-9).all()
     assert risk.rm.pos.qty == pytest.approx(0.0)

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -87,6 +87,8 @@ def test_fills_csv_export(tmp_path, monkeypatch):
         "base_after",
         "equity_after",
         "realized_pnl",
+        "trade_id",
+        "roundtrip_id",
     ]
     # Comprobar cálculo de fee
     expected_fee = df["price"] * df["qty"] * 0.001
@@ -153,6 +155,8 @@ def test_spot_long_only_enforced(tmp_path, monkeypatch):
             "base_after",
             "equity_after",
             "realized_pnl",
+            "trade_id",
+            "roundtrip_id",
         ],
     )
     assert fills.loc[fills.side == "sell", "qty"].max() <= fills.loc[fills.side == "buy", "qty"].max() + 1e-9
@@ -255,6 +259,8 @@ def test_spot_balances_never_negative(tmp_path, monkeypatch):
             "base_after",
             "equity_after",
             "realized_pnl",
+            "trade_id",
+            "roundtrip_id",
         ],
     )
     assert (fills.cash_after >= -1e-9).all()
@@ -320,6 +326,8 @@ def test_spot_venue_config_applied(tmp_path, monkeypatch):
             "base_after",
             "equity_after",
             "realized_pnl",
+            "trade_id",
+            "roundtrip_id",
         ],
     )
     assert math.isclose(
@@ -596,6 +604,8 @@ def test_intrabar_levels_trigger(tmp_path, monkeypatch):
             "base_after",
             "equity_after",
             "realized_pnl",
+            "trade_id",
+            "roundtrip_id",
         ],
     )
     assert len(fills) == 2

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,8 +34,8 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 12
-    assert {"fee", "realized_pnl"}.issubset(df.columns)
+    assert df.shape[1] == 15
+    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 
 def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
@@ -59,8 +59,8 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 12
-    assert {"fee", "realized_pnl"}.issubset(df.columns)
+    assert df.shape[1] == 15
+    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 
 class OneShotStrategy:
@@ -122,8 +122,8 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 12
-    assert {"fee", "realized_pnl"}.issubset(df.columns)
+    assert df.shape[1] == 15
+    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 
 def test_equity_loss_capped_by_risk_pct(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- assign roundtrip and trade ids when positions open and include them in each fill
- extend fills CSV and documentation with the new identifiers
- adjust tests for identifier-based pairing

## Testing
- `pytest tests/test_backtest_engine.py tests/test_backtesting_integration.py tests/integration/test_recorded_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d2703c70832d9aaf6a2f0d1a5f1c