### PR TITLE
Account for pending open orders in risk checks

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -855,6 +855,7 @@ class EventDrivenBacktestEngine:
                         sig.side,
                         place_price,
                         strength=sig.strength,
+                        pending_qty=svc.account.open_orders.get(symbol, 0.0),
                     )
                     if not allowed or abs(delta) < self.min_order_qty:
                         continue

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -277,6 +277,9 @@ class RiskService:
 
         Returns ``(allowed, reason, delta)`` where ``delta`` is the signed size
         based solely on ``signal_strength`` and ``price``.
+        ``pending_qty`` represents quantity already reserved by open orders and
+        is subtracted from ``delta`` so subsequent orders account for any
+        outstanding amounts.
         """
 
         # refresh caps based on current account cash

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -32,7 +32,7 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
     risk = engine.risk[("alwaysbuy", sym)]
     engine.verbose_fills = True
     result = engine.run()
-    assert result["fill_count"] == 1
+    assert result["fill_count"] == 2
     fills = pd.DataFrame(
         result["fills"],
         columns=[
@@ -68,5 +68,5 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
     final_price = df["close"].iloc[-1]
     expected_equity = cash + base * final_price
     assert result["equity"] == pytest.approx(expected_equity)
-    assert result["equity"] == pytest.approx(104.02308726847399)
-    assert result["pnl"] == pytest.approx(3.5230872684739865)
+    assert result["equity"] == pytest.approx(103.86715654853998)
+    assert result["pnl"] == pytest.approx(3.367156548539981)

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -33,3 +33,28 @@ def test_check_global_exposure_includes_pending():
     svc = make_service(account)
     assert svc.check_global_exposure("BTC", 400.0)
     assert not svc.check_global_exposure("BTC", 600.0)
+
+
+def test_check_order_pending_qty_reduces_next_size():
+    account = Account(float("inf"), cash=1000.0)
+    account.mark_price("BTC", 100.0)
+    svc = make_service(account)
+
+    allowed, _, delta = svc.check_order("BTC", "buy", 100.0, strength=1.0)
+    assert allowed
+    svc.account.update_open_order("BTC", delta)
+
+    allowed_raw, _, delta_raw = svc.check_order("BTC", "buy", 100.0, strength=1.0)
+    assert allowed_raw
+    assert delta_raw > 0
+
+    allowed2, reason2, delta2 = svc.check_order(
+        "BTC",
+        "buy",
+        100.0,
+        strength=1.0,
+        pending_qty=svc.account.open_orders.get("BTC", 0.0),
+    )
+    assert not allowed2
+    assert reason2 == "zero_size"
+    assert delta2 == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- pass pending open order quantity to risk checks in backtest engine
- document pending quantity parameter in RiskService
- test pending orders reduce sizing and adjust integration expectation

## Testing
- `pytest tests/test_open_orders.py::test_check_order_pending_qty_reduces_next_size -q`
- `pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q`
- `pytest -q` *(killed: exit status 137)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b8d965b4832d84f392667f2c312c