### PR TITLE
Gestionar posiciones abiertas antes de generar nuevas señales

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -62,50 +62,8 @@ class BreakoutVol(Strategy):
         self.favorable_price: float | None = None
         self.hold_bars: int = 0
 
-    @record_signal_metrics
-    def on_bar(self, bar: dict) -> Signal | None:
-        df: pd.DataFrame = bar["window"]
-        if len(df) < self.lookback + 1:
-            return None
-        closes = df["close"]
-        mean = closes.rolling(self.lookback).mean().iloc[-1]
-        std = closes.rolling(self.lookback).std().iloc[-1]
-        last = closes.iloc[-1]
-        upper = mean + self.mult * std
-        lower = mean - self.mult * std
-
-        returns = closes.pct_change().dropna()
-        vol = (
-            returns.rolling(self.lookback).std().iloc[-1]
-            if len(returns) >= self.lookback
-            else 0.0
-        )
-        vol_bps = vol * 10000
-        if vol_bps < self.min_volatility:
-            return None
-        size = max(0.0, min(1.0, vol_bps * self.volatility_factor))
-
-        if self.pos_side == 0:
-            if last > upper:
-                expected_edge_bps = (last - upper) / abs(last) * 10000
-                if expected_edge_bps <= self.min_edge_bps:
-                    return None
-                self.pos_side = 1
-                self.entry_price = last
-                self.favorable_price = last
-                self.hold_bars = 0
-                return Signal("buy", size, expected_edge_bps=expected_edge_bps)
-            if last < lower:
-                expected_edge_bps = (lower - last) / abs(last) * 10000
-                if expected_edge_bps <= self.min_edge_bps:
-                    return None
-                self.pos_side = -1
-                self.entry_price = last
-                self.favorable_price = last
-                self.hold_bars = 0
-                return Signal("sell", size, expected_edge_bps=expected_edge_bps)
-            return None
-
+    def _manage_position(self, last: float) -> Signal | None:
+        """Handle an open position and return an exit signal if needed."""
         self.hold_bars += 1
         assert self.entry_price is not None and self.favorable_price is not None
         if self.pos_side > 0:
@@ -113,10 +71,17 @@ class BreakoutVol(Strategy):
         else:
             self.favorable_price = min(self.favorable_price, last)
 
-        pnl_bps = (last - self.entry_price) / self.entry_price * 10000 * self.pos_side
+        pnl_bps = (
+            (last - self.entry_price) / self.entry_price * 10000 * self.pos_side
+        )
         trail_hit = False
         if self.trailing_stop_bps is not None:
-            best_pnl = (last - self.favorable_price) / self.favorable_price * 10000 * self.pos_side
+            best_pnl = (
+                (last - self.favorable_price)
+                / self.favorable_price
+                * 10000
+                * self.pos_side
+            )
             trail_hit = best_pnl <= -self.trailing_stop_bps
         if (
             pnl_bps >= self.tp_bps
@@ -130,4 +95,49 @@ class BreakoutVol(Strategy):
             self.favorable_price = None
             self.hold_bars = 0
             return Signal(side, 1.0)
+        return None
+
+    @record_signal_metrics
+    def on_bar(self, bar: dict) -> Signal | None:
+        df: pd.DataFrame = bar["window"]
+        if len(df) < self.lookback + 1:
+            return None
+        closes = df["close"]
+        mean = closes.rolling(self.lookback).mean().iloc[-1]
+        std = closes.rolling(self.lookback).std().iloc[-1]
+        last = closes.iloc[-1]
+        upper = mean + self.mult * std
+        lower = mean - self.mult * std
+
+        returns = closes.pct_change().dropna()
+        if self.pos_side != 0:
+            return self._manage_position(last)
+        vol = (
+            returns.rolling(self.lookback).std().iloc[-1]
+            if len(returns) >= self.lookback
+            else 0.0
+        )
+        vol_bps = vol * 10000
+        if vol_bps < self.min_volatility:
+            return None
+        size = max(0.0, min(1.0, vol_bps * self.volatility_factor))
+
+        if last > upper:
+            expected_edge_bps = (last - upper) / abs(last) * 10000
+            if expected_edge_bps <= self.min_edge_bps:
+                return None
+            self.pos_side = 1
+            self.entry_price = last
+            self.favorable_price = last
+            self.hold_bars = 0
+            return Signal("buy", size, expected_edge_bps=expected_edge_bps)
+        if last < lower:
+            expected_edge_bps = (lower - last) / abs(last) * 10000
+            if expected_edge_bps <= self.min_edge_bps:
+                return None
+            self.pos_side = -1
+            self.entry_price = last
+            self.favorable_price = last
+            self.hold_bars = 0
+            return Signal("sell", size, expected_edge_bps=expected_edge_bps)
         return None


### PR DESCRIPTION
## Summary
- Gestiona posiciones existentes al inicio de `on_bar` en estrategias de breakout, momentum, mean reversion y trend following
- Añade métodos `_manage_position` para centralizar la lógica de salida

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b25357f904832dae944a632c145bef