### PR TITLE
docs: update fill reason descriptions

### DIFF
--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -6,7 +6,7 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | Columna | Descripción |
 | --- | --- |
 | `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
-| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `take_profit`, `stop_loss`, `trailing_stop` o `exit` (cierre manual u otros motivos) |
+| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `stop_loss`, `take_profit`, `trailing_stop` y `manual_close` (cierre manual) |
 | `side` | `buy` o `sell` |
 | `price` | Precio de ejecución |
 | `qty` | Cantidad ejecutada |


### PR DESCRIPTION
## Summary
- document all current fill `reason` values, including `manual_close`

## Testing
- `pytest tests/test_backtest_engine.py -q` *(fails: RiskManager object has no attribute 'mark_price')*

------
https://chatgpt.com/codex/tasks/task_e_68b39d2657a4832d876f210c0c8dbcbe