### PR TITLE
feat(ui): add strategy params switch in backtest

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -91,15 +91,10 @@
           Exportar fills (CSV)
         </label>
       </div>
-      <div id="field-toggle-params" style="display:flex;align-items:center">
-        <label for="bt-toggle-params" style="display:flex;align-items:center;gap:4px">
-          <input id="bt-toggle-params" type="checkbox"/>
-          Configurar parámetros
-        </label>
+      <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
+        <span>Configurar parámetros</span>
+        <label class="switch"><input id="bt-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
-    </div>
-    <div id="bt-param-config" style="display:none">
-      <div id="bt-strategy-params" style="display:contents"></div>
     </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
@@ -107,6 +102,10 @@
     <button id="bt-clear" style="margin-top:10px;margin-left:8px">Limpiar</button>
     <span id="bt-working">Procesando<span id="bt-dots"></span></span>
     <pre id="bt-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card" id="bt-param-card" style="display:none">
+    <div id="bt-strategy-params" style="display:contents"></div>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -516,7 +515,7 @@ document.getElementById('bt-strategy').addEventListener('change',()=>{
   loadStrategyParams(document.getElementById('bt-strategy').value);
 });
 document.getElementById('bt-toggle-params').addEventListener('change',e=>{
-  document.getElementById('bt-param-config').style.display=e.target.checked?'block':'none';
+  document.getElementById('bt-param-card').style.display=e.target.checked?'block':'none';
 });
 updateBtFields();
 loadStrategies();

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -273,6 +273,13 @@ input[type="checkbox"]{
 }
 .chk{display:flex;align-items:center;font-size:12px;color:var(--muted);margin:8px 0 4px}
 
+.switch{position:relative;display:inline-block;width:36px;height:20px}
+.switch input{opacity:0;width:0;height:0;margin:0}
+.slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#314156;border-radius:20px;transition:.4s}
+.slider:before{position:absolute;content:"";height:16px;width:16px;left:2px;bottom:2px;background:var(--text);border-radius:50%;transition:.4s}
+.switch input:checked + .slider{background:var(--primary)}
+.switch input:checked + .slider:before{transform:translateX(16px)}
+
 /* ====== Menú minimal ====== */
 nav{
   margin: 14px auto 28px;


### PR DESCRIPTION
## Summary
- replace checkbox with switch to show strategy parameters
- move strategy params to dedicated hidden card
- add switch styling and JS handler for card toggle

## Testing
- `pytest tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dd2dae10832db61055846d069a87