### PR TITLE
feat: add config path support to scalp pingpong

### DIFF
--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-from .base import Strategy, Signal, record_signal_metrics
+from .base import Strategy, Signal, load_params, record_signal_metrics
 
 
 PARAM_INFO = {
@@ -16,6 +16,7 @@ PARAM_INFO = {
     "max_hold_bars": "Barras máximas en posición",
     "trailing_stop_bps": "Trailing stop en puntos básicos",
     "volatility_factor": "Factor de tamaño según volatilidad",
+    "config_path": "Ruta opcional al archivo de configuración",
 }
 
 
@@ -61,8 +62,15 @@ class ScalpPingPong(Strategy):
 
     name = "scalp_pingpong"
 
-    def __init__(self, cfg: ScalpPingPongConfig | None = None, **kwargs):
-        self.cfg = cfg or ScalpPingPongConfig(**kwargs)
+    def __init__(
+        self,
+        cfg: ScalpPingPongConfig | None = None,
+        *,
+        config_path: str | None = None,
+        **kwargs,
+    ):
+        params = {**load_params(config_path), **kwargs}
+        self.cfg = cfg or ScalpPingPongConfig(**params)
         self.pos_side: int = 0  # 0 flat, +1 long, -1 short
         self.entry_price: float | None = None
         self.hold_bars: int = 0

--- a/tests/test_scalp_pingpong.py
+++ b/tests/test_scalp_pingpong.py
@@ -1,0 +1,14 @@
+import yaml
+from tradingbot.strategies.scalp_pingpong import ScalpPingPong
+
+
+def test_config_path_overrides(tmp_path):
+    data = {"lookback": 25, "z_threshold": 0.3, "trailing_stop_bps": 7.0}
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(yaml.safe_dump(data))
+
+    strat = ScalpPingPong(config_path=str(cfg_file))
+
+    assert strat.cfg.lookback == 25
+    assert strat.cfg.z_threshold == 0.3
+    assert strat.cfg.trailing_stop_bps == 7.0


### PR DESCRIPTION
## Summary
- allow ScalpPingPong strategy to load parameters from optional YAML file
- test config file overrides for ScalpPingPong

## Testing
- `pytest tests/test_scalp_pingpong.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b239026208832d9d17857c9fadd219