### PR TITLE
Use param-grid layout for strategy parameters

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -105,7 +105,7 @@
   </div>
 
   <div class="card" id="bt-param-card" style="display:none">
-    <div id="bt-strategy-params" style="display:contents"></div>
+    <div id="bt-strategy-params" class="param-grid"></div>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -233,6 +233,7 @@ async function loadStrategyParams(name){
       help.textContent='?';
       label.appendChild(help);
       const input=document.createElement('input');
+      input.className='param-input';
       input.id=`bt-param-${p.name}`;
       input.dataset.name=p.name;
       input.dataset.type=p.type||'';
@@ -350,7 +351,7 @@ function updateBtFields(){
   ['field-risk-pct'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
-  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'contents':'none';
+  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'':'none';
 }
 
 function updateStrategyInfo(){

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -88,7 +88,7 @@
         <button id="bot-toggle-params" type="button">Parámetros estrategia</button>
       </div>
       <div id="bot-param-config" style="display:none; grid-column:1/-1">
-        <div id="strategy-params" style="display:contents"></div>
+        <div id="strategy-params" class="param-grid"></div>
       </div>
       <div>
         <label for="bot-risk-pct">Risk %</label>
@@ -189,6 +189,7 @@ const api = (path) => `${location.origin}${path}`;
           label.appendChild(help);
         }
         const input=document.createElement('input');
+        input.className='param-input';
         input.id=`param-${p.name}`;
         input.dataset.name=p.name;
         input.dataset.type=p.type||'';

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -358,3 +358,7 @@ nav a.active::after{
   margin-right: 2px; /* micro-espacio visual */
 }
 
+/* ====== Parámetros dinámicos ====== */
+.param-grid{display:flex;flex-wrap:wrap;gap:8px}
+.param-input{width:80px}
+


### PR DESCRIPTION
## Summary
- style strategy parameter forms with new `.param-grid` and `.param-input` classes
- apply `param-grid` to strategy parameter sections in backtest and bot pages
- assign `param-input` to dynamically created parameter fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1df2a5ef8832dad52e9caef66e6bd