### PR TITLE
feat: integrate risk service in strategy commands

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -6,8 +6,8 @@ continuación se presenta un resumen en lenguaje sencillo.
 Todas las señales incluyen un campo `strength` continuo que dimensiona las
 órdenes mediante `notional = equity * strength`. Opcionalmente pueden definir
 `limit_price` para cotizar órdenes *limit* a través del broker. El
-`RiskManager` universal utiliza estos valores para calcular el tamaño y aplicar
-un trailing stop adaptativo.
+`RiskService` combina `RiskManager` y `CoreRiskManager` para calcular el tamaño
+y aplicar un trailing stop adaptativo.
 
 Ejemplo de señal:
 
@@ -53,7 +53,7 @@ compra o venta.
 ### Triple Barrier (`triple_barrier`)
 Emplea tres barreras (objetivo, límite de pérdida y tiempo) únicamente para
 etiquetar los datos; la gestión de la posición (stops y cierres) la realiza el
-`RiskManager`.
+`RiskService`.
 
 ### Cash and Carry (`cash_and_carry`)
 Aprovecha diferencias de precio entre el mercado spot y los futuros para


### PR DESCRIPTION
## Summary
- initialize RiskService and core account in strategy/daemon CLI commands
- document RiskService usage and `strength`-based sizing in README and docs

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b3c14e6b44832da89d08414fa295b2