### PR TITLE
test: expand risk manager coverage and adjust strategy tests

### DIFF
--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -24,3 +24,51 @@ def test_service_calc_position_size_passes_strength():
     full = svc.calc_position_size(1.0, price)
     partial = svc.calc_position_size(0.37, price)
     assert partial == pytest.approx(full * 0.37)
+
+
+def test_calc_position_size_handles_edge_cases():
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_per_trade=0.1)
+    assert rm.calc_position_size(1.0, 0.0) == 0.0
+    assert rm.calc_position_size(-0.5, 100.0) == 0.0
+
+
+def test_update_trailing_advances_stop_and_stage():
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_per_trade=0.1)
+    trade = {
+        "side": "buy",
+        "entry_price": 100.0,
+        "stop": 90.0,
+        "atr": 5.0,
+        "stage": 0,
+        "qty": 1.0,
+    }
+    rm.update_trailing(trade, 105.0)
+    assert trade["stop"] == pytest.approx(100.0)
+    assert trade["stage"] == 1
+    rm.update_trailing(trade, 112.0)
+    assert trade["stage"] == 2
+    assert trade["stop"] == pytest.approx(101.0)
+    rm.update_trailing(trade, 120.0)
+    assert trade["stage"] >= 3
+    assert trade["stop"] == pytest.approx(110.0)
+
+
+def test_manage_position_handles_stop_and_signals():
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account)
+    trade = {"side": "buy", "stop": 100.0, "current_price": 99.0}
+    assert rm.manage_position(trade) == "close"
+    trade = {"side": "buy", "stop": 90.0, "current_price": 100.0}
+    assert rm.manage_position(trade, {"side": "sell"}) == "close"
+    assert rm.manage_position(trade, {"exit": True}) == "close"
+    assert rm.manage_position(trade, {"side": "buy"}) == "hold"
+
+
+def test_check_global_exposure_enforces_limit():
+    account = Account(max_symbol_exposure=1000.0, cash=0.0)
+    account.update_position("BTC", 2.0, price=100.0)
+    rm = CoreRiskManager(account)
+    assert rm.check_global_exposure("BTC", 700.0)
+    assert not rm.check_global_exposure("BTC", 900.0)


### PR DESCRIPTION
## Summary
- remove outdated tp/sl assertions from TripleBarrier strategy tests and validate RiskManager-driven exits
- add RiskManager tests for position sizing edge cases, trailing updates, stop management and exposure limits

## Testing
- `pytest tests/test_triple_barrier.py tests/test_core_position_size.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34edf34c4832dbc79aefbbb903253