### PR TITLE
Refactor strategies risk handling

### DIFF
--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -1,23 +1,17 @@
 import pandas as pd
-
 from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import atr, keltner_channels
-
 
 PARAM_INFO = {
     "ema_n": "Periodo de la EMA para la línea central",
     "atr_n": "Periodo del ATR usado en los canales",
     "mult": "Multiplicador aplicado al ATR",
-    "min_bars_between_trades": "Barras mínimas entre operaciones (min 5)",
-    "tp_bps": "Take profit en puntos básicos",
-    "sl_bps": "Stop loss en puntos básicos",
-    "max_hold_bars": "Máximo de barras en posición (5-10)",
     "min_atr": "ATR mínimo para operar",
     "min_volatility": "Volatilidad mínima reciente en bps",
-    "trail_atr_mult": "Multiplicador del trailing stop basado en ATR",
     "min_edge_bps": "Edge mínimo en puntos básicos para operar",
     "config_path": "Ruta opcional al archivo de configuración",
 }
+
 
 class BreakoutATR(Strategy):
     name = "breakout_atr"
@@ -27,13 +21,8 @@ class BreakoutATR(Strategy):
         ema_n: int = 20,
         atr_n: int = 14,
         mult: float = 1.0,
-        min_bars_between_trades: int = 5,
-        tp_bps: float = 5.0,
-        sl_bps: float = 5.0,
-        max_hold_bars: int = 5,
         min_atr: float = 0.0,
         min_volatility: float = 0.0,
-        trail_atr_mult: float = 1.0,
         min_edge_bps: float = 0.0,
         *,
         config_path: str | None = None,
@@ -42,107 +31,31 @@ class BreakoutATR(Strategy):
         self.ema_n = int(params.get("ema_n", ema_n))
         self.atr_n = int(params.get("atr_n", atr_n))
         self.mult = float(params.get("mult", mult))
-        mbbt = params.get("min_bars_between_trades", min_bars_between_trades)
-        # min_bars_between_trades clamped to a minimum of 5
-        self.min_bars_between_trades = max(int(mbbt), 5)
-        self._last_trade_idx: int | None = None
-        self._last_trade_side: str | None = None
-        self.tp_bps = float(params.get("tp_bps", tp_bps))
-        self.sl_bps = float(params.get("sl_bps", sl_bps))
-        mhb = params.get("max_hold_bars", max_hold_bars)
-        # max_hold_bars clamped to the range [5, 10]
-        self.max_hold_bars = max(5, min(int(mhb), 10))
         self.min_atr = float(params.get("min_atr", min_atr))
         self.min_volatility = float(params.get("min_volatility", min_volatility))
-        self.trail_atr_mult = float(params.get("trail_atr_mult", trail_atr_mult))
         self.min_edge_bps = float(params.get("min_edge_bps", min_edge_bps))
-        self.pos_side: int = 0
-        self.entry_price: float | None = None
-        self.hold_bars: int = 0
-        self.trailing_stop: float | None = None
-
-    def _manage_position(
-        self, last_close: float, atr_val: float, current_idx: int
-    ) -> Signal | None:
-        """Handle an open position and return an exit signal if needed."""
-        self.hold_bars += 1
-        assert self.entry_price is not None and self.trailing_stop is not None
-        pnl_bps = (
-            (last_close - self.entry_price) / self.entry_price * 10000 * self.pos_side
-        )
-        if self.pos_side > 0:
-            self.trailing_stop = max(
-                self.trailing_stop, last_close - atr_val * self.trail_atr_mult
-            )
-            stop_hit = last_close <= self.trailing_stop
-        else:
-            self.trailing_stop = min(
-                self.trailing_stop, last_close + atr_val * self.trail_atr_mult
-            )
-            stop_hit = last_close >= self.trailing_stop
-        if (
-            pnl_bps >= self.tp_bps
-            or pnl_bps <= -self.sl_bps
-            or self.hold_bars >= self.max_hold_bars
-            or stop_hit
-        ):
-            side = "sell" if self.pos_side > 0 else "buy"
-            self.pos_side = 0
-            self.entry_price = None
-            self.hold_bars = 0
-            self.trailing_stop = None
-            self._last_trade_idx = current_idx
-            self._last_trade_side = side
-            return Signal(side, 1.0)
-        return None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
-        # bar should include a small rolling window (as dict of lists)
-        # or a pandas row with context
         df: pd.DataFrame = bar["window"]
