### PR TITLE
Expose initial stop helper on risk service

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -70,6 +70,11 @@ class RiskService:
     def check_global_exposure(self, symbol: str, new_alloc: float) -> bool:
         return self.core.check_global_exposure(symbol, new_alloc)
 
+    def initial_stop(
+        self, entry_price: float, side: str, atr: float | None = None
+    ) -> float:
+        return self.core.initial_stop(entry_price, side, atr)
+
     def update_trailing(
         self, trade: dict | object, current_price: float, fees_slip: float = 0.0
     ) -> None:

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -104,7 +104,7 @@ class MeanRevOFI(Strategy):
             qty = self.risk_service.calc_position_size(strength, last_close)
             trade = {"side": side, "entry_price": last_close, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 last_close, side, atr
             )
             trade["atr"] = atr

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -151,7 +151,7 @@ class ScalpPingPong(Strategy):
             qty = self.risk_service.calc_position_size(size, price)
             trade = {"side": side, "entry_price": price, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 price, side, atr
             )
             trade["atr"] = atr

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -70,7 +70,7 @@ class TrendFollowing(Strategy):
             qty = self.risk_service.calc_position_size(strength, price)
             trade = {"side": side, "entry_price": price, "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(
+            trade["stop"] = self.risk_service.initial_stop(
                 price, side, atr
             )
             trade["atr"] = atr

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -193,7 +193,7 @@ class TripleBarrier(Strategy):
             qty = self.risk_service.calc_position_size(1.0, last)
             trade = {"side": side, "entry_price": float(last), "qty": qty}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(last, side, atr)
+            trade["stop"] = self.risk_service.initial_stop(last, side, atr)
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, float(last))
             self.trade = trade


### PR DESCRIPTION
## Summary
- Add `initial_stop` method to `RiskService` delegating to core manager
- Use new `RiskService.initial_stop` in triple_barrier, scalp_pingpong, trend_following, and mean_rev_ofi strategies

## Testing
- `pytest tests/test_triple_barrier.py tests/test_scalp_pingpong.py tests/test_trend_following.py tests/test_strategies.py::test_mean_rev_ofi_signals tests/test_strategies.py::test_mean_rev_ofi_trailing_stop_uses_atr -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36cb401c0832da4e010de0b21195e