### PR TITLE
Refactor tests to use RiskService

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,19 +113,20 @@ def equity_data():
 
 
 @pytest.fixture
-def risk_manager(equity_data):
-    from tradingbot.risk.manager import RiskManager
+def risk_service(equity_data):
+    from tradingbot.core import Account
+    from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+    from tradingbot.risk.service import RiskService
 
-    risk_pct = 0.02      # arriesgar 2% del notional
     price = 100.0
-
-    rm = RiskManager(risk_pct=risk_pct)
-    # Atributos auxiliares para las pruebas
-    rm.price = price
-    rm.equity = float(equity_data.iloc[-1])
-    rm.risk_pct = risk_pct
-    rm.equity_history = equity_data
-    return rm
+    equity = float(equity_data.iloc[-1])
+    account = Account(float("inf"), cash=equity)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="test")
+    )
+    svc = RiskService(guard, account=account, risk_pct=0.0, risk_per_trade=1.0)
+    svc.mark_price("SYM", price)
+    return svc
 
 
 @pytest.fixture

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,68 +1,84 @@
 import asyncio
 import pytest
 
+from tradingbot.core import Account
+from tradingbot.risk.exceptions import StopLossExceeded
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+
+
+def _make_rs(equity: float, risk_pct: float = 0.0) -> RiskService:
+    account = Account(float("inf"), cash=equity)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="test")
+    )
+    return RiskService(guard, account=account, risk_pct=risk_pct, risk_per_trade=1.0)
+
 
 def test_size_scales_with_equity_and_strength():
-    from tradingbot.risk.manager import RiskManager
-
     price = 100.0
     equity_small = 10_000.0
     equity_big = 20_000.0
-    rm_small = RiskManager()
-    rm_big = RiskManager()
+    rs_small = _make_rs(equity_small)
+    rs_big = _make_rs(equity_big)
 
     expected_small = equity_small * 0.5 / price
     expected_big = equity_big * 0.5 / price
-    assert rm_small.size("buy", price, equity_small, strength=0.5) == pytest.approx(expected_small)
-    assert rm_big.size("buy", price, equity_big, strength=0.5) == pytest.approx(expected_big)
+    assert rs_small.calc_position_size(0.5, price) == pytest.approx(expected_small)
+    assert rs_big.calc_position_size(0.5, price) == pytest.approx(expected_big)
 
 
 def test_stop_loss_risk_pct():
-    from tradingbot.risk.manager import RiskManager
-    from tradingbot.risk.exceptions import StopLossExceeded
-
     equity = 10_000.0
     risk_pct = 0.02
     price = 100.0
 
     qty = equity * 0.10 / price
-    rm = RiskManager(risk_pct=risk_pct)
-    rm.set_position(qty)
+    rs = _make_rs(equity, risk_pct=risk_pct)
+    rs.rm.set_position(qty)
 
-    assert rm.check_limits(price)
+    assert rs.rm.check_limits(price)
     with pytest.raises(StopLossExceeded):
-        rm.check_limits(price * (1 - risk_pct - 0.01))
-    assert rm.enabled is True
-    assert rm.last_kill_reason == "stop_loss"
+        rs.rm.check_limits(price * (1 - risk_pct - 0.01))
+    assert rs.rm.enabled is True
+    assert rs.rm.last_kill_reason == "stop_loss"
 
 
-def test_pyramiding_and_scaling(risk_manager):
-    rm = risk_manager
+def test_pyramiding_and_scaling(risk_service):
+    rs = risk_service
+    rm = rs.rm
+    account = rs.account
+    price = 100.0
+    symbol = "SYM"
+
     rm.risk_pct = 0.0
-    max_qty = rm.equity / rm.price
+    max_qty = account.cash / price
 
-    delta = rm.size("buy", rm.price, rm.equity, strength=0.5)
-    rm.add_fill("buy", delta)
-    assert rm.pos.qty == pytest.approx(max_qty * 0.5)
+    delta = rm.size("buy", price, account.cash, strength=0.5)
+    rm.add_fill("buy", delta, price)
+    rs.update_position("test", symbol, rm.pos.qty, entry_price=price)
+    assert account.positions[symbol] == pytest.approx(max_qty * 0.5)
 
-    delta = rm.size("buy", rm.price, rm.equity, strength=1.0)
-    rm.add_fill("buy", delta)
-    assert rm.pos.qty == pytest.approx(max_qty)
+    delta = rm.size("buy", price, account.cash, strength=1.0)
+    rm.add_fill("buy", delta, price)
+    rs.update_position("test", symbol, rm.pos.qty, entry_price=price)
+    assert account.positions[symbol] == pytest.approx(max_qty)
 
-    delta = rm.size("buy", rm.price, rm.equity, strength=0.5)
-    rm.add_fill("sell", abs(delta))
-    assert rm.pos.qty == pytest.approx(max_qty * 0.5)
+    delta = rm.size("buy", price, account.cash, strength=0.5)
+    rm.add_fill("sell", abs(delta), price)
+    rs.update_position("test", symbol, rm.pos.qty, entry_price=price)
+    assert account.positions[symbol] == pytest.approx(max_qty * 0.5)
 
