### PR TITLE
docs: clarify triple barrier description

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -51,8 +51,9 @@ Analiza el flujo de órdenes que llegan al mercado para detectar presiones de
 compra o venta.
 
 ### Triple Barrier (`triple_barrier`)
-Define tres barreras (objetivo, límite de pérdida y tiempo) y cierra la
-posición según cuál se alcance primero.
+Emplea tres barreras (objetivo, límite de pérdida y tiempo) únicamente para
+etiquetar los datos; la gestión de la posición (stops y cierres) la realiza el
+`RiskManager`.
 
 ### Cash and Carry (`cash_and_carry`)
 Aprovecha diferencias de precio entre el mercado spot y los futuros para


### PR DESCRIPTION
## Summary
- Clarify that Triple Barrier uses barriers only for labeling data, while the `RiskManager` handles stops and closes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3b776ac8c832d865294f05e9b9e87