### PR TITLE
Refactor timeframe step computation

### DIFF
--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -108,7 +108,11 @@ async def backfill(
     end_ms = int(end_dt.timestamp() * 1000)
     start_ms = int(start_dt.timestamp() * 1000)
 
-    step_ms = ccxt.Exchange.parse_timeframe(timeframe) * 1000
+    # Determine the interval duration in milliseconds according to the
+    # requested timeframe. ``ccxt.Exchange.parse_timeframe`` returns the
+    # duration in seconds, so multiply by 1000 and cast to ``int`` to obtain
+    # a precise millisecond step for advancing the cursor.
+    step_ms = int(ccxt.Exchange.parse_timeframe(timeframe) * 1000)
 
     try:
         for symbol in symbols:


### PR DESCRIPTION
## Summary
- clarify step calculation for timeframe-based backfill

## Testing
- `pytest tests/test_data_ingestion_batch.py::test_run_orderbook_ingestion_batches -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47fa7e12c832d84a7eb43938f4ead