### PR TITLE
Ensure minimum trade spacing and hold ranges

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -12,7 +12,7 @@ local basado en `notional * risk_pct`.
 Compra cuando el precio supera el canal superior calculado con el indicador
 ATR y vende cuando cae por debajo del canal inferior. El parámetro
 `min_bars_between_trades` limita la emisión de señales opuestas hasta que
-transcurra un mínimo de velas.
+transcurra un mínimo de 5 velas.
 
 ### Breakout por Volumen (`breakout_vol`)
 Detecta rupturas de precio acompañadas de incrementos de volumen.

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -8,7 +8,8 @@ strategies:
   default: breakout_atr
   params:
     breakout_atr:
-      min_bars_between_trades: 1
+      min_bars_between_trades: 5
+      max_hold_bars: 5
       min_edge_bps: 0.0
     mean_rev_ofi:
       ofi_window: 20

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -8,10 +8,10 @@ PARAM_INFO = {
     "ema_n": "Periodo de la EMA para la línea central",
     "atr_n": "Periodo del ATR usado en los canales",
     "mult": "Multiplicador aplicado al ATR",
-    "min_bars_between_trades": "Barras mínimas entre operaciones",
+    "min_bars_between_trades": "Barras mínimas entre operaciones (min 5)",
     "tp_bps": "Take profit en puntos básicos",
     "sl_bps": "Stop loss en puntos básicos",
-    "max_hold_bars": "Máximo de barras en posición",
+    "max_hold_bars": "Máximo de barras en posición (5-10)",
     "min_atr": "ATR mínimo para operar",
     "trail_atr_mult": "Multiplicador del trailing stop basado en ATR",
     "min_edge_bps": "Edge mínimo en puntos básicos para operar",
@@ -26,10 +26,10 @@ class BreakoutATR(Strategy):
         ema_n: int = 20,
         atr_n: int = 14,
         mult: float = 1.0,
-        min_bars_between_trades: int = 1,
+        min_bars_between_trades: int = 5,
         tp_bps: float = 5.0,
         sl_bps: float = 5.0,
-        max_hold_bars: int = 3,
+        max_hold_bars: int = 5,
         min_atr: float = 0.0,
         trail_atr_mult: float = 1.0,
         min_edge_bps: float = 0.0,
@@ -41,12 +41,15 @@ class BreakoutATR(Strategy):
         self.atr_n = int(params.get("atr_n", atr_n))
         self.mult = float(params.get("mult", mult))
         mbbt = params.get("min_bars_between_trades", min_bars_between_trades)
-        self.min_bars_between_trades = max(int(mbbt), 1)
+        # min_bars_between_trades clamped to a minimum of 5
+        self.min_bars_between_trades = max(int(mbbt), 5)
         self._last_trade_idx: int | None = None
         self._last_trade_side: str | None = None
         self.tp_bps = float(params.get("tp_bps", tp_bps))
         self.sl_bps = float(params.get("sl_bps", sl_bps))
-        self.max_hold_bars = int(params.get("max_hold_bars", max_hold_bars))
+        mhb = params.get("max_hold_bars", max_hold_bars)
+        # max_hold_bars clamped to the range [5, 10]
+        self.max_hold_bars = max(5, min(int(mhb), 10))
         self.min_atr = float(params.get("min_atr", min_atr))
         self.trail_atr_mult = float(params.get("trail_atr_mult", trail_atr_mult))
         self.min_edge_bps = float(params.get("min_edge_bps", min_edge_bps))

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -13,7 +13,7 @@ PARAM_INFO = {
     "exit_z": "Z-score para cerrar la posición",
     "tp_bps": "Take profit en puntos básicos",
     "sl_bps": "Stop loss en puntos básicos",
-    "max_hold_bars": "Barras máximas en posición",
+    "max_hold_bars": "Barras máximas en posición (5-10)",
     "trailing_stop_bps": "Trailing stop en puntos básicos",
     "volatility_factor": "Factor de tamaño según volatilidad",
     "config_path": "Ruta opcional al archivo de configuración",
@@ -38,7 +38,8 @@ class ScalpPingPongConfig:
     sl_bps : float, optional
         Stop loss in basis points, by default ``15``.
     max_hold_bars : int, optional
-        Maximum number of bars to hold a trade, by default ``8``.
+        Maximum number of bars to hold a trade, by default ``8`` (clamped to
+        the range ``5``–``10``).
     trailing_stop_bps : float, optional
         Distance from the best price in basis points to trigger a trailing stop,
         default ``10``.
@@ -55,6 +56,10 @@ class ScalpPingPongConfig:
     max_hold_bars: int = 8
     trailing_stop_bps: float | None = 10.0
     volatility_factor: float = 0.02
+
+    def __post_init__(self) -> None:
+        # Ensure max_hold_bars stays within [5, 10]
+        self.max_hold_bars = max(5, min(self.max_hold_bars, 10))
 
 
 class ScalpPingPong(Strategy):


### PR DESCRIPTION
## Summary
- Require at least 5 bars between BreakoutATR trades and cap its holding period to 5–10 bars
- Clamp ScalpPingPong max_hold_bars to the range 5–10
- Update docs and example config with new defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b24be9ca68832d942eb1bc62e9e1ce