### PR TITLE
feat: add param grid styling

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -99,7 +99,7 @@
       </div>
     </div>
     <div id="bt-param-config" style="display:none">
-      <div id="bt-strategy-params" style="display:contents"></div>
+      <div id="bt-strategy-params" class="param-grid"></div>
     </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
@@ -234,6 +234,7 @@ async function loadStrategyParams(name){
       help.textContent='?';
       label.appendChild(help);
       const input=document.createElement('input');
+      input.className='param-input';
       input.id=`bt-param-${p.name}`;
       input.dataset.name=p.name;
       input.dataset.type=p.type||'';
@@ -351,7 +352,7 @@ function updateBtFields(){
   ['field-risk-pct'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
-  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'contents':'none';
+  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'flex':'none';
 }
 
 function updateStrategyInfo(){

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -88,7 +88,7 @@
         <button id="bot-toggle-params" type="button">Parámetros estrategia</button>
       </div>
       <div id="bot-param-config" style="display:none; grid-column:1/-1">
-        <div id="strategy-params" style="display:contents"></div>
+        <div id="strategy-params" class="param-grid"></div>
       </div>
       <div>
         <label for="bot-risk-pct">Risk %</label>
@@ -189,6 +189,7 @@ const api = (path) => `${location.origin}${path}`;
           label.appendChild(help);
         }
         const input=document.createElement('input');
+        input.className='param-input';
         input.id=`param-${p.name}`;
         input.dataset.name=p.name;
         input.dataset.type=p.type||'';

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -272,6 +272,8 @@ input[type="checkbox"]{
   margin-right:4px;
 }
 .chk{display:flex;align-items:center;font-size:12px;color:var(--muted);margin:8px 0 4px}
+.param-grid{ display:flex; flex-wrap:wrap; gap:8px }
+.param-input{ width:80px }
 
 /* ====== Menú minimal ====== */
 nav{


### PR DESCRIPTION
## Summary
- style strategy parameter inputs using param-grid and param-input classes
- apply new classes in backtest and bots pages for clearer parameter layout

## Testing
- `pytest tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dd2ff3b4832d97c28fff40052718