### PR TITLE
Track pending open orders in account and risk service

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -87,10 +87,22 @@ class RiskService:
 
     # Delegates to core risk manager
     def calc_position_size(self, signal_strength: float, price: float) -> float:
-        return self.core.calc_position_size(signal_strength, price)
+        pending = sum(
+            abs(qty) * self.account.prices.get(sym, 0.0)
+            for sym, qty in self.account.open_orders.items()
+        )
+        balance = self.account.cash - pending
+        alloc = balance * self.core.risk_per_trade * float(signal_strength)
+        if price <= 0:
+            return 0.0
+        size = alloc / float(price)
+        return max(0.0, size)
 
     def check_global_exposure(self, symbol: str, new_alloc: float) -> bool:
-        return self.core.check_global_exposure(symbol, new_alloc)
+        current = self.account.current_exposure(symbol)[1]
+        pending = self.account.pending_exposure(symbol)
+        limit = float(self.account.max_symbol_exposure)
+        return current + pending + abs(float(new_alloc)) <= limit
 
     def initial_stop(
         self, entry_price: float, side: str, atr: float | None = None
@@ -177,6 +189,7 @@ class RiskService:
             return False, reason, delta
         if action == "soft_allow":
             self._persist("INFO", symbol, reason, metrics)
+        self.account.update_open_order(symbol, qty)
         return True, reason, delta
 
     # ------------------------------------------------------------------
@@ -266,6 +279,7 @@ class RiskService:
         """Update internal position books after a fill."""
         self.rm.add_fill(side, qty, price=price)
         self.guard.update_position_on_order(symbol, side, qty, venue=venue)
+        self.account.update_open_order(symbol, -abs(qty))
         delta = qty if side == "buy" else -qty
         self.account.update_position(symbol, delta, price=price)
         if venue is not None:

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tradingbot.core import Account
+from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+
+
+def make_service(account: Account) -> RiskService:
+    rm = RiskManager()
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    return RiskService(rm, guard, account=account, risk_per_trade=0.1)
+
+
+def test_calc_position_size_accounts_for_open_orders():
+    account = Account(float("inf"), cash=1000.0)
+    account.mark_price("BTC", 100.0)
+    account.update_open_order("BTC", 2.0)  # reserves $200
+    svc = make_service(account)
+    size = svc.calc_position_size(1.0, 100.0)
+    assert size == pytest.approx(0.8)
+
+
+def test_check_global_exposure_includes_pending():
+    account = Account(max_symbol_exposure=1000.0, cash=0.0)
+    account.update_position("BTC", 2.0, price=100.0)  # $200 exposure
+    account.mark_price("BTC", 100.0)
+    account.update_open_order("BTC", 3.0)  # $300 pending
+    svc = make_service(account)
+    assert svc.check_global_exposure("BTC", 400.0)
+    assert not svc.check_global_exposure("BTC", 600.0)


### PR DESCRIPTION
## Summary
- track open order quantities per symbol in Account and expose pending exposure
- size positions and exposure checks in RiskService now account for pending orders
- adjust open order ledger on fills and new orders

## Testing
- `pytest tests/test_open_orders.py tests/test_core_position_size.py -q`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b394b85bb4832d911baeae1daae7e7