### PR TITLE
Add slippage and fee metrics to fills

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@ Si es la primera vez que lo utiliza, comience por revisar el
 - [Estrategias disponibles](strategies.md)
 - [Dashboards de monitoreo](dashboards.md)
 - [Gestión de riesgo](risk.md)
+- [Estructura del CSV de fills](fills_csv.md)

--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -1,0 +1,31 @@
+# Estructura del CSV de fills
+
+El motor de backtesting puede exportar cada fill ejecutado en un archivo CSV.
+Cada fila representa una operación ejecutada e incluye la siguiente información:
+
+| Columna | Descripción |
+| --- | --- |
+| `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
+| `bar_index` | Índice del bar dentro de la serie de precios |
+| `order_id` | Identificador interno de la orden |
+| `trade_id` | Secuencia incremental de fills |
+| `roundtrip_id` | Identificador del roundtrip al que pertenece el fill |
+| `reason` | Motivo del fill (`order`, `take_profit`, `stop_loss`, etc.) |
+| `side` | `buy` o `sell` |
+| `price` | Precio de ejecución |
+| `qty` | Cantidad ejecutada |
+| `strategy` | Estrategia que generó la orden |
+| `symbol` | Símbolo negociado |
+| `exchange` | Venue en el que se ejecutó |
+| `fee_type` | Tipo de comisión (`maker` o `taker`) |
+| `fee_cost` | Coste de comisión pagado |
+| `slip_bps` | Slippage aplicado en puntos básicos |
+| `slippage_pnl` | PnL debido al slippage (positivo si es favorable) |
+| `cash_after` | Saldo de efectivo tras el fill |
+| `base_after` | Posición en unidades del activo tras el fill |
+| `equity_after` | Equity total tras el fill |
+| `realized_pnl` | PnL realizado del fill, neto de comisiones y slippage |
+| `realized_pnl_total` | PnL realizado acumulado hasta este fill |
+
+Estas columnas permiten auditar el resultado de la simulación y analizar el
+impacto de costes y deslizamientos en cada operación.

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,8 +34,15 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 19
-    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
+    assert df.shape[1] == 21
+    assert {
+        "fee_cost",
+        "slippage_pnl",
+        "realized_pnl",
+        "realized_pnl_total",
+        "trade_id",
+        "roundtrip_id",
+    }.issubset(df.columns)
 
 
 def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
@@ -59,8 +66,15 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 19
-    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
+    assert df.shape[1] == 21
+    assert {
+        "fee_cost",
+        "slippage_pnl",
+        "realized_pnl",
+        "realized_pnl_total",
+        "trade_id",
+        "roundtrip_id",
+    }.issubset(df.columns)
 
 
 class OneShotStrategy:
@@ -122,8 +136,15 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 19
-    assert {"fee", "realized_pnl", "trade_id", "roundtrip_id"}.issubset(df.columns)
+    assert df.shape[1] == 21
+    assert {
+        "fee_cost",
+        "slippage_pnl",
+        "realized_pnl",
+        "realized_pnl_total",
+        "trade_id",
+        "roundtrip_id",
+    }.issubset(df.columns)
 
 
 def test_equity_loss_capped_by_risk_pct(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Track slippage and fee costs for every fill and compute cumulative realized PnL
- Record new fill columns (`fee_cost`, `slippage_pnl`, `realized_pnl_total`) and document the CSV structure
- Update tests for the new fill metrics

## Testing
- `pytest tests/test_backtest_engine.py::test_fills_csv_export -q`
- `pytest tests/test_backtesting_integration.py::test_event_engine_runs -q`
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2102e087c832d9765776d90771aad