### PR TITLE
feat: display 1H/4H timeframe options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -114,7 +114,7 @@ Descarga datos históricos con límites de velocidad.
 - `--venue`: nombre del venue (`binance_spot`, `binance_futures`, etc.).
 - `--start`: fecha inicial en formato ISO.
 - `--end`: fecha final en formato ISO.
-- `--timeframe`: intervalo de las velas (3m por defecto).
+- `--timeframe`: intervalo de las velas (por defecto `3m`; soporta `1m, 2m, 3m, 5m, 15m, 30m, 1H, 4H`).
 
 ## `ingest-historical`
 Obtiene datos históricos de Kaiko o CoinAPI.

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -100,8 +100,8 @@
           <option value="5m">5m</option>
           <option value="15m">15m</option>
           <option value="30m">30m</option>
-          <option value="1h">1h</option>
-          <option value="4h">4h</option>
+          <option value="1H">1H</option>
+          <option value="4H">4H</option>
         </select>
       </div>
       <div id="field-source">


### PR DESCRIPTION
## Summary
- show 1H and 4H alternatives in the data management timeframe dropdown
- document supported `backfill` timeframe values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b47fa4a25c832da8b0a458b5219245