### PR TITLE
Add uniqueness constraints for market trades and bars

### DIFF
--- a/sql/schema_timescale.sql
+++ b/sql/schema_timescale.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS market.trades (
   px numeric NOT NULL,
   qty numeric NOT NULL,
   side text,        -- buy/sell if available
-  trade_id text
+  trade_id text,
+  UNIQUE (ts, exchange, symbol)
 );
 SELECT create_hypertable('market.trades', by_range('ts'), if_not_exists => TRUE);
 
@@ -56,7 +57,8 @@ CREATE TABLE IF NOT EXISTS market.bars (
   timeframe text NOT NULL,   -- e.g. 1s,3m,5m
   exchange text NOT NULL,
   symbol text NOT NULL,
-  o numeric, h numeric, l numeric, c numeric, v numeric
+  o numeric, h numeric, l numeric, c numeric, v numeric,
+  UNIQUE (ts, timeframe, exchange, symbol)
 );
 SELECT create_hypertable('market.bars', by_range('ts'), if_not_exists => TRUE);
 

--- a/src/tradingbot/storage/timescale.py
+++ b/src/tradingbot/storage/timescale.py
@@ -58,6 +58,7 @@ def insert_trades(engine, trades: Iterable[Any]):
                 """
             INSERT INTO market.trades (ts, exchange, symbol, px, qty, side, trade_id)
             VALUES (:ts, :exchange, :symbol, :px, :qty, :side, :trade_id)
+            ON CONFLICT DO NOTHING
             """
             ),
             payload,
@@ -93,6 +94,7 @@ def insert_bars(engine, bars: Iterable[Any]):
                 """
             INSERT INTO market.bars (ts, timeframe, exchange, symbol, o, h, l, c, v)
             VALUES (:ts, :timeframe, :exchange, :symbol, :o, :h, :l, :c, :v)
+            ON CONFLICT DO NOTHING
             """
             ),
             payload,


### PR DESCRIPTION
## Summary
- enforce unique (ts, exchange, symbol) for trades
- enforce unique (ts, timeframe, exchange, symbol) for bars
- avoid insert errors by ignoring duplicates in Timescale storage

## Testing
- `pytest tests/test_storage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46e9146e8832da597dd0acb7646d3