### PR TITLE
Add CSV fills export option to backtest page

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -106,13 +106,8 @@
         <label for="bt-slippage-bps">Slippage (bps)</label>
         <input id="bt-slippage-bps" type="number" step="any" placeholder="1"/>
       </div>
-      <div id="field-fills-mode">
-        <label for="bt-fills-mode">Fills</label>
-        <select id="bt-fills-mode">
-          <option value="none">Ninguno</option>
-          <option value="verbose">Verbose fills</option>
-          <option value="csv">Exportar fills (CSV)</option>
-        </select>
+      <div id="field-fills-csv" style="display:flex;align-items:center;gap:4px">
+        <label><input type="checkbox" id="bt-fills-csv"> Exportar fills a CSV</label>
       </div>
 
       <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
@@ -461,9 +456,8 @@ async function runBacktest(){
     else if(t.includes('float')||t.includes('number')) v=parseFloat(v);
     cmd+=` --param ${el.dataset.name}=${v}`;
   });
-  const fillsMode=document.getElementById('bt-fills-mode').value;
-  if(fillsMode==='verbose') cmd+=' --verbose-fills';
-  else if(fillsMode==='csv') cmd+=' --fills-csv fills.csv';
+  const exportCsv=document.getElementById('bt-fills-csv').checked;
+  if(exportCsv) cmd+=' --fills-csv fills.csv';
   try{
     const r=await fetch(api('/cli/start'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})});
     const j=await r.json();


### PR DESCRIPTION
## Summary
- replace fills mode selector with checkbox to export fills to CSV
- update `runBacktest` to append `--fills-csv` when enabled

## Testing
- `pytest` *(fails: KeyboardInterrupt after 18 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b47b9d64bc832d865c9c1d6900b3df