### PR TITLE
Hide config_path from strategy parameter panel

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -228,10 +228,18 @@ const dataInfo = {
 async function loadStrategyParams(name){
   const container=document.getElementById('bt-strategy-params');
   container.innerHTML='';
+  const card=document.getElementById('bt-param-card');
+  card.style.display='none';
+  const toggle=document.getElementById('bt-toggle-params');
+  toggle.checked=false;
+  const field=document.getElementById('field-toggle-params');
+  field.style.display='none';
   try{
     const r=await fetch(api(`/strategies/${name}/schema`));
     const j=await r.json();
-    (j.params||[]).forEach(p=>{
+    const params=(j.params||[]).filter(p=>p.name!=='config_path');
+    field.style.display=params.length?'':'none';
+    params.forEach(p=>{
       const div=document.createElement('div');
       const label=document.createElement('label');
       label.htmlFor=`bt-param-${p.name}`;

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -178,12 +178,12 @@ const api = (path) => `${location.origin}${path}`;
     try{
       const r=await fetch(api(`/strategies/${name}/schema`));
       const j=await r.json();
-      const params=j.params||[];
+      const params=(j.params||[]).filter(p=>p.name!=='config_path');
+      field.style.display=params.length?'':'none';
       if(!params.length){
         document.getElementById('bot-output').textContent='No se pudieron cargar los parámetros';
         return;
       }
-      field.style.display='';
       params.forEach(p=>{
         const div=document.createElement('div');
         const label=document.createElement('label');
@@ -216,7 +216,6 @@ const api = (path) => `${location.origin}${path}`;
       });
     }catch(e){
       document.getElementById('bot-output').textContent=String(e);
-      field.style.display='';
     }
   }
 


### PR DESCRIPTION
## Summary
- filter out config_path when loading strategy params in backtest and bot pages
- hide the parameter toggle if no other params remain

## Testing
- `node -e "const {JSDOM}=require('jsdom');const dom=new JSDOM('<div id=\"params\"></div><div id=\"field-toggle-params\"></div>');const document=dom.window.document;const container=document.getElementById('params');const field=document.getElementById('field-toggle-params');const j={params:[{name:'a'},{name:'config_path'},{name:'b'}]};const params=(j.params||[]).filter(p=>p.name!=='config_path');field.style.display=params.length?'':'none';params.forEach(p=>{const div=document.createElement('div');div.id=p.name;container.appendChild(div);});console.log('params',Array.from(container.children).map(c=>c.id));console.log('toggle',field.style.display);"`
- `node -e "const {JSDOM}=require('jsdom');const dom=new JSDOM('<div id=\"params\"></div><div id=\"field-toggle-params\"></div>');const document=dom.window.document;const container=document.getElementById('params');const field=document.getElementById('field-toggle-params');const j={params:[{name:'config_path'}]};const params=(j.params||[]).filter(p=>p.name!=='config_path');field.style.display=params.length?'':'none';params.forEach(p=>{const div=document.createElement('div');div.id=p.name;container.appendChild(div);});console.log('params',Array.from(container.children).map(c=>c.id));console.log('toggle',field.style.display);"`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b242aa4590832db2632c29a862c971