### PR TITLE
Fix backtest CLI config_path handling

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1040,7 +1040,10 @@ def backtest(
     strat_cls = STRATEGIES.get(strategy)
     if strat_cls is None:
         raise typer.BadParameter(f"unknown strategy: {strategy}")
-    strat = strat_cls(config_path=config, **params) if (config or params) else strat_cls()
+    kwargs = dict(params)
+    if config is not None:
+        kwargs["config_path"] = config
+    strat = strat_cls(**kwargs)
     eng.strategies[(strategy, symbol)] = strat
     result = eng.run(fills_csv=fills_csv)
     typer.echo(result)
@@ -1248,7 +1251,10 @@ def backtest_db(
         strat_cls = STRATEGIES.get(strategy)
         if strat_cls is None:
             raise typer.BadParameter(f"unknown strategy: {strategy}")
-        strat = strat_cls(config_path=config, **params) if (config or params) else strat_cls()
+        kwargs = dict(params)
+        if config is not None:
+            kwargs["config_path"] = config
+        strat = strat_cls(**kwargs)
         eng.strategies[(strategy, symbol)] = strat
         result = eng.run(fills_csv=fills_csv)
         typer.echo(result)

--- a/tests/test_cli_backtest_param_config.py
+++ b/tests/test_cli_backtest_param_config.py
@@ -1,0 +1,40 @@
+def test_backtest_param_config_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("TRADINGBOT_SKIP_NTP_CHECK", "1")
+    from tradingbot.cli import main as cli_main
+    from tradingbot.backtest import event_engine as ev_module
+    from tradingbot import strategies as strat_module
+
+    datafile = tmp_path / "data.csv"
+    datafile.write_text("ts,o,h,l,c,v\n0,1,1,1,1,1\n")
+    cfgfile = tmp_path / "cfg.yaml"
+    cfgfile.write_text("{}")
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            self.strategies = {}
+        def run(self, fills_csv=None):
+            return {}
+
+    monkeypatch.setattr(ev_module, "EventDrivenBacktestEngine", DummyEngine)
+    monkeypatch.setattr(cli_main, "generate_report", lambda result: "")
+
+    captured = {}
+
+    class DummyStrategy:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+        def on_bar(self, bar):
+            pass
+
+    monkeypatch.setitem(strat_module.STRATEGIES, "dummy", DummyStrategy)
+
+    cli_main.backtest(
+        data=str(datafile),
+        symbol="BTC/USDT",
+        strategy="dummy",
+        config=None,
+        param=[f"config_path={cfgfile}"]
+    )
+
+    assert captured["config_path"] == str(cfgfile)
+


### PR DESCRIPTION
## Summary
- avoid passing duplicate config_path to strategies when --config is omitted
- cover config_path override via CLI parameters

## Testing
- `pytest tests/test_cli_backtest_param_config.py::test_backtest_param_config_path -q`


------
https://chatgpt.com/codex/tasks/task_e_68b23cbcc360832d9d63f7fe014837b0