-        # expects columns: open, high, low, close, volume
         if len(df) < max(self.ema_n, self.atr_n) + 2:
             return None
         upper, lower = keltner_channels(df, self.ema_n, self.atr_n, self.mult)
         last_close = df["close"].iloc[-1]
-        current_idx = len(df) - 1
         atr_val = atr(df, self.atr_n).iloc[-1]
         atr_bps = atr_val / abs(last_close) * 10000 if last_close else 0.0
 
-        if self.pos_side != 0:
-            return self._manage_position(last_close, atr_val, current_idx)
-
         if atr_val < self.min_atr or atr_bps < self.min_volatility:
             return None
-        side: str | None = None
-        expected_edge_bps = 0.0
-        trail_stop: float | None = None
+
         if last_close > upper.iloc[-1]:
-            expected_edge_bps = (
-                (last_close - upper.iloc[-1]) / abs(last_close) * 10000
-            )
-            side = "buy"
-            trail_stop = last_close - atr_val * self.trail_atr_mult
-        elif last_close < lower.iloc[-1]:
-            expected_edge_bps = (
-                (lower.iloc[-1] - last_close) / abs(last_close) * 10000
-            )
-            side = "sell"
-            trail_stop = last_close + atr_val * self.trail_atr_mult
-        if side is None or expected_edge_bps <= self.min_edge_bps:
-            return None
-        if (
-            self._last_trade_idx is not None
-            and self._last_trade_side is not None
-            and side != self._last_trade_side
-            and current_idx - self._last_trade_idx < self.min_bars_between_trades
-        ):
-            return None
-        self.pos_side = 1 if side == "buy" else -1
-        self.entry_price = last_close
-        self.hold_bars = 0
-        self.trailing_stop = trail_stop
-        self._last_trade_idx = current_idx
-        self._last_trade_side = side
-        return Signal(side, 1.0, expected_edge_bps=expected_edge_bps)
+            expected_edge_bps = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
+            if expected_edge_bps <= self.min_edge_bps:
+                return None
+            return Signal("buy", 1.0, expected_edge_bps=expected_edge_bps)
+        if last_close < lower.iloc[-1]:
+            expected_edge_bps = (lower.iloc[-1] - last_close) / abs(last_close) * 10000
+            if expected_edge_bps <= self.min_edge_bps:
+                return None
+            return Signal("sell", 1.0, expected_edge_bps=expected_edge_bps)
+        return None

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -1,15 +1,9 @@
 import pandas as pd
-
 from .base import Strategy, Signal, record_signal_metrics
