### PR TITLE
feat(risk): expose initial stop helper

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -70,6 +70,12 @@ class RiskService:
     def check_global_exposure(self, symbol: str, new_alloc: float) -> bool:
         return self.core.check_global_exposure(symbol, new_alloc)
 
+    def initial_stop(
+        self, entry_price: float, side: str, atr: float | None = None
+    ) -> float:
+        """Return the initial stop price for a new position."""
+        return self.core.initial_stop(entry_price, side, atr)
+
     def update_trailing(
         self, trade: dict | object, current_price: float, fees_slip: float = 0.0
     ) -> None:

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -104,7 +104,7 @@ class MeanRevOFI(Strategy):
             qty = self.risk_service.calc_position_size(strength, last_close)
             trade = {"side": side, "entry_price": last_close, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 last_close, side, atr
             )
             self.risk_service.update_trailing(trade, last_close)

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -151,7 +151,7 @@ class ScalpPingPong(Strategy):
             qty = self.risk_service.calc_position_size(size, price)
             trade = {"side": side, "entry_price": price, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 price, side, atr
             )
             self.risk_service.update_trailing(trade, price)

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -70,7 +70,7 @@ class TrendFollowing(Strategy):
             qty = self.risk_service.calc_position_size(strength, price)
             trade = {"side": side, "entry_price": price, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 price, side, atr
             )
             self.risk_service.update_trailing(trade, price)

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -193,7 +193,7 @@ class TripleBarrier(Strategy):
             qty = self.risk_service.calc_position_size(1.0, last)
             trade = {"side": side, "entry_price": float(last), "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(last, side, atr)
+            trade["stop"] = self.risk_service.initial_stop(last, side, atr)
             self.risk_service.update_trailing(trade, float(last))
             self.trade = trade
         return Signal(side, 1.0)

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -40,6 +40,16 @@ def test_initial_stop_uses_risk_pct():
     assert rm.initial_stop(100.0, "sell") == pytest.approx(102.0)
 
 
+def test_service_initial_stop_delegates_to_core():
+    account = Account(float("inf"), cash=1000.0)
+    rm = RiskManager()
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    svc = RiskService(rm, guard, account=account, risk_per_trade=0.1)
+    assert svc.initial_stop(100.0, "buy") == pytest.approx(
+        svc.core.initial_stop(100.0, "buy")
+    )
+
+
 def test_update_trailing_advances_stop_and_stage():
     account = Account(float("inf"), cash=1000.0)
     rm = CoreRiskManager(account, risk_per_trade=0.1)


### PR DESCRIPTION
## Summary
- expose `initial_stop` on RiskService
- use RiskService.initial_stop in sample strategies
- cover RiskService.initial_stop delegation with tests

## Testing
- `pytest` *(failed: tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk - assert 0 == 1, tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress - IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68b362580728832db7ceac4ac8bd6b73