### PR TITLE
feat: parametrize backfill timeframe

### DIFF
--- a/tests/test_backfill_persistence.py
+++ b/tests/test_backfill_persistence.py
@@ -87,7 +87,10 @@ async def test_backfill_persists_data(monkeypatch, setup_db, input_symbol):
     monkeypatch.setattr(job_backfill.ccxt, "binance", lambda *_, **__: DummyExchange())
 
     await job_backfill.backfill(
-        days=1, symbols=[input_symbol], exchange_name="binance_spot"
+        days=1,
+        symbols=[input_symbol],
+        exchange_name="binance_spot",
+        timeframe="3m",
     )
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient
@@ -131,6 +134,7 @@ async def test_backfill_overlapping_range(monkeypatch, setup_db, input_symbol):
         start=start1,
         end=end1,
         exchange_name="binance_spot",
+        timeframe="3m",
     )
 
     start2 = start1 + timedelta(minutes=1)
@@ -141,6 +145,7 @@ async def test_backfill_overlapping_range(monkeypatch, setup_db, input_symbol):
         start=start2,
         end=end2,
         exchange_name="binance_spot",
+        timeframe="3m",
     )
 
     from tradingbot.storage.async_timescale import AsyncTimescaleClient

--- a/tests/test_data_ingestion_batch.py
+++ b/tests/test_data_ingestion_batch.py
@@ -206,6 +206,9 @@ async def test_backfill_applies_rate_limit(monkeypatch):
     class DummyExchange:
         rateLimit = 1200
 
+        async def load_markets(self):
+            self.symbols = ["BTC/USDT", "ETH/USDT"]
+
         async def fetch_ohlcv(self, symbol, timeframe, since, limit):
             calls.append(symbol)
             return []
@@ -246,6 +249,7 @@ async def test_backfill_applies_rate_limit(monkeypatch):
         1,
         ["BTC/USDT", "ETH/USDT"],
         exchange_name="binance_spot",
+        timeframe="3m",
     )
 
     assert calls == ["BTC/USDT", "ETH/USDT"]


### PR DESCRIPTION
## Summary
- allow backfill to accept configurable timeframe
- persist timeframe value and compute step based on it
- adjust tests to use new timeframe parameter

## Testing
- `pytest tests/test_backfill_persistence.py tests/test_data_ingestion_batch.py::test_backfill_applies_rate_limit -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46753f068832d9709e691a35089c8