### PR TITLE
Add timeframe option to backfill command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -114,6 +114,7 @@ Descarga datos históricos con límites de velocidad.
 - `--venue`: nombre del venue (`binance_spot`, `binance_futures`, etc.).
 - `--start`: fecha inicial en formato ISO.
 - `--end`: fecha final en formato ISO.
+- `--timeframe`: intervalo de las velas (3m por defecto).
 
 ## `ingest-historical`
 Obtiene datos históricos de Kaiko o CoinAPI.

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -455,6 +455,9 @@ def backfill(
     end: str | None = typer.Option(
         None, "--end", help="End datetime in ISO format"
     ),
+    timeframe: str = typer.Option(
+        "3m", "--timeframe", help="1m, 2m, 3m, 5m, 15m, 30m, 1H, 4H, ..."
+    ),
 ) -> None:
     """Backfill OHLCV and trades for symbols with rate limiting."""
 
@@ -477,6 +480,7 @@ def backfill(
             exchange_name=exchange,
             start=_parse(start),
             end=_parse(end),
+            timeframe=timeframe,
         )
     )
 


### PR DESCRIPTION
## Summary
- add timeframe option to backfill CLI command and pass through to job
- document timeframe flag in command reference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b469b37f6c832db8621473de85f94e