### PR TITLE
chore: update paper and testnet fee settings

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -53,18 +53,18 @@ class Settings(BaseSettings):
     binance_futures_market: str = "USDT-M"  # informativo
 
     # Fees (bps) configurable por entorno
-    paper_maker_fee_bps: float = 10.0
-    paper_taker_fee_bps: float = 10.0
+    paper_maker_fee_bps: float = 7.5
+    paper_taker_fee_bps: float = 7.5
 
     # Generic broker fees
-    maker_fee_bps: float = 0.0
+    maker_fee_bps: float = 7.5
     passive_rebate_bps: float = 0.0
 
     # Binance Spot
-    binance_spot_maker_fee_bps: float = 10.0
-    binance_spot_taker_fee_bps: float = 10.0
-    binance_spot_testnet_maker_fee_bps: float = 10.0
-    binance_spot_testnet_taker_fee_bps: float = 10.0
+    binance_spot_maker_fee_bps: float = 7.5
+    binance_spot_taker_fee_bps: float = 7.5
+    binance_spot_testnet_maker_fee_bps: float = 7.5
+    binance_spot_testnet_taker_fee_bps: float = 7.5
 
     # Binance Futuros USD-M
     binance_futures_maker_fee_bps: float = 2.0
@@ -75,8 +75,8 @@ class Settings(BaseSettings):
     # OKX Spot
     okx_spot_maker_fee_bps: float = 8.0
     okx_spot_taker_fee_bps: float = 10.0
-    okx_spot_testnet_maker_fee_bps: float = 8.0
-    okx_spot_testnet_taker_fee_bps: float = 10.0
+    okx_spot_testnet_maker_fee_bps: float = 7.5
+    okx_spot_testnet_taker_fee_bps: float = 7.5
 
     # OKX Futuros USDT-M
     okx_futures_maker_fee_bps: float = 2.0

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -1,4 +1,4 @@
-maker_fee_bps: 0.0
+maker_fee_bps: 7.5
 passive_rebate_bps: 0.0
 exchanges:
   binance_api_key: ""
@@ -55,14 +55,14 @@ risk:
 exchange_configs:
   binance_spot:
     market_type: spot
-    maker_fee_bps: 10.0
-    taker_fee_bps: 10.0
+    maker_fee_bps: 7.5
+    taker_fee_bps: 7.5
     tick_size: 0.01
     min_fill_qty: 0.001
   binance_futures:
     market_type: perp
-    maker_fee_bps: 5.0
-    taker_fee_bps: 5.0
+    maker_fee_bps: 2.0
+    taker_fee_bps: 4.0
     tick_size: 0.01
     min_fill_qty: 0.001
   okx_spot:
@@ -72,7 +72,7 @@ exchange_configs:
     tick_size: 0.1
   okx_spot_testnet:
     market_type: spot
-    maker_fee_bps: 8.0
-    taker_fee_bps: 10.0
+    maker_fee_bps: 7.5
+    taker_fee_bps: 7.5
     tick_size: 0.1
     min_fill_qty: 0.001


### PR DESCRIPTION
## Summary
- Align fee configuration with real account rates
- Synchronize paper and testnet settings for spot and futures fees

## Testing
- `pytest -q` *(killed)*
- `pytest tests/test_execution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2234ef344832d99bc84b5dafadf90