### PR TITLE
Expose min order quantity on risk service

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -177,7 +177,7 @@ async def run_live_binance(
 
         pos_qty, _ = risk.account.current_exposure(symbol)
         trade = risk.get_trade(symbol)
-        if trade and abs(pos_qty) > risk.rm.min_order_qty:
+        if trade and abs(pos_qty) > risk.min_order_qty:
             risk.update_trailing(trade, px)
             decision = risk.manage_position(trade)
             if decision == "close":
@@ -205,7 +205,7 @@ async def run_live_binance(
             if decision in {"scale_in", "scale_out"}:
                 target = risk.calc_position_size(trade.get("strength", 1.0), px)
                 delta_qty = target - abs(pos_qty)
-                if abs(delta_qty) > risk.rm.min_order_qty:
+                if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")
                     prev_rpnl = broker.state.realized_pnl
                     price = _limit_price(side)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -87,7 +87,7 @@ async def run_paper(
             risk.update_correlation(corr._returns.corr(), corr_threshold)
             pos_qty, _ = risk.account.current_exposure(symbol)
             trade = risk.get_trade(symbol)
-            if trade and abs(pos_qty) > risk.rm.min_order_qty:
+            if trade and abs(pos_qty) > risk.min_order_qty:
                 risk.update_trailing(trade, px)
                 decision = risk.manage_position(trade)
                 if decision == "close":
@@ -109,7 +109,7 @@ async def run_paper(
                 if decision in {"scale_in", "scale_out"}:
                     target = risk.calc_position_size(trade.get("strength", 1.0), px)
                     delta_qty = target - abs(pos_qty)
-                    if abs(delta_qty) > risk.rm.min_order_qty:
+                    if abs(delta_qty) > risk.min_order_qty:
                         side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")
                         prev_rpnl = broker.state.realized_pnl
                         resp = await router.execute(

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -171,7 +171,7 @@ async def _run_symbol(
             break
         pos_qty, _ = risk.account.current_exposure(cfg.symbol)
         trade = risk.get_trade(cfg.symbol)
-        if trade and abs(pos_qty) > risk.rm.min_order_qty:
+        if trade and abs(pos_qty) > risk.min_order_qty:
             risk.update_trailing(trade, px)
             decision = risk.manage_position(trade)
             if decision == "close":
@@ -207,7 +207,7 @@ async def _run_symbol(
             if decision in {"scale_in", "scale_out"}:
                 target = risk.calc_position_size(trade.get("strength", 1.0), px)
                 delta_qty = target - abs(pos_qty)
-                if abs(delta_qty) > risk.rm.min_order_qty:
+                if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else (
                         "sell" if trade["side"] == "buy" else "buy"
                     )

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -159,6 +159,10 @@ class RiskService:
         )
         self.trades: Dict[str, dict] = {}
 
+    @property
+    def min_order_qty(self) -> float:
+        return self.rm.min_order_qty
+
     def reset(self) -> None:
         """Reset underlying risk manager state."""
         self.rm.reset()

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -35,7 +35,8 @@ class DummyStrat:
 class DummyRisk:
     def __init__(self, *a, **k):
         self.last_strength: float | None = None
-        self.rm = types.SimpleNamespace(min_order_qty=0.0)
+        self.min_order_qty = 0.0
+        self.rm = types.SimpleNamespace(allow_short=True)
         self.account = types.SimpleNamespace(current_exposure=lambda symbol: (0.0, 0.0))
         self.trades: dict = {}
 
@@ -61,6 +62,9 @@ class DummyRisk:
     def on_fill(self, symbol, side, qty, price=None, venue=None):
         pass
 
+    def daily_mark(self, broker, symbol, price, delta_rpnl):
+        return False, ""
+
 
 class DummyRouter:
     last_order = None
@@ -76,9 +80,10 @@ class DummyRouter:
 class DummyBroker:
     def __init__(self):
         self.account = object()
+        self.state = SimpleNamespace(realized_pnl=0.0, last_px={}, order_book={})
 
     def update_last_price(self, symbol, px):
-        pass
+        self.state.last_px[symbol] = px
 
     def equity(self, mark_prices):
         return 1000.0


### PR DESCRIPTION
## Summary
- expose `min_order_qty` as a property on `RiskService`
- use new property in live runners instead of reaching into internal risk manager
- update paper runner test stubs for the new API

## Testing
- `pytest tests/test_paper_runner.py`
- `pytest tests/test_risk.py tests/test_live_runner.py` *(fails: '_RiskManager' object has no attribute ...')*


------
https://chatgpt.com/codex/tasks/task_e_68b3cb43e428832d8f36332fa518c79a