### PR TITLE
refactor: use service initial_stop

### DIFF
--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -62,7 +62,7 @@ class DepthImbalance(Strategy):
             qty = self.risk_service.calc_position_size(strength, price)
             trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(price, side, atr)
+            trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -88,7 +88,7 @@ class LiquidityEvents(Strategy):
                 qty = self.risk_service.calc_position_size(strength, last_price)
                 trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
                 atr = bar.get("atr") or bar.get("volatility")
-                trade["stop"] = self.risk_service.core.initial_stop(last_price, side, atr)
+                trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
@@ -101,7 +101,7 @@ class LiquidityEvents(Strategy):
                 qty = self.risk_service.calc_position_size(strength, last_price)
                 trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
                 atr = bar.get("atr") or bar.get("volatility")
-                trade["stop"] = self.risk_service.core.initial_stop(last_price, side, atr)
+                trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
@@ -117,7 +117,7 @@ class LiquidityEvents(Strategy):
                 qty = self.risk_service.calc_position_size(strength, last_price)
                 trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
                 atr = bar.get("atr") or bar.get("volatility")
-                trade["stop"] = self.risk_service.core.initial_stop(last_price, side, atr)
+                trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
@@ -130,7 +130,7 @@ class LiquidityEvents(Strategy):
                 qty = self.risk_service.calc_position_size(strength, last_price)
                 trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
                 atr = bar.get("atr") or bar.get("volatility")
-                trade["stop"] = self.risk_service.core.initial_stop(last_price, side, atr)
+                trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -113,7 +113,7 @@ class MLStrategy(Strategy):
             qty = self.risk_service.calc_position_size(strength, price)
             trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(price, side, atr)
+            trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -79,7 +79,7 @@ class OrderFlow(Strategy):
             qty = self.risk_service.calc_position_size(strength, price)
             trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.core.initial_stop(price, side, atr)
+            trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -82,7 +82,7 @@ def test_liquidity_events_risk_service_handles_stop_and_size():
     assert trade is not None
     expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])
     assert trade["qty"] == pytest.approx(expected_qty)
-    expected_stop = svc.core.initial_stop(trade["entry_price"], "buy")
+    expected_stop = svc.initial_stop(trade["entry_price"], "buy")
     assert trade["stop"] == pytest.approx(expected_stop)
 
 

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -48,5 +48,5 @@ def test_ml_strategy_risk_service_handles_stop_and_size():
     assert trade is not None
     expected_qty = svc.calc_position_size(sig.strength, bar_open["close"])
     assert trade["qty"] == pytest.approx(expected_qty)
-    expected_stop = svc.core.initial_stop(bar_open["close"], "buy")
+    expected_stop = svc.initial_stop(bar_open["close"], "buy")
     assert trade["stop"] == pytest.approx(expected_stop)


### PR DESCRIPTION
## Summary
- call `risk_service.initial_stop` in strategies instead of going through `risk_service.core`
- update unit tests to expect `svc.initial_stop`

## Testing
- `pytest tests/test_ml_strategy.py tests/test_liquidity_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68b36fc01408832d99eb4d01fcce762b