### PR TITLE
Drop take-profit/stop-loss flags from adapters

### DIFF
--- a/src/tradingbot/adapters/binance_futures.py
+++ b/src/tradingbot/adapters/binance_futures.py
@@ -158,8 +158,6 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
     ):
         """
         UM Futures: idempotencia + retries + reconciliación.
@@ -178,8 +176,6 @@ class BinanceFuturesAdapter(ExchangeAdapter):
                     post_only=post_only,
                     time_in_force=time_in_force,
                     iceberg_qty=iceberg_qty,
-                    take_profit=take_profit,
-                    stop_loss=stop_loss,
                 )
                 params.update(
                     {

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -271,8 +271,6 @@ class BybitFuturesAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
         params: dict | None = None,
     ) -> dict:
@@ -282,8 +280,6 @@ class BybitFuturesAdapter(ExchangeAdapter):
             post_only=post_only,
             time_in_force=time_in_force,
             iceberg_qty=iceberg_qty,
-            take_profit=take_profit,
-            stop_loss=stop_loss,
             reduce_only=reduce_only,
         )
         params.update(extra)

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -351,8 +351,6 @@ class OKXFuturesAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
         params: dict | None = None,
     ) -> dict:
@@ -362,8 +360,6 @@ class OKXFuturesAdapter(ExchangeAdapter):
             post_only=post_only,
             time_in_force=time_in_force,
             iceberg_qty=iceberg_qty,
-            take_profit=take_profit,
-            stop_loss=stop_loss,
             reduce_only=reduce_only,
         )
         params.update(extra)

--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -102,8 +102,6 @@ class BinanceConnector(ExchangeConnector):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
     ) -> dict:
         """Submit an order to Binance via CCXT.
@@ -118,8 +116,6 @@ class BinanceConnector(ExchangeConnector):
             post_only=post_only,
             time_in_force=time_in_force,
             iceberg_qty=iceberg_qty,
-            take_profit=take_profit,
-            stop_loss=stop_loss,
             reduce_only=reduce_only,
         )
 

--- a/src/tradingbot/connectors/bybit.py
+++ b/src/tradingbot/connectors/bybit.py
@@ -89,10 +89,8 @@ class BybitConnector(ExchangeConnector):
         price: float | None = None,
         *,
         post_only: bool = False,
-        time_in_force: str | None = None,
+       time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
     ) -> dict:
         """Submit an order through the CCXT Bybit client."""
@@ -102,8 +100,6 @@ class BybitConnector(ExchangeConnector):
             post_only=post_only,
             time_in_force=time_in_force,
             iceberg_qty=iceberg_qty,
-            take_profit=take_profit,
-            stop_loss=stop_loss,
             reduce_only=reduce_only,
         )
 

--- a/src/tradingbot/connectors/okx.py
+++ b/src/tradingbot/connectors/okx.py
@@ -90,8 +90,6 @@ class OKXConnector(ExchangeConnector):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
     ) -> dict:
         """Place an order via the underlying CCXT client.
@@ -106,8 +104,6 @@ class OKXConnector(ExchangeConnector):
             post_only=post_only,
             time_in_force=time_in_force,
             iceberg_qty=iceberg_qty,
-            take_profit=take_profit,
-            stop_loss=stop_loss,
             reduce_only=reduce_only,
         )
 

--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -238,8 +238,6 @@ class PaperAdapter(ExchangeAdapter):
         post_only: bool = False,
         time_in_force: str | None = None,
         iceberg_qty: float | None = None,
-        take_profit: float | None = None,
-        stop_loss: float | None = None,
         reduce_only: bool = False,
     ) -> dict:
         order_id = self._next_order_id()

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -234,10 +234,6 @@ class ExecutionRouter:
                 or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
             ):
                 kwargs["iceberg_qty"] = order.iceberg_qty
-        if order.take_profit is not None:
-            kwargs["take_profit"] = order.take_profit
-        if order.stop_loss is not None:
-            kwargs["stop_loss"] = order.stop_loss
 
         try:
             res = await adapter.place_order(**kwargs)

--- a/src/tradingbot/execution/venue_adapter.py
+++ b/src/tradingbot/execution/venue_adapter.py
@@ -15,10 +15,6 @@ Currently the translator understands the following flags:
     requested the maker flag takes precedence.
 ``iceberg_qty``
     Quantity for iceberg orders.  The parameter name differs per exchange.
-``take_profit`` and ``stop_loss``
-    Prices for one-cancels-the-other (OCO) orders.  Exchanges use different
-    names for these fields (``tpPrice``/``stopPrice`` on Binance vs
-    ``takeProfit``/``stopLoss`` on Bybit/OKX).
 ``reduce_only``
     Ensure an order only decreases an existing position.  Typically maps to a
     ``reduceOnly`` parameter on derivative venues.
@@ -34,8 +30,6 @@ def translate_order_flags(
     post_only: bool = False,
     time_in_force: Optional[str] = None,
     iceberg_qty: Optional[float] = None,
-    take_profit: Optional[float] = None,
-    stop_loss: Optional[float] = None,
     reduce_only: bool = False,
 ) -> Dict[str, Any]:
     """Translate generic order flags into venue specific ``params``.
