### PR TITLE
refactor: remove deprecated take profit/stop loss params

### DIFF
--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -6,7 +6,7 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | Columna | Descripción |
 | --- | --- |
 | `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
-| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `take_profit`, `stop_loss`, `trailing_stop` o `exit` (cierre manual u otros motivos) |
+| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `stop_loss`, `trailing_stop` o `exit` (cierre manual u otros motivos) |
 | `side` | `buy` o `sell` |
 | `price` | Precio de ejecución |
 | `qty` | Cantidad ejecutada |

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -67,8 +67,6 @@ class Order:
     queue_pos: float = field(default=0.0, compare=False)
     latency: int | None = field(default=None, compare=False)
     post_only: bool = field(default=False, compare=False)
-    take_profit: float | None = field(default=None, compare=False)
-    stop_loss: float | None = field(default=None, compare=False)
     trailing_pct: float | None = field(default=None, compare=False)
 
 
@@ -335,20 +333,17 @@ class EventDrivenBacktestEngine:
             key = (strat_name, symbol)
             self.strategies[key] = strat_cls()
             allow_short = self.exchange_mode.get(exchange, "perp") != "spot"
-            rm = RiskManager(
-                risk_pct=self._risk_pct,
-                allow_short=allow_short,
-                min_order_qty=self.min_order_qty,
-            )
             guard = PortfolioGuard(GuardConfig(venue=exchange))
             account = CoreAccount(float("inf"), cash=self.initial_equity)
-            self.risk[key] = RiskService(
-                rm,
+            svc = RiskService(
                 guard,
                 account=account,
                 risk_per_trade=1.0,
                 risk_pct=self._risk_pct,
             )
+            svc.rm.allow_short = allow_short
+            svc.rm.min_order_qty = self.min_order_qty
+            self.risk[key] = svc
             self.strategy_exchange[key] = exchange
 
         # Internal flag to avoid repeated on_bar calls per bar index
@@ -618,8 +613,6 @@ class EventDrivenBacktestEngine:
                 elif prev_sign == 0 or prev_sign != new_sign:
                     position_levels[key] = {
                         "entry_i": i,
-                        "take_profit": order.take_profit,
-                        "stop_loss": order.stop_loss,
                         "trail_pct": order.trailing_pct,
                         "best_price": price,
                     }
@@ -627,10 +620,6 @@ class EventDrivenBacktestEngine:
                     state = position_levels.get(key)
                     if state is not None:
                         state["entry_i"] = i
-                        if order.take_profit is not None:
-                            state["take_profit"] = order.take_profit
-                        if order.stop_loss is not None:
-                            state["stop_loss"] = order.stop_loss
                         if order.trailing_pct is not None:
                             state["trail_pct"] = order.trailing_pct
                         if state.get("trail_pct") is not None:
@@ -714,8 +703,6 @@ class EventDrivenBacktestEngine:
                 low = float(arrs.get("low", arrs["close"])[i])
                 exit_price = None
                 side = None
-                tp = state.get("take_profit")
-                sl = state.get("stop_loss")
                 trail = state.get("trail_pct")
                 best = state.get("best_price", float(arrs["close"][i]))
                 reason = ""
@@ -724,33 +711,19 @@ class EventDrivenBacktestEngine:
                         best = max(best, high)
                         state["best_price"] = best
                         tr_stop = best * (1 - trail)
-                        if sl is None or tr_stop > sl:
-                            sl = tr_stop
-                            state["stop_loss"] = sl
-                    if sl is not None and low <= sl:
-                        exit_price = sl
-                        side = "sell"
-                        reason = "trailing_stop" if trail is not None else "stop_loss"
-                    elif tp is not None and high >= tp:
-                        exit_price = tp
-                        side = "sell"
-                        reason = "take_profit"
+                        if low <= tr_stop:
+                            exit_price = tr_stop
+                            side = "sell"
+                            reason = "trailing_stop"
                 elif qty < 0:
                     if trail is not None:
                         best = min(best, low)
                         state["best_price"] = best
                         tr_stop = best * (1 + trail)
-                        if sl is None or tr_stop < sl:
-                            sl = tr_stop
-                            state["stop_loss"] = sl
-                    if sl is not None and high >= sl:
-                        exit_price = sl
-                        side = "buy"
-                        reason = "trailing_stop" if trail is not None else "stop_loss"
-                    elif tp is not None and low <= tp:
-                        exit_price = tp
-                        side = "buy"
-                        reason = "take_profit"
+                        if high >= tr_stop:
+                            exit_price = tr_stop
+                            side = "buy"
+                            reason = "trailing_stop"
                 if exit_price is not None:
                     exit_qty = abs(qty)
                     exchange = self.strategy_exchange[(strat_name, symbol)]
@@ -886,8 +859,6 @@ class EventDrivenBacktestEngine:
                         None,
                         post_only,
                         None,
-                        None,
-                        None,
                     )
                     orders.append(order)
                     heapq.heappush(order_queue, order)
@@ -950,8 +921,6 @@ class EventDrivenBacktestEngine:
                             0.0,
                             None,
                             False,
-                            None,
-                            None,
                             None,
                         )
                         orders.append(order)

--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -10,8 +10,6 @@ class Order:
     post_only: bool = False
     time_in_force: str | None = None
     iceberg_qty: float | None = None
-    take_profit: float | None = None
-    stop_loss: float | None = None
     reduce_only: bool = False
     reason: str | None = None
     slip_bps: float | None = None

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -303,28 +303,6 @@ class ExecutionRouter:
                 mid = (bid + ask) / 2.0
                 spread = ask - bid
                 fill_price = mid + spread / 2.0 if order.side == "buy" else mid - spread / 2.0
-            elif fill_mode == "hl_intrabar" and state is not None:
-                bar = None
-                last_bar = getattr(state, "last_bar", None)
-                if isinstance(last_bar, dict):
-                    bar = last_bar.get(order.symbol)
-                if bar is None:
-                    bars = getattr(state, "bars", None)
-                    if isinstance(bars, dict):
-                        bar = bars.get(order.symbol)
-                if bar:
-                    high = bar.get("high") or bar.get("h")
-                    low = bar.get("low") or bar.get("l")
-                    if order.side == "sell":
-                        if order.stop_loss is not None and low is not None and low <= order.stop_loss:
-                            fill_price = low
-                        elif order.take_profit is not None and high is not None and high >= order.take_profit:
-                            fill_price = high
-                    elif order.side == "buy":
-                        if order.stop_loss is not None and high is not None and high >= order.stop_loss:
-                            fill_price = high
-                        elif order.take_profit is not None and low is not None and low <= order.take_profit:
-                            fill_price = low
             if fill_price is not None and slip_bps:
                 slip_mult = slip_bps / 10000.0
                 if order.side == "buy":

--- a/tests/test_execution_router_fill_mode.py
+++ b/tests/test_execution_router_fill_mode.py
@@ -6,11 +6,11 @@ from tradingbot.storage import timescale
 
 
 class MockAdapter:
-    def __init__(self, order_book=None, last_bar=None):
+    def __init__(self, order_book=None):
         self.name = "m"
         self.state = type("S", (), {
             "order_book": order_book or {},
-            "last_bar": last_bar or {},
+            "last_bar": {},
             "last_px": {},
         })()
 
@@ -28,27 +28,6 @@ async def test_fill_price_bidask_with_slip():
     expected = 101.0 * 1.005
     assert res["price"] == pytest.approx(expected)
     assert res["fill_price"] == res["price"]
-
-
-@pytest.mark.asyncio
-async def test_fill_price_hl_intrabar_stop_loss():
-    bar = {"XYZ": {"high": 105.0, "low": 94.0}}
-    adapter = MockAdapter(last_bar=bar)
-    router = ExecutionRouter(adapter)
-    order = Order(symbol="XYZ", side="sell", type_="market", qty=1.0, stop_loss=95.0)
-    res = await router.execute(order, fill_mode="hl_intrabar")
-    assert res["price"] == 94.0
-
-
-@pytest.mark.asyncio
-async def test_fill_price_hl_intrabar_take_profit():
-    bar = {"XYZ": {"high": 106.0, "low": 98.0}}
-    adapter = MockAdapter(last_bar=bar)
-    router = ExecutionRouter(adapter)
-    order = Order(symbol="XYZ", side="sell", type_="market", qty=1.0, take_profit=105.0)
-    res = await router.execute(order, fill_mode="hl_intrabar")
-    assert res["price"] == 106.0
-
 
 @pytest.mark.asyncio
 async def test_fill_price_persisted(monkeypatch):


### PR DESCRIPTION
## Summary
- drop `take_profit`/`stop_loss` from `Order` and backtesting engine
- simplify router fill logic to bid/ask only
- update fills docs and tests

## Testing
- `pytest tests/test_execution_router_fill_mode.py -q`
- `pytest tests/test_backtesting_integration.py::test_stop_loss_triggers_close -q`
- `pytest -q` *(fails: process killed after running suite)*

------
https://chatgpt.com/codex/tasks/task_e_68b39d233038832dabe50e3b672d6a92