### PR TITLE
Always include risk and cost params in backtest

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -387,9 +387,8 @@ function updateBtFields(){
   document.getElementById('field-start').style.display=mode==='db'?'':'none';
   document.getElementById('field-end').style.display=mode==='db'?'':'none';
   document.getElementById('field-timeframe').style.display=mode==='db'?'':'none';
-  const showRisk = mode!=='walk';
   ['field-risk-pct','field-fee-bps','field-slippage-bps'].forEach(id=>{
-    document.getElementById(id).style.display=showRisk?'':'none';
+    document.getElementById(id).style.display='';
   });
   document.getElementById('bt-strategy-params').style.display=(mode==='csv'||mode==='db')?'':'none';
 }
@@ -445,14 +444,12 @@ async function runBacktest(){
   if(capital && mode!=='walk'){
     cmd+=` --capital ${capital}`;
   }
-  if(mode!=='walk'){
-    const sl=document.getElementById('bt-risk-pct').value.trim();
-    if(sl) cmd+=` --risk-pct ${sl}`;
-    const fee=document.getElementById('bt-fee-bps').value.trim();
-    if(fee) cmd+=` --fee-bps ${fee}`;
-    const sb=document.getElementById('bt-slippage-bps').value.trim();
-    if(sb) cmd+=` --slippage-bps ${sb}`;
-  }
+  const sl=document.getElementById('bt-risk-pct').value.trim();
+  if(sl) cmd+=` --risk-pct ${sl}`;
+  const fee=document.getElementById('bt-fee-bps').value.trim();
+  if(fee) cmd+=` --fee-bps ${fee}`;
+  const sb=document.getElementById('bt-slippage-bps').value.trim();
+  if(sb) cmd+=` --slippage-bps ${sb}`;
   const stratCfg=document.getElementById('bt-strategy-config').value.trim();
   if(stratCfg) cmd+=` --config ${stratCfg}`;
   const paramEls=document.querySelectorAll('#bt-strategy-params input');


### PR DESCRIPTION
## Summary
- Always show risk percentage, fee bps and slippage bps fields regardless of walk mode
- Include risk, fee and slippage CLI arguments in backtests whenever values are provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b466d765b8832dbe213a2d5f33aa42