### PR TITLE
Refactor execution modules to use RiskService

### DIFF
--- a/src/tradingbot/strategies/cross_exchange_arbitrage.py
+++ b/src/tradingbot/strategies/cross_exchange_arbitrage.py
@@ -282,14 +282,14 @@ async def run_cross_exchange_arbitrage(cfg: CrossArbConfig) -> None:
                     else:
                         price_ref = last["spot"]
                     try:
-                        await rebalance_between_exchanges(
-                            asset,
-                            price=float(price_ref),
-                            venues=venues,
-                            risk=risk.rm,
-                            engine=engine,
-                            threshold=cfg.rebalance_threshold,
-                        )
+                            await rebalance_between_exchanges(
+                                asset,
+                                price=float(price_ref),
+                                venues=venues,
+                                risk=risk,
+                                engine=engine,
+                                threshold=cfg.rebalance_threshold,
+                            )
                     except Exception as e:  # pragma: no cover - logging only
                         log.debug("No se pudo rebalancear %s: %s", asset, e)
 

--- a/tests/test_balance_rebalance.py
+++ b/tests/test_balance_rebalance.py
@@ -56,7 +56,7 @@ async def test_rebalance_moves_funds_and_records_snapshot(monkeypatch):
         "USDT",
         price=px,
         venues={"A": ex_a, "B": ex_b},
-        risk=risk.rm,
+        risk=risk,
         engine=engine,
         threshold=1.0,
     )
@@ -110,7 +110,7 @@ async def test_daemon_periodic_rebalance(monkeypatch):
     daemon = TradeBotDaemon(
         {"A": ex_a, "B": ex_b},
         [],
-        risk.rm,
+        risk,
         router,
         symbols=[],
         accounts={"A": ex_a, "B": ex_b},

--- a/tests/test_daemon_routing.py
+++ b/tests/test_daemon_routing.py
@@ -5,7 +5,8 @@ import pytest
 from tradingbot.bus import EventBus
 from tradingbot.live.daemon import TradeBotDaemon
 from tradingbot.execution.router import ExecutionRouter
-from tradingbot.risk.manager import RiskManager
+from tradingbot.risk.service import RiskService
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 
 
 class DummyAdapter:
@@ -31,7 +32,7 @@ class DummyStrategy:
 @pytest.mark.asyncio
 async def test_daemon_routes_funding_and_basis():
     bus = EventBus()
-    risk = RiskManager(bus=bus)
+    risk = RiskService(PortfolioGuard(GuardConfig(venue="d")), bus=bus)
     router = ExecutionRouter([])
     strat = DummyStrategy()
     daemon = TradeBotDaemon({"d": DummyAdapter()}, [strat], risk, router, symbols=["BTCUSDT"])


### PR DESCRIPTION
## Summary
- switch ExecutionRouter to accept a RiskService and update open orders/positions through it
- update balance rebalancing to use RiskService and optional Account
- adjust strategy and tests for new RiskService interface

## Testing
- `pytest tests/test_balance_rebalance.py tests/test_daemon_routing.py tests/test_daemon_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3c4d60fa4832d8cd16f58225ed384