### PR TITLE
Handle strategy exit signals in backtest engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -836,8 +836,7 @@ class EventDrivenBacktestEngine:
                         continue
                     svc = self.risk[(strat_name, symbol)]
                     pos_qty, _ = svc.account.current_exposure(symbol)
-                    if abs(pos_qty) > self.min_order_qty:
-                        continue
+                    trade = svc.get_trade(symbol)
                     start_idx = i - self.window
                     if getattr(strat, "needs_window_df", True):
                         window_df = df.iloc[start_idx:i]
@@ -845,14 +844,71 @@ class EventDrivenBacktestEngine:
                     else:
                         bar_arrays = {col: arrs[col][start_idx:i] for col in arrs}
                         sig = strat.on_bar(bar_arrays)
-                    if sig is None or sig.side == "flat":
-                        continue
                     place_price = float(arrs["close"][i])
                     svc.mark_price(symbol, place_price)
                     if equity < 0:
                         continue
                     equity_for_order = max(equity, 1.0)
                     svc.account.cash = equity_for_order
+                    if trade:
+                        decision = svc.manage_position(trade, sig)
+                        if decision == "close":
+                            delta_qty = -pos_qty
+                        elif decision in {"scale_in", "scale_out"}:
+                            target = svc.calc_position_size(sig.strength, place_price)
+                            delta_qty = target - abs(pos_qty)
+                        else:
+                            continue
+                        if abs(delta_qty) < self.min_order_qty:
+                            continue
+                        if decision == "close":
+                            side = "buy" if delta_qty > 0 else "sell"
+                        else:
+                            side = (
+                                trade["side"]
+                                if delta_qty > 0
+                                else ("sell" if trade["side"] == "buy" else "buy")
+                            )
+                        qty = abs(delta_qty)
+                        notional = qty * place_price
+                        if not svc.register_order(notional):
+                            continue
+                        exchange = self.strategy_exchange[(strat_name, symbol)]
+                        base_latency = self.exchange_latency.get(exchange, self.latency)
+                        delay = max(1, int(base_latency * self.stress.latency))
+                        exec_index = i + delay
+                        queue_pos = 0.0
+                        if self.use_l2:
+                            vol_key = "ask_size" if side == "buy" else "bid_size"
+                            depth = self.exchange_depth.get(exchange, self.default_depth)
+                            vol_arr = arrs.get(vol_key)
+                            avail = float(vol_arr[i]) if vol_arr is not None else 0.0
+                            queue_pos = min(avail, depth)
+                        post_only = bool(getattr(sig, "post_only", False))
+                        order_seq += 1
+                        order = Order(
+                            exec_index,
+                            order_seq,
+                            i,
+                            strat_name,
+                            symbol,
+                            side,
+                            qty,
+                            exchange,
+                            place_price,
+                            qty,
+                            0.0,
+                            0.0,
+                            queue_pos,
+                            None,
+                            post_only,
+                            None,
+                        )
+                        orders.append(order)
+                        heapq.heappush(order_queue, order)
+                        continue
+                    if sig is None or sig.side == "flat":
+                        continue
                     allowed, _reason, delta = svc.check_order(
                         symbol,
                         sig.side,

--- a/tests/test_backtest_exit_signal.py
+++ b/tests/test_backtest_exit_signal.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from types import SimpleNamespace
+from tradingbot.backtesting.engine import run_backtest_csv
+from tradingbot.strategies import STRATEGIES
+
+
+class Signal(SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class ExitStrategy:
+    def __init__(self):
+        self.i = 0
+
+    def on_bar(self, bar):
+        self.i += 1
+        if self.i == 1:
+            return Signal(side="buy", strength=1.0)
+        if self.i == 2:
+            return Signal(side="sell", strength=1.0)
+        return Signal(side="flat")
+
+
+def test_exit_signal_closes_before_liquidation(tmp_path, monkeypatch):
+    rng = pd.date_range("2021-01-01", periods=5, freq="T")
+    df = pd.DataFrame(
+        {
+            "timestamp": rng.view("int64") // 10**9,
+            "open": [100, 101, 102, 103, 104],
+            "high": [100, 101, 102, 103, 104],
+            "low": [100, 101, 102, 103, 104],
+            "close": [100, 101, 102, 103, 104],
+            "volume": [1000] * 5,
+        }
+    )
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+
+    monkeypatch.setitem(STRATEGIES, "exit_strat", ExitStrategy)
+    strategies = [("exit_strat", "SYM")]
+    data = {"SYM": str(path)}
+    res = run_backtest_csv(data, strategies, latency=1, window=1, verbose_fills=True)
+
+    fills = res["fills"]
+    sides = [f[2] for f in fills]
+    reasons = [f[1] for f in fills]
+    assert "buy" in sides and "sell" in sides
+    assert "liquidation" not in reasons


### PR DESCRIPTION
## Summary
- always run strategy `on_bar` regardless of current position
- use `svc.manage_position` with signal to scale or close existing trades
- add regression test ensuring exit fills occur before final liquidation

## Testing
- `pytest tests/test_backtest_exit_signal.py::test_exit_signal_closes_before_liquidation -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4cacfc96c832d86bb67bcb1d19e76