### PR TITLE
Add minimum volatility filter to strategies

### DIFF
--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -5,8 +5,8 @@ def test_mean_reversion_on_bar_signals():
     df_down = pd.DataFrame({"close": list(range(20, 0, -1))})
     df_up = pd.DataFrame({"close": list(range(1, 21))})
     strat = MeanReversion(rsi_n=5, upper=70, lower=30)
-    sig_buy = strat.on_bar({"window": df_down})
-    sig_sell = strat.on_bar({"window": df_up})
+    sig_buy = strat.on_bar({"window": df_down, "volatility": 0.0})
+    sig_sell = strat.on_bar({"window": df_up, "volatility": 0.0})
     assert sig_buy.side == "buy"
     assert sig_sell.side == "sell"
 


### PR DESCRIPTION
## Summary
- add `min_volatility` parameter to breakout_atr, breakout_vol, mean_reversion, mean_rev_ofi, order_flow and scalp_pingpong
- skip trading signals when recent ATR or return volatility is below threshold
- document new parameter and update mean reversion test

## Testing
- `pytest tests/test_strategies.py tests/test_mean_reversion.py tests/test_scalp_pingpong.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24ff2ee58832db0188aa9c5a886da