### PR TITLE
docs: update fill reason list

### DIFF
--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -6,7 +6,7 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | Columna | Descripción |
 | --- | --- |
 | `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
-| `reason` | Motivo del fill (`order`, `take_profit`, `stop_loss`, etc.) |
+| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `take_profit`, `stop_loss`, `trailing_stop` o `exit` (cierre manual u otros motivos) |
 | `side` | `buy` o `sell` |
 | `price` | Precio de ejecución |
 | `qty` | Cantidad ejecutada |


### PR DESCRIPTION
## Summary
- detail current fill reasons (`order`, `take_profit`, `stop_loss`, `trailing_stop`, `exit`) in fills CSV documentation

## Testing
- `pytest tests/test_backtest_engine.py -q` *(fails: fee cost calculation, spot long-only enforcement, funding payment)*

------
https://chatgpt.com/codex/tasks/task_e_68b3982931bc832da8767c7bdfb87829