### PR TITLE
Improve strategy parameter loading

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -179,7 +179,11 @@ const api = (path) => `${location.origin}${path}`;
       const r=await fetch(api(`/strategies/${name}/schema`));
       const j=await r.json();
       const params=j.params||[];
-      field.style.display=params.length ? '' : 'none';
+      if(!params.length){
+        document.getElementById('bot-output').textContent='No se pudieron cargar los parámetros';
+        return;
+      }
+      field.style.display='';
       params.forEach(p=>{
         const div=document.createElement('div');
         const label=document.createElement('label');
@@ -211,7 +215,8 @@ const api = (path) => `${location.origin}${path}`;
         container.appendChild(div);
       });
     }catch(e){
-      field.style.display='none';
+      document.getElementById('bot-output').textContent=String(e);
+      field.style.display='';
     }
   }
 

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -25,6 +25,20 @@ except Exception:  # pragma: no cover - Timescale optional
 
 log = logging.getLogger(__name__)
 
+# Descriptions used by ``/strategies/{name}/schema`` to expose configurable
+# parameters of :class:`CrossArbConfig` in the API/front-end.  Each key must
+# match a field defined on the dataclass below so the schema can surface it.
+PARAM_INFO: dict[str, str] = {
+    "symbol": "Par a arbitrar, por ejemplo 'BTC/USDT'",
+    "spot": "Conector para el mercado spot",
+    "perp": "Conector para el mercado perp",
+    "threshold": "Umbral de premium como decimal",
+    "persist_pg": "Persistir señales y fills en TimescaleDB",
+    "rebalance_assets": "Activos a rebalancear periódicamente",
+    "rebalance_threshold": "Desequilibrio mínimo para rebalancear",
+    "latency": "Latencia simulada antes de enviar órdenes (s)",
+}
+
 
 @dataclass
 class CrossArbConfig:


### PR DESCRIPTION
## Summary
- Show schema load failures in bot output without hiding the parameter toggle
- Warn when a strategy returns no parameters
- Document cross arbitrage config parameters with `PARAM_INFO`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b23bf9b480832d92f56515c009079c