-
 
 PARAM_INFO = {
     "lookback": "Ventana para medias y desviación estándar",
     "mult": "Multiplicador aplicado a la desviación",
-    "tp_bps": "Take profit en puntos básicos",
-    "sl_bps": "Stop loss en puntos básicos",
-    "max_hold_bars": "Barras máximas en posición",
-    "trailing_stop_bps": "Distancia del trailing stop en bps",
     "volatility_factor": "Factor para dimensionar según volatilidad",
     "min_edge_bps": "Edge mínimo en puntos básicos para operar",
     "min_volatility": "Volatilidad mínima reciente en bps",
@@ -17,85 +11,16 @@ PARAM_INFO = {
 
 
 class BreakoutVol(Strategy):
-    """Volatility breakout strategy using rolling standard deviation.
-
-    Parameters are supplied via ``**kwargs`` and stored as attributes.  The
-    strategy computes a rolling mean and standard deviation of the close price
-    and generates a ``buy`` signal when price breaks above ``mean + mult *
-    std``.  A ``sell`` signal is produced for a break below ``mean - mult *
-    std``.
-
-    Parameters
-    ----------
-    lookback : int, optional
-        Window size for the rolling statistics, default ``10``.
-    mult : float, optional
-        Multiplier applied to the standard deviation, default ``2``.
-    tp_bps : float, optional
-        Take profit in basis points, default ``10``.
-    sl_bps : float, optional
-        Stop loss in basis points, default ``15``.
-    trailing_stop_bps : float, optional
-        Distance from the best price in basis points to trigger a trailing stop,
-        default ``10``.
-    volatility_factor : float, optional
-        Multiplier applied to recent volatility (in bps) to size positions,
-        default ``0.02``.
-    min_edge_bps : float, optional
-        Edge mínimo en puntos básicos requerido para operar, default ``0``.
-    """
+    """Volatility breakout strategy using rolling standard deviation."""
 
     name = "breakout_vol"
 
     def __init__(self, **kwargs):
         self.lookback = kwargs.get("lookback", 10)
         self.mult = kwargs.get("mult", 1.5)
-        self.tp_bps = kwargs.get("tp_bps", 10.0)
-        self.sl_bps = kwargs.get("sl_bps", 15.0)
-        self.max_hold_bars = kwargs.get("max_hold_bars", 10)
-        self.trailing_stop_bps = kwargs.get("trailing_stop_bps", 10.0)
         self.volatility_factor = kwargs.get("volatility_factor", 0.02)
         self.min_edge_bps = kwargs.get("min_edge_bps", 0.0)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
-        self.pos_side: int = 0
-        self.entry_price: float | None = None
-        self.favorable_price: float | None = None
-        self.hold_bars: int = 0
-
-    def _manage_position(self, last: float) -> Signal | None:
-        """Handle an open position and return an exit signal if needed."""
-        self.hold_bars += 1
-        assert self.entry_price is not None and self.favorable_price is not None
-        if self.pos_side > 0:
-            self.favorable_price = max(self.favorable_price, last)
-        else:
-            self.favorable_price = min(self.favorable_price, last)
-
-        pnl_bps = (
-            (last - self.entry_price) / self.entry_price * 10000 * self.pos_side
-        )
-        trail_hit = False
-        if self.trailing_stop_bps is not None:
-            best_pnl = (
-                (last - self.favorable_price)
-                / self.favorable_price
-                * 10000
-                * self.pos_side
-            )
-            trail_hit = best_pnl <= -self.trailing_stop_bps
-        if (
-            pnl_bps >= self.tp_bps
-            or pnl_bps <= -self.sl_bps
-            or self.hold_bars >= self.max_hold_bars
-            or trail_hit
-        ):
-            side = "sell" if self.pos_side > 0 else "buy"
-            self.pos_side = 0
-            self.entry_price = None
-            self.favorable_price = None
-            self.hold_bars = 0
-            return Signal(side, 1.0)
-        return None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -110,8 +35,6 @@ class BreakoutVol(Strategy):
         lower = mean - self.mult * std
 
         returns = closes.pct_change().dropna()
-        if self.pos_side != 0:
-            return self._manage_position(last)
         vol = (
             returns.rolling(self.lookback).std().iloc[-1]
             if len(returns) >= self.lookback
@@ -126,18 +49,10 @@ class BreakoutVol(Strategy):
             expected_edge_bps = (last - upper) / abs(last) * 10000
             if expected_edge_bps <= self.min_edge_bps:
                 return None
-            self.pos_side = 1
-            self.entry_price = last
-            self.favorable_price = last
-            self.hold_bars = 0
             return Signal("buy", size, expected_edge_bps=expected_edge_bps)
         if last < lower:
             expected_edge_bps = (lower - last) / abs(last) * 10000
             if expected_edge_bps <= self.min_edge_bps:
                 return None
-            self.pos_side = -1
-            self.entry_price = last
-            self.favorable_price = last
-            self.hold_bars = 0
             return Signal("sell", size, expected_edge_bps=expected_edge_bps)
         return None

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -2,54 +2,24 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi
 
-
 PARAM_INFO = {
     "rsi_n": "Ventana para el cálculo del RSI",
     "upper": "Nivel RSI superior para vender",
     "lower": "Nivel RSI inferior para comprar",
-    "tp_bps": "Take profit en puntos básicos",
-    "sl_bps": "Stop loss en puntos básicos",
-    "max_hold_bars": "Barras máximas en posición (rango 5-10)",
-    "min_bars_between_trades": "Barras mínimas entre operaciones",
-    "scale_by": "Método para escalar la fuerza de la señal",
     "trend_ma": "Ventana para la media móvil de tendencia",
     "trend_rsi_n": "Ventana del RSI para medir tendencia",
     "trend_threshold": "Umbral para considerar la tendencia fuerte",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
 
+
 class MeanReversion(Strategy):
     """RSI based mean reversion strategy with adaptive strength.
 
-    Besides generating ``buy``/``sell`` signals based on RSI levels,
-    the strategy adjusts the ``strength`` of those signals according to the
-    performance of the current position or the distance of RSI from the
-    threshold levels. The same tracking logic used in
-    :class:`ScalpPingPong` is applied to handle take profit, stop loss and
-    maximum holding time.
-
-    Parameters are accepted through ``**kwargs`` for easy configuration.
-
-    Parameters
-    ----------
-    rsi_n : int, optional
-        Lookback window for the RSI calculation, by default ``14``.
-    upper : float, optional
-        Upper RSI level above which a ``sell`` signal is triggered, by default
-        ``70``.
-    lower : float, optional
-        Lower RSI level below which a ``buy`` signal is triggered, by default
-        ``30``.
-    tp_bps : float, optional
-        Take profit in basis points, by default ``30``.
-    sl_bps : float, optional
-        Stop loss in basis points, by default ``40``.
-    max_hold_bars : int, optional
-        Maximum number of bars to hold a trade (clamped to 5-10), by default ``10``.
-    min_bars_between_trades : int, optional
-        Minimum bars between trades to enforce a cooldown, by default ``5``.
-    scale_by : {"pnl", "rsi"}, optional
-        Method used to scale signal ``strength``, by default ``"pnl"``.
+    Generates ``buy`` or ``sell`` signals when the RSI crosses ``lower`` or
+    ``upper`` thresholds.  Signal strength scales with the distance from the
+    threshold.  Risk management (stops, cooldowns, etc.) is expected to be
+    handled externally.
     """
 
     name = "mean_reversion"
@@ -58,76 +28,21 @@ class MeanReversion(Strategy):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.upper = kwargs.get("upper", 60.0)
         self.lower = kwargs.get("lower", 40.0)
-        self.tp_bps = kwargs.get("tp_bps", 30.0)
-        self.sl_bps = kwargs.get("sl_bps", 40.0)
-        max_hold_val = kwargs.get("max_hold_bars", 10)
-        self.max_hold_bars = max(min(max_hold_val, 10), 5)
-        self.min_bars_between_trades = kwargs.get("min_bars_between_trades", 5)
-        self.scale_by = kwargs.get("scale_by", "pnl")
         self.trend_ma = kwargs.get("trend_ma", 50)
         self.trend_rsi_n = kwargs.get("trend_rsi_n", 50)
         self.trend_threshold = kwargs.get("trend_threshold", 10.0)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
-        # Track current position to adapt strength
-        self._pos_side: str | None = None
-        self._entry_price: float | None = None
-        self._hold_bars: int = 0
-        self._last_trade_idx: int = -self.min_bars_between_trades
-
-    def _manage_position(self, price: float, last_rsi: float, idx: int) -> Signal | None:
-        """Handle an open position and return an exit signal if needed."""
-        self._hold_bars += 1
-        assert self._entry_price is not None
-        pnl_bps = (price - self._entry_price) / self._entry_price * 10000
-        if self._pos_side == "sell":
-            pnl_bps = -pnl_bps
-        exit_rsi = self.lower < last_rsi < self.upper
-        exit_tp = pnl_bps >= self.tp_bps
-        exit_sl = pnl_bps <= -self.sl_bps
-        exit_time = self._hold_bars >= self.max_hold_bars
-        if exit_rsi or exit_tp or exit_sl or exit_time:
-            side = "sell" if self._pos_side == "buy" else "buy"
-            self._pos_side = None
-            self._entry_price = None
-            self._hold_bars = 0
-            self._last_trade_idx = idx
-            return Signal(side, 1.0)
-        return None
-
-    def _calc_strength(self, side: str, price: float, last_rsi: float) -> float:
-        """Return adaptive strength based on PnL or RSI distance."""
-        strength = 1.0
-        if self.scale_by == "pnl" and self._pos_side and self._entry_price:
-            # positive when current position is in profit
-            pnl = (price - self._entry_price) / self._entry_price
-            if self._pos_side == "sell":
-                pnl = -pnl
-            if side == self._pos_side:
-                strength += pnl
-            else:
-                strength = -pnl
-        elif self.scale_by == "rsi":
-            if side == "buy":
-                strength = min(1.0, (self.lower - last_rsi) / self.lower)
-            else:
-                strength = min(1.0, (last_rsi - self.upper) / (100 - self.upper))
-        return strength
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.rsi_n + 1:
             return None
-        idx = len(df) - 1
         price_col = "close" if "close" in df.columns else "price"
         price_series = df[price_col]
         price = float(price_series.iloc[-1])
         rsi_series = rsi(df, self.rsi_n)
         last_rsi = rsi_series.iloc[-1]
-        if self._pos_side is not None:
-            return self._manage_position(price, last_rsi, idx)
-        if idx - self._last_trade_idx < self.min_bars_between_trades:
-            return None
 
         returns = price_series.pct_change().dropna()
         vol = (
@@ -135,13 +50,12 @@ class MeanReversion(Strategy):
             if len(returns) >= self.rsi_n
             else 0.0
         )
-        vol_bps = vol * 10000
-        if vol_bps < self.min_volatility:
+        if vol * 10000 < self.min_volatility:
             return None
 
         trend_dir = 0
         if len(df) >= self.trend_ma:
-            ma = df[price_col].rolling(self.trend_ma).mean().iloc[-1]
+            ma = price_series.rolling(self.trend_ma).mean().iloc[-1]
             if not pd.isna(ma) and ma != 0:
                 diff_pct = (price - ma) / ma * 100
                 if diff_pct > self.trend_threshold:
@@ -159,18 +73,10 @@ class MeanReversion(Strategy):
         lower = self.lower - (self.trend_threshold if trend_dir == -1 else 0)
 
         if last_rsi > upper:
-            strength = self._calc_strength("sell", price, last_rsi)
-            self._pos_side = "sell"
-            self._entry_price = price
-            self._hold_bars = 0
-            self._last_trade_idx = idx
+            strength = min(1.0, (last_rsi - upper) / (100 - upper))
             return Signal("sell", strength)
         if last_rsi < lower:
-            strength = self._calc_strength("buy", price, last_rsi)
-            self._pos_side = "buy"
-            self._entry_price = price
-            self._hold_bars = 0
-            self._last_trade_idx = idx
+            strength = min(1.0, (lower - last_rsi) / lower)
             return Signal("buy", strength)
         return None
 
@@ -184,8 +90,6 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     position_size = params.get("position_size", 1)
     fee = params.get("fee", 0.0)
     slippage = params.get("slippage", 0.0)
-    sl_pct = params.get("stop_loss", 0.0)
-    tp_pct = params.get("take_profit", 0.0)
 
     ma = df["price"].rolling(window).mean()
     df["signal"] = 0
@@ -193,9 +97,7 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     df.loc[df["price"] > ma + threshold, "signal"] = -1
 
     df["position"] = df["signal"].shift(1).fillna(0) * position_size
-    df["stop_loss"] = df["price"] * (1 - sl_pct)
-    df["take_profit"] = df["price"] * (1 + tp_pct)
     df["fee"] = df["position"].abs() * fee
     df["slippage"] = df["position"].abs() * slippage
 
-    return df[["signal", "position", "stop_loss", "take_profit", "fee", "slippage"]]
+    return df[["signal", "position", "fee", "slippage"]]

--- a/tests/test_basic_strategies.py
+++ b/tests/test_basic_strategies.py
@@ -15,8 +15,6 @@ def test_momentum_backtest():
     base_params = {
         "window": 2,
         "position_size": 1,
-        "stop_loss": 0.05,
-        "take_profit": 0.1,
     }
     pnl_no_fee = backtest(
         data,
@@ -37,8 +35,6 @@ def test_mean_reversion_backtest():
         "window": 2,
         "threshold": 0.1,
         "position_size": 1,
-        "stop_loss": 0.05,
-        "take_profit": 0.1,
     }
     pnl_no_fee = backtest(
         data,

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -14,5 +14,5 @@ def test_mean_reversion_generate_signals():
     df = pd.DataFrame({"price": [1, 2, 3, 4, 3, 2, 1, 2, 3]})
     params = {"window": 3, "threshold": 0.5, "position_size": 1}
     res = generate_signals(df, params)
-    assert {"signal", "position", "stop_loss", "take_profit", "fee", "slippage"} <= set(res.columns)
+    assert {"signal", "position", "fee", "slippage"} <= set(res.columns)
     assert len(res) == len(df)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -18,21 +18,7 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     last_close = breakout_df_buy["close"].iloc[-1]
     expected_edge = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
     assert sig_buy.expected_edge_bps == pytest.approx(expected_edge)
-
-    # ensure at least one bar passes before opposite signal
-    row = {
-        "open": 4,
-        "high": 5,
-        "low": 3.5,
-        "close": -20.0,
-        "volume": 1,
-    }
-    df_wait = pd.concat(
-        [breakout_df_sell, pd.DataFrame([row])],
-        ignore_index=True,
-    )
-
-    sig_sell = strat.on_bar({"window": df_wait, "volatility": 0.0})
+    sig_sell = strat.on_bar({"window": breakout_df_sell, "volatility": 0.0})
     assert sig_sell.side == "sell"
 
 


### PR DESCRIPTION
## Summary
- Remove TP/SL and cooldown logic from Momentum and Mean Reversion strategies
- Simplify Breakout ATR and Breakout Vol strategies to rely on external risk management
- Update basic strategy tests to match new signal outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34668d6d8832db6353ee1753a6df0