### PR TITLE
Use param card component for bot settings

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -114,13 +114,12 @@
         <label class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
     </div>
-    <div id="bot-params-section" style="display:none">
-      <div id="bot-strategy-params" class="param-grid"></div>
-      <p id="bot-strategy-info" class="dm-kind-desc" style="grid-column:1 / -1;"></p>
+      <div id="bot-param-card" style="display:none">
+        <div id="bot-strategy-params" class="param-grid"></div>
+      </div>
+      <button id="bot-start" style="margin-top:10px">Start</button>
+      <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
     </div>
-    <button id="bot-start" style="margin-top:10px">Start</button>
-    <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
 
   <div class="card" style="margin-top:16px">
     <h2>Bots activos</h2>
@@ -170,7 +169,7 @@ const api = (path) => `${location.origin}${path}`;
   async function loadStrategyParams(name){
     const container=document.getElementById('bot-strategy-params');
     container.innerHTML='';
-    const card=document.getElementById('bot-params-section');
+    const card=document.getElementById('bot-param-card');
     card.style.display='none';
     const toggle=document.getElementById('bot-toggle-params');
     toggle.checked=false;
@@ -376,7 +375,7 @@ document.getElementById('bot-start').addEventListener('click', startBot);
 document.getElementById('bot-strategy').addEventListener('change', updateForm);
 document.getElementById('bot-market').addEventListener('change', updateMarketFields);
 document.getElementById('bot-toggle-params').addEventListener('change', e => {
-  document.getElementById('bot-params-section').style.display = e.target.checked ? 'block' : 'none';
+  document.getElementById('bot-param-card').style.display = e.target.checked ? 'block' : 'none';
 });
 loadStrategies();
 updateMarketFields();


### PR DESCRIPTION
## Summary
- Replace bot parameter section with backtest-style param card
- Update JavaScript bindings to toggle the new param card container

## Testing
- `pytest tests/test_adapter_base.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2369535b0832da88f53fc5c3089d0