### PR TITLE
Normalizar timeframes en minúsculas

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -90,8 +90,8 @@
           <option value="5m">5m</option>
           <option value="15m">15m</option>
           <option value="30m">30m</option>
-          <option value="1H">1H</option>
-          <option value="4H">4H</option>
+          <option value="1h">1h</option>
+          <option value="4h">4h</option>
         </select>
       </div>
       <div id="field-risk-pct">
@@ -438,7 +438,7 @@ async function runBacktest(){
     const strat=document.getElementById('bt-strategy').value.trim();
     const start=document.getElementById('bt-start').value;
     const end=document.getElementById('bt-end').value;
-    const tf=document.getElementById('bt-timeframe').value.trim();
+    const tf=document.getElementById('bt-timeframe').value.trim().toLowerCase();
     cmd=`backtest-db --venue ${venue} --symbol ${sym} --strategy ${strat} --start ${start} --end ${end} --timeframe ${tf}`;
   }
   if(capital && mode!=='walk'){

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -100,8 +100,8 @@
           <option value="5m">5m</option>
           <option value="15m">15m</option>
           <option value="30m">30m</option>
-          <option value="1H">1H</option>
-          <option value="4H">4H</option>
+          <option value="1h">1h</option>
+          <option value="4h">4h</option>
         </select>
       </div>
       <div id="field-source">
@@ -274,7 +274,7 @@ async function runData(){
     const start=document.getElementById('dm-start').value;
     const end=document.getElementById('dm-end').value;
     const exchange=document.getElementById('dm-exchange-name').value;
-    const tf=document.getElementById('dm-timeframe').value;
+    const tf=document.getElementById('dm-timeframe').value.toLowerCase();
     if(start && end){
       const s=new Date(start);
       const e=new Date(end);


### PR DESCRIPTION
## Summary
- Ajusta opciones de timeframe a `1h` y `4h` en las vistas de datos y backtest
- Envía el timeframe siempre en minúsculas al backend

## Testing
- `pytest` *(errored: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b46e9e04e0832d99c737e11d946ee1