### PR TITLE
Remove vol_target from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ backtest:
 
 risk:
   risk_pct: 0.02
-  vol_target: 0.01
   total_cap_pct: null
   per_symbol_cap_pct: null
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,15 +16,13 @@ A continuación se describen los comandos disponibles. Todas las estrategias
 emiten señales con un campo `strength`. El `RiskService` utiliza esa señal para
 dimensionar automáticamente la posición (`notional = equity * strength`).
 Valores mayores a `1.0` piramidan la exposición, menores la desescalan. El
-parámetro `risk_pct` establece la pérdida máxima permitida y `vol_target`
-dimensiona la posición según la volatilidad.
+parámetro `risk_pct` establece la pérdida máxima permitida.
 
 Ejemplo de configuración de riesgo:
 
 ```yaml
 risk:
   risk_pct: 0.02
-  vol_target: 0.01
   total_cap_pct: null
   per_symbol_cap_pct: null
 ```

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -48,7 +48,6 @@ ingestion:
 risk:
   risk_pct: 0.02
   max_symbol_exposure: null
-  vol_target: 0.01
   total_cap_pct: null
   per_symbol_cap_pct: null
 

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -70,7 +70,6 @@ class RiskConfig:
 
     risk_pct: float = 0.0
     max_symbol_exposure: float | None = None
-    vol_target: float = 0.0
     total_cap_pct: float | None = None
     per_symbol_cap_pct: float | None = None
     correlation_threshold: float = 0.8


### PR DESCRIPTION
## Summary
- drop `vol_target` option from default YAML risk config
- remove `vol_target` field from Hydra risk config
- update docs to no longer mention `vol_target`

## Testing
- `pytest tests/test_monitoring_panel.py::test_config_roundtrip tests/test_cli_backtest_param_config.py tests/test_rehydrate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b37664eda8832daba1ea189bad77b6