### PR TITLE
docs: describe universal risk manager

### DIFF
--- a/MVP.md
+++ b/MVP.md
@@ -27,7 +27,16 @@ python -m tradingbot.cli paper-run --symbol BTC/USDT --strategy breakout_atr
 ```
 
 El bot aplica la estrategia de rompimiento con ATR sobre el símbolo elegido y
-expone métricas en `http://localhost:8000/metrics`.
+expone métricas en `http://localhost:8000/metrics`. El
+`RiskManager` universal (`core/risk_manager.py`) junto con `Account`
+(`core/account.py`) dimensiona la posición a partir de un `signal.strength`
+continuo y ajusta un trailing stop adaptativo.
+
+Ejemplo de señal:
+
+```python
+{"side": "buy", "strength": 0.7, "atr": 3.5}
+```
 
 ### 3. Revisar métricas
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -3,16 +3,20 @@
 Las estrategias definen cómo se toman decisiones de compra o venta. A
 continuación se presenta un resumen en lenguaje sencillo.
 
-Todas las señales incluyen un campo `strength` que dimensiona las órdenes
-mediante `notional = equity * strength`. Valores superiores a `1.0` piramidan
-la posición y menores la desescalan. Además, `risk_pct` define un stop‑loss
-local basado en `notional * risk_pct`.
+Todas las señales incluyen un campo `strength` continuo que dimensiona las
+órdenes mediante `notional = equity * strength`. El `RiskManager` universal
+utiliza este valor para calcular el tamaño y aplicar un trailing stop
+adaptativo.
+
+Ejemplo de señal:
+
+```python
+signal = {"side": "buy", "strength": 0.75, "atr": 4.2}
+```
 
 ### Breakout con ATR (`breakout_atr`)
 Compra cuando el precio supera el canal superior calculado con el indicador
-ATR y vende cuando cae por debajo del canal inferior. El parámetro
-`min_bars_between_trades` limita la emisión de señales opuestas hasta que
-transcurra un mínimo de 5 velas.
+ATR y vende cuando cae por debajo del canal inferior.
 
 ### Breakout por Volumen (`breakout_vol`)
 Detecta rupturas de precio acompañadas de incrementos de volumen.
@@ -42,8 +46,8 @@ Analiza el flujo de órdenes que llegan al mercado para detectar presiones de
 compra o venta.
 
 ### Triple Barrier (`triple_barrier`)
-Define tres barreras (objetivo, stop loss y tiempo) y cierra la posición
-según cuál se alcance primero.
+Define tres barreras (objetivo, límite de pérdida y tiempo) y cierra la
+posición según cuál se alcance primero.
 
 ### Cash and Carry (`cash_and_carry`)
 Aprovecha diferencias de precio entre el mercado spot y los futuros para


### PR DESCRIPTION
## Summary
- document universal `RiskManager` and its interface
- remove references to fixed TP/SL and trade cooldowns
- add continuous `signal.strength` and adaptive trailing stop examples

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68b3509edd24832da4512f56192665be