### PR TITLE
Propagate signal strength to risk sizing

### DIFF
--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -474,12 +474,12 @@ class TradeBotDaemon:
     # ------------------------------------------------------------------
     async def _on_signal(self, evt: dict) -> None:
         """Size and route signals coming from strategies."""
-        signal = evt.get("signal")
+        signal = evt["signal"]
         trade = evt.get("trade")
         symbol = getattr(trade, "symbol", None)
         price = getattr(trade, "price", None)
-        side = getattr(signal, "side", "")
-        strength = getattr(signal, "strength", 1.0)
+        side = signal.side
+        strength = signal.strength
         symbol_vol = 0.0
         if symbol and price is not None:
             hist = self.price_history[symbol]

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -41,9 +41,7 @@ class Strategy(ABC):
     # ------------------------------------------------------------------
     def _edge_still_exists(self, order: Order) -> bool:
         last = getattr(self, "_last_signal", {}).get(order.symbol)
-        return bool(
-            last and last.side == order.side and getattr(last, "strength", 0.0) > 0.0
-        )
+        return bool(last and last.side == order.side and last.strength > 0.0)
 
     # ------------------------------------------------------------------
     def on_partial_fill(self, order: Order, res: dict[str, Any]):

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tradingbot.core import Account, RiskManager as CoreRiskManager
+from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+
+
+def test_core_calc_position_size_scales_with_strength():
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_per_trade=0.1)
+    price = 100.0
+    full = rm.calc_position_size(1.0, price)
+    partial = rm.calc_position_size(0.37, price)
+    assert partial == pytest.approx(full * 0.37)
+
+
+def test_service_calc_position_size_passes_strength():
+    account = Account(float("inf"), cash=1000.0)
+    rm = RiskManager()
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    svc = RiskService(rm, guard, account=account, risk_per_trade=0.1)
+    price = 100.0
+    full = svc.calc_position_size(1.0, price)
+    partial = svc.calc_position_size(0.37, price)
+    assert partial == pytest.approx(full * 0.37)


### PR DESCRIPTION
## Summary
- Ensure strategies and daemon expect `Signal` instances with explicit `strength`
- Verify risk sizing scales linearly with signal strength via new tests
- Exercise runner to confirm strength is forwarded to risk checks

## Testing
- `pytest tests/test_core_position_size.py tests/test_paper_runner.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b337e961e0832d8ca80dc9b0ff7651