### PR TITLE
Refactor strategies to delegate risk management

### DIFF
--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -9,9 +9,6 @@ from ..data.features import depth_imbalance
 PARAM_INFO = {
     "window": "Ventana para promediar el desequilibrio",
     "threshold": "Umbral de desequilibrio para operar",
-    "tp": "Take profit como fracción del precio",
-    "sl": "Stop loss como fracción del precio",
-    "max_duration": "Máxima duración de la posición",
 }
 
 
@@ -28,18 +25,13 @@ class DepthImbalance(Strategy):
         self,
         window: int = 3,
         threshold: float = 0.2,
-        tp: float | None = None,
-        sl: float | None = None,
-        max_duration: pd.Timedelta | int | float | str | None = None,
+        *,
+        risk_service=None,
     ):
         self.window = window
         self.threshold = threshold
-        self.tp = tp
-        self.sl = sl
-        self.max_duration = pd.Timedelta(max_duration) if max_duration else None
-        self.pos_side: str | None = None
-        self.entry_price: float | None = None
-        self.entry_time: pd.Timestamp | None = None
+        self.risk_service = risk_service
+        self.trade: dict | None = None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -49,49 +41,37 @@ class DepthImbalance(Strategy):
             return None
 
         price = bar.get("close")
-        now = pd.Timestamp(bar.get("ts") or bar.get("timestamp") or pd.Timestamp.utcnow())
 
-        if self.pos_side and self.entry_price is not None:
-            pnl = (
-                price - self.entry_price
-                if self.pos_side == "buy"
-                else self.entry_price - price
-            ) if price is not None else None
-            pct = pnl / self.entry_price if pnl is not None else None
-            if pct is not None:
-                if self.tp is not None and pct >= self.tp:
-                    side = self.pos_side
-                    self.pos_side = None
-                    self.entry_price = None
-                    self.entry_time = None
-                    return Signal(side, 0.0)
-                if self.sl is not None and pct <= -self.sl:
-                    side = self.pos_side
-                    self.pos_side = None
-                    self.entry_price = None
-                    self.entry_time = None
-                    return Signal(side, 0.0)
-            if (
-                self.max_duration is not None
-                and self.entry_time is not None
-                and now - self.entry_time >= self.max_duration
-            ):
-                side = self.pos_side
-                self.pos_side = None
-                self.entry_price = None
-                self.entry_time = None
-                return Signal(side, 0.0)
+        if self.trade and self.risk_service and price is not None:
+            self.risk_service.update_trailing(self.trade, price)
+            decision = self.risk_service.manage_position(
+                {**self.trade, "current_price": price}
+            )
+            if decision == "close":
+                side = "sell" if self.trade["side"] == "buy" else "buy"
+                self.trade = None
+                return Signal(side, 1.0)
+            return None
 
         di_series = depth_imbalance(df[list(needed)])
         di_mean = di_series.iloc[-self.window :].mean()
+        side = None
         if di_mean > self.threshold:
-            self.pos_side = "buy"
-            self.entry_price = price
-            self.entry_time = now
-            return Signal("buy", 1.0)
-        if di_mean < -self.threshold:
-            self.pos_side = "sell"
-            self.entry_price = price
-            self.entry_time = now
-            return Signal("sell", 1.0)
-        return None
+            side = "buy"
+        elif di_mean < -self.threshold:
+            side = "sell"
+        if side is None:
+            return None
+        strength = 1.0
+        if self.risk_service and price is not None:
+            qty = self.risk_service.calc_position_size(strength, price)
+            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            atr = bar.get("atr") or bar.get("volatility")
+            stop_fn = getattr(self.risk_service, "initial_stop", None)
+            if stop_fn is None and hasattr(self.risk_service, "core"):
+                stop_fn = getattr(self.risk_service.core, "initial_stop", None)
+            if stop_fn is not None:
+                trade["stop"] = stop_fn(price, side, atr)
+            self.risk_service.update_trailing(trade, price)
+            self.trade = trade
+        return Signal(side, strength)

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -7,9 +7,6 @@ PARAM_INFO = {
     "window": "Ventana para promediar el OFI",
     "buy_threshold": "Umbral de compra para OFI",
     "sell_threshold": "Umbral de venta para OFI",
-    "tp": "Take profit como fracción",
-    "sl": "Stop loss como fracción",
-    "max_duration": "Duración máxima de la posición",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
 
@@ -28,21 +25,16 @@ class OrderFlow(Strategy):
         window: int = 3,
         buy_threshold: float = 1.0,
         sell_threshold: float = 1.0,
-        tp: float | None = None,
-        sl: float | None = None,
-        max_duration: pd.Timedelta | int | float | str | None = None,
         min_volatility: float = 0.0,
+        *,
+        risk_service=None,
     ):
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
-        self.tp = tp
-        self.sl = sl
-        self.max_duration = pd.Timedelta(max_duration) if max_duration else None
         self.min_volatility = min_volatility
