### PR TITLE
Add risk percentage option to walk-forward backtests

### DIFF
--- a/src/tradingbot/backtesting/walk_forward.py
+++ b/src/tradingbot/backtesting/walk_forward.py
@@ -48,6 +48,7 @@ def walk_forward_backtest(
     exchange_configs: Dict[str, Dict[str, float]] | None = None,
     min_fill_qty: float = MIN_FILL_QTY,
     slippage: SlippageModel | None = None,
+    risk_pct: float = 0.0,
 ) -> pd.DataFrame:
     """Run a basic walk-forward analysis and return metrics for each split."""
 
@@ -80,6 +81,7 @@ def walk_forward_backtest(
                 slippage=slippage,
                 fee_bps=fee_bps,
                 slippage_bps=slippage_bps,
+                risk_pct=risk_pct,
             )
             engine.strategies[(strategy_name, symbol)] = strat
             res = engine.run()
@@ -100,6 +102,7 @@ def walk_forward_backtest(
             slippage=slippage,
             fee_bps=fee_bps,
             slippage_bps=slippage_bps,
+            risk_pct=risk_pct,
         )
         engine.strategies[(strategy_name, symbol)] = strat
         test_res = engine.run(fills_csv=fills_csv)

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -1314,6 +1314,12 @@ def walk_forward_cfg(
     fills_csv: str | None = typer.Option(
         None, "--fills-csv", help="Export fills to CSV"
     ),
+    risk_pct: float = typer.Option(
+        0.0,
+        "--risk-pct",
+        callback=_parse_risk_pct,
+        help="Risk manager loss percentage (0-1 or 0-100)",
+    ),
 ) -> None:
     """Run walk-forward optimization from a Hydra configuration."""
 
@@ -1363,6 +1369,7 @@ def walk_forward_cfg(
             exchange_configs=exchange_cfg,
             min_fill_qty=min_fill_qty,
             slippage=slippage,
+            risk_pct=risk_pct,
         )
 
         reports_dir = Path("reports")


### PR DESCRIPTION
## Summary
- allow setting `--risk-pct` on the `walk-forward` CLI command
- pass the new risk percentage through the walk-forward backtest helper and into the backtest engine

## Testing
- `pytest` *(killed)*
- `pytest tests/test_risk_pct_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b46e868314832db11c257c1eccb15d