### PR TITLE
Integrate core risk manager and delegate position handling

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -422,6 +422,19 @@ class EventDrivenBacktestEngine:
                 for svc in self.risk.values():
                     svc.update_correlation(corr_df, 0.8)
                     svc.update_covariance(cov_df, 0.8)
+            for (strat, sym), svc in self.risk.items():
+                arrs = data_arrays[sym]
+                sym_len = data_lengths[sym]
+                if i < sym_len:
+                    price = float(arrs["close"][i])
+                    pos_qty = svc.rm.pos.qty
+                    if abs(pos_qty) > self.min_order_qty:
+                        trade = {
+                            "side": "buy" if pos_qty > 0 else "sell",
+                            "current_price": price,
+                            "stop": getattr(svc.rm, "_entry_price", None),
+                        }
+                        svc.manage_position(trade)
             # Execute queued orders for this index
             while order_queue and order_queue[0].execute_index <= i:
                 order = heapq.heappop(order_queue)


### PR DESCRIPTION
## Summary
- Instantiate core RiskManager inside RiskService and expose helpers for sizing, exposure checks and trailing updates
- Use manage_position in live and paper runners, dropping legacy TP/SL hooks
- Invoke manage_position per bar in backtesting engine for position supervision

## Testing
- `pytest` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b3339bae54832d9edac9ebb4fbc049