### PR TITLE
Normalize timeframe input

### DIFF
--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -100,8 +100,8 @@
           <option value="5m">5m</option>
           <option value="15m">15m</option>
           <option value="30m">30m</option>
-          <option value="1H">1H</option>
-          <option value="4H">4H</option>
+          <option value="1h">1h</option>
+          <option value="4h">4h</option>
         </select>
       </div>
       <div id="field-source">

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -456,7 +456,7 @@ def backfill(
         None, "--end", help="End datetime in ISO format"
     ),
     timeframe: str = typer.Option(
-        "3m", "--timeframe", help="1m, 2m, 3m, 5m, 15m, 30m, 1H, 4H, ..."
+        "3m", "--timeframe", help="1m, 2m, 3m, 5m, 15m, 30m, 1h, 4h, ..."
     ),
 ) -> None:
     """Backfill OHLCV and trades for symbols with rate limiting."""
@@ -473,6 +473,7 @@ def backfill(
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed
 
+    timeframe = timeframe.lower()
     asyncio.run(
         run_backfill(
             days=days,
@@ -1217,6 +1218,7 @@ def backtest_db(
     from ..config.hydra_conf import load_config
 
     setup_logging()
+    timeframe = timeframe.lower()
     log.info(
         "Iniciando backtest DB: %s %s %s–%s (%s)",
         venue,

--- a/src/tradingbot/jobs/backfill.py
+++ b/src/tradingbot/jobs/backfill.py
@@ -69,6 +69,8 @@ async def backfill(
     when requesting OHLCV candles.
     """
 
+    timeframe = timeframe.lower()
+
     if end is None:
         end_dt = datetime.now(timezone.utc)
     else:


### PR DESCRIPTION
## Summary
- normalize `timeframe` arguments to lowercase in CLI and backfill job
- avoid confusion by using lowercase `1h`/`4h` options in data management UI
- test backfill persists `timeframe` in lowercase

## Testing
- `PG_TEST=1 pytest tests/test_backfill_persistence.py::test_backfill_normalizes_timeframe -q` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68b48672ae8c832da220c0ebae5d03ac