-        self.pos_side: str | None = None
-        self.entry_price: float | None = None
-        self.entry_time: pd.Timestamp | None = None
+        self.risk_service = risk_service
+        self.trade: dict | None = None
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -51,7 +43,6 @@ class OrderFlow(Strategy):
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
         price = bar.get("close")
-        now = pd.Timestamp(bar.get("ts") or bar.get("timestamp") or pd.Timestamp.utcnow())
 
         vol_bps = float("inf")
         price_col = "close" if "close" in df.columns else None
@@ -67,47 +58,36 @@ class OrderFlow(Strategy):
         if vol_bps < self.min_volatility:
             return None
 
-        if self.pos_side and self.entry_price is not None:
-            pnl = (
-                price - self.entry_price
-                if self.pos_side == "buy"
-                else self.entry_price - price
-            ) if price is not None else None
-            pct = pnl / self.entry_price if pnl is not None else None
-            if pct is not None:
-                if self.tp is not None and pct >= self.tp:
-                    side = self.pos_side
-                    self.pos_side = None
-                    self.entry_price = None
-                    self.entry_time = None
-                    return Signal(side, 0.0)
-                if self.sl is not None and pct <= -self.sl:
-                    side = self.pos_side
-                    self.pos_side = None
-                    self.entry_price = None
-                    self.entry_time = None
-                    return Signal(side, 0.0)
-            if (
-                self.max_duration is not None
-                and self.entry_time is not None
-                and now - self.entry_time >= self.max_duration
-            ):
-                side = self.pos_side
-                self.pos_side = None
-                self.entry_price = None
-                self.entry_time = None
-                return Signal(side, 0.0)
+        if self.trade and self.risk_service and price is not None:
+            self.risk_service.update_trailing(self.trade, price)
+            decision = self.risk_service.manage_position(
+                {**self.trade, "current_price": price}
+            )
+            if decision == "close":
+                side = "sell" if self.trade["side"] == "buy" else "buy"
+                self.trade = None
+                return Signal(side, 1.0)
+            return None
 
         ofi_series = calc_ofi(df[list(needed)])
         ofi_mean = ofi_series.iloc[-self.window:].mean()
+        side = None
         if ofi_mean > self.buy_threshold:
-            self.pos_side = "buy"
-            self.entry_price = price
-            self.entry_time = now
-            return Signal("buy", 1.0)
-        if ofi_mean < -self.sell_threshold:
-            self.pos_side = "sell"
-            self.entry_price = price
-            self.entry_time = now
-            return Signal("sell", 1.0)
-        return None
+            side = "buy"
+        elif ofi_mean < -self.sell_threshold:
+            side = "sell"
+        if side is None:
+            return None
+        strength = 1.0
+        if self.risk_service and price is not None:
+            qty = self.risk_service.calc_position_size(strength, price)
+            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            atr = bar.get("atr") or bar.get("volatility")
+            stop_fn = getattr(self.risk_service, "initial_stop", None)
+            if stop_fn is None and hasattr(self.risk_service, "core"):
+                stop_fn = getattr(self.risk_service.core, "initial_stop", None)
+            if stop_fn is not None:
+                trade["stop"] = stop_fn(price, side, atr)
+            self.risk_service.update_trailing(trade, price)
+            self.trade = trade
+        return Signal(side, strength)

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -55,69 +55,6 @@ def test_liquidity_events_no_signal_returns_none():
     assert sig is None
 
 
