### PR TITLE
Refactor runners to use Account-based trade tracking

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -114,8 +114,9 @@ async def _run_symbol(
     if engine is not None:
         pos_map = load_positions(engine, guard.cfg.venue)
         for sym, data in pos_map.items():
-            risk.update_position(guard.cfg.venue, sym, data.get("qty", 0.0))
-            risk.rm._entry_price = data.get("avg_price")
+            risk.update_position(
+                guard.cfg.venue, sym, data.get("qty", 0.0), entry_price=data.get("avg_price")
+            )
         oco_book.preload(
             load_active_oco(engine, venue=guard.cfg.venue, symbols=[cfg.symbol])
         )

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -35,13 +35,24 @@ class DummyStrat:
 class DummyRisk:
     def __init__(self, *a, **k):
         self.last_strength: float | None = None
-        self.rm = types.SimpleNamespace(pos=types.SimpleNamespace(qty=0.0), min_order_qty=0.0)
+        self.rm = types.SimpleNamespace(min_order_qty=0.0)
+        self.account = types.SimpleNamespace(current_exposure=lambda symbol: (0.0, 0.0))
+        self.trades: dict = {}
 
     def mark_price(self, symbol, price):
         pass
 
     def update_correlation(self, *a, **k):
         pass
+
+    def get_trade(self, symbol):
+        return self.trades.get(symbol)
+
+    def update_trailing(self, trade, px):
+        pass
+
+    def manage_position(self, trade):
+        return "hold"
 
     def check_order(self, symbol, side, equity, price, strength=1.0, **_):
         self.last_strength = strength


### PR DESCRIPTION
## Summary
- Track open trades inside `RiskService` and expose `get_trade`
- Rely on `Account.current_exposure` and `RiskService` trades in live runners and backtest engine
- Update paper runner test for new risk service API

## Testing
- `pytest` *(fails: tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk, tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress)*

------
https://chatgpt.com/codex/tasks/task_e_68b3764efcb0832db04f4e20ef309f2c