### PR TITLE
docs: update risk manager examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ from tradingbot.core.account import Account
 from tradingbot.core.risk_manager import RiskManager
 
 account = Account(max_symbol_exposure=1000.0, cash=1000.0)
-rm = RiskManager(account, risk_per_trade=0.02)
+rm = RiskManager(account, risk_per_trade=0.02)  # --risk-pct 2 en la CLI
 
 signal = {"side": "buy", "strength": 0.5, "atr": 6}
-size = rm.calc_position_size(signal["strength"], price=100)
-stop = rm.initial_stop(100, "buy", atr=signal["atr"])
-trade = {"side": "buy", "entry_price": 100, "qty": size, "stop": stop, "atr": signal["atr"]}
-rm.update_trailing(trade, current_price=108)
+price = 100
+size = rm.calc_position_size(signal["strength"], price)
+if rm.check_global_exposure("BTC/USDT", size * price):
+    stop = rm.initial_stop(price, "buy", atr=signal["atr"])
+    trade = {"side": "buy", "entry_price": price, "qty": size, "stop": stop, "atr": signal["atr"]}
+    rm.update_trailing(trade, current_price=108)
+    trade["current_price"] = 108
+    decision = rm.manage_position(trade)
 ```
 
 El parámetro `risk_per_trade` debe indicarse como una fracción entre 0 y 1.


### PR DESCRIPTION
## Summary
- update risk management docs with universal RiskManager workflow
- clarify risk_per_trade (`--risk-pct`) usage in examples

## Testing
- `pytest tests/test_risk_manager_limits.py tests/test_risk.py tests/test_risk_pct_validation.py -q` *(fails: assert statements in tests/test_risk.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b359f39c2c832d800827d33cc87427