### PR TITLE
Document strategy parameters for schema tooltips

### DIFF
--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -14,6 +14,9 @@ import pandas as pd
 from .base import Strategy, Signal
 
 
+PARAM_INFO: dict[str, str] = {}
+
+
 class Arbitrage(Strategy):
     """Placeholder arbitrage strategy used for live experimentation."""
 

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -5,6 +5,12 @@ from typing import Optional, Dict
 
 from .base import Strategy, Signal, record_signal_metrics
 
+PARAM_INFO = {
+    "taker_fee_bps": "Comisión taker por tramo en puntos básicos",
+    "buffer_bps": "Margen adicional por tramo en puntos básicos",
+    "min_edge": "Edge mínimo neto para operar",
+}
+
 @dataclass
 class TriRoute:
     base: str   # p.ej. "BTC"

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -4,6 +4,19 @@ from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import atr, keltner_channels
 
 
+PARAM_INFO = {
+    "ema_n": "Periodo de la EMA para la línea central",
+    "atr_n": "Periodo del ATR usado en los canales",
+    "mult": "Multiplicador aplicado al ATR",
+    "min_bars_between_trades": "Barras mínimas entre operaciones",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Máximo de barras en posición",
+    "min_atr": "ATR mínimo para operar",
+    "trail_atr_mult": "Multiplicador del trailing stop basado en ATR",
+    "config_path": "Ruta opcional al archivo de configuración",
+}
+
 class BreakoutATR(Strategy):
     name = "breakout_atr"
 

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -3,6 +3,17 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 
 
+PARAM_INFO = {
+    "lookback": "Ventana para medias y desviación estándar",
+    "mult": "Multiplicador aplicado a la desviación",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "trailing_stop_bps": "Distancia del trailing stop en bps",
+    "volatility_factor": "Factor para dimensionar según volatilidad",
+}
+
+
 class BreakoutVol(Strategy):
     """Volatility breakout strategy using rolling standard deviation.
 

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -14,6 +14,14 @@ except Exception:  # pragma: no cover - optional
 
 log = logging.getLogger(__name__)
 
+PARAM_INFO = {
+    "symbol": "Par de trading, ej. BTC/USDT",
+    "spot_exchange": "Nombre del exchange spot",
+    "perp_exchange": "Nombre del exchange perp",
+    "threshold": "Base mínima para actuar",
+    "persist_pg": "Persistir señales en TimescaleDB",
+}
+
 @dataclass
 class CashCarryConfig:
     """Configuration parameters for :class:`CashAndCarry`.

--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -5,6 +5,13 @@ from typing import Sequence, Type
 from .base import Strategy, Signal, record_signal_metrics
 
 
+PARAM_INFO = {
+    "strategies": "Lista de subestrategias y sus parámetros",
+    "tp_pct": "Take profit porcentual",
+    "sl_pct": "Stop loss porcentual",
+}
+
+
 class CompositeSignals(Strategy):
     """Combine signals from multiple sub-strategies."""
 

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -6,6 +6,15 @@ from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import depth_imbalance
 
 
+PARAM_INFO = {
+    "window": "Ventana para promediar el desequilibrio",
+    "threshold": "Umbral de desequilibrio para operar",
+    "tp": "Take profit como fracción del precio",
+    "sl": "Stop loss como fracción del precio",
+    "max_duration": "Máxima duración de la posición",
+}
+
+
 class DepthImbalance(Strategy):
     """Depth Imbalance strategy.
 

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -6,6 +6,17 @@ from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import book_vacuum, liquidity_gap
 
 
+PARAM_INFO = {
+    "vacuum_threshold": "Umbral para detectar vacíos de liquidez",
+    "gap_threshold": "Umbral para detectar gaps de liquidez",
+    "tp_pct": "Take profit porcentual",
+    "sl_pct": "Stop loss porcentual",
+    "max_hold": "Barras máximas en posición",
+    "vol_window": "Ventana para calcular la volatilidad",
+    "dynamic_thresholds": "Ajustar umbrales según volatilidad",
+}
+
+
 class LiquidityEvents(Strategy):
     """React to liquidity vacuum and gap events.
 

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -5,6 +5,18 @@ from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import calc_ofi, returns
 
 
+PARAM_INFO = {
+    "ofi_window": "Ventana para estadísticos de OFI",
+    "zscore_threshold": "Z-score absoluto requerido",
+    "vol_window": "Ventana para volatilidad de retornos",
+    "vol_threshold": "Volatilidad máxima permitida",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "config_path": "Ruta opcional de configuración",
+}
+
+
 class MeanRevOFI(Strategy):
     """Mean reversion strategy based on OFI z-score and volatility.
 

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -2,6 +2,17 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi
 
+
+PARAM_INFO = {
+    "rsi_n": "Ventana para el cálculo del RSI",
+    "upper": "Nivel RSI superior para vender",
+    "lower": "Nivel RSI inferior para comprar",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "scale_by": "Método para escalar la fuerza de la señal",
+}
+
 class MeanReversion(Strategy):
     """RSI based mean reversion strategy with adaptive strength.
 

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -11,6 +11,14 @@ from joblib import dump, load
 from .base import Strategy, Signal, record_signal_metrics
 
 
