### PR TITLE
Add fee and slippage basis point options to backtests

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -85,6 +85,14 @@
         <label for="bt-risk-pct">Risk %</label>
         <input id="bt-risk-pct" type="number" step="any"/>
       </div>
+      <div id="field-fee-bps">
+        <label for="bt-fee-bps">Comisión (bps)</label>
+        <input id="bt-fee-bps" type="number" step="any" placeholder="5"/>
+      </div>
+      <div id="field-slippage-bps">
+        <label for="bt-slippage-bps">Slippage (bps)</label>
+        <input id="bt-slippage-bps" type="number" step="any" placeholder="1"/>
+      </div>
       <div id="field-verbose-fills">
   <span>Exportar fills (CSV)</span>
   <label class="switch">
@@ -365,7 +373,7 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   const showRisk = mode!=='walk';
-  ['field-risk-pct'].forEach(id=>{
+  ['field-risk-pct','field-fee-bps','field-slippage-bps'].forEach(id=>{
     document.getElementById(id).style.display=showRisk?'':'none';
   });
   document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'':'none';
@@ -424,6 +432,10 @@ async function runBacktest(){
   if(mode!=='walk'){
     const sl=document.getElementById('bt-risk-pct').value.trim();
     if(sl) cmd+=` --risk-pct ${sl}`;
+    const fee=document.getElementById('bt-fee-bps').value.trim();
+    if(fee) cmd+=` --fee-bps ${fee}`;
+    const sb=document.getElementById('bt-slippage-bps').value.trim();
+    if(sb) cmd+=` --slippage-bps ${sb}`;
   }
   const stratCfg=document.getElementById('bt-strategy-config').value.trim();
   if(stratCfg) cmd+=` --config ${stratCfg}`;

--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -43,6 +43,8 @@ def walk_forward_backtest(
     window: int = 120,
     verbose_fills: bool = False,
     fills_csv: str | None = None,
+    fee_bps: float = 5.0,
+    slippage_bps: float = 1.0,
     exchange_configs: Dict[str, Dict[str, float]] | None = None,
     min_fill_qty: float = MIN_FILL_QTY,
     slippage: SlippageModel | None = None,
@@ -76,6 +78,8 @@ def walk_forward_backtest(
                 exchange_configs=exchange_configs,
                 min_fill_qty=min_fill_qty,
                 slippage=slippage,
+                fee_bps=fee_bps,
+                slippage_bps=slippage_bps,
             )
             engine.strategies[(strategy_name, symbol)] = strat
             res = engine.run()
@@ -94,6 +98,8 @@ def walk_forward_backtest(
             exchange_configs=exchange_configs,
             min_fill_qty=min_fill_qty,
             slippage=slippage,
+            fee_bps=fee_bps,
+            slippage_bps=slippage_bps,
         )
         engine.strategies[(strategy_name, symbol)] = strat
         test_res = engine.run(fills_csv=fills_csv)

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -990,6 +990,8 @@ def backtest(
         callback=_parse_risk_pct,
         help="Risk stop loss % (0-1 or 0-100)",
     ),
+    fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
+    slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -1033,6 +1035,8 @@ def backtest(
         exchange_configs=exchange_cfg,
         min_fill_qty=min_fill_qty,
         slippage=slippage,
+        fee_bps=fee_bps,
+        slippage_bps=slippage_bps,
     )
     params = _parse_params(param) if isinstance(param, list) else {}
     from ..strategies import STRATEGIES
@@ -1061,6 +1065,8 @@ def backtest_cfg(
         callback=_parse_risk_pct,
         help="Risk stop loss % (0-1 or 0-100)",
     ),
+    fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
+    slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -1122,6 +1128,8 @@ def backtest_cfg(
             exchange_configs=exchange_cfg,
             min_fill_qty=min_fill_qty,
             slippage=slippage,
+            fee_bps=fee_bps,
+            slippage_bps=slippage_bps,
         )
         result = eng.run(fills_csv=fills_csv)
         typer.echo(OmegaConf.to_yaml(cfg))
@@ -1163,6 +1171,8 @@ def backtest_db(
         callback=_parse_risk_pct,
         help="Risk stop loss % (0-1 or 0-100)",
     ),
+    fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
+    slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -1242,6 +1252,8 @@ def backtest_db(
             exchange_configs=exchange_cfg,
             min_fill_qty=min_fill_qty,
             slippage=slippage,
+            fee_bps=fee_bps,
+            slippage_bps=slippage_bps,
         )
         params = _parse_params(param) if isinstance(param, list) else {}
         if not isinstance(config, str):
@@ -1268,6 +1280,8 @@ def backtest_db(
 @app.command("walk-forward")
 def walk_forward_cfg(
     config: str,
+    fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
+    slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -1318,6 +1332,8 @@ def walk_forward_cfg(
             window=getattr(wf_cfg, "window", 120),
             verbose_fills=verbose_fills,
             fills_csv=fills_csv,
+            fee_bps=fee_bps,
+            slippage_bps=slippage_bps,
             exchange_configs=exchange_cfg,
             min_fill_qty=min_fill_qty,
             slippage=slippage,

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -24,9 +24,10 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
         [("alwaysbuy", sym)],
         latency=1,
         window=1,
-        slippage=SlippageModel(volume_impact=0.0),
+        slippage=SlippageModel(volume_impact=0.0, pct=0.0),
         initial_equity=df["close"].iloc[0],
         exchange_configs={"default": {"market_type": "spot"}},
+        slippage_bps=0.0,
     )
     risk = engine.risk[("alwaysbuy", sym)]
     engine.verbose_fills = True
@@ -67,5 +68,5 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
     final_price = df["close"].iloc[-1]
     expected_equity = cash + base * final_price
     assert result["equity"] == pytest.approx(expected_equity)
-    assert result["equity"] == pytest.approx(103.97112767590798)
-    assert result["pnl"] == pytest.approx(3.4711276759079794)
+    assert result["equity"] == pytest.approx(104.02308726847399)
+    assert result["pnl"] == pytest.approx(3.5230872684739865)


### PR DESCRIPTION
## Summary
- allow configuring global fee_bps and slippage_bps in EventDrivenBacktestEngine
- add pct-based slippage to SlippageModel
- expose fee and slippage inputs in backtest UI and CLI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b24beddf48832d9f38926691e96922