### PR TITLE
test: align core position size with new RiskService API

### DIFF
--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -32,6 +32,7 @@ def test_service_calc_position_size_passes_strength():
         "BTC", "buy", account.cash, price, strength=0.37
     )
     assert allowed is True
+    assert reason == "caps desactivados"
     assert delta == pytest.approx(partial)
 
 


### PR DESCRIPTION
## Summary
- assert reason returned by RiskService.check_order
- ensure RiskService instantiated with PortfolioGuard parameters only

## Testing
- `pytest tests/test_core_position_size.py`

------
https://chatgpt.com/codex/tasks/task_e_68b39d1fe628832db7ce23e322dcdb23