### PR TITLE
Normalize symbol before DB backtests

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -66,7 +66,7 @@ from ..adapters import (
 )
 from ..logging_conf import setup_logging
 from tradingbot.analysis.backtest_report import generate_report
-from tradingbot.core.symbols import normalize
+from tradingbot.core import normalize
 from tradingbot.utils.time_sync import check_ntp_offset
 from ..exchanges import SUPPORTED_EXCHANGES
 
@@ -1231,6 +1231,7 @@ def backtest_db(
     from ..config.hydra_conf import load_config
 
     setup_logging()
+    symbol = normalize(symbol)
     timeframe = timeframe.lower()
     log.info(
         "Iniciando backtest DB: %s %s %s–%s (%s)",
@@ -1253,7 +1254,7 @@ def backtest_db(
             timeframe=timeframe,
         )
         if not rows:
-            typer.echo("no data")
+            typer.echo(f"no data for {symbol}")
             raise typer.Exit()
         df = (
             pd.DataFrame(rows)

--- a/tests/test_backtest_db_cli.py
+++ b/tests/test_backtest_db_cli.py
@@ -48,6 +48,9 @@ def _run_backtest(monkeypatch, venue):
         timeframe="3m",
         capital=0.0,
         risk_pct=0.0,
+        fee_bps=5.0,
+        slippage_bps=1.0,
+        verbose_fills=False,
     )
     return captured["engine"]
 
@@ -68,7 +71,7 @@ def test_backtest_db_futures_config(monkeypatch):
         cfg["taker_fee_bps"] / 10000.0
     )
     assert eng.exchange_tick_size["binance_futures"] == cfg["tick_size"]
-    rm = eng.risk[("dummy", "BTC/USDT")].rm
+    rm = eng.risk[("dummy", "BTCUSDT")].rm
     assert rm.allow_short is True
 
 
@@ -83,5 +86,56 @@ def test_backtest_db_spot_config(monkeypatch):
         cfg["taker_fee_bps"] / 10000.0
     )
     assert eng.exchange_tick_size["binance_spot"] == cfg["tick_size"]
-    rm = eng.risk[("dummy", "BTC/USDT")].rm
+    rm = eng.risk[("dummy", "BTCUSDT")].rm
     assert rm.allow_short is False
+
+
+def test_backtest_db_normalizes_symbol(monkeypatch):
+    captured = {}
+
+    class DummyEngine(EventDrivenBacktestEngine):
+        def run(self, fills_csv=None):
+            captured["engine"] = self
+            return {"equity": 0.0, "orders": []}
+
+    monkeypatch.setattr(ev_module, "EventDrivenBacktestEngine", DummyEngine)
+
+    class DummyDB:
+        def dispose(self):
+            pass
+
+    monkeypatch.setattr(ts_module, "get_engine", lambda: DummyDB())
+
+    rows = [
+        {"ts": 0, "o": 1.0, "h": 1.0, "l": 1.0, "c": 1.0, "v": 1.0},
+    ]
+
+    def fake_select_bars(*args, **kwargs):
+        captured["symbol"] = kwargs["symbol"]
+        return rows
+
+    monkeypatch.setattr(ts_module, "select_bars", fake_select_bars)
+
+    class DummyStrategy:
+        name = "dummy"
+
+        def on_bar(self, bar):
+            return SimpleNamespace(side="buy", strength=1.0)
+
+    monkeypatch.setitem(STRATEGIES, "dummy", DummyStrategy)
+
+    cli_main.backtest_db(
+        venue="binance_spot",
+        symbol="BTC/USDT",
+        strategy="dummy",
+        start="2021-01-01",
+        end="2021-01-02",
+        timeframe="3m",
+        capital=0.0,
+        risk_pct=0.0,
+        fee_bps=5.0,
+        slippage_bps=1.0,
+        verbose_fills=False,
+    )
+
+    assert captured["symbol"] == "BTCUSDT"


### PR DESCRIPTION
## Summary
- normalize symbol from CLI before querying bars in DB backtest
- log and error messages display normalized symbol
- add regression test confirming BTC/USDT retrieves data after backfill

## Testing
- `pytest tests/test_backtest_db_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b489fcc928832d92d08e889b617e09