### PR TITLE
Expose risk pct configuration in risk service

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -342,7 +342,13 @@ class EventDrivenBacktestEngine:
             )
             guard = PortfolioGuard(GuardConfig(venue=exchange))
             account = CoreAccount(float("inf"), cash=self.initial_equity)
-            self.risk[key] = RiskService(rm, guard, account=account, risk_per_trade=1.0)
+            self.risk[key] = RiskService(
+                rm,
+                guard,
+                account=account,
+                risk_per_trade=1.0,
+                risk_pct=self._risk_pct,
+            )
             self.strategy_exchange[key] = exchange
 
         # Internal flag to avoid repeated on_bar calls per bar index

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -124,7 +124,14 @@ async def run_live_binance(
         halt_action="close_all",
     ), venue="binance")
     pg_engine = get_engine() if (persist_pg and _CAN_PG) else None
-    risk = RiskService(risk_core, guard, dguard, engine=pg_engine, account=broker.account)
+    risk = RiskService(
+        risk_core,
+        guard,
+        dguard,
+        engine=pg_engine,
+        account=broker.account,
+        risk_pct=risk_pct,
+    )
     guard.refresh_usd_caps(broker.equity({}))
     oco_book = OcoBook()
     if pg_engine is not None:

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -48,6 +48,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
             RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="cross")),
             daily=None,
+            risk_pct=0.0,
         )
 
     engine = get_engine() if _CAN_PG else None

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -55,7 +55,13 @@ async def run_paper(
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
     guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()
-    risk = RiskService(risk_core, guard, corr_service=corr, account=broker.account)
+    risk = RiskService(
+        risk_core,
+        guard,
+        corr_service=corr,
+        account=broker.account,
+        risk_pct=risk_pct,
+    )
     engine = get_engine() if _CAN_PG else None
     oco_book = OcoBook()
     if engine is not None:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -133,7 +133,14 @@ async def _run_symbol(
     )
     corr = CorrelationService()
     broker = PaperAdapter(fee_bps=1.5)
-    risk = RiskService(risk_core, guard, dguard, corr_service=corr, account=broker.account)
+    risk = RiskService(
+        risk_core,
+        guard,
+        dguard,
+        corr_service=corr,
+        account=broker.account,
+        risk_pct=cfg.risk_pct,
+    )
     try:
         guard.refresh_usd_caps(broker.equity({}))
     except Exception:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -103,7 +103,13 @@ async def _run_symbol(
         halt_action="close_all",
     ), venue=venue)
     corr = CorrelationService()
-    risk = RiskService(risk_core, guard, dguard, corr_service=corr)
+    risk = RiskService(
+        risk_core,
+        guard,
+        dguard,
+        corr_service=corr,
+        risk_pct=cfg.risk_pct,
+    )
     broker = PaperAdapter(fee_bps=1.5)
     try:
         guard.refresh_usd_caps(broker.equity({}))

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -52,6 +52,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
         risk = RiskService(
             RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="binance")),
+            risk_pct=0.0,
         )
 
     engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -39,6 +39,7 @@ class RiskService:
         account: CoreAccount | None = None,
         risk_per_trade: float = 0.01,
         atr_mult: float = 2.0,
+        risk_pct: float = 0.01,
     ) -> None:
         self.rm = manager
         self.guard = guard
@@ -47,7 +48,10 @@ class RiskService:
         self.engine = engine
         self.account = account or CoreAccount(float("inf"))
         self.core = CoreRiskManager(
-            self.account, risk_per_trade=risk_per_trade, atr_mult=atr_mult
+            self.account,
+            risk_per_trade=risk_per_trade,
+            atr_mult=atr_mult,
+            risk_pct=risk_pct,
         )
         self.trades: Dict[str, dict] = {}
 

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -101,7 +101,11 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
     if cfg.persist_pg and not _CAN_PG:
         log.warning("Persistencia habilitada pero Timescale no disponible.")
     risk_mgr = RiskManager(risk_pct=0.0)
-    risk = RiskService(risk_mgr, PortfolioGuard(GuardConfig(venue="cross")))
+    risk = RiskService(
+        risk_mgr,
+        PortfolioGuard(GuardConfig(venue="cross")),
+        risk_pct=0.0,
+    )
 
     async def maybe_trade() -> None:
         nonlocal position_sign, entry_edge

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -19,7 +19,13 @@ def test_service_calc_position_size_passes_strength():
     account = Account(float("inf"), cash=1000.0)
     rm = RiskManager()
     guard = PortfolioGuard(GuardConfig(venue="test"))
-    svc = RiskService(rm, guard, account=account, risk_per_trade=0.1)
+    svc = RiskService(
+        rm,
+        guard,
+        account=account,
+        risk_per_trade=0.1,
+        risk_pct=0.01,
+    )
     price = 100.0
     full = svc.calc_position_size(1.0, price)
     partial = svc.calc_position_size(0.37, price)

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -56,7 +56,7 @@ def test_risk_service_uses_correlation_service():
     guard.refresh_usd_caps(1.0)
     rm = RiskManager(vol_target=0.02)
     corr = CorrelationService()
-    svc = RiskService(rm, guard, corr_service=corr)
+    svc = RiskService(rm, guard, corr_service=corr, risk_pct=0.0)
     now = datetime.now(timezone.utc)
     price_btc = 100.0
     price_eth = 200.0

