### PR TITLE
Use icons for bot action controls

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -6,6 +6,7 @@
   <title>DMI - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-+0Y4FzfwS0Ax7AnCM1j7rwhhtjfiPgk41IrT9jp+1rssZCvGSqtEtFPi0P5xGX2YeliYg+6TSGT+bVfVgY2G4w==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 </head>
 <body>
 <header class="center" style="margin-bottom:8px">
@@ -312,13 +313,13 @@ async function refreshBots(){
       <td>${stats.risk_triggers||0}</td>
       <td>${b.last_error||''}</td>
       <td>
-        <button onclick="pauseBot(${b.pid})">Pause</button>
-        <button onclick="resumeBot(${b.pid})">Resume</button>
+        <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause"><i class="fa-solid fa-pause"></i></button>
+        <button class="icon-btn" onclick="resumeBot(${b.pid})" title="Resume"><i class="fa-solid fa-play"></i></button>
         <button class='warn' onclick="haltBot(${b.pid})">Halt</button>
         <button class='danger' onclick="flattenBot(${b.pid})">Flatten</button>
-        <button onclick="reloadBot(${b.pid})">Reload</button>
-        <button onclick="stopBot(${b.pid})">Stop</button>
-        <button onclick="deleteBot(${b.pid})">Delete</button>
+        <button class="icon-btn" onclick="reloadBot(${b.pid})" title="Reload"><i class="fa-solid fa-rotate-right"></i></button>
+        <button class="icon-btn" onclick="stopBot(${b.pid})" title="Stop"><i class="fa-solid fa-stop"></i></button>
+        <button class="icon-btn" onclick="deleteBot(${b.pid})" title="Delete"><i class="fa-solid fa-trash"></i></button>
       </td>`;
       body.appendChild(tr);
     });

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -259,6 +259,15 @@ button:focus-visible{
   box-shadow: 0 0 0 2px rgba(34,211,238,.25);
 }
 
+button.icon-btn{
+  width:32px;
+  height:32px;
+  padding:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+
 /* variantes */
 button.primary{
   color: var(--primary);


### PR DESCRIPTION
## Summary
- add Font Awesome to bots page
- replace bot action text with icon buttons and tooltips
- add CSS helper for uniform icon button sizing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b22ea1a600832da7eee8647f97f0fa