### PR TITLE
refactor: update risk configuration

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     maker_fee_bps: float = 7.5
     passive_rebate_bps: float = 0.0
 
+    # Risk manager defaults
+    risk_pct: float = 0.0
+    max_symbol_exposure: float | None = None
+
     # Binance Spot
     binance_spot_maker_fee_bps: float = 7.5
     binance_spot_taker_fee_bps: float = 7.5

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -8,8 +8,6 @@ strategies:
   default: breakout_atr
   params:
     breakout_atr:
-      min_bars_between_trades: 5
-      max_hold_bars: 5
       min_edge_bps: 0.0
     mean_rev_ofi:
       ofi_window: 20
@@ -49,6 +47,7 @@ ingestion:
 
 risk:
   risk_pct: 0.02
+  max_symbol_exposure: null
   vol_target: 0.01
   total_cap_pct: null
   per_symbol_cap_pct: null

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -68,6 +68,11 @@ class StorageConfig:
 class RiskConfig:
     """Risk management parameters used by strategies/daemon."""
 
+    risk_pct: float = 0.0
+    max_symbol_exposure: float | None = None
+    vol_target: float = 0.0
+    total_cap_pct: float | None = None
+    per_symbol_cap_pct: float | None = None
     correlation_threshold: float = 0.8
     returns_window: int = 100
 


### PR DESCRIPTION
## Summary
- drop unused breakout_atr params from default config
- expose risk_pct and max_symbol_exposure in settings and Hydra RiskConfig

## Testing
- `pytest` *(killed after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b34b0a8630832d8d7e87a609a5e9fd