-    delta = rm.size("buy", rm.price, rm.equity, strength=0.0)
-    rm.add_fill("sell", abs(delta))
-    assert rm.pos.qty == pytest.approx(0.0)
+    delta = rm.size("buy", price, account.cash, strength=0.0)
+    rm.add_fill("sell", abs(delta), price)
+    rs.update_position("test", symbol, rm.pos.qty, entry_price=price)
+    assert account.positions[symbol] == pytest.approx(0.0)
 
 
 def test_kill_switch_disables():
-    from tradingbot.risk.manager import RiskManager
     from tradingbot.utils.metrics import RISK_EVENTS
 
-    rm = RiskManager()
+    rm = _make_rs(0.0).rm
     before = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
     rm.kill_switch("manual")
     after = RISK_EVENTS.labels(event_type="kill_switch")._value.get()
@@ -71,19 +87,17 @@ def test_kill_switch_disables():
     assert after == before + 1
 
 
-@pytest.mark.asyncio
-async def test_daily_loss_limit_via_bus():
-    from tradingbot.risk.manager import RiskManager
-    from tradingbot.bus import EventBus
+def test_daily_loss_limit_via_guard():
+    from datetime import datetime, timezone
+    from tradingbot.risk.daily_guard import DailyGuard, GuardLimits
 
-    bus = EventBus()
-    events = []
-    bus.subscribe("risk:halted", lambda e: events.append(e))
-    rm = RiskManager(daily_loss_limit=50, bus=bus)
-    await bus.publish("pnl", {"delta": -60})
-    await asyncio.sleep(0)
-    assert rm.enabled is False
-    assert events and events[0]["reason"] == "daily_loss"
+    guard = DailyGuard(GuardLimits(daily_max_loss_pct=0.05), venue="paper")
+    now = datetime.now(timezone.utc)
+    guard.on_mark(now, equity_now=1000.0)
+    guard.on_realized_delta(-60)
+    guard.on_mark(now, equity_now=940.0)
+    halted, reason = guard.check_halt()
+    assert halted and reason == "daily_loss"
 
 
 @pytest.mark.asyncio
@@ -98,11 +112,17 @@ async def test_daily_guard_halts_on_loss():
     broker.state.cash = 100.0
 
     broker.update_last_price(symbol, 100.0)
-    guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 100.0}))
+    guard.on_mark(
+        datetime.now(timezone.utc),
+        equity_now=broker.equity(mark_prices={symbol: 100.0}),
+    )
     buy = await broker.place_order(symbol, "buy", "limit", 1, price=100.0)
 
     broker.update_last_price(symbol, 90.0)
-    guard.on_mark(datetime.now(timezone.utc), equity_now=broker.equity(mark_prices={symbol: 90.0}))
+    guard.on_mark(
+        datetime.now(timezone.utc),
+        equity_now=broker.equity(mark_prices={symbol: 90.0}),
+    )
     sell = await broker.place_order(symbol, "sell", "limit", 1, price=90.0)
     delta = (sell["price"] - buy["price"]) * 1
     guard.on_realized_delta(delta)
@@ -111,36 +131,31 @@ async def test_daily_guard_halts_on_loss():
 
 
 def test_covariance_limit_triggers_kill():
-    from tradingbot.risk.manager import RiskManager
-
-    rm = RiskManager()
+    rs = _make_rs(0.0)
     positions = {"BTC": 1.0, "ETH": 1.0}
     cov = {
         ("BTC", "BTC"): 0.04,
         ("ETH", "ETH"): 0.04,
         ("BTC", "ETH"): 0.039,
     }
-    ok = rm.check_portfolio_risk(positions, cov, max_variance=0.1)
+    ok = rs.rm.check_portfolio_risk(positions, cov, max_variance=0.1)
     assert ok is False
-    assert rm.enabled is False
-    assert rm.last_kill_reason == "covariance_limit"
+    assert rs.rm.enabled is False
+    assert rs.rm.last_kill_reason == "covariance_limit"
 
 
 def test_long_only_prevents_shorts():
-    from tradingbot.risk.manager import RiskManager
-
-    rm = RiskManager(allow_short=False)
-    rm.set_position(1.0)
-    allowed, _, delta = rm.check_order("SYM", "sell", equity=100.0, price=100.0)
+    rs = _make_rs(0.0)
+    rs.rm.allow_short = False
+    rs.rm.set_position(1.0)
+    allowed, _, delta = rs.rm.check_order("SYM", "sell", equity=100.0, price=100.0)
     assert allowed and delta == pytest.approx(-1.0)
 
 
 def test_min_order_qty_blocks_small_orders():
