### PR TITLE
Handle near-zero open orders and test clearing

### DIFF
--- a/src/tradingbot/core/account.py
+++ b/src/tradingbot/core/account.py
@@ -57,10 +57,10 @@ class Account:
     def update_open_order(self, symbol: str, delta_qty: float) -> None:
         """Adjust pending quantity for ``symbol`` by ``delta_qty``."""
         qty = self.open_orders.get(symbol, 0.0) + float(delta_qty)
-        if abs(qty) > 0.0:
-            self.open_orders[symbol] = qty
-        else:
+        if abs(qty) < 1e-9:
             self.open_orders.pop(symbol, None)
+        else:
+            self.open_orders[symbol] = qty
 
     def pending_exposure(self, symbol: str) -> float:
         """Return notional exposure tied up in open orders for ``symbol``."""

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -16,6 +16,13 @@ def make_service(account: Account) -> RiskService:
     )
 
 
+def test_update_open_order_clears_when_offset():
+    account = Account(float("inf"), cash=0.0)
+    account.update_open_order("BTC", 1.0)
+    account.update_open_order("BTC", -1.0)
+    assert account.open_orders == {}
+
+
 def test_calc_position_size_accounts_for_open_orders():
     account = Account(float("inf"), cash=1000.0)
     account.mark_price("BTC", 100.0)


### PR DESCRIPTION
## Summary
- avoid lingering open orders when remaining quantity is below 1e-9
- add regression test ensuring offsetting orders clear the open order book

## Testing
- `pytest tests/test_open_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4c4ff8b88832db184b0e8d65931de