### PR TITLE
feat: embed bot param panel

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -84,11 +84,9 @@
         <label for="bot-config">Config YAML</label>
         <input id="bot-config" placeholder="config.yaml"/>
       </div>
-      <div id="field-toggle-params" style="grid-column:1/-1;display:flex;align-items:center">
-        <label for="bot-toggle-params" style="display:flex;align-items:center;gap:4px">
-          <input id="bot-toggle-params" type="checkbox"/>
-          Configurar parámetros
-        </label>
+      <div id="field-toggle-params" style="grid-column:1/-1;display:flex;align-items:center;gap:4px">
+        <span>Configurar parámetros</span>
+        <label class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
       <div>
         <label for="bot-risk-pct">Risk %</label>
@@ -115,15 +113,11 @@
         </select>
       </div>
     </div>
-    <button id="bot-start" style="margin-top:10px">Start</button>
-    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
-
-  <div class="card" id="bot-param-card" style="display:none; margin-top:16px">
-    <h2>Parámetros estrategia</h2>
-    <div id="bot-param-config">
+    <div id="bot-param-card" style="display:none">
       <div id="strategy-params" class="param-grid"></div>
     </div>
+    <button id="bot-start" style="margin-top:10px">Start</button>
+    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
   <div class="card" style="margin-top:16px">


### PR DESCRIPTION
## Summary
- place bot parameter block inside main card above start button
- match toggle styling with backtest using existing grid and switch classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22e9f8d48832da0674a095ceff828