### PR TITLE
Refactor RiskService order sizing to use account balance

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -842,10 +842,10 @@ class EventDrivenBacktestEngine:
                     if equity < 0:
                         continue
                     equity_for_order = max(equity, 1.0)
+                    svc.account.cash = equity_for_order
                     allowed, _reason, delta = svc.check_order(
                         symbol,
                         sig.side,
-                        equity_for_order,
                         place_price,
                         strength=sig.strength,
                     )

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -251,11 +251,11 @@ async def run_live_binance(
             continue
 
         eq = broker.equity(mark_prices={symbol: px})
+        risk.account.cash = eq
         pending = getattr(strat, "pending_qty", {}).get(symbol, 0.0)
         allowed, reason, delta = risk.check_order(
             symbol,
             signal.side,
-            eq,
             closed.c,
             strength=signal.strength,
             pending_qty=pending,

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -82,17 +82,16 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
             equity = eq
         if equity <= 0:
             equity = max(last["spot"], last["perp"])
+        risk.account.cash = equity
         ok1, _r1, delta1 = risk.check_order(
             cfg.symbol,
             spot_side,
-            equity,
             last["spot"],
             strength=strength,
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
-            equity,
             last["perp"],
             strength=strength,
         )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -118,10 +118,10 @@ async def run_paper(
             if signal is None:
                 continue
             eq = broker.equity(mark_prices={symbol: closed.c})
+            risk.account.cash = eq
             allowed, _reason, delta = risk.check_order(
                 symbol,
                 signal.side,
-                eq,
                 closed.c,
                 strength=signal.strength,
             )

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -240,10 +240,10 @@ async def _run_symbol(
         if sig is None:
             continue
         eq = broker.equity(mark_prices={cfg.symbol: px})
+        risk.account.cash = eq
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
-            eq,
             closed.c,
             strength=sig.strength,
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -151,10 +151,10 @@ async def _run_symbol(
         if sig is None:
             continue
         eq = broker.equity(mark_prices={cfg.symbol: px})
+        risk.account.cash = eq
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
-            eq,
             closed.c,
             strength=sig.strength,
             corr_threshold=corr_threshold,

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -103,6 +103,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                             f"{cfg.route.mid}/{cfg.route.quote}": last["mq"],
                         }
                     )
+                    risk.account.cash = eq
 
                     legs: list[tuple[str, str, float, dict]] = []
                     notional = 0.0
@@ -111,7 +112,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["bq"],
                             strength=strength,
                         )
@@ -123,7 +123,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "buy",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -135,7 +134,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["mq"],
                             strength=s3,
                         )
@@ -171,7 +169,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["mq"],
                             strength=strength,
                         )
@@ -183,7 +180,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "sell",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -195,7 +191,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["bq"],
                             strength=s3,
                         )

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -174,18 +174,17 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
             )
             if equity <= 0:
                 equity = max(last["spot"], last["perp"])
+            risk.account.cash = equity
 
             ok_s, _r1, delta_s = risk.check_order(
                 cfg.symbol,
                 spot_side,
-                equity,
                 last["spot"],
                 strength=strength,
             )
             ok_p, _r2, delta_p = risk.check_order(
                 cfg.symbol,
                 perp_side,
-                equity,
                 last["perp"],
                 strength=strength,
             )

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -54,7 +54,7 @@ class DummyRisk:
     def manage_position(self, trade):
         return "hold"
 
-    def check_order(self, symbol, side, equity, price, strength=1.0, **_):
+    def check_order(self, symbol, side, price, strength=1.0, **_):
         self.last_strength = strength
         return True, "", 1.0
 

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -94,7 +94,9 @@ def test_risk_service_updates_and_persists(monkeypatch):
         timescale, "insert_risk_event", lambda engine, **kw: events.append(kw)
     )
     svc = RiskService(rm, guard, daily, engine=object(), risk_pct=1.0)
-    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, 1.0, strength=1.0)
+    svc.account.update_cash(1.0)
+    monkeypatch.setattr(rm, "check_limits", lambda price: False)
+    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, strength=1.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
 
@@ -103,11 +105,12 @@ def test_risk_service_stop_loss_triggers_close():
     rm = RiskManager(risk_pct=0.05)
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
     svc = RiskService(rm, guard, risk_pct=0.05)
+    svc.account.update_cash(10_000.0)
     rm.set_position(1.0)
     svc.update_position("X", "BTC", 1.0)
     rm.check_limits(100.0)
 
-    allowed, reason, delta = svc.check_order("BTC", "buy", 10_000.0, 94.0)
+    allowed, reason, delta = svc.check_order("BTC", "buy", 94.0)
     assert allowed is True
     assert reason == "stop_loss"
     assert delta == pytest.approx(-1.0)

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -32,7 +32,8 @@ async def test_risk_service_correlation_limits_and_sizing():
     )
     guard.refresh_usd_caps(200.0)
     corr = CorrelationService()
-    svc = RiskService(rm, guard, corr_service=corr, risk_pct=1.0)
+    svc = RiskService(rm, guard, corr_service=corr, risk_pct=1.0, risk_per_trade=0.5)
+    svc.account.update_cash(200.0)
 
     _feed_correlated_prices(corr)
     corr_df = corr._returns.corr()
@@ -42,7 +43,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     assert events and events[0]["reason"] == "correlation"
 
     allowed, reason, delta = svc.check_order(
-        "AAA", "buy", 200.0, 100.0, corr_threshold=0.8, strength=0.5
+        "AAA", "buy", 100.0, corr_threshold=0.8, strength=0.5
     )
     assert allowed
     assert delta == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- compute order size via `calc_position_size` and validate exposure in `check_order`
- drop `equity` parameter from `RiskService.check_order` and use account cash
- update runners, strategies, and tests for new `check_order` signature

## Testing
- `pytest tests/test_risk_service_correlation.py tests/test_risk_manager_limits.py tests/test_paper_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68b398248804832dbcfbe772ba78eb82