### PR TITLE
feat: support limit order callbacks

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from typing import Callable, Optional
 
 from ..config import settings
+from ..execution.order_types import Order
 
 
 class Broker:
     """Simple broker wrapping an exchange adapter.
 
     Provides convenience helpers for limit orders with basic time-in-force
-    handling and accounting of partial fills.
+    handling, partial fills and re-quoting through optional callbacks.
     """
 
     def __init__(self, adapter, maker_fee_bps: float | None = None):
@@ -29,6 +31,8 @@ class Broker:
         price: float,
         qty: float,
         tif: str = "GTC|PO",
+        on_partial_fill: Optional[Callable[[Order, dict], str | None]] = None,
+        on_order_expiry: Optional[Callable[[Order, dict], str | None]] = None,
     ) -> dict:
         """Place a limit order respecting ``tif`` semantics.
 
@@ -46,6 +50,12 @@ class Broker:
             Time-in-force flags. Supports ``GTC``/``IOC``/``FOK`` and optional
             ``PO`` for post-only.  A ``GTD:<seconds>`` flag will cancel and
             replace the remaining quantity after the given number of seconds.
+        on_partial_fill: callable, optional
+            Callback executed when an order is partially filled. Should return
+            ``"re_quote"`` to place the remaining quantity again.
+        on_order_expiry: callable, optional
+            Callback executed when an order expires (``GTD``). Should return
+            ``"re_quote"`` to place the remaining quantity again.
         """
 
         time_in_force = "GTC"
@@ -68,8 +78,18 @@ class Broker:
         total_time = 0.0
         remaining = qty
         attempts = 0
-        max_attempts = 5 if expiry is not None else 1
+        max_attempts = 5
         last_res: dict = {}
+
+        order = Order(
+            symbol=symbol,
+            side=side,
+            type_="limit",
+            qty=qty,
+            price=price,
+            post_only=post_only,
+            time_in_force=time_in_force,
+        )
 
         while remaining > 0 and attempts < max_attempts:
             attempts += 1
@@ -83,21 +103,47 @@ class Broker:
                 post_only=post_only,
                 time_in_force=time_in_force,
             )
-            qty_filled = float(res.get("qty") or res.get("filled") or 0.0)
+            qty_filled = float(
+                res.get("qty") or res.get("filled") or res.get("filled_qty") or 0.0
+            )
             filled += qty_filled
             remaining = max(remaining - qty_filled, 0.0)
+            order.pending_qty = remaining
             end = datetime.utcnow()
             total_time += (end - start).total_seconds()
+            res.setdefault("filled_qty", qty_filled)
+            res.setdefault("pending_qty", remaining)
             last_res = res
-            if remaining <= 0 or expiry is None or res.get("status") in {"canceled", "rejected"}:
+
+            # Fully filled or adapter rejected/canceled the order
+            status = res.get("status")
+            if remaining <= 0 or status in {"canceled", "rejected"}:
                 break
-            await asyncio.sleep(expiry)
-            total_time += expiry
-            try:
-                await self.adapter.cancel_order(res.get("order_id"), symbol)
-            except Exception:
-                pass
+
+            # Handle partial fills
+            if qty_filled > 0 and remaining > 0:
+                action = on_partial_fill(order, res) if on_partial_fill else None
+                if action in {"re_quote", "requote", "re-quote"}:
+                    continue
+                break
+
+            # Handle expiry/re-quote
+            if expiry is not None and status not in {"canceled", "rejected"}:
+                await asyncio.sleep(expiry)
+                total_time += expiry
+                try:
+                    await self.adapter.cancel_order(res.get("order_id"), symbol)
+                except Exception:
+                    pass
+                action = on_order_expiry(order, res) if on_order_expiry else "re_quote"
+                if action in {"re_quote", "requote", "re-quote"}:
+                    continue
+                break
+
+            # Nothing else to do (no expiry and not fully filled)
+            break
 
         last_res.setdefault("filled_qty", filled)
         last_res.setdefault("time_in_book", total_time)
