### PR TITLE
feat(ui): switch for bot parameter config

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -80,51 +80,45 @@
         <label for="bot-threshold">Threshold</label>
         <input id="bot-threshold" type="number" step="0.0001" value="0.001"/>
       </div>
-      <div>
-        <label for="bot-config">Config YAML</label>
-        <input id="bot-config" placeholder="config.yaml"/>
+        <div>
+          <label for="bot-config">Config YAML</label>
+          <input id="bot-config" placeholder="config.yaml"/>
+        </div>
+        <div>
+          <label for="bot-risk-pct">Risk %</label>
+          <input id="bot-risk-pct" type="number" step="0.0001" required/>
+        </div>
+        <div>
+          <label for="bot-daily-max-loss-pct">Daily max loss %
+            <span class="help-icon" title="Pérdida diaria máxima permitida (porcentaje del equity)">?</span>
+          </label>
+          <input id="bot-daily-max-loss-pct" type="number" step="0.0001"/>
+        </div>
+        <div>
+          <label for="bot-daily-max-drawdown-pct">Daily max drawdown %
+            <span class="help-icon" title="Drawdown diario máximo relativo al pico intradía">?</span>
+          </label>
+          <input id="bot-daily-max-drawdown-pct" type="number" step="0.0001"/>
+        </div>
+        <div>
+          <label for="bot-env">Entorno</label>
+          <select id="bot-env">
+            <option value="live">Live</option>
+            <option value="paper">Paper trading</option>
+            <option value="testnet" selected>Testnet</option>
+          </select>
+        </div>
+        <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
+          <span>Configurar parámetros</span>
+          <label class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
+        </div>
       </div>
-      <div id="field-toggle-params" style="grid-column:1/-1;display:flex;align-items:center">
-        <label for="bot-toggle-params" style="display:flex;align-items:center;gap:4px">
-          <input id="bot-toggle-params" type="checkbox"/>
-          Configurar parámetros
-        </label>
+      <div id="bot-param-card" style="display:none">
+        <div id="bot-strategy-params" class="param-grid"></div>
       </div>
-      <div>
-        <label for="bot-risk-pct">Risk %</label>
-        <input id="bot-risk-pct" type="number" step="0.0001" required/>
-      </div>
-      <div>
-        <label for="bot-daily-max-loss-pct">Daily max loss %
-          <span class="help-icon" title="Pérdida diaria máxima permitida (porcentaje del equity)">?</span>
-        </label>
-        <input id="bot-daily-max-loss-pct" type="number" step="0.0001"/>
-      </div>
-      <div>
-        <label for="bot-daily-max-drawdown-pct">Daily max drawdown %
-          <span class="help-icon" title="Drawdown diario máximo relativo al pico intradía">?</span>
-        </label>
-        <input id="bot-daily-max-drawdown-pct" type="number" step="0.0001"/>
-      </div>
-      <div>
-        <label for="bot-env">Entorno</label>
-        <select id="bot-env">
-          <option value="live">Live</option>
-          <option value="paper">Paper trading</option>
-          <option value="testnet" selected>Testnet</option>
-        </select>
-      </div>
+      <button id="bot-start" style="margin-top:10px">Start</button>
+      <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
     </div>
-    <button id="bot-start" style="margin-top:10px">Start</button>
-    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
-
-  <div class="card" id="bot-param-card" style="display:none; margin-top:16px">
-    <h2>Parámetros estrategia</h2>
-    <div id="bot-param-config">
-      <div id="strategy-params" class="param-grid"></div>
-    </div>
-  </div>
 
   <div class="card" style="margin-top:16px">
     <h2>Bots activos</h2>
@@ -172,7 +166,7 @@ const api = (path) => `${location.origin}${path}`;
   }
 
   async function loadStrategyParams(name){
-    const container=document.getElementById('strategy-params');
+    const container=document.getElementById('bot-strategy-params');
     container.innerHTML='';
     const card=document.getElementById('bot-param-card');
     card.style.display='none';
@@ -188,7 +182,7 @@ const api = (path) => `${location.origin}${path}`;
       params.forEach(p=>{
         const div=document.createElement('div');
         const label=document.createElement('label');
-        label.htmlFor=`param-${p.name}`;
+        label.htmlFor=`bot-param-${p.name}`;
         label.textContent=p.name;
         if(p.desc){
           const help=document.createElement('span');
@@ -200,7 +194,7 @@ const api = (path) => `${location.origin}${path}`;
         }
         const input=document.createElement('input');
         input.className='param-input';
-        input.id=`param-${p.name}`;
+        input.id=`bot-param-${p.name}`;
         input.dataset.name=p.name;
         input.dataset.type=p.type||'';
         let type=(p.type||'').toLowerCase();
@@ -257,7 +251,7 @@ async function startBot(){
     const spot = document.getElementById('bot-spot').value;
     const perp = document.getElementById('bot-perp').value;
     const threshold = document.getElementById('bot-threshold').value;
-    const paramEls=document.querySelectorAll('#strategy-params input');
+    const paramEls=document.querySelectorAll('#bot-strategy-params input');
     const params={};
     paramEls.forEach(el=>{
       if(!el.value) return;

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -128,7 +128,8 @@ nav a:hover{
 @media (max-width: 600px){ .grid4, .grid3, .grid5{ grid-template-columns: 1fr } }
 
 /* === Sección parámetros estrategia === */
-#bt-param-card {
+#bt-param-card,
+#bot-param-card {
   margin-top: 14px;
   padding: 14px;
   border-radius: 12px;
@@ -138,7 +139,8 @@ nav a:hover{
 }
 
 /* Grid compacto */
-#bt-strategy-params {
+#bt-strategy-params,
+#bot-strategy-params {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, auto));
   gap: 8px 12px; /* menos espacio entre inputs */
@@ -146,7 +148,8 @@ nav a:hover{
 }
 
 /* Labels */
-#bt-strategy-params label {
+#bt-strategy-params label,
+#bot-strategy-params label {
   font-size: 13px;
   font-weight: 500;
   color: var(--muted);
@@ -156,13 +159,15 @@ nav a:hover{
   gap: 4px;
 }
 
-#bt-strategy-params .help-icon {
+#bt-strategy-params .help-icon,
+#bot-strategy-params .help-icon {
   margin-left: 2px;
   flex-shrink: 0;
 }
 
 /* Inputs */
-#bt-strategy-params input.param-input {
+#bt-strategy-params input.param-input,
+#bot-strategy-params input.param-input {
   width: 90px;              /* más compactos */
   padding: 5px 6px;
   border-radius: 8px;
@@ -172,11 +177,14 @@ nav a:hover{
 
 /* Quitar flechitas number */
 #bt-strategy-params input.param-input[type=number]::-webkit-inner-spin-button,
-#bt-strategy-params input.param-input[type=number]::-webkit-outer-spin-button {
+#bt-strategy-params input.param-input[type=number]::-webkit-outer-spin-button,
+#bot-strategy-params input.param-input[type=number]::-webkit-inner-spin-button,
+#bot-strategy-params input.param-input[type=number]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-#bt-strategy-params input.param-input[type=number] {
+#bt-strategy-params input.param-input[type=number],
+#bot-strategy-params input.param-input[type=number] {
   -moz-appearance: textfield;
 }
 


### PR DESCRIPTION
## Summary
- replace bot parameter checkbox with styled switch
- embed strategy parameter section in bot form with IDs and styles mirroring backtest
- support strategy param styling for bots in global CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b22ea09cb8832da65a1ebfa623f6f6