### PR TITLE
Adjust backtest parameter UI and strategy metadata

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -96,16 +96,15 @@
         <label class="switch"><input id="bt-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
     </div>
+    <div id="bt-param-card" style="display:none">
+      <div id="bt-strategy-params" class="param-grid"></div>
+    </div>
     <p id="bt-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
     <button id="bt-run" style="margin-top:10px">Ejecutar</button>
     <button id="bt-stop" style="margin-top:10px;margin-left:8px" disabled>Detener</button>
     <button id="bt-clear" style="margin-top:10px;margin-left:8px">Limpiar</button>
     <span id="bt-working">Procesando<span id="bt-dots"></span></span>
     <pre id="bt-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
-
-  <div class="card" id="bt-param-card" style="display:none">
-    <div id="bt-strategy-params" class="param-grid"></div>
   </div>
 
   <div class="card" style="margin-top:16px">

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -130,6 +130,14 @@ nav a:hover{
 /* Parámetros estrategia */
 .param-grid{display:flex;flex-wrap:wrap;gap:8px}
 .param-input{width:80px}
+.param-input[type=number]::-webkit-inner-spin-button,
+.param-input[type=number]::-webkit-outer-spin-button{
+  -webkit-appearance:none;
+  margin:0;
+}
+.param-input[type=number]{
+  -moz-appearance:textfield;
+}
 
 /* ====== Tablas ====== */
 table{ width:100%; border-collapse:collapse; font-size:14px }

--- a/src/tradingbot/strategies/__init__.py
+++ b/src/tradingbot/strategies/__init__.py
@@ -90,6 +90,14 @@ STRATEGY_INFO: dict[str, dict] = {
         "desc": "Reversión a la media con OFI",
         "requires": ["book_delta"],
     },
+    "scalp_pingpong": {
+        "desc": "Scalping de reversión a la media con z-score",
+        "requires": ["ohlcv"],
+    },
+    "composite_signals": {
+        "desc": "Combina señales de múltiples subestrategias",
+        "requires": [],
+    },
 }
 
 __all__ = [

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -15,7 +15,6 @@ except Exception:  # pragma: no cover - optional
 log = logging.getLogger(__name__)
 
 PARAM_INFO = {
-    "symbol": "Par de trading, ej. BTC/USDT",
     "spot_exchange": "Nombre del exchange spot",
     "perp_exchange": "Nombre del exchange perp",
     "threshold": "Base mínima para actuar",


### PR DESCRIPTION
## Summary
- Move strategy parameter inputs into main backtest form and hide number spinners
- Remove duplicated symbol field for cash-and-carry
- Add descriptions for scalp_pingpong and composite_signals strategies

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b1e9a70b44832dbc68c5c0b935d8e6