### PR TITLE
refactor: streamline risk order checks

### DIFF
--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -44,9 +44,8 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     broker = PaperAdapter()
     if risk is None:
         risk = RiskService(
-            RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="cross")),
-            daily=None,
+            account=broker.account,
             risk_pct=0.0,
         )
 
@@ -82,17 +81,16 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
             equity = eq
         if equity <= 0:
             equity = max(last["spot"], last["perp"])
+        risk.account.cash = equity
         ok1, _r1, delta1 = risk.check_order(
             cfg.symbol,
             spot_side,
-            equity,
             last["spot"],
             strength=strength,
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
-            equity,
             last["perp"],
             strength=strength,
         )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -117,11 +117,9 @@ async def run_paper(
             signal = strat.on_bar({"window": df})
             if signal is None:
                 continue
-            eq = broker.equity(mark_prices={symbol: closed.c})
             allowed, _reason, delta = risk.check_order(
                 symbol,
                 signal.side,
-                eq,
                 closed.c,
                 strength=signal.strength,
             )

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -116,7 +116,6 @@ async def _run_symbol(
         raise ValueError(f"unknown strategy: {strategy_name}")
     params = params or {}
     strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
-    risk_core = RiskManager(risk_pct=cfg.risk_pct, allow_short=(market != "spot"))
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,
@@ -140,13 +139,13 @@ async def _run_symbol(
     limit_offset = settings.limit_offset_ticks * tick_size
     tif = f"GTD:{settings.limit_expiry_sec}|PO"
     risk = RiskService(
-        risk_core,
         guard,
         dguard,
         corr_service=corr,
         account=broker.account,
         risk_pct=cfg.risk_pct,
     )
+    risk.rm.allow_short = market != "spot"
     try:
         guard.refresh_usd_caps(broker.equity({}))
     except Exception:
@@ -239,11 +238,9 @@ async def _run_symbol(
         sig = strat.on_bar({"window": df})
         if sig is None:
             continue
-        eq = broker.equity(mark_prices={cfg.symbol: px})
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
-            eq,
             closed.c,
             strength=sig.strength,
         )

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -103,6 +103,7 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                             f"{cfg.route.mid}/{cfg.route.quote}": last["mq"],
                         }
                     )
+                    risk.account.cash = eq
 
                     legs: list[tuple[str, str, float, dict]] = []
                     notional = 0.0
@@ -111,7 +112,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["bq"],
                             strength=strength,
                         )
@@ -123,7 +123,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "buy",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -135,7 +134,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["mq"],
                             strength=s3,
                         )
@@ -171,7 +169,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["mq"],
                             strength=strength,
                         )
@@ -183,7 +180,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "sell",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -195,7 +191,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["bq"],
                             strength=s3,
                         )

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -128,7 +128,6 @@ class RiskService:
         self,
         symbol: str,
         side: str,
-        equity: float,
         price: float,
         strength: float = 1.0,
         *,
@@ -141,7 +140,8 @@ class RiskService:
         based solely on ``signal_strength`` and ``price``.
         """
 
-        self.guard.refresh_usd_caps(equity)
+        # refresh caps based on current account cash
+        self.guard.refresh_usd_caps(self.account.cash)
 
         corr_pairs: Dict[tuple[str, str], float] = {}
         if self.corr is not None:

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -174,18 +174,16 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
             )
             if equity <= 0:
                 equity = max(last["spot"], last["perp"])
-
+            risk.account.cash = equity
             ok_s, _r1, delta_s = risk.check_order(
                 cfg.symbol,
                 spot_side,
-                equity,
                 last["spot"],
                 strength=strength,
             )
             ok_p, _r2, delta_p = risk.check_order(
                 cfg.symbol,
                 perp_side,
-                equity,
                 last["perp"],
                 strength=strength,
             )

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -28,9 +28,7 @@ def test_service_calc_position_size_passes_strength():
     partial = svc.calc_position_size(0.37, price)
     assert partial == pytest.approx(full * 0.37)
 
-    allowed, reason, delta = svc.check_order(
-        "BTC", "buy", account.cash, price, strength=0.37
-    )
+    allowed, reason, delta = svc.check_order("BTC", "buy", price, strength=0.37)
     assert allowed is True
     assert delta == pytest.approx(partial)
 

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -54,7 +54,7 @@ class DummyRisk:
     def manage_position(self, trade):
         return "hold"
 
-    def check_order(self, symbol, side, equity, price, strength=1.0, **_):
+    def check_order(self, symbol, side, price, strength=1.0, **_):
         self.last_strength = strength
         return True, "", 1.0
 

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -32,7 +32,9 @@ async def test_risk_service_correlation_limits_and_sizing():
     )
     guard.refresh_usd_caps(200.0)
     corr = CorrelationService()
-    svc = RiskService(rm, guard, corr_service=corr, risk_pct=1.0)
+    svc = RiskService(guard, corr_service=corr, risk_pct=1.0)
+    svc.rm.bus = bus
+    svc.account.cash = 1000.0
 
     _feed_correlated_prices(corr)
     corr_df = corr._returns.corr()
@@ -42,7 +44,7 @@ async def test_risk_service_correlation_limits_and_sizing():
     assert events and events[0]["reason"] == "correlation"
 
     allowed, reason, delta = svc.check_order(
-        "AAA", "buy", 200.0, 100.0, corr_threshold=0.8, strength=0.5
+        "AAA", "buy", 100.0, corr_threshold=0.8, strength=0.5
     )
     assert allowed
     assert delta == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- remove explicit equity parameter from RiskService.check_order
- refresh caps and size orders using internal account balances
- update runners, backtester, and tests to new check_order API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b39d1d3880832da70c4c4f5d0d2452