### PR TITLE
Add tests for fetch_bars persistence behavior

### DIFF
--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -1200,17 +1200,47 @@ async def poll_basis(
             log.debug("Basis poll failed: %s", exc)
         await asyncio.sleep(interval)
 
-async def fetch_bars(adapter: Any, symbol: str, *, timeframe: str = "3m", backend: Backends = "timescale", sleep_s: int = 180):
-    """Periodically fetch OHLCV bars and persist them."""
-    storage = _get_storage(backend)
-    engine = storage.get_engine()
+async def fetch_bars(
+    adapter: Any,
+    symbol: str,
+    *,
+    timeframe: str = "3m",
+    backend: Backends = "timescale",
+    sleep_s: int = 180,
+    persist: bool = True,
+):
+    """Periodically fetch OHLCV bars and optionally persist them."""
+    storage = None if not persist else _get_storage(backend)
+    engine = None if storage is None else storage.get_engine()
     while True:
         try:
             bars = await adapter.fetch_ohlcv(symbol, timeframe=timeframe, limit=1)
             for ts_ms, o, h, l, c, v in bars:
                 ts = datetime.fromtimestamp(ts_ms / 1000, timezone.utc)
-                bar = Bar(ts=ts, timeframe=timeframe, exchange=getattr(adapter, "name", "unknown"), symbol=symbol, o=o, h=h, l=l, c=c, v=v)
-                storage.insert_bar(engine, bar.exchange, bar.symbol, bar.ts, bar.timeframe, bar.o, bar.h, bar.l, bar.c, bar.v)
+                bar = Bar(
+                    ts=ts,
+                    timeframe=timeframe,
+                    exchange=getattr(adapter, "name", "unknown"),
+                    symbol=symbol,
+                    o=o,
+                    h=h,
+                    l=l,
+                    c=c,
+                    v=v,
+                )
+                if persist and storage is not None and engine is not None:
+                    storage.insert_bar(
+                        engine,
+                        bar.exchange,
+                        bar.symbol,
+                        bar.ts,
+                        bar.timeframe,
+                        bar.o,
+                        bar.h,
+                        bar.l,
+                        bar.c,
+                        bar.v,
+                    )
         except Exception as exc:  # pragma: no cover - logging only
             log.debug("Bar fetch failed: %s", exc)
         await asyncio.sleep(sleep_s)


### PR DESCRIPTION
## Summary
- allow `fetch_bars` to optionally skip persistence via a new `persist` flag
- test `fetch_bars` to ensure no records are stored when `persist=False`
- test `fetch_bars` to ensure exactly one record is stored when `persist=True`

## Testing
- `pytest tests/test_data_ingestion.py::test_fetch_bars_no_persist tests/test_data_ingestion.py::test_fetch_bars_persist -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4995e8428832d96ffc15ece07e0b7