### PR TITLE
Refactor risk sizing and exposure handling

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -14,7 +14,6 @@ import pandas as pd
 import random
 import math
 
-from ..risk.manager import RiskManager
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
 from ..core.account import Account as CoreAccount
@@ -335,15 +334,9 @@ class EventDrivenBacktestEngine:
             key = (strat_name, symbol)
             self.strategies[key] = strat_cls()
             allow_short = self.exchange_mode.get(exchange, "perp") != "spot"
-            rm = RiskManager(
-                risk_pct=self._risk_pct,
-                allow_short=allow_short,
-                min_order_qty=self.min_order_qty,
-            )
             guard = PortfolioGuard(GuardConfig(venue=exchange))
             account = CoreAccount(float("inf"), cash=self.initial_equity)
             self.risk[key] = RiskService(
-                rm,
                 guard,
                 account=account,
                 risk_per_trade=1.0,
@@ -841,11 +834,9 @@ class EventDrivenBacktestEngine:
                     svc.mark_price(symbol, place_price)
                     if equity < 0:
                         continue
-                    equity_for_order = max(equity, 1.0)
                     allowed, _reason, delta = svc.check_order(
                         symbol,
                         sig.side,
-                        equity_for_order,
                         place_price,
                         strength=sig.strength,
                     )

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -14,7 +14,7 @@ from ..strategies.cross_exchange_arbitrage import CrossArbConfig
 from ..data.funding import poll_funding
 from ..data.open_interest import poll_open_interest
 from ..data.basis import poll_basis
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import load_positions
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
 
@@ -44,9 +44,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
     broker = PaperAdapter()
     if risk is None:
         risk = RiskService(
-            RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="cross")),
-            daily=None,
             risk_pct=0.0,
         )
 
@@ -85,14 +83,12 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         ok1, _r1, delta1 = risk.check_order(
             cfg.symbol,
             spot_side,
-            equity,
             last["spot"],
             strength=strength,
         )
         ok2, _r2, delta2 = risk.check_order(
             cfg.symbol,
             perp_side,
-            equity,
             last["perp"],
             strength=strength,
         )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -10,7 +10,7 @@ from ..adapters.binance_ws import BinanceWSAdapter
 from ..execution.order_types import Order
 from ..execution.paper import PaperAdapter
 from ..execution.router import ExecutionRouter
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import load_positions
 from ..risk.portfolio_guard import GuardConfig, PortfolioGuard
 from ..risk.service import RiskService
 from ..risk.correlation_service import CorrelationService
@@ -50,12 +50,12 @@ async def run_paper(
     broker = PaperAdapter()
     router = ExecutionRouter([broker])
 
-    risk_core = RiskManager(risk_pct=risk_pct, allow_short=False)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper")
+    )
     guard.refresh_usd_caps(1000.0)
     corr = CorrelationService()
     risk = RiskService(
-        risk_core,
         guard,
         corr_service=corr,
         account=broker.account,
@@ -117,11 +117,10 @@ async def run_paper(
             signal = strat.on_bar({"window": df})
             if signal is None:
                 continue
-            eq = broker.equity(mark_prices={symbol: closed.c})
+            broker.equity(mark_prices={symbol: closed.c})
             allowed, _reason, delta = risk.check_order(
                 symbol,
                 signal.side,
-                eq,
                 closed.c,
                 strength=signal.strength,
             )

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -13,7 +13,7 @@ from ..execution.paper import PaperAdapter
 from ..strategies.arbitrage_triangular import (
     TriRoute, make_symbols, compute_edge
 )
-from ..risk.manager import RiskManager, load_positions
+from ..risk.manager import load_positions
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
 
@@ -49,7 +49,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
     fills = 0
     if risk is None:
         risk = RiskService(
-            RiskManager(risk_pct=0.0),
             PortfolioGuard(GuardConfig(venue="binance")),
             risk_pct=0.0,
         )
@@ -111,7 +110,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["bq"],
                             strength=strength,
                         )
@@ -123,7 +121,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "buy",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -135,7 +132,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["mq"],
                             strength=s3,
                         )
@@ -171,7 +167,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok1, _, d1 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "buy",
-                            eq,
                             last["mq"],
                             strength=strength,
                         )
