### PR TITLE
Add limit order broker with TIF and fee config

### DIFF
--- a/src/tradingbot/broker/__init__.py
+++ b/src/tradingbot/broker/__init__.py
@@ -1,0 +1,3 @@
+from .broker import Broker
+
+__all__ = ["Broker"]

--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from ..config import settings
+
+
+class Broker:
+    """Simple broker wrapping an exchange adapter.
+
+    Provides convenience helpers for limit orders with basic time-in-force
+    handling and accounting of partial fills.
+    """
+
+    def __init__(self, adapter):
+        self.adapter = adapter
+        self.maker_fee_bps = getattr(adapter, "maker_fee_bps", settings.maker_fee_bps)
+        self.passive_rebate_bps = getattr(settings, "passive_rebate_bps", 0.0)
+
+    async def place_limit(
+        self,
+        symbol: str,
+        side: str,
+        price: float,
+        qty: float,
+        tif: str = "GTC|PO",
+    ) -> dict:
+        """Place a limit order respecting ``tif`` semantics.
+
+        Parameters
+        ----------
+        symbol: str
+            Trading pair, e.g. ``"BTC/USDT"``.
+        side: str
+            ``"buy"`` or ``"sell"``.
+        price: float
+            Limit price.
+        qty: float
+            Order quantity.
+        tif: str, optional
+            Time-in-force flags. Supports ``GTC``/``IOC``/``FOK`` and optional
+            ``PO`` for post-only.  A ``GTD:<seconds>`` flag will cancel and
+            replace the remaining quantity after the given number of seconds.
+        """
+
+        time_in_force = "GTC"
+        post_only = False
+        expiry = None
+        for part in str(tif).split("|"):
+            p = part.strip().upper()
+            if p in {"GTC", "IOC", "FOK"}:
+                time_in_force = p
+            elif p == "PO":
+                post_only = True
+            elif p.startswith("GTD"):
+                time_in_force = "GTD"
+                try:
+                    expiry = float(p.split(":", 1)[1])
+                except (IndexError, ValueError):
+                    expiry = None
+
+        filled = 0.0
+        total_time = 0.0
+        remaining = qty
+        attempts = 0
+        max_attempts = 5 if expiry is not None else 1
+        last_res: dict = {}
+
+        while remaining > 0 and attempts < max_attempts:
+            attempts += 1
+            start = datetime.utcnow()
+            res = await self.adapter.place_order(
+                symbol,
+                side,
+                "limit",
+                remaining,
+                price,
+                post_only=post_only,
+                time_in_force=time_in_force,
+            )
+            qty_filled = float(res.get("qty") or res.get("filled") or 0.0)
+            filled += qty_filled
+            remaining = max(remaining - qty_filled, 0.0)
+            end = datetime.utcnow()
+            total_time += (end - start).total_seconds()
+            last_res = res
+            if remaining <= 0 or expiry is None or res.get("status") in {"canceled", "rejected"}:
+                break
+            await asyncio.sleep(expiry)
+            total_time += expiry
+            try:
+                await self.adapter.cancel_order(res.get("order_id"), symbol)
+            except Exception:
+                pass
+
+        last_res.setdefault("filled_qty", filled)
+        last_res.setdefault("time_in_book", total_time)
+        return last_res

--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     paper_maker_fee_bps: float = 10.0
     paper_taker_fee_bps: float = 10.0
 
+    # Generic broker fees
+    maker_fee_bps: float = 0.0
+    passive_rebate_bps: float = 0.0
+
     # Binance Spot
     binance_spot_maker_fee_bps: float = 10.0
     binance_spot_taker_fee_bps: float = 10.0

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -1,3 +1,5 @@
+maker_fee_bps: 0.0
+passive_rebate_bps: 0.0
 exchanges:
   binance_api_key: ""
   binance_api_secret: ""

--- a/tests/test_broker_place_limit.py
+++ b/tests/test_broker_place_limit.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.broker import Broker
+
+
+@pytest.mark.asyncio
+async def test_place_limit_immediate_fill():
+    adapter = PaperAdapter()
+    adapter.state.cash = 1000.0
+    adapter.update_last_price("BTC/USDT", 100.0)
+    broker = Broker(adapter)
+    res = await broker.place_limit("BTC/USDT", "buy", 100.0, 1.0)
+    assert res["status"] == "filled"
+    assert res["filled_qty"] == pytest.approx(1.0)
+    assert res["time_in_book"] >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_place_limit_tif_expiry():
+    adapter = PaperAdapter()
+    adapter.state.cash = 1000.0
+    adapter.update_last_price("BTC/USDT", 100.0)
+    broker = Broker(adapter)
+    res = await broker.place_limit("BTC/USDT", "buy", 90.0, 1.0, tif="GTD:0.01|PO")
+    assert res["filled_qty"] == 0.0
+    assert res["time_in_book"] >= 0.01


### PR DESCRIPTION
## Summary
- Introduce `Broker` class with `place_limit` supporting TIF parsing, partial fill tracking, and cancel/retry logic.
- Expose `maker_fee_bps` and `passive_rebate_bps` settings in configuration.
- Provide tests verifying limit placement and TIF expiry behavior.

## Testing
- `pytest tests/test_broker_place_limit.py -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b21034ce44832d9f3238bc0849ae3f