### PR TITLE
Streamline backtest fill export fields

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -192,7 +192,7 @@ backtest:
 ```
 
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
-`timestamp, bar_index, order_id, trade_id, roundtrip_id, reason, side, price, qty, strategy, symbol, exchange, fee_type, fee, slip_bps, cash_after, base_after, equity_after, realized_pnl`.
+`timestamp, reason, side, price, qty, strategy, symbol, exchange, fee_cost, slippage_pnl, realized_pnl, realized_pnl_total, equity_after`.
 La columna `price` refleja el precio final de ejecución con spread y slippage aplicados.
 Desde este archivo puede reconstruirse el efectivo y la posición para validar el PnL final:
 
@@ -200,7 +200,7 @@ Desde este archivo puede reconstruirse el efectivo y la posición para validar e
 import pandas as pd
 
 fills = pd.read_csv("fills.csv")
-# `base_after`, `cash_after` y `equity_after` ya contienen los balances tras cada fill.
+# Puede calcularse el balance acumulado aplicando `price`, `qty` y `fee_cost`.
 ```
 
 La última fila de `cash` y `position` debe coincidir con los valores reportados

--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -6,10 +6,6 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | Columna | Descripción |
 | --- | --- |
 | `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
-| `bar_index` | Índice del bar dentro de la serie de precios |
-| `order_id` | Identificador interno de la orden |
-| `trade_id` | Secuencia incremental de fills |
-| `roundtrip_id` | Identificador del roundtrip al que pertenece el fill |
 | `reason` | Motivo del fill (`order`, `take_profit`, `stop_loss`, etc.) |
 | `side` | `buy` o `sell` |
 | `price` | Precio de ejecución |
@@ -17,15 +13,11 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | `strategy` | Estrategia que generó la orden |
 | `symbol` | Símbolo negociado |
 | `exchange` | Venue en el que se ejecutó |
-| `fee_type` | Tipo de comisión (`maker` o `taker`) |
 | `fee_cost` | Coste de comisión pagado |
-| `slip_bps` | Slippage aplicado en puntos básicos |
 | `slippage_pnl` | PnL debido al slippage (positivo si es favorable) |
-| `cash_after` | Saldo de efectivo tras el fill |
-| `base_after` | Posición en unidades del activo tras el fill |
-| `equity_after` | Equity total tras el fill |
 | `realized_pnl` | PnL realizado del fill, neto de comisiones y slippage |
 | `realized_pnl_total` | PnL realizado acumulado hasta este fill |
+| `equity_after` | Equity total tras el fill |
 
 Estas columnas permiten auditar el resultado de la simulación y analizar el
 impacto de costes y deslizamientos en cada operación.

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -36,10 +36,6 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         result["fills"],
         columns=[
             "timestamp",
-            "bar_index",
-            "order_id",
-            "trade_id",
-            "roundtrip_id",
             "reason",
             "side",
             "price",
@@ -47,24 +43,29 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
             "strategy",
             "symbol",
             "exchange",
-            "fee_type",
             "fee_cost",
-            "slip_bps",
             "slippage_pnl",
-            "cash_after",
-            "base_after",
-            "equity_after",
             "realized_pnl",
             "realized_pnl_total",
+            "equity_after",
         ],
     )
-    assert len(result["fills"][0]) == 21
-    assert (fills["cash_after"] >= -1e-9).all()
-    assert (fills["base_after"] >= -1e-9).all()
+    assert len(result["fills"][0]) == 13
+    cash = engine.initial_equity
+    base = 0.0
+    for row in fills.itertuples():
+        if row.side == "buy":
+            cash -= row.price * row.qty + row.fee_cost
+            base += row.qty
+        else:
+            cash += row.price * row.qty - row.fee_cost
+            base -= row.qty
+        assert cash >= -1e-9
+        assert base >= -1e-9
     assert risk.rm.pos.qty == pytest.approx(0.0)
     assert risk.rm.pos.realized_pnl == pytest.approx(fills["realized_pnl"].sum())
     final_price = df["close"].iloc[-1]
-    expected_equity = fills["cash_after"].iloc[-1] + fills["base_after"].iloc[-1] * final_price
+    expected_equity = cash + base * final_price
     assert result["equity"] == pytest.approx(expected_equity)
     assert result["equity"] == pytest.approx(103.97112767590798)
     assert result["pnl"] == pytest.approx(3.4711276759079794)

--- a/tests/test_backtesting_integration.py
+++ b/tests/test_backtesting_integration.py
@@ -34,14 +34,12 @@ def test_event_engine_runs(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 21
+    assert df.shape[1] == 13
     assert {
         "fee_cost",
         "slippage_pnl",
         "realized_pnl",
         "realized_pnl_total",
-        "trade_id",
-        "roundtrip_id",
     }.issubset(df.columns)
 
 
@@ -66,14 +64,12 @@ def test_event_engine_single_symbol_cov(tmp_path, monkeypatch):
     assert "equity" in res
     df = pd.read_csv(out)
     assert not df.empty
-    assert df.shape[1] == 21
+    assert df.shape[1] == 13
     assert {
         "fee_cost",
         "slippage_pnl",
         "realized_pnl",
         "realized_pnl_total",
-        "trade_id",
-        "roundtrip_id",
     }.issubset(df.columns)
 
 
@@ -136,14 +132,12 @@ def test_stop_loss_triggers_close(tmp_path, monkeypatch):
     exit_price = df.iloc[1]["price"]
     assert exit_price <= entry_price * (1 - 0.1)
     assert res["orders"][1]["filled"] == res["orders"][0]["qty"]
-    assert df.shape[1] == 21
+    assert df.shape[1] == 13
     assert {
         "fee_cost",
         "slippage_pnl",
         "realized_pnl",
         "realized_pnl_total",
-        "trade_id",
-        "roundtrip_id",
     }.issubset(df.columns)
 
 


### PR DESCRIPTION
## Summary
- trim backtest fill records to essential fields and export minimal CSV columns
- adjust strategies, integration tests, and docs to the simplified fill schema

## Testing
- `pytest tests/test_backtest_engine.py tests/test_backtesting_integration.py tests/integration/test_recorded_flow.py`

------
https://chatgpt.com/codex/tasks/task_e_68b21c1350ec832d9fa6edd118199185