--- a/tests/test_cross_exchange_arbitrage.py
+++ b/tests/test_cross_exchange_arbitrage.py
@@ -76,7 +76,11 @@ async def test_cross_exchange_updates_risk_positions(monkeypatch):
     spot = MockAdapter("spot", spot_trades, spot_ob, {"USDT": 200.0})
     perp = MockAdapter("perp", perp_trades, perp_ob, {"BTC": 1.0})
     cfg = CrossArbConfig(symbol="BTC/USDT", spot=spot, perp=perp, threshold=0.001)
-    risk = RiskService(RiskManager(), PortfolioGuard(GuardConfig(venue="test")))
+    risk = RiskService(
+        RiskManager(),
+        PortfolioGuard(GuardConfig(venue="test")),
+        risk_pct=0.0,
+    )
     monkeypatch.setattr(
         "tradingbot.live.runner_cross_exchange.balances",
         {spot.name: 2.0, perp.name: 1.0},

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -68,7 +68,7 @@ def test_liquidity_events_risk_service_handles_stop_and_size():
     })
     rm = RiskManager(risk_pct=0.02)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = LiquidityEvents(
         vacuum_threshold=0.5,

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -37,7 +37,7 @@ def test_ml_strategy_risk_service_handles_stop_and_size():
     stub = StubModel(0.7)
     rm = RiskManager(risk_pct=0.02)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = MLStrategy(model=stub, margin=0.1, risk_service=svc)
     strat.scaler.fit([[0.0]])

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -23,7 +23,7 @@ def test_rehydrate_state():
     rm = RiskManager()
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper"))
     guard.refresh_usd_caps(1e6)
-    risk = RiskService(rm, guard)
+    risk = RiskService(rm, guard, risk_pct=0.0)
 
     # Rehydrate
     pos_map = load_positions(engine, "paper")

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -93,7 +93,7 @@ def test_risk_service_updates_and_persists(monkeypatch):
     monkeypatch.setattr(
         timescale, "insert_risk_event", lambda engine, **kw: events.append(kw)
     )
-    svc = RiskService(rm, guard, daily, engine=object())
+    svc = RiskService(rm, guard, daily, engine=object(), risk_pct=0.0)
     allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, 1.0, strength=1.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
@@ -102,7 +102,7 @@ def test_risk_service_updates_and_persists(monkeypatch):
 def test_risk_service_stop_loss_triggers_close():
     rm = RiskManager(risk_pct=0.05)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.05)
     rm.set_position(1.0)
     svc.update_position("X", "BTC", 1.0)
     rm.check_limits(100.0)

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -32,7 +32,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     )
     guard.refresh_usd_caps(200.0)
     corr = CorrelationService()
-    svc = RiskService(rm, guard, corr_service=corr)
+    svc = RiskService(rm, guard, corr_service=corr, risk_pct=0.0)
 
     _feed_correlated_prices(corr)
     corr_df = corr._returns.corr()
@@ -57,7 +57,7 @@ async def test_risk_service_covariance_limit():
     guard = PortfolioGuard(
         GuardConfig(total_cap_pct=50.0, per_symbol_cap_pct=50.0, venue="test")
     )
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.0)
     cov_df = pd.DataFrame(
         [[0.04, 0.039], [0.039, 0.04]], index=["AAA", "BBB"], columns=["AAA", "BBB"]
     )

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -67,7 +67,7 @@ def test_risk_service_uses_guard_volatility():
     rm = RiskManager(vol_target=0.02)
     rm_guard_equity = 1.0
     guard.refresh_usd_caps(rm_guard_equity)
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.0)
     guard.st.returns["BTC"].extend([0.01, -0.02, 0.03])
     base = rm.size(
         "buy", 1.0, 1.0, strength=0.1, symbol="BTC", symbol_vol=guard.volatility("BTC")

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -107,7 +107,12 @@ def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
     svc = engine.risk[("sell_once", "SYM")]
     svc.rm.set_position(1.0)
     engine.risk[("sell_once", "SYM")] = CheatingRiskService(
-        svc.rm, svc.guard, svc.daily, svc.corr, engine=engine
+        svc.rm,
+        svc.guard,
+        svc.daily,
+        svc.corr,
+        engine=engine,
+        risk_pct=svc.core.risk_pct,
     )
     with pytest.raises(AssertionError, match="position went negative"):
         engine.run()

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -40,7 +40,7 @@ def test_breakout_atr_min_edge(breakout_df_buy, breakout_df_sell):
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
     rm = RiskManager(risk_pct=0.02)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, risk_service=svc)
     sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
@@ -135,7 +135,7 @@ def test_breakout_vol_risk_service_handles_stop_and_size():
     df_buy = pd.DataFrame({"close": [1, 2, 3, 10]})
     rm = RiskManager(risk_pct=0.02)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard)
+    svc = RiskService(rm, guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = BreakoutVol(lookback=2, mult=0.5, risk_service=svc)
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})


### PR DESCRIPTION
## Summary
- allow RiskService to accept a `risk_pct` and forward it to `CoreRiskManager`
- supply `risk_pct` from config when creating RiskService in runners and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3851fafe8832dbc4687624f450a55