### PR TITLE
feat: support expected edge bps for breakouts

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -9,6 +9,7 @@ strategies:
   params:
     breakout_atr:
       min_bars_between_trades: 1
+      min_edge_bps: 0.0
     mean_rev_ofi:
       ofi_window: 20
       zscore_threshold: 1.0

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -28,6 +28,7 @@ class Signal:
     take_profit: float | None = None  # optional TP price level
     stop_loss: float | None = None  # optional SL price level
     trailing_pct: float | None = None  # optional trailing stop distance as fraction
+    expected_edge_bps: float | None = None  # optional expected edge in basis points
 
 class Strategy(ABC):
     name: str
@@ -83,6 +84,9 @@ def record_signal_metrics(fn):
         if sig and sig.side in {"buy", "sell"} and {"exchange", "symbol"} <= bar.keys():
             try:
                 engine = timescale.get_engine()
+                notes = None
+                if sig.expected_edge_bps is not None:
+                    notes = {"expected_edge_bps": float(sig.expected_edge_bps)}
                 timescale.insert_order(
                     engine,
                     strategy=self.name,
@@ -93,6 +97,7 @@ def record_signal_metrics(fn):
                     qty=float(sig.strength),
                     px=bar.get("close"),
                     status="signal",
+                    notes=notes,
                 )
             except Exception:
                 # Persistence is best-effort only

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -101,7 +101,7 @@ class BreakoutATR(Strategy):
             self.trailing_stop = trail_stop
             self._last_trade_idx = current_idx
             self._last_trade_side = side
-            return Signal(side, 1.0)
+            return Signal(side, 1.0, expected_edge_bps=expected_edge_bps)
         
 
         # manage existing position

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -86,7 +86,7 @@ class BreakoutVol(Strategy):
                 self.entry_price = last
                 self.favorable_price = last
                 self.hold_bars = 0
-                return Signal("buy", size)
+                return Signal("buy", size, expected_edge_bps=expected_edge_bps)
             if last < lower:
                 expected_edge_bps = (lower - last) / abs(last) * 10000
                 if expected_edge_bps <= self.min_edge_bps:
@@ -95,7 +95,7 @@ class BreakoutVol(Strategy):
                 self.entry_price = last
                 self.favorable_price = last
                 self.hold_bars = 0
-                return Signal("sell", size)
+                return Signal("sell", size, expected_edge_bps=expected_edge_bps)
             return None
 
         self.hold_bars += 1

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import yaml
+import pytest
+from tradingbot.data.features import keltner_channels
 from tradingbot.strategies.breakout_atr import BreakoutATR
 from tradingbot.strategies.order_flow import OrderFlow
 from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
@@ -10,8 +12,12 @@ from hypothesis import given, strategies as st
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0)
 
-    sig_buy = strat.on_bar({"window": breakout_df_buy})
+    sig_buy = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
     assert sig_buy.side == "buy"
+    upper, _ = keltner_channels(breakout_df_buy, 2, 2, 1.0)
+    last_close = breakout_df_buy["close"].iloc[-1]
+    expected_edge = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
+    assert sig_buy.expected_edge_bps == pytest.approx(expected_edge)
 
     # ensure at least one bar passes before opposite signal
     row = {
@@ -26,19 +32,24 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
         ignore_index=True,
     )
 
-    sig_sell = strat.on_bar({"window": df_wait})
+    sig_sell = strat.on_bar({"window": df_wait, "volatility": 0.0})
     assert sig_sell.side == "sell"
 
 
 def test_breakout_atr_min_edge(breakout_df_buy, breakout_df_sell):
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=200)
-    assert strat.on_bar({"window": breakout_df_buy}) is None
+    assert strat.on_bar({"window": breakout_df_buy, "volatility": 0.0}) is None
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=100)
-    assert strat.on_bar({"window": breakout_df_buy}).side == "buy"
+    assert (
+        strat.on_bar({"window": breakout_df_buy, "volatility": 0.0}).side == "buy"
+    )
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=1000)
-    assert strat.on_bar({"window": breakout_df_sell}) is None
+    assert strat.on_bar({"window": breakout_df_sell, "volatility": 0.0}) is None
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=900)
-    assert strat.on_bar({"window": breakout_df_sell}).side == "sell"
+    assert (
+        strat.on_bar({"window": breakout_df_sell, "volatility": 0.0}).side
+        == "sell"
+    )
 
 
 def test_order_flow_signals():