-def test_take_profit_exit():
-    df_entry = pd.DataFrame({
-        "bid_qty": [10, 10],
-        "ask_qty": [10, 4],
-        "bid_px": [[100, 99], [100, 99]],
-        "ask_px": [[101, 102], [101, 102]],
-    })
-    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.01, sl_pct=0.01, max_hold=10, dynamic_thresholds=False)
-    sig = strat.on_bar({"window": df_entry})
-    assert sig is not None and sig.side == "buy"
-
-    df_exit = pd.DataFrame({
-        "bid_qty": [10, 10, 10],
-        "ask_qty": [10, 4, 10],
-        "bid_px": [[100, 99], [100, 99], [102, 101]],
-        "ask_px": [[101, 102], [101, 102], [103, 104]],
-    })
-    sig_exit = strat.on_bar({"window": df_exit})
-    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
-
-
-def test_stop_loss_exit():
-    df_entry = pd.DataFrame({
-        "bid_qty": [10, 10],
-        "ask_qty": [10, 4],
-        "bid_px": [[100, 99], [100, 99]],
-        "ask_px": [[101, 102], [101, 102]],
-    })
-    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.05, sl_pct=0.01, max_hold=10, dynamic_thresholds=False)
-    sig = strat.on_bar({"window": df_entry})
-    assert sig is not None and sig.side == "buy"
-
-    df_exit = pd.DataFrame({
-        "bid_qty": [10, 10, 10],
-        "ask_qty": [10, 4, 10],
-        "bid_px": [[100, 99], [100, 99], [99, 98]],
-        "ask_px": [[101, 102], [101, 102], [99.8, 100]],
-    })
-    sig_exit = strat.on_bar({"window": df_exit})
-    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
-
-
-def test_time_exit():
-    df_entry = pd.DataFrame({
-        "bid_qty": [10, 10],
-        "ask_qty": [10, 4],
-        "bid_px": [[100, 99], [100, 99]],
-        "ask_px": [[101, 102], [101, 102]],
-    })
-    strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, tp_pct=0.05, sl_pct=0.05, max_hold=1, dynamic_thresholds=False)
-    sig = strat.on_bar({"window": df_entry})
-    assert sig is not None and sig.side == "buy"
-
-    df_exit = pd.DataFrame({
-        "bid_qty": [10, 10, 10],
-        "ask_qty": [10, 4, 10],
-        "bid_px": [[100, 99], [100, 99], [100, 99]],
-        "ask_px": [[101, 102], [101, 102], [101, 102]],
-    })
-    sig_exit = strat.on_bar({"window": df_exit})
-    assert sig_exit is not None and sig_exit.side == "sell" and sig_exit.reduce_only
-
-
 def test_dynamic_thresholds_increase_events():
     df = pd.DataFrame({
         "bid_qty": [10, 10, 10, 10],

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -20,41 +20,9 @@ def test_ml_strategy_margin_and_entry():
 
     stub.proba = 0.7
     sig = strat.on_bar(bar)
-    assert sig and sig.side == "buy" and strat.pos_side == 1
+    assert sig and sig.side == "buy" and strat.trade["side"] == "buy"
 
     strat2 = MLStrategy(model=StubModel(0.3), margin=0.1)
     strat2.scaler.fit([[0.0]])
     sig = strat2.on_bar(bar)
-    assert sig and sig.side == "sell" and strat2.pos_side == -1
-
-
-def test_ml_strategy_exit_tp_sl_rev():
-    stub = StubModel(0.7)
-    strat = MLStrategy(model=stub, margin=0.1, tp_pct=0.02, sl_pct=0.02)
-    strat.scaler.fit([[0.0]])
-    bar_open = {"features": [0.0], "close": 100.0}
-    strat.on_bar(bar_open)
-
-    bar_tp = {"features": [0.0], "close": 102.0}
-    sig = strat.on_bar(bar_tp)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
-
-    strat.on_bar(bar_open)
-    bar_sl = {"features": [0.0], "close": 98.0}
-    sig = strat.on_bar(bar_sl)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
-
-    strat.on_bar(bar_open)
-    stub.proba = 0.2
-    bar_rev = {"features": [0.0], "close": 100.0}
-    sig = strat.on_bar(bar_rev)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
-
-    strat_short = MLStrategy(model=StubModel(0.3), margin=0.1, tp_pct=0.02, sl_pct=0.02)
-    strat_short.scaler.fit([[0.0]])
-    strat_short.on_bar(bar_open)
-    stub2 = strat_short.model
-    assert isinstance(stub2, StubModel)
-    stub2.proba = 0.8
-    sig = strat_short.on_bar(bar_rev)
-    assert sig and sig.side == "buy" and strat_short.pos_side == 0
+    assert sig and sig.side == "sell" and strat2.trade["side"] == "sell"


### PR DESCRIPTION
## Summary
- Simplify order flow and depth imbalance strategies to emit only entry signals
- Rework liquidity event and ML strategies to rely on risk service for sizing and stops
- Drop obsolete exit-parameter tests and adapt ML strategy tests

## Testing
- `pytest`
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -vv` (fails: assert 0 == 1)
- `pytest tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress -vv` (fails: IndexError)


------
https://chatgpt.com/codex/tasks/task_e_68b362559274832d908b71719b5ab001