### PR TITLE
feat(cli): allow persisting bar ingestion

### DIFF
--- a/src/tradingbot/adapters/deribit.py
+++ b/src/tradingbot/adapters/deribit.py
@@ -41,7 +41,7 @@ class DeribitAdapter(ExchangeAdapter):
     """
 
     name = "deribit_futures"
-    supported_kinds = ["trades", "funding"]  # ``open_interest`` no disponible
+    supported_kinds = ["trades", "funding", "bars"]  # ``open_interest`` no disponible
 
     # Deribit listaba originalmente únicamente perpetuos de BTC y ETH pero ha
     # ampliado su oferta con varios altcoins.  Este mapa traduce símbolos


### PR DESCRIPTION
## Summary
- ensure `--persist` forwards to bar ingestion
- make Typer Option monkey patch reload-safe
- advertise bar support for Deribit REST adapter

## Testing
- `pytest tests/test_cli_supported_kinds.py tests/test_data_ingestion.py tests/test_data_ingestion_batch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a22bdfcc832d964c21ce78d38201