### PR TITLE
Support limit prices in signals and runners

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -267,7 +267,7 @@ async def run_live_binance(
 
         side = "buy" if delta > 0 else "sell"
         prev_rpnl = broker.state.realized_pnl
-        price = _limit_price(side)
+        price = signal.limit_price if signal.limit_price is not None else _limit_price(side)
         resp = await exec_broker.place_limit(
             symbol,
             side,

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -254,7 +254,9 @@ async def _run_symbol(
         side = "buy" if delta > 0 else "sell"
         qty = abs(delta)
         price = (
-            closed.c - limit_offset if side == "buy" else closed.c + limit_offset
+            sig.limit_price
+            if sig.limit_price is not None
+            else (closed.c - limit_offset if side == "buy" else closed.c + limit_offset)
         )
         resp = await exec_broker.place_limit(
             cfg.symbol,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -166,7 +166,9 @@ async def _run_symbol(
         side = "buy" if delta > 0 else "sell"
         qty = abs(delta)
         price = (
-            closed.c - limit_offset if side == "buy" else closed.c + limit_offset
+            sig.limit_price
+            if sig.limit_price is not None
+            else (closed.c - limit_offset if side == "buy" else closed.c + limit_offset)
         )
         resp = await exec_broker.place_limit(
             cfg.symbol,

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -25,6 +25,7 @@ class Signal:
     side: str  # 'buy' | 'sell' | 'flat'
     strength: float = 1.0  # fraction of the base equity allocation
     reduce_only: bool = False
+    limit_price: float | None = None
 
 class Strategy(ABC):
     name: str

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -86,4 +86,7 @@ class BreakoutATR(Strategy):
             trade["atr"] = atr_val
             self.risk_service.update_trailing(trade, last_close)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        level = float(upper.iloc[-1]) if side == "buy" else float(lower.iloc[-1])
+        sig.limit_price = level
+        return sig

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -101,7 +101,9 @@ class MeanReversion(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- extend `Signal` with optional `limit_price`
- set `limit_price` in breakout and mean reversion strategies
- runners honour `Signal.limit_price` when placing orders, falling back to book-derived price

## Testing
- `pytest` *(failed: process killed)*
- `pytest tests/strategies/test_execution_callbacks.py tests/broker/test_place_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_68b39cc841cc832d84400fd18344f7dc