### PR TITLE
Integrate risk service into trend following strategy

### DIFF
--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -1,5 +1,11 @@
+import pandas as pd
 import pytest
+
 from tradingbot.core import Account, RiskManager as CoreRiskManager
+from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+from tradingbot.strategies.trend_following import TrendFollowing
 
 
 def test_trend_following_trailing_stop_uses_atr():
@@ -15,4 +21,21 @@ def test_trend_following_trailing_stop_uses_atr():
     }
     rm.update_trailing(trade, 110.0)
     assert trade["stop"] == pytest.approx(110.0 - 2 * trade["atr"])
+
+
+def test_trend_following_risk_service_handles_stop_and_size():
+    df = pd.DataFrame({"close": [1, 2, 3]})
+    rm = RiskManager(risk_pct=0.02)
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
+    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc.account.update_cash(1000.0)
+    strat = TrendFollowing(risk_service=svc, rsi_n=2)
+    sig = strat.on_bar({"window": df, "atr": 1.0, "volatility": 0.0})
+    assert sig and sig.side == "buy"
+    trade = strat.trade
+    assert trade is not None
+    expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])
+    assert trade["qty"] == pytest.approx(expected_qty)
+    expected_stop = svc.initial_stop(trade["entry_price"], "buy", trade["atr"])
+    assert trade["stop"] == pytest.approx(expected_stop)
 


### PR DESCRIPTION
## Summary
- extend TrendFollowing strategy to use an optional risk service for sizing, stop placement and trailing management
- add trade lifecycle handling for scaling and closing positions via risk service
- test TrendFollowing integration with risk service and ATR-based trailing stops

## Testing
- `pytest tests/test_trend_following.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b38b9a04d8832d8c06ce7ca3260c4d