### PR TITLE
refactor: hide risk service injection

### DIFF
--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -23,16 +23,16 @@ class BreakoutATR(Strategy):
         min_atr: float = 0.0,
         min_volatility: float = 0.0,
         *,
-        risk_service=None,
         config_path: str | None = None,
+        **kwargs,
     ):
-        params = load_params(config_path)
+        params = {**load_params(config_path), **kwargs}
+        self.risk_service = params.pop("risk_service", None)
         self.ema_n = int(params.get("ema_n", ema_n))
         self.atr_n = int(params.get("atr_n", atr_n))
         self.mult = float(params.get("mult", mult))
         self.min_atr = float(params.get("min_atr", min_atr))
         self.min_volatility = float(params.get("min_volatility", min_volatility))
-        self.risk_service = risk_service
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -14,12 +14,12 @@ class BreakoutVol(Strategy):
 
     name = "breakout_vol"
 
-    def __init__(self, risk_service=None, **kwargs):
+    def __init__(self, **kwargs):
         self.lookback = kwargs.get("lookback", 10)
         self.mult = kwargs.get("mult", 1.5)
         self.volatility_factor = kwargs.get("volatility_factor", 0.02)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -25,11 +25,11 @@ class DepthImbalance(Strategy):
         self,
         window: int = 3,
         threshold: float = 0.2,
-        risk_service=None,
+        **kwargs,
     ):
         self.window = window
         self.threshold = threshold
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -37,13 +37,13 @@ class LiquidityEvents(Strategy):
         gap_threshold: float = 1.0,
         vol_window: int = 20,
         dynamic_thresholds: bool = True,
-        risk_service=None,
+        **kwargs,
     ):
         self.vacuum_threshold = vacuum_threshold
         self.gap_threshold = gap_threshold
         self.vol_window = vol_window
         self.dynamic_thresholds = dynamic_thresholds
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     def _mid_prices(self, df: pd.DataFrame) -> pd.Series:

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -44,16 +44,16 @@ class MeanRevOFI(Strategy):
         vol_threshold: float = 0.01,
         min_volatility: float = 0.0,
         *,
-        risk_service=None,
         config_path: str | None = None,
+        **kwargs,
     ) -> None:
-        params = load_params(config_path)
+        params = {**load_params(config_path), **kwargs}
+        self.risk_service = params.pop("risk_service", None)
         self.ofi_window = int(params.get("ofi_window", ofi_window))
         self.zscore_threshold = float(params.get("zscore_threshold", zscore_threshold))
         self.vol_window = int(params.get("vol_window", vol_window))
         self.vol_threshold = float(params.get("vol_threshold", vol_threshold))
         self.min_volatility = float(params.get("min_volatility", min_volatility))
-        self.risk_service = risk_service
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -23,7 +23,7 @@ class MeanReversion(Strategy):
 
     name = "mean_reversion"
 
-    def __init__(self, risk_service=None, **kwargs):
+    def __init__(self, **kwargs):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.upper = kwargs.get("upper", 60.0)
         self.lower = kwargs.get("lower", 40.0)
@@ -31,7 +31,7 @@ class MeanReversion(Strategy):
         self.trend_rsi_n = kwargs.get("trend_rsi_n", 50)
         self.trend_threshold = kwargs.get("trend_threshold", 10.0)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -32,12 +32,12 @@ class MLStrategy(Strategy):
         model: BaseEstimator | None = None,
         model_path: str | Path | None = None,
         margin: float = 0.1,
-        risk_service=None,
+        **kwargs,
     ) -> None:
         self.model: BaseEstimator | None = model
         self.scaler = StandardScaler()
         self.margin = float(margin)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
         if model_path:
             self.load_model(model_path)

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -28,14 +28,14 @@ class Momentum(Strategy):
 
     name = "momentum"
 
