### PR TITLE
feat(backtest): configurable base spread for slippage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ El modelo de *slippage* admite dos fuentes (`source`):
 - `"fixed_spread"` siempre aplica el valor de `base_spread` sin considerar las
   columnas de mejor bid/ask.
 
+Ejemplo en la configuración:
+
+```yaml
+backtest:
+  slippage:
+    source: bba
+    base_spread: 0.1
+```
+
 El motor de backtesting ignora ejecuciones cuya cantidad sea menor a
 `min_fill_qty` para evitar registrar residuos irrelevantes. El umbral
 predeterminado es la constante `MIN_FILL_QTY = 1e-3`, pero puede ajustarse

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -182,6 +182,15 @@ del mejor bid/ask (o `bid_px`/`ask_px`) y, si no están disponibles, utiliza el
 `base_spread` configurado. `"fixed_spread"` ignora las columnas de bid/ask y
 aplica siempre `base_spread`.
 
+Ejemplo de configuración YAML:
+
+```yaml
+backtest:
+  slippage:
+    source: bba
+    base_spread: 0.1
+```
+
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
 `timestamp, bar_index, order_id, trade_id, roundtrip_id, reason, side, price, qty, strategy, symbol, exchange, fee_type, fee, slip_bps, cash_after, base_after, equity_after, realized_pnl`.
 La columna `price` refleja el precio final de ejecución con spread y slippage aplicados.

--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
 
 import pandas as pd
 
-from .engine import EventDrivenBacktestEngine, MIN_FILL_QTY
+from .engine import EventDrivenBacktestEngine, MIN_FILL_QTY, SlippageModel
 from ..strategies import STRATEGIES
 from ..reporting.metrics import evaluate
 
@@ -45,6 +45,7 @@ def walk_forward_backtest(
     fills_csv: str | None = None,
     exchange_configs: Dict[str, Dict[str, float]] | None = None,
     min_fill_qty: float = MIN_FILL_QTY,
+    slippage: SlippageModel | None = None,
 ) -> pd.DataFrame:
     """Run a basic walk-forward analysis and return metrics for each split."""
 
@@ -74,6 +75,7 @@ def walk_forward_backtest(
                 verbose_fills=verbose_fills,
                 exchange_configs=exchange_configs,
                 min_fill_qty=min_fill_qty,
+                slippage=slippage,
             )
             engine.strategies[(strategy_name, symbol)] = strat
             res = engine.run()
@@ -91,6 +93,7 @@ def walk_forward_backtest(
             verbose_fills=verbose_fills,
             exchange_configs=exchange_configs,
             min_fill_qty=min_fill_qty,
+            slippage=slippage,
         )
         engine.strategies[(strategy_name, symbol)] = strat
         test_res = engine.run(fills_csv=fills_csv)

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -33,6 +33,17 @@ class StrategiesConfig:
 
 
 @dataclass
+class SlippageConfig:
+    """Parameters for the backtest slippage model."""
+
+    source: str = "bba"
+    base_spread: float = 0.0
+    volume_impact: float = 0.1
+    spread_mult: float = 1.0
+    ofi_impact: float = 0.0
+
+
+@dataclass
 class BacktestConfig:
     """CSV paths and runtime options for the backtest."""
 
@@ -42,6 +53,7 @@ class BacktestConfig:
     latency: int = 1
     window: int = 120
     min_fill_qty: float = 1e-3
+    slippage: "SlippageConfig | None" = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- expose SlippageConfig with base_spread in Hydra configuration
- load slippage settings in CLI backtest commands and walk-forward utilities
- allow walk-forward backtests to receive a SlippageModel

## Testing
- `pytest tests/test_execution_router_slippage.py -q`
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage -q`
- `pytest tests/test_backtest_db_cli.py -q`
- `pytest tests/test_walk_forward.py -q`
- `pytest tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21785a8bc832d991194f4023d7271