### PR TITLE
Add scalp pingpong and composite signals strategies

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -203,6 +203,14 @@ const strategies = {
     desc: "Arbitraje del mismo par entre dos exchanges; compra donde esté barato y vende donde esté caro.",
     requires: ["prices"],
   },
+  scalp_pingpong: {
+    desc: "Scalping de reversión a la media con z‑score",
+    requires: ["ohlcv"],
+  },
+  composite_signals: {
+    desc: "Combina señales de múltiples subestrategias",
+    requires: [],
+  },
 };
 
 const dataInfo = {


### PR DESCRIPTION
## Summary
- expose scalp_pingpong and composite_signals in backtest strategies list

## Testing
- `node - <<'NODE' ... NODE`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21c116814832da8b5df98a70d2c34