### PR TITLE
Style strategy parameters layout

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -105,7 +105,7 @@
   </div>
 
   <div class="card" id="bt-param-card" style="display:none">
-    <div id="bt-strategy-params" style="display:contents"></div>
+    <div id="bt-strategy-params" class="param-grid"></div>
   </div>
 
   <div class="card" style="margin-top:16px">
@@ -233,6 +233,7 @@ async function loadStrategyParams(name){
       help.textContent='?';
       label.appendChild(help);
       const input=document.createElement('input');
+      input.className='param-input';
       input.id=`bt-param-${p.name}`;
       input.dataset.name=p.name;
       input.dataset.type=p.type||'';
@@ -350,7 +351,7 @@ function updateBtFields(){
   ['field-risk-pct'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
-  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'contents':'none';
+  document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'':'none';
 }
 
 function updateStrategyInfo(){

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -122,7 +122,7 @@
   <div class="card" id="bot-param-card" style="display:none; margin-top:16px">
     <h2>Parámetros estrategia</h2>
     <div id="bot-param-config">
-      <div id="strategy-params" style="display:contents"></div>
+      <div id="strategy-params" class="param-grid"></div>
     </div>
   </div>
 
@@ -199,6 +199,7 @@ const api = (path) => `${location.origin}${path}`;
           label.appendChild(help);
         }
         const input=document.createElement('input');
+        input.className='param-input';
         input.id=`param-${p.name}`;
         input.dataset.name=p.name;
         input.dataset.type=p.type||'';

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -127,6 +127,10 @@ nav a:hover{
 @media (max-width: 900px){ .grid4, .grid3, .grid5{ grid-template-columns: repeat(2,1fr) } }
 @media (max-width: 600px){ .grid4, .grid3, .grid5{ grid-template-columns: 1fr } }
 
+/* Parámetros estrategia */
+.param-grid{display:flex;flex-wrap:wrap;gap:8px}
+.param-input{width:80px}
+
 /* ====== Tablas ====== */
 table{ width:100%; border-collapse:collapse; font-size:14px }
 th,td{ padding:10px 8px; border-bottom:1px solid #253346 }


### PR DESCRIPTION
## Summary
- Add `.param-grid` and `.param-input` styles for flexible parameter layouts
- Apply `param-grid` to strategy parameter containers in backtest and bot pages
- Assign `param-input` class to dynamically created strategy parameter inputs

## Testing
- `pytest` *(fails: killed during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e17ba8cc832dbb7388422ca137ca