@@ -183,7 +178,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok2, _, d2 = risk.check_order(
                             f"{cfg.route.mid}/{cfg.route.base}",
                             "sell",
-                            eq,
                             last["mb"],
                             strength=s2,
                         )
@@ -195,7 +189,6 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ok3, _, d3 = risk.check_order(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "sell",
-                            eq,
                             last["bq"],
                             strength=s3,
                         )

--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -8,7 +8,6 @@ from typing import Dict, Optional
 
 from ..adapters.base import ExchangeAdapter
 from ..execution.balance import rebalance_between_exchanges
-from ..risk.manager import RiskManager
 from ..risk.portfolio_guard import GuardConfig, PortfolioGuard
 from ..risk.service import RiskService
 
@@ -100,9 +99,7 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
     engine = get_engine() if (cfg.persist_pg and _CAN_PG) else None
     if cfg.persist_pg and not _CAN_PG:
         log.warning("Persistencia habilitada pero Timescale no disponible.")
-    risk_mgr = RiskManager(risk_pct=0.0)
     risk = RiskService(
-        risk_mgr,
         PortfolioGuard(GuardConfig(venue="cross")),
         risk_pct=0.0,
     )
@@ -178,14 +175,12 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
             ok_s, _r1, delta_s = risk.check_order(
                 cfg.symbol,
                 spot_side,
-                equity,
                 last["spot"],
                 strength=strength,
             )
             ok_p, _r2, delta_p = risk.check_order(
                 cfg.symbol,
                 perp_side,
-                equity,
                 last["perp"],
                 strength=strength,
             )

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -29,7 +29,7 @@ def test_service_calc_position_size_passes_strength():
     assert partial == pytest.approx(full * 0.37)
 
     allowed, reason, delta = svc.check_order(
-        "BTC", "buy", account.cash, price, strength=0.37
+        "BTC", "buy", price, strength=0.37
     )
     assert allowed is True
     assert delta == pytest.approx(partial)

--- a/tests/test_cross_exchange_arbitrage.py
+++ b/tests/test_cross_exchange_arbitrage.py
@@ -77,7 +77,6 @@ async def test_cross_exchange_updates_risk_positions(monkeypatch):
     perp = MockAdapter("perp", perp_trades, perp_ob, {"BTC": 1.0})
     cfg = CrossArbConfig(symbol="BTC/USDT", spot=spot, perp=perp, threshold=0.001)
     risk = RiskService(
-        RiskManager(),
         PortfolioGuard(GuardConfig(venue="test")),
         risk_pct=0.0,
     )

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -67,8 +67,10 @@ def test_liquidity_events_risk_service_handles_stop_and_size():
         "ask_px": [[101, 102], [101, 102]],
     })
     rm = RiskManager(risk_pct=0.02)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = LiquidityEvents(
         vacuum_threshold=0.5,

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -36,8 +36,10 @@ def test_ml_strategy_margin_and_entry():
 def test_ml_strategy_risk_service_handles_stop_and_size():
     stub = StubModel(0.7)
     rm = RiskManager(risk_pct=0.02)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = MLStrategy(model=stub, margin=0.1, risk_service=svc)
     strat.scaler.fit([[0.0]])

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -1,15 +1,13 @@
 import pytest
 
 from tradingbot.core import Account
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 
 
 def make_service(account: Account) -> RiskService:
-    rm = RiskManager()
     guard = PortfolioGuard(GuardConfig(venue="test"))
-    return RiskService(rm, guard, account=account, risk_per_trade=0.1)
+    return RiskService(guard, account=account, risk_per_trade=0.1)
 
 
 def test_calc_position_size_accounts_for_open_orders():

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -54,7 +54,7 @@ class DummyRisk:
     def manage_position(self, trade):
         return "hold"
 
-    def check_order(self, symbol, side, equity, price, strength=1.0, **_):
+    def check_order(self, symbol, side, price, strength=1.0, **_):
         self.last_strength = strength
         return True, "", 1.0
 

--- a/tests/test_rehydrate.py
+++ b/tests/test_rehydrate.py
@@ -18,9 +18,11 @@ def test_rehydrate_state():
         conn.execute(text('INSERT INTO "market.positions" (venue, symbol, qty, avg_price, realized_pnl, fees_paid) VALUES ("paper", "BTCUSDT", 1.5, 10000, 0, 0);'))
 
     rm = RiskManager()
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper"))
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="paper")
+    )
     guard.refresh_usd_caps(1e6)