-    from tradingbot.risk.manager import RiskManager
-
-    rm = RiskManager(min_order_qty=0.01)
-    # Strength yields a delta of 0.001 which is below the threshold
-    allowed, reason, delta = rm.check_order(
+    rs = _make_rs(0.0)
+    rs.rm.min_order_qty = 0.01
+    allowed, reason, delta = rs.rm.check_order(
         "SYM", "buy", equity=100.0, price=100.0, strength=0.001
     )
     assert not allowed

--- a/tests/test_risk_api.py
+++ b/tests/test_risk_api.py
@@ -2,7 +2,9 @@ import importlib
 
 from fastapi.testclient import TestClient
 from tradingbot.bus import EventBus
-from tradingbot.risk.manager import RiskManager
+from tradingbot.core import Account
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
 
 
 def get_app():
@@ -33,7 +35,9 @@ def test_risk_reset_resets_and_auth(monkeypatch):
     monkeypatch.setenv("API_USER", "u")
     monkeypatch.setenv("API_PASS", "p")
     app = get_app()
-    rm = RiskManager()
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
+    rs = RiskService(guard, account=Account(float("inf")))
+    rm = rs.rm
     rm.enabled = False
     rm.last_kill_reason = "dd"
     app.state.risk_manager = rm

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -2,33 +2,43 @@ import numpy as np
 import numpy as np
 import pytest
 
-from tradingbot.risk.manager import RiskManager
+from tradingbot.core import Account
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+
+
+def _make_rs() -> RiskService:
+    account = Account(float("inf"), cash=0.0)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="test")
+    )
+    return RiskService(guard, account=account, risk_pct=0.0, risk_per_trade=1.0)
 
 
 def test_covariance_and_aggregation():
-    rm = RiskManager()
+    rs = _make_rs()
     returns = {"A": [0.1, 0.2, 0.15], "B": [0.05, 0.07, 0.06]}
-    cov = rm.covariance_matrix(returns)
+    cov = rs.rm.covariance_matrix(returns)
     assert pytest.approx(cov[("A", "A")]) == np.var(returns["A"], ddof=1)
     assert pytest.approx(cov[("A", "B")]) == np.cov(returns["A"], returns["B"])[0, 1]
 
-    rm.update_position("ex1", "BTC", 1.0)
-    rm.update_position("ex2", "BTC", -0.3)
-    agg = rm.aggregate_positions()
+    rs.rm.update_position("ex1", "BTC", 1.0)
+    rs.rm.update_position("ex2", "BTC", -0.3)
+    agg = rs.rm.aggregate_positions()
     assert agg["BTC"] == pytest.approx(0.7)
 
 
 def test_adjust_size_and_portfolio_risk():
-    rm = RiskManager()
+    rs = _make_rs()
     corr = {("A", "B"): 0.9}
-    size = rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
+    size = rs.rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
     assert size == pytest.approx(1.0)
-    size2 = rm.adjust_size_for_correlation("A", 2.0, corr, 0.95)
+    size2 = rs.rm.adjust_size_for_correlation("A", 2.0, corr, 0.95)
     assert size2 == 2.0
 
     cov = {("BTC", "BTC"): 0.04}
-    assert rm.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
-    assert not rm.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
-    assert rm.enabled is False
-    assert rm.last_kill_reason == "covariance_limit"
+    assert rs.rm.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
+    assert not rs.rm.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
+    assert rs.rm.enabled is False
+    assert rs.rm.last_kill_reason == "covariance_limit"
 

--- a/tests/test_risk_vol_sizing.py
+++ b/tests/test_risk_vol_sizing.py
@@ -1,7 +1,9 @@
 import pytest
 
-from tradingbot.risk.manager import RiskManager
+from tradingbot.core import Account
 from tradingbot.risk.position_sizing import delta_from_strength
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
 
 
 def test_delta_from_strength_respects_risk_pct():
@@ -12,9 +14,14 @@ def test_delta_from_strength_respects_risk_pct():
 
 
 def test_risk_manager_caps_position_via_risk_pct():
-    rm = RiskManager(risk_pct=0.1)
-    rm.set_position(5.0)
-    allowed, reason, delta = rm.check_order(
+    account = Account(float("inf"), cash=1000.0)
+    guard = PortfolioGuard(
+        GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="test")
+    )
+    rs = RiskService(guard, account=account, risk_pct=0.1, risk_per_trade=1.0)
+    rs.rm.set_position(5.0)
+    rs.update_position("test", "BTC", 5.0, entry_price=10.0)
+    allowed, reason, delta = rs.rm.check_order(
         "BTC", "buy", equity=1000.0, price=10.0, strength=1.0
     )
     assert allowed


### PR DESCRIPTION
## Summary
- Replace legacy RiskManager fixtures with RiskService + Account
- Update risk-related tests to interact with RiskService and underlying account/trade data
- Adjust balance rebalance and API tests to use RiskService

## Testing
- `pytest tests/test_risk.py tests/test_risk_vol_sizing.py tests/test_risk_manager_extra.py tests/test_balance_rebalance.py tests/test_risk_api.py tests/test_correlation_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3c14a3b64832d8516da6e9410335a