@@ -66,8 +77,6 @@ vol_window: 2
 vol_threshold: 1.0
 """
     )
-    strat = MeanRevOFI(**cfg)
-
     df_sell = pd.DataFrame(
         {
             "bid_qty": [1, 2, 10],
@@ -75,6 +84,10 @@ vol_threshold: 1.0
             "close": [100, 100, 100],
         }
     )
+    strat = MeanRevOFI(**cfg)
+    sig_sell = strat.on_bar({"window": df_sell, "volatility": 0.0})
+    assert sig_sell.side == "sell"
+
     df_buy = pd.DataFrame(
         {
             "bid_qty": [3, 1, 0],
@@ -82,25 +95,32 @@ vol_threshold: 1.0
             "close": [100, 100, 100],
         }
     )
-
-    sig_sell = strat.on_bar({"window": df_sell})
-    assert sig_sell.side == "sell"
-
-    sig_buy = strat.on_bar({"window": df_buy})
+    strat = MeanRevOFI(**cfg)
+    sig_buy = strat.on_bar({"window": df_buy, "volatility": 0.0})
     assert sig_buy.side == "buy"
 
 
 def test_breakout_vol_min_edge():
     df_buy = pd.DataFrame({"close": [1, 2, 3, 10]})
     strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=1100)
-    assert strat.on_bar({"window": df_buy}) is None
+    assert strat.on_bar({"window": df_buy, "volatility": 0.0}) is None
     strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=1000)
-    assert strat.on_bar({"window": df_buy}).side == "buy"
+    sig_buy = strat.on_bar({"window": df_buy, "volatility": 0.0})
+    assert sig_buy.side == "buy"
+    mean = df_buy["close"].rolling(2).mean().iloc[-1]
+    std = df_buy["close"].rolling(2).std().iloc[-1]
+    expected_edge = (df_buy["close"].iloc[-1] - (mean + 0.5 * std)) / abs(df_buy["close"].iloc[-1]) * 10000
+    assert sig_buy.expected_edge_bps == pytest.approx(expected_edge)
     df_sell = pd.DataFrame({"close": [1, 2, 3, -5]})
     strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=2400)
-    assert strat.on_bar({"window": df_sell}) is None
+    assert strat.on_bar({"window": df_sell, "volatility": 0.0}) is None
     strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=2000)
-    assert strat.on_bar({"window": df_sell}).side == "sell"
+    sig_sell = strat.on_bar({"window": df_sell, "volatility": 0.0})
+    assert sig_sell.side == "sell"
+    mean = df_sell["close"].rolling(2).mean().iloc[-1]
+    std = df_sell["close"].rolling(2).std().iloc[-1]
+    expected_edge = ((mean - 0.5 * std) - df_sell["close"].iloc[-1]) / abs(df_sell["close"].iloc[-1]) * 10000
+    assert sig_sell.expected_edge_bps == pytest.approx(expected_edge)
 
 
 @given(start=st.floats(1, 10), inc=st.floats(0.1, 5))


### PR DESCRIPTION
## Summary
- track expected edge in basis points on Signal and persist as order notes
- require breakout strategies to exceed configurable min_edge_bps
- document `min_edge_bps` in config and add tests for expected edge values

## Testing
- `PYTHONPATH=src pytest tests/test_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2178412b8832d9ecb3d383652c82f