### PR TITLE
Display strategy parameter toggle on bots page

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -109,7 +109,7 @@
           <option value="testnet" selected>Testnet</option>
         </select>
       </div>
-      <div id="field-toggle-params" style="display:none;align-items:center;gap:4px">
+      <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
         <span>Configurar parámetros</span>
         <label class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
@@ -180,7 +180,7 @@ async function loadStrategyParams(name){
     const r=await fetch(api(`/strategies/${name}/schema`));
     const j=await r.json();
     const params=(j.params||[]).filter(p=>p.name!=='config_path');
-    field.style.display=params.length?'flex':'none';
+    field.style.display=params.length?'':'none';
     params.forEach(p=>{
       const div=document.createElement('div');
 


### PR DESCRIPTION
## Summary
- show strategy parameter toggle in bots dashboard
- show toggle only when strategy exposes parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3504bc368832d9da9a6b2938b335d