### PR TITLE
feat: expand fills with order and slippage details

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,7 +178,8 @@ Ejecuta un backtest vectorizado desde un archivo CSV.
 - `--fills-csv PATH`: exporta los fills a un CSV.
 
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
-`timestamp, side, price, qty, strategy, symbol, exchange, fee_type, fee, cash_after, base_after, equity_after, realized_pnl, trade_id, roundtrip_id`.
+`timestamp, bar_index, order_id, trade_id, roundtrip_id, reason, side, price, qty, strategy, symbol, exchange, fee_type, fee, slip_bps, cash_after, base_after, equity_after, realized_pnl`.
+La columna `price` refleja el precio final de ejecución con spread y slippage aplicados.
 Desde este archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
 ```python

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -36,6 +36,11 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         result["fills"],
         columns=[
             "timestamp",
+            "bar_index",
+            "order_id",
+            "trade_id",
+            "roundtrip_id",
+            "reason",
             "side",
             "price",
             "qty",
@@ -44,20 +49,28 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
             "exchange",
             "fee_type",
             "fee",
+            "slip_bps",
             "cash_after",
             "base_after",
             "equity_after",
             "realized_pnl",
-            "trade_id",
-            "roundtrip_id",
         ],
     )
-    assert len(result["fills"][0]) == 15
+    assert len(result["fills"][0]) == 19
     assert (fills["cash_after"] >= -1e-9).all()
     assert (fills["base_after"] >= -1e-9).all()
     assert risk.rm.pos.qty == pytest.approx(0.0)
-    assert risk.rm.pos.realized_pnl == pytest.approx(
-        fills["realized_pnl"].iloc[-1]
+    slip_cash_total = 0.0
+    for row in fills.itertuples():
+        slip_mult = row.slip_bps / 10000.0
+        if row.side == "buy":
+            place_price = row.price / (1 + slip_mult) if 1 + slip_mult != 0 else row.price
+            slip_cash_total += (row.price - place_price) * row.qty
+        else:
+            place_price = row.price / (1 - slip_mult) if 1 - slip_mult != 0 else row.price
+            slip_cash_total += (place_price - row.price) * row.qty
+    assert risk.rm.pos.realized_pnl - fills["fee"].sum() - slip_cash_total == pytest.approx(
+        fills["realized_pnl"].sum()
     )
     final_price = df["close"].iloc[-1]
     expected_equity = fills["cash_after"].iloc[-1] + fills["base_after"].iloc[-1] * final_price

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,7 +34,7 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 15
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 
@@ -59,7 +59,7 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 15
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 
@@ -122,7 +122,7 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 15
+    assert df.shape[1] == 19
     assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
 
 


### PR DESCRIPTION
## Summary
- track order id, bar index, reasons and slippage per fill
- compute per-fill realized PnL including fees and slippage
- document extended fills CSV columns and export price with spread/slippage

## Testing
- `pytest tests/test_backtest_engine.py::test_fills_csv_export tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk tests/test_backtesting_integration.py::test_event_engine_runs`

------
https://chatgpt.com/codex/tasks/task_e_68b1d7c7dc58832d9a021b92dd24ed94