### PR TITLE
feat(cli): add timeframe option to backfill

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -112,6 +112,7 @@ Descarga datos históricos con límites de velocidad.
 - `--days`: número de días hacia atrás (1 por defecto).
 - `--symbols`: lista de símbolos a descargar.
 - `--venue`: nombre del venue (`binance_spot`, `binance_futures`, etc.).
+- `--timeframe`: intervalo de cada vela OHLCV (por defecto `3m`, e.g. `1m`, `2m`, `3m`, `5m`, `15m`, `30m`, `1H`, `4H`, ...).
 - `--start`: fecha inicial en formato ISO.
 - `--end`: fecha final en formato ISO.
 

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -449,6 +449,9 @@ def backfill(
             f"{', '.join(BACKFILL_EXCHANGES)}"
         ),
     ),
+    timeframe: str = typer.Option(
+        "3m", "--timeframe", help="1m, 2m, 3m, 5m, 15m, 30m, 1H, 4H, ..."
+    ),
     start: str | None = typer.Option(
         None, "--start", help="Start datetime in ISO format"
     ),
@@ -475,6 +478,7 @@ def backfill(
             days=days,
             symbols=symbols,
             exchange_name=exchange,
+            timeframe=timeframe,
             start=_parse(start),
             end=_parse(end),
         )

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -56,6 +56,7 @@ async def backfill(
     days: int,
     symbols: Sequence[str],
     exchange_name: str = "binance_spot",
+    timeframe: str = "3m",
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> None:
@@ -64,7 +65,8 @@ async def backfill(
     ``exchange_name`` must match the identifiers used by the ingestion
     command (``binance_spot``, ``binance_futures``, etc.).  If *start* or *end*
     are not provided, the range defaults to the past ``days`` days ending at
-    ``datetime.now(timezone.utc)``.
+    ``datetime.now(timezone.utc)``. ``timeframe`` sets the duration of each
+    OHLCV bar (e.g. "3m", "1H").
     """
 
     if end is None:
@@ -126,7 +128,7 @@ async def backfill(
                 ohlcvs = await _retry(
                     ex.fetch_ohlcv,
                     ccxt_symbol,
-                    "3m",
+                    timeframe,
                     since,
                     1000,
                 )
@@ -138,7 +140,7 @@ async def backfill(
                         "market.bars",
                         {
                             "ts": datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc),
-                            "timeframe": "3m",
+                            "timeframe": timeframe,
                             "exchange": ex.id,
                             "symbol": db_symbol,
                             "o": o,


### PR DESCRIPTION
## Summary
- allow setting OHLCV timeframe when running backfills
- document new `--timeframe` option

## Testing
- `pytest tests/test_data_ingestion_batch.py` *(fails: AttributeError: 'DummyExchange' object has no attribute 'load_markets')*
- `pytest tests/test_backfill_persistence.py` *(skipped: 1, warning: PydanticDeprecatedSince20)*

------
https://chatgpt.com/codex/tasks/task_e_68b46753d074832da8f2d78cf2818d82