### PR TITLE
feat: allow triple barrier params via config file

### DIFF
--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -2,7 +2,7 @@ import pandas as pd
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.base import ClassifierMixin
 
-from .base import Strategy, Signal, record_signal_metrics
+from .base import Strategy, Signal, record_signal_metrics, load_params
 
 
 PARAM_INFO = {
@@ -14,6 +14,7 @@ PARAM_INFO = {
     "tp_bps": "Take profit en puntos básicos",
     "sl_bps": "Stop loss en puntos básicos",
     "max_hold_bars": "Barras máximas en posición",
+    "config_path": "Ruta opcional al archivo de configuración",
 }
 
 
@@ -115,7 +116,19 @@ class TripleBarrier(Strategy):
         tp_bps: float = 10.0,
         sl_bps: float = 15.0,
         max_hold_bars: int = 10,
+        *,
+        config_path: str | None = None,
     ) -> None:
+        params = load_params(config_path)
+        horizon = params.get("horizon", horizon)
+        upper_pct = params.get("upper_pct", upper_pct)
+        lower_pct = params.get("lower_pct", lower_pct)
+        training_window = params.get("training_window", training_window)
+        meta_model = params.get("meta_model", meta_model)
+        tp_bps = params.get("tp_bps", tp_bps)
+        sl_bps = params.get("sl_bps", sl_bps)
+        max_hold_bars = params.get("max_hold_bars", max_hold_bars)
+
         self.horizon = int(horizon)
         self.upper_pct = float(upper_pct)
         self.lower_pct = float(lower_pct)

--- a/tests/test_triple_barrier.py
+++ b/tests/test_triple_barrier.py
@@ -44,7 +44,7 @@ def test_triple_barrier_meta_filtering():
 
     signal = None
     for i in range(len(prices)):
-        signal = strat.on_bar({"window": prices.iloc[: i + 1]})
+        signal = strat.on_bar({"window": prices.iloc[: i + 1], "volatility": 0})
     assert meta_model.fit_called
     assert signal is None
 
@@ -57,7 +57,7 @@ def test_triple_barrier_meta_filtering():
     strat2.model = primary_model2
     signal = None
     for i in range(len(prices)):
-        signal = strat2.on_bar({"window": prices.iloc[: i + 1]})
+        signal = strat2.on_bar({"window": prices.iloc[: i + 1], "volatility": 0})
         if signal is not None:
             break
     assert signal is not None
@@ -81,6 +81,30 @@ def test_triple_barrier_scalping_exit():
     strat.model = primary_model
     signals = []
     for i in range(len(prices)):
-        signals.append(strat.on_bar({"window": prices.iloc[: i + 1]}))
+        signals.append(strat.on_bar({"window": prices.iloc[: i + 1], "volatility": 0}))
     assert signals[2] is not None and signals[2].side == "buy"
     assert signals[3] is not None and signals[3].side == "sell"
+
+
+def test_triple_barrier_loads_config(tmp_path):
+    cfg = tmp_path / "tb.yaml"
+    cfg.write_text(
+        """
+horizon: 3
+upper_pct: 0.05
+lower_pct: 0.01
+training_window: 50
+tp_bps: 20.0
+sl_bps: 30.0
+max_hold_bars: 7
+"""
+    )
+    strat = TripleBarrier(config_path=str(cfg))
+    assert strat.horizon == 3
+    assert strat.upper_pct == 0.05
+    assert strat.lower_pct == 0.01
+    assert strat.training_window == 50
+    assert strat.tp_bps == 20.0
+    assert strat.sl_bps == 30.0
+    assert strat.max_hold_bars == 7
+


### PR DESCRIPTION
## Summary
- allow TripleBarrier strategy to load parameters from optional YAML config
- expand parameter info to document config_path option
- test config override and update existing tests for liquidity filter

## Testing
- `python -m pytest tests/test_triple_barrier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2386b1ed4832db194fa846d61e259