### PR TITLE
Remove obsolete min_edge_bps parameter from breakout strategies

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -7,8 +7,7 @@ exchanges:
 strategies:
   default: breakout_atr
   params:
-    breakout_atr:
-      min_edge_bps: 0.0
+    breakout_atr: {}
     mean_rev_ofi:
       ofi_window: 20
       zscore_threshold: 1.0

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -8,7 +8,6 @@ PARAM_INFO = {
     "mult": "Multiplicador aplicado al ATR",
     "min_atr": "ATR mínimo para operar",
     "min_volatility": "Volatilidad mínima reciente en bps",
-    "min_edge_bps": "Edge mínimo en puntos básicos para operar",
     "config_path": "Ruta opcional al archivo de configuración",
 }
 
@@ -23,7 +22,6 @@ class BreakoutATR(Strategy):
         mult: float = 1.0,
         min_atr: float = 0.0,
         min_volatility: float = 0.0,
-        min_edge_bps: float = 0.0,
         *,
         risk_service=None,
         config_path: str | None = None,
@@ -34,7 +32,6 @@ class BreakoutATR(Strategy):
         self.mult = float(params.get("mult", mult))
         self.min_atr = float(params.get("min_atr", min_atr))
         self.min_volatility = float(params.get("min_volatility", min_volatility))
-        self.min_edge_bps = float(params.get("min_edge_bps", min_edge_bps))
         self.risk_service = risk_service
         self.trade: dict | None = None
 
@@ -65,14 +62,8 @@ class BreakoutATR(Strategy):
 
         side: str | None = None
         if last_close > upper.iloc[-1]:
-            edge_bps = (last_close - upper.iloc[-1]) / abs(last_close) * 10000
-            if edge_bps <= self.min_edge_bps:
-                return None
             side = "buy"
         elif last_close < lower.iloc[-1]:
-            edge_bps = (lower.iloc[-1] - last_close) / abs(last_close) * 10000
-            if edge_bps <= self.min_edge_bps:
-                return None
             side = "sell"
         if side is None:
             return None

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -5,7 +5,6 @@ PARAM_INFO = {
     "lookback": "Ventana para medias y desviación estándar",
     "mult": "Multiplicador aplicado a la desviación",
     "volatility_factor": "Factor para dimensionar según volatilidad",
-    "min_edge_bps": "Edge mínimo en puntos básicos para operar",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
 
@@ -19,7 +18,6 @@ class BreakoutVol(Strategy):
         self.lookback = kwargs.get("lookback", 10)
         self.mult = kwargs.get("mult", 1.5)
         self.volatility_factor = kwargs.get("volatility_factor", 0.02)
-        self.min_edge_bps = kwargs.get("min_edge_bps", 0.0)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
         self.risk_service = risk_service
         self.trade: dict | None = None
@@ -61,14 +59,8 @@ class BreakoutVol(Strategy):
 
         side: str | None = None
         if last > upper:
-            edge_bps = (last - upper) / abs(last) * 10000
-            if edge_bps <= self.min_edge_bps:
-                return None
             side = "buy"
         elif last < lower:
-            edge_bps = (lower - last) / abs(last) * 10000
-            if edge_bps <= self.min_edge_bps:
-                return None
             side = "sell"
         if side is None:
             return None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -20,22 +20,6 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     assert sig_sell.side == "sell"
 
 
-def test_breakout_atr_min_edge(breakout_df_buy, breakout_df_sell):
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=200)
-    assert strat.on_bar({"window": breakout_df_buy, "volatility": 0.0}) is None
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=100)
-    assert (
-        strat.on_bar({"window": breakout_df_buy, "volatility": 0.0}).side == "buy"
-    )
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=1000)
-    assert strat.on_bar({"window": breakout_df_sell, "volatility": 0.0}) is None
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_edge_bps=900)
-    assert (
-        strat.on_bar({"window": breakout_df_sell, "volatility": 0.0}).side
-        == "sell"
-    )
-
-
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
     account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
@@ -119,21 +103,6 @@ def test_mean_rev_ofi_trailing_stop_uses_atr():
     }
     rm.update_trailing(trade, 90.0)
     assert trade["stop"] == pytest.approx(90.0 + 2 * trade["atr"])
-
-
-def test_breakout_vol_min_edge():
-    df_buy = pd.DataFrame({"close": [1, 2, 3, 10]})
-    strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=1100)
-    assert strat.on_bar({"window": df_buy, "volatility": 0.0}) is None
-    strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=1000)
-    sig_buy = strat.on_bar({"window": df_buy, "volatility": 0.0})
-    assert sig_buy.side == "buy"
-    df_sell = pd.DataFrame({"close": [1, 2, 3, -5]})
-    strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=2400)
-    assert strat.on_bar({"window": df_sell, "volatility": 0.0}) is None
-    strat = BreakoutVol(lookback=2, mult=0.5, min_edge_bps=2000)
-    sig_sell = strat.on_bar({"window": df_sell, "volatility": 0.0})
-    assert sig_sell.side == "sell"
 
 
 def test_breakout_vol_risk_service_handles_stop_and_size():


### PR DESCRIPTION
## Summary
- drop `min_edge_bps` threshold from ATR and volatility breakout strategies
- remove `min_edge_bps` from default configuration
- clean up tests by eliminating min_edge-specific cases

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_strategies.py::test_breakout_atr_signals tests/test_strategies.py::test_breakout_atr_risk_service_handles_stop_and_size tests/test_strategies.py::test_breakout_vol_risk_service_handles_stop_and_size -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4772204dc832da18e94a05b587f1e