### PR TITLE
test: update risk service coverage

### DIFF
--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -1,5 +1,10 @@
 import numpy as np
 
+import pytest
+
+from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
 from tradingbot.strategies.ml_models import MLStrategy
 
 
@@ -28,33 +33,30 @@ def test_ml_strategy_margin_and_entry():
     assert sig and sig.side == "sell" and strat2.pos_side == -1
 
 
-def test_ml_strategy_exit_tp_sl_rev():
+def test_ml_strategy_risk_service_handles_stop_and_size():
     stub = StubModel(0.7)
-    strat = MLStrategy(model=stub, margin=0.1, tp_pct=0.02, sl_pct=0.02)
+    strat = MLStrategy(model=stub, margin=0.1)
     strat.scaler.fit([[0.0]])
     bar_open = {"features": [0.0], "close": 100.0}
-    strat.on_bar(bar_open)
+    sig = strat.on_bar(bar_open)
+    assert sig and sig.side == "buy"
 
-    bar_tp = {"features": [0.0], "close": 102.0}
-    sig = strat.on_bar(bar_tp)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
+    rm = RiskManager(risk_pct=0.02)
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
+    svc = RiskService(rm, guard)
+    svc.account.update_cash(1000.0)
 
-    strat.on_bar(bar_open)
-    bar_sl = {"features": [0.0], "close": 98.0}
-    sig = strat.on_bar(bar_sl)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
+    allowed, reason, delta = svc.check_order(
+        "AAA", sig.side, 1000.0, bar_open["close"], strength=sig.strength
+    )
+    assert allowed and delta == pytest.approx(0.07)
 
-    strat.on_bar(bar_open)
-    stub.proba = 0.2
-    bar_rev = {"features": [0.0], "close": 100.0}
-    sig = strat.on_bar(bar_rev)
-    assert sig and sig.side == "sell" and strat.pos_side == 0
+    rm.add_fill(sig.side, delta, price=bar_open["close"])
+    svc.update_position("X", "AAA", delta)
 
-    strat_short = MLStrategy(model=StubModel(0.3), margin=0.1, tp_pct=0.02, sl_pct=0.02)
-    strat_short.scaler.fit([[0.0]])
-    strat_short.on_bar(bar_open)
-    stub2 = strat_short.model
-    assert isinstance(stub2, StubModel)
-    stub2.proba = 0.8
-    sig = strat_short.on_bar(bar_rev)
-    assert sig and sig.side == "buy" and strat_short.pos_side == 0
+    stop_price = bar_open["close"] * (1 - rm.risk_pct) - 1
+    allowed, reason, delta_stop = svc.check_order(
+        "AAA", sig.side, 1000.0, stop_price
+    )
+    assert allowed and reason == "stop_loss"
+    assert delta_stop == pytest.approx(-delta)


### PR DESCRIPTION
## Summary
- adjust ML strategy test to rely on RiskService for sizing and stops
- revise LiquidityEvents tests to validate RiskService handling of signals

## Testing
- `pytest tests/test_ml_strategy.py tests/test_liquidity_events.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3626f6e9c832d875935a714983012