-    def __init__(self, risk_service=None, **kwargs):
+    def __init__(self, **kwargs):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.threshold = kwargs.get("rsi_threshold", 55.0)
         # Optional market activity filters
         self.min_volume = kwargs.get("min_volume")
         self.min_volatility = kwargs.get("min_volatility")
         self.vol_window = kwargs.get("vol_window", 20)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -27,13 +27,13 @@ class OrderFlow(Strategy):
         buy_threshold: float = 1.0,
         sell_threshold: float = 1.0,
         min_volatility: float = 0.0,
-        risk_service=None,
+        **kwargs,
     ):
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
         self.min_volatility = min_volatility
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -64,12 +64,12 @@ class ScalpPingPong(Strategy):
         cfg: ScalpPingPongConfig | None = None,
         *,
         config_path: str | None = None,
-        risk_service=None,
         **kwargs,
     ):
         params = {**load_params(config_path), **kwargs}
+        params.pop("risk_service", None)
         self.cfg = cfg or ScalpPingPongConfig(**params)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     def _calc_zscore(self, closes: pd.Series) -> float:

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -21,12 +21,12 @@ class TrendFollowing(Strategy):
 
     name = "trend_following"
 
-    def __init__(self, risk_service=None, **kwargs):
+    def __init__(self, **kwargs):
         self.rsi_n = kwargs.get("rsi_n", 14)
         self.threshold = kwargs.get("rsi_threshold", 60.0)
         self.min_volatility = kwargs.get("min_volatility", 0.0)
         self.vol_lookback = kwargs.get("vol_lookback", self.rsi_n)
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     @record_signal_metrics

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -112,7 +112,7 @@ class TripleBarrier(Strategy):
         meta_model: ClassifierMixin | None = None,
         *,
         config_path: str | None = None,
-        risk_service=None,
+        **kwargs,
     ) -> None:
         params = load_params(config_path)
         horizon = params.get("horizon", horizon)
@@ -129,7 +129,7 @@ class TripleBarrier(Strategy):
         self.meta_model = meta_model or GradientBoostingClassifier()
         self.fitted = False
         self.meta_fitted = False
-        self.risk_service = risk_service
+        self.risk_service = kwargs.get("risk_service")
         self.trade: dict | None = None
 
     def _prepare_features(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -80,7 +80,7 @@ def test_liquidity_events_risk_service_handles_stop_and_size():
         vacuum_threshold=0.5,
         gap_threshold=2,
         dynamic_thresholds=False,
-        risk_service=svc,
+        **{"risk_service": svc},
     )
     sig = strat.on_bar({"window": df_entry})
     assert sig is not None and sig.side == "buy"

--- a/tests/test_ml_strategy.py
+++ b/tests/test_ml_strategy.py
@@ -45,7 +45,7 @@ def test_ml_strategy_risk_service_handles_stop_and_size():
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = MLStrategy(model=stub, margin=0.1, risk_service=svc)
+    strat = MLStrategy(model=stub, margin=0.1, **{"risk_service": svc})
     strat.scaler.fit([[0.0]])
     bar_open = {"features": [0.0], "close": 100.0}
     sig = strat.on_bar(bar_open)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -31,7 +31,7 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, risk_service=svc)
+    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, **{"risk_service": svc})
     sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
     trade = strat.trade
@@ -117,7 +117,7 @@ def test_breakout_vol_risk_service_handles_stop_and_size():
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = BreakoutVol(lookback=2, mult=0.5, risk_service=svc)
+    strat = BreakoutVol(lookback=2, mult=0.5, **{"risk_service": svc})
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
     trade = strat.trade

--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -34,7 +34,7 @@ def test_trend_following_risk_service_handles_stop_and_size():
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = TrendFollowing(risk_service=svc, rsi_n=2)
+    strat = TrendFollowing(rsi_n=2, **{"risk_service": svc})
     sig = strat.on_bar({"window": df, "atr": 1.0, "volatility": 0.0})
     assert sig and sig.side == "buy"
     trade = strat.trade


### PR DESCRIPTION
## Summary
- inject risk service through kwargs across strategies
- update tests to pass risk service via kwargs injection

## Testing
- `pytest tests/test_trend_following.py tests/test_strategies.py tests/test_ml_strategy.py tests/test_liquidity_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68b47b9615d0832dbedf0f5b3d820735