### PR TITLE
Add liquidity filter for strategies

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -30,6 +30,11 @@ balance:
   interval: 60.0
   assets: []
 
+filters:
+  max_spread: 0.5
+  min_volume: 1000.0
+  max_volatility: 0.05
+
 ingestion:
   funding:
     binance_futures:

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -82,6 +82,15 @@ class ExchangeVenueConfig:
 
 
 @dataclass
+class FiltersConfig:
+    """Thresholds for pre-signal liquidity checks."""
+
+    max_spread: float = float("inf")
+    min_volume: float = 0.0
+    max_volatility: float = float("inf")
+
+
+@dataclass
 class AppConfig:
     """Top level application configuration."""
 
@@ -91,6 +100,7 @@ class AppConfig:
     storage: StorageConfig = field(default_factory=StorageConfig)
     risk: RiskConfig = field(default_factory=RiskConfig)
     balance: BalanceConfig = field(default_factory=BalanceConfig)
+    filters: FiltersConfig = field(default_factory=FiltersConfig)
     exchange_configs: Dict[str, ExchangeVenueConfig] = field(default_factory=dict)
 
 

--- a/src/tradingbot/filters/__init__.py
+++ b/src/tradingbot/filters/__init__.py
@@ -1,0 +1,5 @@
+"""Filter utilities for trading strategies."""
+
+from .liquidity import LiquidityFilter, passes
+
+__all__ = ["LiquidityFilter", "passes"]

--- a/src/tradingbot/filters/liquidity.py
+++ b/src/tradingbot/filters/liquidity.py
@@ -1,0 +1,83 @@
+"""Liquidity filters for strategy signals.
+
+Provides basic checks for market liquidity conditions before allowing
+strategies to emit trading signals.  The filter verifies that the current
+market spread is below ``max_spread``, that traded volume exceeds
+``min_volume`` and that price volatility stays below ``max_volatility``.
+
+Thresholds are loaded from the application configuration when the module
+is imported.  If a particular metric is missing from the bar data, the
+check for that metric is skipped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from ..config.hydra_conf import load_config
+
+
+@dataclass
+class LiquidityFilter:
+    """Simple liquidity filter with spread, volume and volatility checks."""
+
+    max_spread: float = float("inf")
+    min_volume: float = 0.0
+    max_volatility: float = float("inf")
+
+    def check(self, bar: dict[str, Any]) -> bool:
+        """Return ``True`` if ``bar`` passes all liquidity checks."""
+
+        spread = bar.get("spread")
+        if spread is None and {"ask", "bid"} <= bar.keys():
+            spread = float(bar["ask"]) - float(bar["bid"])
+        if spread is not None and spread > self.max_spread:
+            return False
+
+        volume = bar.get("volume")
+        if volume is not None and volume < self.min_volume:
+            return False
+
+        vol = bar.get("volatility")
+        if vol is None:
+            window = bar.get("window")
+            if isinstance(window, pd.DataFrame) and "close" in window.columns and len(window) > 1:
+                vol = window["close"].pct_change().dropna().std()
+        if vol is not None and vol > self.max_volatility:
+            return False
+
+        return True
+
+
+def _load_default_filter() -> LiquidityFilter:
+    cfg = load_config()
+    filt_cfg = getattr(cfg, "filters", None)
+    if filt_cfg is None:
+        return LiquidityFilter()
+    return LiquidityFilter(
+        max_spread=float(getattr(filt_cfg, "max_spread", float("inf"))),
+        min_volume=float(getattr(filt_cfg, "min_volume", 0.0)),
+        max_volatility=float(getattr(filt_cfg, "max_volatility", float("inf"))),
+    )
+
+
+_default_filter = _load_default_filter()
+
+
+def passes(bar: dict[str, Any], filt: LiquidityFilter | None = None) -> bool:
+    """Return ``True`` if ``bar`` passes liquidity checks.
+
+    Parameters
+    ----------
+    bar:
+        Market data bar containing metrics like ``bid``, ``ask``, ``volume``
+        or a pandas ``DataFrame`` under the ``window`` key.
+    filt:
+        Optional :class:`LiquidityFilter` instance.  If ``None``, the
+        module's default filter configured via ``config.yaml`` is used.
+    """
+
+    return (filt or _default_filter).check(bar)

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -8,6 +8,7 @@ import yaml
 
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
+from ..filters import passes as liquidity_passes
 
 @dataclass
 class Signal:
@@ -69,6 +70,8 @@ def record_signal_metrics(fn):
     """
 
     def wrapper(self: Strategy, bar: dict[str, Any]) -> Signal | None:  # type: ignore[misc]
+        if not liquidity_passes(bar):
+            return None
         start = time.monotonic()
         sig = fn(self, bar)
         duration = time.monotonic() - start


### PR DESCRIPTION
## Summary
- add liquidity filter module with spread, volume and volatility checks
- load filter thresholds from config and apply to all strategies
- expose configuration via hydra config

## Testing
- `pytest` *(killed: out of memory)*
- `pytest tests/test_adapter_base.py tests/test_adapter_order_retries.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2102fb270832d986fbcfd1d0e9469