### PR TITLE
Replace fills toggle with mode selector

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -93,13 +93,14 @@
         <label for="bt-slippage-bps">Slippage (bps)</label>
         <input id="bt-slippage-bps" type="number" step="any" placeholder="1"/>
       </div>
-      <div id="field-verbose-fills">
-  <span>Exportar fills (CSV)</span>
-  <label class="switch">
-    <input id="bt-verbose-fills" type="checkbox">
-    <span class="slider"></span>
-  </label>
-</div>
+      <div id="field-fills-mode">
+        <label for="bt-fills-mode">Fills</label>
+        <select id="bt-fills-mode">
+          <option value="none">Ninguno</option>
+          <option value="verbose">Verbose fills</option>
+          <option value="csv">Exportar fills (CSV)</option>
+        </select>
+      </div>
 
       <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
         <span>Configurar parámetros</span>
@@ -448,8 +449,9 @@ async function runBacktest(){
     else if(t.includes('float')||t.includes('number')) v=parseFloat(v);
     cmd+=` --param ${el.dataset.name}=${v}`;
   });
-  const verbose=document.getElementById('bt-verbose-fills').checked;
-  if(verbose) cmd+=' --fills-csv fills.csv';
+  const fillsMode=document.getElementById('bt-fills-mode').value;
+  if(fillsMode==='verbose') cmd+=' --verbose-fills';
+  else if(fillsMode==='csv') cmd+=' --fills-csv fills.csv';
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});
     const j=await r.json();

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -179,7 +179,6 @@ nav a:hover{
 }
 
 /* === Switches de opciones === */
-#field-verbose-fills,
 #field-toggle-params {
   display: flex;
   align-items: center;
@@ -189,7 +188,6 @@ nav a:hover{
   color: var(--text);
 }
 
-#field-verbose-fills .switch,
 #field-toggle-params .switch {
   margin-left: 6px;
 }


### PR DESCRIPTION
## Summary
- replace bt-verbose-fills checkbox with bt-fills-mode select
- support verbose and CSV fills modes in runBacktest
- remove obsolete CSS for verbose fills switch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b464a4da48832dac764e53b71da4ac