### PR TITLE
docs: refine risk and strategy descriptions

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -11,7 +11,7 @@ adaptativo.
 Ejemplo de señal:
 
 ```python
-signal = {"side": "buy", "strength": 0.75, "atr": 4.2}
+signal = {"side": "buy", "strength": 0.75}
 ```
 
 ### Breakout con ATR (`breakout_atr`)

--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -46,8 +46,8 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     data : pd.DataFrame
         Data with ``asset_a`` and ``asset_b`` price columns.
     params : dict
-        Parameters including ``threshold``, ``position_size``, ``stop_loss``,
-        ``take_profit``, ``fee`` and ``slippage``.
+        Parameters including ``threshold``, ``position_size``, ``fee`` y
+        ``slippage``.
 
     Returns
     -------

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -9,8 +9,6 @@ from ..data.features import depth_imbalance
 PARAM_INFO = {
     "window": "Ventana para promediar el desequilibrio",
     "threshold": "Umbral de desequilibrio para operar",
-    "tp": "Take profit como fracción del precio",
-    "sl": "Stop loss como fracción del precio",
     "max_duration": "Máxima duración de la posición",
 }
 

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -9,8 +9,6 @@ from ..data.features import book_vacuum, liquidity_gap
 PARAM_INFO = {
     "vacuum_threshold": "Umbral para detectar vacíos de liquidez",
     "gap_threshold": "Umbral para detectar gaps de liquidez",
-    "tp_pct": "Take profit porcentual",
-    "sl_pct": "Stop loss porcentual",
     "max_hold": "Barras máximas en posición",
     "vol_window": "Ventana para calcular la volatilidad",
     "dynamic_thresholds": "Ajustar umbrales según volatilidad",
@@ -21,14 +19,15 @@ class LiquidityEvents(Strategy):
     """React to liquidity vacuum and gap events.
 
     A wipe on the ask side triggers a buy signal while a wipe on the bid side
-    results in a sell signal.  If no vaciado is detected, the strategy checks
+    results in a sell signal. If no vaciado is detected, the strategy checks
     for large gaps between the first and second level of the book and trades in
     the direction of the gap.
 
-    The strategy maintains an internal state and exits positions based on take
-    profit, stop loss or maximum holding period.  Thresholds for detecting
-    vacuums and gaps can be dynamically adjusted according to recent price
-    volatility to increase the frequency of events during turbulent markets.
+    The strategy maintains an internal state and exits positions automáticamente
+    según umbrales predefinidos y un período máximo de permanencia. Los
+    umbrales para detectar vacíos y gaps pueden ajustarse dinámicamente según
+    la volatilidad reciente del precio para incrementar la frecuencia de eventos
+    durante mercados turbulentos.
     """
 
     name = "liquidity_events"

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -17,9 +17,8 @@ class MeanReversion(Strategy):
     """RSI based mean reversion strategy with adaptive strength.
 
     Generates ``buy`` or ``sell`` signals when the RSI crosses ``lower`` or
-    ``upper`` thresholds.  Signal strength scales with the distance from the
-    threshold.  Risk management (stops, cooldowns, etc.) is expected to be
-    handled externally.
+    ``upper`` thresholds. Signal strength scales with the distance from the
+    threshold.
     """
 
     name = "mean_reversion"

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -15,8 +15,6 @@ PARAM_INFO = {
     "model": "Instancia de modelo sklearn preentrenado",
     "model_path": "Ruta para cargar el modelo",
     "margin": "Margen de probabilidad sobre 0.5",
-    "tp_pct": "Take profit porcentual",
-    "sl_pct": "Stop loss porcentual",
 }
 
 class MLStrategy(Strategy):

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -7,8 +7,6 @@ PARAM_INFO = {
     "window": "Ventana para promediar el OFI",
     "buy_threshold": "Umbral de compra para OFI",
     "sell_threshold": "Umbral de venta para OFI",
-    "tp": "Take profit como fracción",
-    "sl": "Stop loss como fracción",
     "max_duration": "Duración máxima de la posición",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }


### PR DESCRIPTION
## Summary
- clarify that `initial_stop` relies on `risk_pct` and ATR is only used for trailing stops
- drop `vol_target` and remove `atr` from signal examples
- clean strategy docs and docstrings by removing manual TP/SL/cooldown references

## Testing
- `pytest` *(fails: tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk; tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress)*

------
https://chatgpt.com/codex/tasks/task_e_68b3626bb954832db7d46f6e9a91ad4a