### PR TITLE
refactor: simplify signal structure

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -840,9 +840,9 @@ class EventDrivenBacktestEngine:
                         queue_pos,
                         None,
                         post_only,
-                        getattr(sig, "take_profit", None),
-                        getattr(sig, "stop_loss", None),
-                        getattr(sig, "trailing_pct", None),
+                        None,
+                        None,
+                        None,
                     )
                     orders.append(order)
                     heapq.heappush(order_queue, order)

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -531,8 +531,6 @@ class TradeBotDaemon:
             side="buy" if delta > 0 else "sell",
             type_="market",
             qty=abs(delta),
-            take_profit=getattr(signal, "take_profit", None),
-            stop_loss=getattr(signal, "stop_loss", None),
             reduce_only=getattr(signal, "reduce_only", False),
         )
         res = await self.router.execute(order)

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -161,8 +161,6 @@ async def _run_symbol(
                 side,
                 "market",
                 qty,
-                take_profit=getattr(sig, "take_profit", None),
-                stop_loss=getattr(sig, "stop_loss", None),
             )
         else:
             resp = await exec_adapter.place_order(
@@ -171,8 +169,6 @@ async def _run_symbol(
                 "market",
                 qty,
                 mark_price=closed.c,
-                take_profit=getattr(sig, "take_profit", None),
-                stop_loss=getattr(sig, "stop_loss", None),
             )
         log.info("LIVE FILL %s", resp)
         risk.on_fill(cfg.symbol, side, qty, venue=venue if not dry_run else "paper")

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -49,13 +49,13 @@ class BreakoutATR(Strategy):
             return None
 
         if last_close > upper.iloc[-1]:
-            expected_edge_bps = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
-            if expected_edge_bps <= self.min_edge_bps:
+            edge_bps = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
+            if edge_bps <= self.min_edge_bps:
                 return None
-            return Signal("buy", 1.0, expected_edge_bps=expected_edge_bps)
+            return Signal("buy", 1.0)
         if last_close < lower.iloc[-1]:
-            expected_edge_bps = (lower.iloc[-1] - last_close) / abs(last_close) * 10000
-            if expected_edge_bps <= self.min_edge_bps:
+            edge_bps = (lower.iloc[-1] - last_close) / abs(last_close) * 10000
+            if edge_bps <= self.min_edge_bps:
                 return None
-            return Signal("sell", 1.0, expected_edge_bps=expected_edge_bps)
+            return Signal("sell", 1.0)
         return None

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -46,13 +46,13 @@ class BreakoutVol(Strategy):
         size = max(0.0, min(1.0, vol_bps * self.volatility_factor))
 
         if last > upper:
-            expected_edge_bps = (last - upper) / abs(last) * 10000
-            if expected_edge_bps <= self.min_edge_bps:
+            edge_bps = (last - upper) / abs(last) * 10000
+            if edge_bps <= self.min_edge_bps:
                 return None
-            return Signal("buy", size, expected_edge_bps=expected_edge_bps)
+            return Signal("buy", size)
         if last < lower:
-            expected_edge_bps = (lower - last) / abs(last) * 10000
-            if expected_edge_bps <= self.min_edge_bps:
+            edge_bps = (lower - last) / abs(last) * 10000
+            if edge_bps <= self.min_edge_bps:
                 return None
-            return Signal("sell", size, expected_edge_bps=expected_edge_bps)
+            return Signal("sell", size)
         return None

--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -7,8 +7,6 @@ from .base import Strategy, Signal, record_signal_metrics
 
 PARAM_INFO = {
     "strategies": "Lista de subestrategias y sus parámetros",
-    "tp_pct": "Take profit porcentual",
-    "sl_pct": "Stop loss porcentual",
 }
 
 
@@ -17,31 +15,8 @@ class CompositeSignals(Strategy):
 
     name = "composite_signals"
 
-    def __init__(
-        self,
-        strategies: Sequence[tuple[Type[Strategy], dict]],
-        *,
-        tp_pct: float = 0.0,
-        sl_pct: float = 0.0,
-    ):
+    def __init__(self, strategies: Sequence[tuple[Type[Strategy], dict]]):
         self.sub_strategies = [cls(**params) for cls, params in strategies]
-        self.tp_pct = float(tp_pct)
-        self.sl_pct = float(sl_pct)
-
-    def _levels(self, side: str, price: float | None) -> dict[str, float | None]:
-        tp = sl = None
-        if price is not None:
-            if side == "buy":
-                if self.tp_pct > 0:
-                    tp = price * (1 + self.tp_pct)
-                if self.sl_pct > 0:
-                    sl = price * (1 - self.sl_pct)
-            else:  # sell
-                if self.tp_pct > 0:
-                    tp = price * (1 - self.tp_pct)
-                if self.sl_pct > 0:
-                    sl = price * (1 + self.sl_pct)
-        return {"take_profit": tp, "stop_loss": sl}
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -55,17 +30,12 @@ class CompositeSignals(Strategy):
                 buys += 1
             elif sig.side == "sell":
                 sells += 1
-        price = bar.get("close") or bar.get("price")
         if buys >= 2 and buys > sells:
-            levels = self._levels("buy", price)
-            return Signal("buy", 1.0, **levels)
+            return Signal("buy", 1.0)
         if sells >= 2 and sells > buys:
-            levels = self._levels("sell", price)
-            return Signal("sell", 1.0, **levels)
+            return Signal("sell", 1.0)
         if buys > len(self.sub_strategies) / 2:
-            levels = self._levels("buy", price)
-            return Signal("buy", 1.0, **levels)
+            return Signal("buy", 1.0)
         if sells > len(self.sub_strategies) / 2:
-            levels = self._levels("sell", price)
-            return Signal("sell", 1.0, **levels)
+            return Signal("sell", 1.0)
         return None

--- a/tests/test_basic_strategies.py
+++ b/tests/test_basic_strategies.py
@@ -56,8 +56,6 @@ def test_arbitrage_backtest():
     base_params = {
         "threshold": 0.0,
         "position_size": 1,
-        "stop_loss": 0.05,
-        "take_profit": 0.1,
     }
     pnl_no_fee = backtest(
         data,

--- a/tests/test_composite_signals.py
+++ b/tests/test_composite_signals.py
@@ -1,6 +1,3 @@
-import pytest
-import pytest
-
 from tradingbot.strategies.base import Strategy, Signal
 from tradingbot.strategies.composite_signals import CompositeSignals
 
@@ -24,14 +21,7 @@ def test_no_consensus_returns_none():
     assert cs.on_bar({"close": 100}) is None
 
 
-def test_tp_sl_applied_on_consensus():
-    cs = CompositeSignals(
-        [(BuyStrat, {}), (BuyStrat, {}), (SellStrat, {})],
-        tp_pct=0.05,
-        sl_pct=0.02,
-    )
+def test_consensus_returns_signal():
+    cs = CompositeSignals([(BuyStrat, {}), (BuyStrat, {}), (SellStrat, {})])
     sig = cs.on_bar({"close": 100})
-    assert sig is not None
-    assert sig.side == "buy"
-    assert pytest.approx(sig.take_profit, rel=1e-9) == 105.0
-    assert pytest.approx(sig.stop_loss, rel=1e-9) == 98.0
+    assert sig is not None and sig.side == "buy"


### PR DESCRIPTION
## Summary
- reduce `Signal` to side, strength and optional reduce-only flag
- drop take-profit/stop-loss handling from strategies and runners
- adjust tests for streamlined signal interface

## Testing
- `pytest` *(killed: out-of-memory?)*

------
https://chatgpt.com/codex/tasks/task_e_68b359f26790832d9326906ccdba8836