### PR TITLE
Use typer.echo for bar logging in ingestion

### DIFF
--- a/src/tradingbot/data/ingestion.py
+++ b/src/tradingbot/data/ingestion.py
@@ -13,6 +13,7 @@ from ..connectors.coinapi import CoinAPIConnector
 from ..storage import timescale as ts_storage
 from ..storage import quest as qs_storage
 import inspect
+import typer
 from ..utils.metrics import ORDERBOOK_INSERT_FAILURES
 from ..core.symbols import normalize
 from ..exchanges import SUPPORTED_EXCHANGES
@@ -1239,7 +1240,7 @@ async def fetch_bars(
                     v=v,
                 )
                 if log:
-                    print(bar)
+                    typer.echo(str(bar))
                 if persist and storage:
                     storage.insert_bar(
                         engine,


### PR DESCRIPTION
## Summary
- use `typer.echo` when logging bars in `fetch_bars`
- import Typer in ingestion module

## Testing
- `pytest tests/test_data_ingestion.py::test_fetch_bars_no_persist tests/test_data_ingestion.py::test_fetch_bars_persist_inserts -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4aa724700832da7a16d5492cc552e