+        last_res.setdefault("pending_qty", remaining)
         return last_res

--- a/tests/broker/test_place_limit.py
+++ b/tests/broker/test_place_limit.py
@@ -1,7 +1,8 @@
 import pytest
 
-from tradingbot.execution.paper import PaperAdapter
 from tradingbot.broker import Broker
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.strategies.base import Strategy, Signal, record_signal_metrics
 
 
 class DummyAdapter:
@@ -43,3 +44,84 @@ def test_broker_maker_fee_override():
     adapter = PaperAdapter(maker_fee_bps=2.0)
     broker = Broker(adapter, maker_fee_bps=1.0)
     assert broker.maker_fee_bps == 1.0
+
+
+class PartialAdapter:
+    def __init__(self):
+        self.calls = []
+        self.maker_fee_bps = 0.0
+
+    async def place_order(self, *args, **kwargs):
+        qty = args[3] if len(args) > 3 else kwargs.get("qty", 0.0)
+        self.calls.append({"qty": qty, **kwargs})
+        if len(self.calls) == 1:
+            return {"status": "partial", "qty": qty / 2, "order_id": 1}
+        return {"status": "filled", "qty": qty, "order_id": 2}
+
+    async def cancel_order(self, *args, **kwargs):
+        return {"status": "canceled"}
+
+
+class ExpiringAdapter:
+    def __init__(self):
+        self.calls = []
+        self.maker_fee_bps = 0.0
+
+    async def place_order(self, *args, **kwargs):
+        qty = args[3] if len(args) > 3 else kwargs.get("qty", 0.0)
+        self.calls.append({"qty": qty, **kwargs})
+        if len(self.calls) == 1:
+            return {"status": "new", "qty": 0.0, "order_id": 1}
+        return {"status": "filled", "qty": qty, "order_id": 2}
+
+    async def cancel_order(self, *args, **kwargs):
+        return {"status": "canceled"}
+
+
+class DummyStrategy(Strategy):
+    name = "dummy"
+
+    @record_signal_metrics
+    def on_bar(self, bar):
+        return Signal(bar.get("side", "buy"), 1.0)
+
+
+def setup_strategy(side="buy"):
+    strat = DummyStrategy()
+    strat.on_bar({"symbol": "BTC/USDT", "exchange": "ex", "close": 100.0, "side": side})
+    return strat
+
+
+@pytest.mark.asyncio
+async def test_place_limit_partial_fill_requotes():
+    strat = setup_strategy("buy")
+    adapter = PartialAdapter()
+    broker = Broker(adapter)
+    res = await broker.place_limit(
+        "BTC/USDT",
+        "buy",
+        100.0,
+        10.0,
+        on_partial_fill=strat.on_partial_fill,
+    )
+    assert res["status"] == "filled"
+    assert strat.pending_qty["BTC/USDT"] == pytest.approx(5.0)
+    assert len(adapter.calls) == 2
+    assert adapter.calls[1]["qty"] == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_place_limit_expiry_respects_callback():
+    strat = setup_strategy("buy")
+    adapter = ExpiringAdapter()
+    broker = Broker(adapter)
+    await broker.place_limit(
+        "BTC/USDT",
+        "buy",
+        90.0,
+        1.0,
+        tif="GTD:0.01",
+        on_order_expiry=strat.on_order_expiry,
+    )
+    assert len(adapter.calls) == 2
+    assert strat.pending_qty["BTC/USDT"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add callback-aware `place_limit` with partial fill and expiry handling
- expose strategy callbacks for partial fills and expiry with `pending_qty`
- cover limit re-quote and expiry behaviour with unit tests

## Testing
- `pytest tests/broker/test_place_limit.py -q`
- `pytest -q` *(failed: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2233b636c832db82626c968ba1375