### PR TITLE
Add account tracking for adapters and runners

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -10,6 +10,7 @@ import json
 import websockets
 
 from ..core.symbols import normalize as normalize_symbol
+from ..core.account import Account
 from ..utils.metrics import WS_FAILURES, WS_RECONNECTS
 
 
@@ -37,6 +38,8 @@ class ExchangeAdapter(ABC):
         self.log = logging.getLogger(getattr(self, "name", self.__class__.__name__))
         # live market data populated by streaming helpers
         self.state = AdapterState()
+        # basic account information for the adapter
+        self.account = Account(float("inf"))
         self.ping_interval = 20.0
         self._fee_task: asyncio.Task | None = None
 

--- a/src/tradingbot/core/__init__.py
+++ b/src/tradingbot/core/__init__.py
@@ -1,4 +1,5 @@
 """Core utilities for tradingbot."""
 from .symbols import normalize
+from .account import Account
 
-__all__ = ["normalize"]
+__all__ = ["normalize", "Account"]

--- a/src/tradingbot/core/account.py
+++ b/src/tradingbot/core/account.py
@@ -1,0 +1,61 @@
+"""Basic account state tracking cash and positions.
+
+This module introduces the :class:`Account` class which keeps a lightweight
+record of cash balances and open positions for a trading venue.  It exposes a
+couple of helper methods used across runners and adapters to query the available
+cash and the current exposure for a given symbol.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Account:
+    """Container for balances and positions.
+
+    Parameters
+    ----------
+    max_symbol_exposure:
+        Maximum notional exposure allowed per symbol.  This limit is stored but
+        enforcement is left to higher level components.
+    cash:
+        Optional starting cash balance.
+    """
+
+    max_symbol_exposure: float
+    cash: float = 0.0
+    positions: Dict[str, float] = field(default_factory=dict)
+    prices: Dict[str, float] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    def update_cash(self, delta: float) -> None:
+        """Adjust available cash by ``delta``."""
+        self.cash += float(delta)
+
+    def update_position(self, symbol: str, delta_qty: float, price: float | None = None) -> None:
+        """Update net position for ``symbol`` and optionally its last price."""
+        self.positions[symbol] = self.positions.get(symbol, 0.0) + float(delta_qty)
+        if price is not None:
+            self.prices[symbol] = float(price)
+
+    def mark_price(self, symbol: str, price: float) -> None:
+        """Record latest mark price for ``symbol``."""
+        self.prices[symbol] = float(price)
+
+    # ------------------------------------------------------------------
+    def get_available_balance(self) -> float:
+        """Return available cash excluding unrealised PnL."""
+        return float(self.cash)
+
+    def current_exposure(self, symbol: str) -> tuple[float, float]:
+        """Return net quantity and notional exposure for ``symbol``.
+
+        The returned notional is the absolute quantity multiplied by the last
+        marked price for the symbol.  If the symbol has not been priced yet the
+        notional defaults to ``0.0``.
+        """
+        qty = float(self.positions.get(symbol, 0.0))
+        price = float(self.prices.get(symbol, 0.0))
+        return qty, abs(qty) * price


### PR DESCRIPTION
## Summary
- add `Account` class for basic cash and position tracking
- initialize an `Account` in every adapter and update paper fills
- allow cross-exchange runner to derive equity from seeded balances

## Testing
- `pytest tests/test_adapter_base.py::test_normalize_helpers -q`
- `pytest tests/test_cross_exchange_runner.py::test_cross_exchange_runner_persists_and_executes -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32d403858832db955dfde3be892cd