### PR TITLE
Handle scaling signals

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -35,13 +35,15 @@ class BreakoutVol(Strategy):
         last = float(closes.iloc[-1])
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, last)
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": last}
-            )
+            trade_state = {**self.trade, "current_price": last}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
         upper = mean + self.mult * std
         lower = mean - self.mult * std
@@ -72,7 +74,7 @@ class BreakoutVol(Strategy):
             return None
         if self.risk_service:
             qty = self.risk_service.calc_position_size(size, last)
-            trade = {"side": side, "entry_price": last, "qty": qty}
+            trade = {"side": side, "entry_price": last, "qty": qty, "strength": size}
             atr = bar.get("atr") or bar.get("volatility") or 0.0
             trade["stop"] = self.risk_service.initial_stop(last, side, atr)
             trade["atr"] = atr

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -42,11 +42,15 @@ class DepthImbalance(Strategy):
         price = bar.get("close")
         if self.trade and self.risk_service and price is not None:
             self.risk_service.update_trailing(self.trade, price)
-            decision = self.risk_service.manage_position({**self.trade, "current_price": price})
+            trade_state = {**self.trade, "current_price": price}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
 
         di_series = depth_imbalance(df[list(needed)])

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -72,11 +72,15 @@ class LiquidityEvents(Strategy):
 
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, last_price)
-            decision = self.risk_service.manage_position({**self.trade, "current_price": last_price})
+            trade_state = {**self.trade, "current_price": last_price}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
 
         vac_thresh = self._vol_adjust(mid, self.vacuum_threshold)

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -63,13 +63,15 @@ class MeanRevOFI(Strategy):
 
         if self.trade and self.risk_service and last_close is not None:
             self.risk_service.update_trailing(self.trade, last_close)
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": last_close}
-            )
+            trade_state = {**self.trade, "current_price": last_close}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
 
         needed = {"bid_qty", "ask_qty", "close"}
@@ -102,7 +104,7 @@ class MeanRevOFI(Strategy):
         strength = 1.0
         if self.risk_service and last_close is not None:
             qty = self.risk_service.calc_position_size(strength, last_close)
-            trade = {"side": side, "entry_price": last_close, "qty": qty}
+            trade = {"side": side, "entry_price": last_close, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(
                 last_close, side, atr

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -44,13 +44,15 @@ class MeanReversion(Strategy):
         price = float(price_series.iloc[-1])
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": price}
-            )
+            trade_state = {**self.trade, "current_price": price}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
         rsi_series = rsi(df, self.rsi_n)
         last_rsi = rsi_series.iloc[-1]
@@ -93,7 +95,7 @@ class MeanReversion(Strategy):
             return None
         if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty}
+            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility") or 0.0
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             trade["atr"] = atr

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -93,11 +93,15 @@ class MLStrategy(Strategy):
         price = float(bar.get("close") or bar.get("price") or 0.0)
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
-            decision = self.risk_service.manage_position({**self.trade, "current_price": price})
+            trade_state = {**self.trade, "current_price": price}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
 
         if proba > 0.5 + self.margin:

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -48,13 +48,15 @@ class Momentum(Strategy):
         price = float(closes.iloc[-1])
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": price}
-            )
+            trade_state = {**self.trade, "current_price": price}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
         rsi_series = rsi(df, self.rsi_n)
         prev_rsi = rsi_series.iloc[-2]
@@ -81,7 +83,7 @@ class Momentum(Strategy):
         strength = 1.0
         if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty}
+            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility") or 0.0
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             trade["atr"] = atr

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -151,13 +151,15 @@ class TripleBarrier(Strategy):
         last = df["close"].iloc[-1]
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, last)
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": last}
-            )
+            trade_state = {**self.trade, "current_price": last}
+            decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
                 return Signal(side, 1.0)
+            if decision in {"scale_in", "scale_out"}:
+                self.trade["strength"] = trade_state.get("strength", 1.0)
+                return Signal(self.trade["side"], self.trade["strength"])
             return None
 
         features = self._prepare_features(df)
@@ -189,12 +191,13 @@ class TripleBarrier(Strategy):
             side = "sell"
         else:
             return None
+        strength = 1.0
         if self.risk_service:
-            qty = self.risk_service.calc_position_size(1.0, last)
-            trade = {"side": side, "entry_price": float(last), "qty": qty}
+            qty = self.risk_service.calc_position_size(strength, last)
+            trade = {"side": side, "entry_price": float(last), "qty": qty, "strength": strength}
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(last, side, atr)
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, float(last))
             self.trade = trade
-        return Signal(side, 1.0)
+        return Signal(side, strength)


### PR DESCRIPTION
## Summary
- allow strategies to emit scale in/out signals
- live runners and backtest engine size and execute scale orders
- support risk service account funding in backtests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37e15c7bc832d8a92ff5d1d118529