### PR TITLE
Support timeframe option for bar ingestion

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,9 +73,10 @@ Recibe datos de mercado en vivo y opcionalmente los almacena.
 - `--venue`: intercambio a utilizar (ej. `binance_spot`, `binance_futures_ws`, `bybit_futures_ws`, `okx_futures_ws`). Los nombres siguen el patrón `<exchange>_<market>` para REST y `<exchange>_<market>_ws` para WebSocket; se añade `_testnet` automáticamente cuando se usa el entorno de prueba.
 - `--symbol`: puede repetirse para varios pares (por defecto `BTC/USDT`).
 - `--depth`: profundidad del libro de órdenes (10).
-- `--kind`: tipo de dato: `trades`, `trades_multi`, `orderbook`, `bba`, `delta`, `funding`, `oi`.
+- `--kind`: tipo de dato: `trades`, `trades_multi`, `orderbook`, `bba`, `delta`, `funding`, `oi`, `bars`.
 - `--persist`: si se indica, guarda los datos en la base de datos.
 - `--backend`: backend de almacenamiento (`timescale` o `csv`).
+- `--timeframe`: intervalo de las velas (por defecto `3m`) cuando se usa `--kind bars`.
 
 Nota: Bybit no provee streams de `funding` ni `open_interest` vía WebSocket;
 para esos datos utilice el adaptador REST (`bybit_futures`).

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -184,7 +184,8 @@ const kindDescriptions={
   trades_multi:"Trades multi: agrupa transacciones de varios símbolos en una sola conexión.",
   orderbook:"Order book: niveles completos de posturas de compra y venta hasta la profundidad solicitada.",
   delta:"Book delta: cambios recientes en las mejores posturas de compra y venta.",
-  book_delta:"Book delta: cambios recientes en las mejores posturas de compra y venta."
+  book_delta:"Book delta: cambios recientes en las mejores posturas de compra y venta.",
+  bars:"Barras OHLCV: vela más reciente según el timeframe especificado."
 };
 
 function showWorking() {
@@ -235,7 +236,8 @@ desc.innerHTML = raw.replace(/^([^:]+:)/, '<span class="desc-lead">$1</span>');
   document.getElementById('field-start').style.display=showRange?'':'none';
   document.getElementById('field-end').style.display=showRange?'':'none';
   document.getElementById('field-exchange-name').style.display=act==='backfill'?'':'none';
-  document.getElementById('field-timeframe').style.display=act==='backfill'?'':'none';
+  const showTf = act==='backfill' || (act==='ingest' && kind==='bars');
+  document.getElementById('field-timeframe').style.display=showTf?'':'none';
   const hist=act==='ingest-historical';
   document.getElementById('field-source').style.display=hist?'':'none';
   document.getElementById('field-exchange').style.display=hist && document.getElementById('dm-source').value==='kaiko'?'':'none';
@@ -269,7 +271,10 @@ async function runData(){
     const kind=document.getElementById('dm-kind').value;
     const persist=document.getElementById('dm-persist').checked;
     const backend=document.getElementById('dm-backend').value;
-    cmd=`ingest --venue ${venue} ${symbols.map(s=>`--symbol ${s}`).join(' ')} --depth ${depth} --kind ${kind} --backend ${backend}`+(persist?' --persist':'');
+    const tf=document.getElementById('dm-timeframe').value.toLowerCase();
+    cmd=`ingest --venue ${venue} ${symbols.map(s=>`--symbol ${s}`).join(' ')} --depth ${depth} --kind ${kind}`;
+    if(kind==='bars') cmd+=` --timeframe ${tf}`;
+    cmd+=` --backend ${backend}`+(persist?' --persist':'');
   }else if(act==='backfill'){
     const start=document.getElementById('dm-start').value;
     const end=document.getElementById('dm-end').value;

--- a/tests/test_cli_supported_kinds.py
+++ b/tests/test_cli_supported_kinds.py
@@ -8,6 +8,7 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
+        "bars",
     },
     "binance_futures": {
         "trades",
@@ -16,6 +17,7 @@ EXPECTED_KINDS = {
         "delta",
         "funding",
         "open_interest",
+        "bars",
     },
     "binance_spot_ws": {"trades", "trades_multi", "orderbook", "bba", "delta"},
     "binance_futures_ws": {
@@ -31,6 +33,7 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
+        "bars",
     },
     "bybit_futures": {
         "trades",
@@ -39,6 +42,7 @@ EXPECTED_KINDS = {
         "delta",
         "funding",
         "open_interest",
+        "bars",
     },
     "bybit_futures_ws": {
         "trades",
@@ -51,6 +55,7 @@ EXPECTED_KINDS = {
         "orderbook",
         "bba",
         "delta",
+        "bars",
     },
     "okx_futures": {
         "trades",
@@ -59,6 +64,7 @@ EXPECTED_KINDS = {
         "delta",
         "funding",
         "open_interest",
+        "bars",
     },
     "okx_futures_ws": {
         "trades",
@@ -68,7 +74,7 @@ EXPECTED_KINDS = {
         "funding",
         "open_interest",
     },
-    "deribit_futures": {"trades", "funding"},
+    "deribit_futures": {"trades", "funding", "bars"},
     "deribit_futures_ws": {
         "trades",
         "orderbook",


### PR DESCRIPTION
## Summary
- add `--timeframe` option to `ingest` for `--kind bars`
- expose timeframe selector for bar ingestion in data UI
- document `ingest --kind bars` timeframe option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b48675149c832db04fb6cea578e2ae