-    risk = RiskService(rm, guard, risk_pct=0.0)
+    risk = RiskService(guard, risk_pct=0.0)
 
     # Rehydrate
     pos_map = load_positions(engine, "paper")

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -83,7 +83,6 @@ def test_daily_loss_limit_triggers_kill_switch():
 
 
 def test_risk_service_updates_and_persists(monkeypatch):
-    rm = RiskManager()
     guard = PortfolioGuard(
         GuardConfig(total_cap_pct=0.5, per_symbol_cap_pct=0.5, venue="X")
     )
@@ -93,21 +92,22 @@ def test_risk_service_updates_and_persists(monkeypatch):
     monkeypatch.setattr(
         timescale, "insert_risk_event", lambda engine, **kw: events.append(kw)
     )
-    svc = RiskService(rm, guard, daily, engine=object(), risk_pct=1.0)
-    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, 1.0, strength=1.0)
+    svc = RiskService(guard, daily, engine=object(), risk_pct=1.0)
+    allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, strength=1.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
 
 
 def test_risk_service_stop_loss_triggers_close():
-    rm = RiskManager(risk_pct=0.05)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.05)
-    rm.set_position(1.0)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.05)
+    svc.rm.set_position(1.0)
     svc.update_position("X", "BTC", 1.0)
-    rm.check_limits(100.0)
+    svc.rm.check_limits(100.0)
 
-    allowed, reason, delta = svc.check_order("BTC", "buy", 10_000.0, 94.0)
+    allowed, reason, delta = svc.check_order("BTC", "buy", 94.0)
     assert allowed is True
     assert reason == "stop_loss"
     assert delta == pytest.approx(-1.0)

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -107,7 +107,6 @@ def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
     svc = engine.risk[("sell_once", "SYM")]
     svc.rm.set_position(1.0)
     engine.risk[("sell_once", "SYM")] = CheatingRiskService(
-        svc.rm,
         svc.guard,
         svc.daily,
         svc.corr,

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -5,7 +5,6 @@ from tradingbot.strategies.order_flow import OrderFlow
 from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
 from tradingbot.strategies.breakout_vol import BreakoutVol
 from tradingbot.core import Account, RiskManager as CoreRiskManager
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 import pytest
@@ -38,9 +37,10 @@ def test_breakout_atr_min_edge(breakout_df_buy, breakout_df_sell):
 
 
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
-    rm = RiskManager(risk_pct=0.02)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, risk_service=svc)
     sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
@@ -133,9 +133,10 @@ def test_breakout_vol_min_edge():
 
 def test_breakout_vol_risk_service_handles_stop_and_size():
     df_buy = pd.DataFrame({"close": [1, 2, 3, 10]})
-    rm = RiskManager(risk_pct=0.02)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = BreakoutVol(lookback=2, mult=0.5, risk_service=svc)
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})

--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 
 from tradingbot.core import Account, RiskManager as CoreRiskManager
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 from tradingbot.strategies.trend_following import TrendFollowing
@@ -25,9 +24,10 @@ def test_trend_following_trailing_stop_uses_atr():
 
 def test_trend_following_risk_service_handles_stop_and_size():
     df = pd.DataFrame({"close": [1, 2, 3]})
-    rm = RiskManager(risk_pct=0.02)
-    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X")
+    )
+    svc = RiskService(guard, risk_pct=0.02)
     svc.account.update_cash(1000.0)
     strat = TrendFollowing(risk_service=svc, rsi_n=2)
     sig = strat.on_bar({"window": df, "atr": 1.0, "volatility": 0.0})


### PR DESCRIPTION
## Summary
- simplify `RiskService.check_order` to compute sizing via internal account balance and enforce exposure limits
- remove `equity` arg in `check_order`; refresh caps from internal account
- propagate optional event bus and update call sites/tests to new API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b39cb6ef40832db81dd35b2c344678