### PR TITLE
Remove take-profit and stop-loss parameters

### DIFF
--- a/docs/fills_csv.md
+++ b/docs/fills_csv.md
@@ -6,7 +6,7 @@ Cada fila representa una operación ejecutada e incluye la siguiente informació
 | Columna | Descripción |
 | --- | --- |
 | `timestamp` | Marca de tiempo del bar donde se ejecutó el fill |
-| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `stop_loss`, `take_profit`, `trailing_stop` y `manual_close` (cierre manual) |
+| `reason` | Motivo del fill. Valores posibles: `order` (ejecución de la orden), `stop_loss`, `trailing_stop` y `manual_close` (cierre manual) |
 | `side` | `buy` o `sell` |
 | `price` | Precio de ejecución |
 | `qty` | Cantidad ejecutada |

--- a/src/tradingbot/execution/order_types.py
+++ b/src/tradingbot/execution/order_types.py
@@ -10,8 +10,6 @@ class Order:
     post_only: bool = False
     time_in_force: str | None = None
     iceberg_qty: float | None = None
-    take_profit: float | None = None
-    stop_loss: float | None = None
     reduce_only: bool = False
     reason: str | None = None
     slip_bps: float | None = None

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -303,28 +303,6 @@ class ExecutionRouter:
                 mid = (bid + ask) / 2.0
                 spread = ask - bid
                 fill_price = mid + spread / 2.0 if order.side == "buy" else mid - spread / 2.0
-            elif fill_mode == "hl_intrabar" and state is not None:
-                bar = None
-                last_bar = getattr(state, "last_bar", None)
-                if isinstance(last_bar, dict):
-                    bar = last_bar.get(order.symbol)
-                if bar is None:
-                    bars = getattr(state, "bars", None)
-                    if isinstance(bars, dict):
-                        bar = bars.get(order.symbol)
-                if bar:
-                    high = bar.get("high") or bar.get("h")
-                    low = bar.get("low") or bar.get("l")
-                    if order.side == "sell":
-                        if order.stop_loss is not None and low is not None and low <= order.stop_loss:
-                            fill_price = low
-                        elif order.take_profit is not None and high is not None and high >= order.take_profit:
-                            fill_price = high
-                    elif order.side == "buy":
-                        if order.stop_loss is not None and high is not None and high >= order.stop_loss:
-                            fill_price = high
-                        elif order.take_profit is not None and low is not None and low <= order.take_profit:
-                            fill_price = low
             if fill_price is not None and slip_bps:
                 slip_mult = slip_bps / 10000.0
                 if order.side == "buy":

--- a/tests/test_execution_router_fill_mode.py
+++ b/tests/test_execution_router_fill_mode.py
@@ -30,24 +30,6 @@ async def test_fill_price_bidask_with_slip():
     assert res["fill_price"] == res["price"]
 
 
-@pytest.mark.asyncio
-async def test_fill_price_hl_intrabar_stop_loss():
-    bar = {"XYZ": {"high": 105.0, "low": 94.0}}
-    adapter = MockAdapter(last_bar=bar)
-    router = ExecutionRouter(adapter)
-    order = Order(symbol="XYZ", side="sell", type_="market", qty=1.0, stop_loss=95.0)
-    res = await router.execute(order, fill_mode="hl_intrabar")
-    assert res["price"] == 94.0
-
-
-@pytest.mark.asyncio
-async def test_fill_price_hl_intrabar_take_profit():
-    bar = {"XYZ": {"high": 106.0, "low": 98.0}}
-    adapter = MockAdapter(last_bar=bar)
-    router = ExecutionRouter(adapter)
-    order = Order(symbol="XYZ", side="sell", type_="market", qty=1.0, take_profit=105.0)
-    res = await router.execute(order, fill_mode="hl_intrabar")
-    assert res["price"] == 106.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drop `take_profit`/`stop_loss` from Order dataclass and related interfaces
- simplify router and backtesting engine, keeping only trailing-stop handling
- update docs and tests accordingly

## Testing
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q`
- `pytest tests/integration/test_stress_resilience.py -q`
- `pytest` *(fails: process killed after partial run)*


------
https://chatgpt.com/codex/tasks/task_e_68b3a37a2728832dbc24a0ce0745d1cf