@@ -52,9 +46,6 @@ def translate_order_flags(
         that use the ``GTX`` encoding.
     iceberg_qty:
         Visible portion for iceberg orders.
-    take_profit, stop_loss:
-        Optional prices for OCO style orders.  If only one of them is provided
-        a simple TP or SL order is produced.
     reduce_only:
         For derivative venues this flag ensures the order only reduces an
         existing position.  Many venues share the same ``reduceOnly`` parameter
@@ -77,10 +68,6 @@ def translate_order_flags(
             params["timeInForce"] = time_in_force
         if iceberg_qty is not None:
             params["icebergQty"] = float(iceberg_qty)
-        if take_profit is not None:
-            params["tpPrice"] = float(take_profit)
-        if stop_loss is not None:
-            params["stopPrice"] = float(stop_loss)
         if reduce_only:
             params["reduceOnly"] = True
         return params
@@ -93,10 +80,6 @@ def translate_order_flags(
             params["postOnly"] = True
         if iceberg_qty is not None:
             params["iceberg"] = float(iceberg_qty)
-        if take_profit is not None:
-            params["takeProfit"] = float(take_profit)
-        if stop_loss is not None:
-            params["stopLoss"] = float(stop_loss)
         if reduce_only:
             params["reduceOnly"] = True
         return params
@@ -108,10 +91,6 @@ def translate_order_flags(
         params["postOnly"] = True
     if iceberg_qty is not None:
         params["icebergQty"] = float(iceberg_qty)
-    if take_profit is not None:
-        params["takeProfit"] = float(take_profit)
-    if stop_loss is not None:
-        params["stopLoss"] = float(stop_loss)
     if reduce_only:
         params["reduceOnly"] = True
     return params

--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -52,7 +52,7 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        Data with generated signals and risk management levels.
+        Data with generated signals.
     """
 
     df = data.copy()
@@ -60,8 +60,6 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     position_size = params.get("position_size", 1)
     fee = params.get("fee", 0.0)
     slippage = params.get("slippage", 0.0)
-    sl_pct = params.get("stop_loss", 0.0)
-    tp_pct = params.get("take_profit", 0.0)
 
     spread = df["asset_a"] - df["asset_b"]
     df["signal"] = 0
@@ -69,12 +67,10 @@ def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:
     df.loc[spread < -threshold, "signal"] = 1
 
     df["position"] = df["signal"].shift(1).fillna(0) * position_size
-    df["stop_loss"] = df["asset_a"] * (1 - sl_pct)
-    df["take_profit"] = df["asset_a"] * (1 + tp_pct)
     df["fee"] = df["position"].abs() * fee
     df["slippage"] = df["position"].abs() * slippage
 
-    return df[["signal", "position", "stop_loss", "take_profit", "fee", "slippage"]]
+    return df[["signal", "position", "fee", "slippage"]]
 
 
 __all__ = ["Arbitrage", "generate_signals"]

--- a/tests/test_execution_flags.py
+++ b/tests/test_execution_flags.py
@@ -100,28 +100,3 @@ async def test_fok_orders(venue):
     assert adapter.orders == {}
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "venue,expected",
-    [
-        ("binance_futures_testnet", {"tpPrice": 110.0, "stopPrice": 90.0}),
-        ("bybit_testnet", {"takeProfit": 110.0, "stopLoss": 90.0}),
-        ("okx_testnet", {"takeProfit": 110.0, "stopLoss": 90.0}),
-    ],
-)
-async def test_oco_orders(venue, expected):
-    adapter = DummyTestnetAdapter(venue)
-    res = await adapter.place_order(
-        "BTC/USDT",
-        "buy",
-        "limit",
-        1,
-        price=100,
-        take_profit=110.0,
-        stop_loss=90.0,
-    )
-    assert res["status"] == "open"
-    assert res["params"] == expected
-    cancel = await adapter.cancel_order(res["order_id"])
-    assert cancel["status"] == "canceled"
-    assert adapter.orders == {}

--- a/tests/test_router_orders.py
+++ b/tests/test_router_orders.py
@@ -47,7 +47,6 @@ async def test_best_venue_selection():
         {"type_": "limit", "price": 100.0, "time_in_force": "IOC"},
         {"type_": "limit", "price": 100.0, "time_in_force": "FOK"},
         {"type_": "limit", "price": 100.0, "iceberg_qty": 0.1},
-        {"type_": "limit", "price": 100.0, "take_profit": 110.0, "stop_loss": 90.0},
         {"type_": "market", "reduce_only": True},
     ],
 )


### PR DESCRIPTION
## Summary
- remove `take_profit` and `stop_loss` from exchange connectors and futures adapters
- simplify order flag translation to exclude TP/SL handling
- update arbitrage strategy, router, and tests for removed parameters

## Testing
- `pytest tests/test_execution_flags.py tests/test_router_orders.py tests/test_basic_strategies.py tests/test_execution_router_fill_mode.py -q`
- `pytest -q` *(killed: out-of-memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b39825e5a8832d958da4c9f4de67b4