+PARAM_INFO = {
+    "model": "Instancia de modelo sklearn preentrenado",
+    "model_path": "Ruta para cargar el modelo",
+    "margin": "Margen de probabilidad sobre 0.5",
+    "tp_pct": "Take profit porcentual",
+    "sl_pct": "Stop loss porcentual",
+}
+
 class MLStrategy(Strategy):
     """Machine learning based strategy using scikit-learn models.
 

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -2,6 +2,18 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, returns
 
+
+PARAM_INFO = {
+    "rsi_n": "Ventana para el cálculo del RSI",
+    "threshold": "Nivel de RSI para generar señal",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "min_volume": "Volumen mínimo requerido",
+    "min_volatility": "Volatilidad mínima requerida",
+    "vol_window": "Ventana para estimar la volatilidad",
+}
+
 class Momentum(Strategy):
     """Simple momentum strategy using the Relative Strength Index (RSI).
 

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -3,6 +3,16 @@ from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import calc_ofi
 
 
+PARAM_INFO = {
+    "window": "Ventana para promediar el OFI",
+    "buy_threshold": "Umbral de compra para OFI",
+    "sell_threshold": "Umbral de venta para OFI",
+    "tp": "Take profit como fracción",
+    "sl": "Stop loss como fracción",
+    "max_duration": "Duración máxima de la posición",
+}
+
+
 class OrderFlow(Strategy):
     """Order Flow Imbalance strategy.
 

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -7,6 +7,18 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 
 
+PARAM_INFO = {
+    "lookback": "Ventana para el cálculo del z-score",
+    "z_threshold": "Z-score absoluto para abrir operación",
+    "exit_z": "Z-score para cerrar la posición",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "trailing_stop_bps": "Trailing stop en puntos básicos",
+    "volatility_factor": "Factor de tamaño según volatilidad",
+}
+
+
 @dataclass
 class ScalpPingPongConfig:
     """Configuration for :class:`ScalpPingPong`.

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -3,6 +3,17 @@ from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, calc_ofi
 
 
+PARAM_INFO = {
+    "rsi_n": "Ventana para el cálculo del RSI",
+    "threshold": "Nivel de RSI para señales de tendencia",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+    "min_volatility": "Volatilidad mínima requerida",
+    "vol_lookback": "Ventana para calcular la volatilidad",
+}
+
+
 class TrendFollowing(Strategy):
     """RSI based trend following strategy with adaptive strength.
 

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -5,6 +5,18 @@ from sklearn.base import ClassifierMixin
 from .base import Strategy, Signal, record_signal_metrics
 
 
+PARAM_INFO = {
+    "horizon": "Número de barras futuras a evaluar",
+    "upper_pct": "Porcentaje de barrera superior",
+    "lower_pct": "Porcentaje de barrera inferior",
+    "training_window": "Ventana para entrenamiento del modelo",
+    "meta_model": "Modelo para meta etiquetado",
+    "tp_bps": "Take profit en puntos básicos",
+    "sl_bps": "Stop loss en puntos básicos",
+    "max_hold_bars": "Barras máximas en posición",
+}
+
+
 def apply_meta_labeling(
     labels: pd.Series,
     features: pd.DataFrame,


### PR DESCRIPTION
## Summary
- add PARAM_INFO dictionaries to strategies to describe their parameters
- enhance `/strategies/{name}/schema` to surface descriptions and expand dataclass configs

## Testing
- `pytest tests/test_mean_reversion.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1dd318920832db482e9497827de26