### PR TITLE
Refactor tests for new RiskService API

### DIFF
--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -21,6 +21,7 @@ def test_service_calc_position_size_passes_strength():
         guard,
         account=account,
         risk_per_trade=0.1,
+        atr_mult=2.0,
         risk_pct=0.01,
     )
     price = 100.0

--- a/tests/test_cross_exchange_arbitrage.py
+++ b/tests/test_cross_exchange_arbitrage.py
@@ -1,11 +1,11 @@
 import pytest
 
+from tradingbot.core import Account
 from tradingbot.live.runner_cross_exchange import run_cross_exchange
 from tradingbot.strategies.cross_exchange_arbitrage import (
     CrossArbConfig,
     run_cross_exchange_arbitrage,
 )
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 from tradingbot.risk.service import RiskService
 
@@ -76,9 +76,13 @@ async def test_cross_exchange_updates_risk_positions(monkeypatch):
     spot = MockAdapter("spot", spot_trades, spot_ob, {"USDT": 200.0})
     perp = MockAdapter("perp", perp_trades, perp_ob, {"BTC": 1.0})
     cfg = CrossArbConfig(symbol="BTC/USDT", spot=spot, perp=perp, threshold=0.001)
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    account = Account(float("inf"))
     risk = RiskService(
-        RiskManager(),
-        PortfolioGuard(GuardConfig(venue="test")),
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
         risk_pct=0.0,
     )
     monkeypatch.setattr(

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
 
+from tradingbot.core import Account
 from tradingbot.data.features import book_vacuum, liquidity_gap
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 from tradingbot.strategies.liquidity_events import LiquidityEvents
@@ -66,9 +66,15 @@ def test_liquidity_events_risk_service_handles_stop_and_size():
         "bid_px": [[100, 99], [100, 99]],
         "ask_px": [[101, 102], [101, 102]],
     })
-    rm = RiskManager(risk_pct=0.02)
+    account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
     svc.account.update_cash(1000.0)
     strat = LiquidityEvents(
         vacuum_threshold=0.5,

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytest
 
-from tradingbot.risk.manager import RiskManager
+from tradingbot.core import Account
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 from tradingbot.strategies.ml_models import MLStrategy
@@ -35,9 +35,15 @@ def test_ml_strategy_margin_and_entry():
 
 def test_ml_strategy_risk_service_handles_stop_and_size():
     stub = StubModel(0.7)
-    rm = RiskManager(risk_pct=0.02)
+    account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
     svc.account.update_cash(1000.0)
     strat = MLStrategy(model=stub, margin=0.1, risk_service=svc)
     strat.scaler.fit([[0.0]])

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -1,15 +1,19 @@
 import pytest
 
 from tradingbot.core import Account
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 
 
 def make_service(account: Account) -> RiskService:
-    rm = RiskManager()
     guard = PortfolioGuard(GuardConfig(venue="test"))
-    return RiskService(rm, guard, account=account, risk_per_trade=0.1)
+    return RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.1,
+        atr_mult=2.0,
+        risk_pct=0.01,
+    )
 
 
 def test_calc_position_size_accounts_for_open_orders():

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from datetime import datetime, timedelta, timezone
 
-from tradingbot.risk.manager import RiskManager
+from tradingbot.core import Account
 from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 from tradingbot.risk.correlation_service import CorrelationService
 from tradingbot.risk.service import RiskService
@@ -26,13 +26,20 @@ async def test_risk_service_correlation_limits_and_sizing():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(bus=bus)
     guard = PortfolioGuard(
         GuardConfig(total_cap_pct=50.0, per_symbol_cap_pct=50.0, venue="test")
     )
     guard.refresh_usd_caps(200.0)
     corr = CorrelationService()
-    svc = RiskService(guard, corr_service=corr, risk_pct=1.0)
+    account = Account(float("inf"))
+    svc = RiskService(
+        guard,
+        corr_service=corr,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=1.0,
+    )
     svc.rm.bus = bus
     svc.account.cash = 1000.0
 
@@ -55,11 +62,18 @@ async def test_risk_service_covariance_limit():
     bus = EventBus()
     events: list = []
     bus.subscribe("risk:paused", lambda e: events.append(e))
-    rm = RiskManager(bus=bus)
     guard = PortfolioGuard(
         GuardConfig(total_cap_pct=50.0, per_symbol_cap_pct=50.0, venue="test")
     )
-    svc = RiskService(rm, guard, risk_pct=1.0)
+    account = Account(float("inf"))
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=1.0,
+    )
+    svc.rm.bus = bus
     cov_df = pd.DataFrame(
         [[0.04, 0.039], [0.039, 0.04]], index=["AAA", "BBB"], columns=["AAA", "BBB"]
     )

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -105,15 +105,18 @@ def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
         risk_pct=1.0,
     )
     svc = engine.risk[("sell_once", "SYM")]
-    svc.rm.set_position(1.0)
-    engine.risk[("sell_once", "SYM")] = CheatingRiskService(
-        svc.rm,
+    cheat = CheatingRiskService(
         svc.guard,
         svc.daily,
         svc.corr,
         engine=engine,
+        account=svc.account,
+        risk_per_trade=svc.core.risk_per_trade,
+        atr_mult=svc.core.atr_mult,
         risk_pct=svc.core.risk_pct,
     )
+    cheat.rm.set_position(1.0)
+    engine.risk[("sell_once", "SYM")] = cheat
     with pytest.raises(AssertionError, match="position went negative"):
         engine.run()
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -5,7 +5,6 @@ from tradingbot.strategies.order_flow import OrderFlow
 from tradingbot.strategies.mean_rev_ofi import MeanRevOFI
 from tradingbot.strategies.breakout_vol import BreakoutVol
 from tradingbot.core import Account, RiskManager as CoreRiskManager
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 import pytest
@@ -38,9 +37,15 @@ def test_breakout_atr_min_edge(breakout_df_buy, breakout_df_sell):
 
 
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
-    rm = RiskManager(risk_pct=0.02)
+    account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
     svc.account.update_cash(1000.0)
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, risk_service=svc)
     sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
@@ -133,9 +138,15 @@ def test_breakout_vol_min_edge():
 
 def test_breakout_vol_risk_service_handles_stop_and_size():
     df_buy = pd.DataFrame({"close": [1, 2, 3, 10]})
-    rm = RiskManager(risk_pct=0.02)
+    account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
     svc.account.update_cash(1000.0)
     strat = BreakoutVol(lookback=2, mult=0.5, risk_service=svc)
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})

--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 
 from tradingbot.core import Account, RiskManager as CoreRiskManager
-from tradingbot.risk.manager import RiskManager
 from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 from tradingbot.strategies.trend_following import TrendFollowing
@@ -25,9 +24,15 @@ def test_trend_following_trailing_stop_uses_atr():
 
 def test_trend_following_risk_service_handles_stop_and_size():
     df = pd.DataFrame({"close": [1, 2, 3]})
-    rm = RiskManager(risk_pct=0.02)
+    account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
-    svc = RiskService(rm, guard, risk_pct=0.02)
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=0.01,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
     svc.account.update_cash(1000.0)
     strat = TrendFollowing(risk_service=svc, rsi_n=2)
     sig = strat.on_bar({"window": df, "atr": 1.0, "volatility": 0.0})


### PR DESCRIPTION
## Summary
- update risk-service tests to instantiate `RiskService` directly with guard and account
- remove `RiskManager` imports from strategy and service tests
- adapt fixtures and assertions for new sizing API

## Testing
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b327a3f4832dabb3f4933783e6b2