### PR TITLE
Initialize trade stops using risk percent

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -438,7 +438,12 @@ class RiskService:
                 "entry_price": getattr(self.rm, "_entry_price", None),
             }
         )
-        trade.setdefault("stop", trade["entry_price"])
+        entry_price = trade.get("entry_price")
+        if entry_price is not None:
+            trade.setdefault(
+                "stop",
+                self.initial_stop(entry_price, trade["side"]),
+            )
         trade.setdefault("stage", 0)
         self.trades[symbol] = trade
 


### PR DESCRIPTION
## Summary
- Set default stop using `initial_stop` both when positions are synced and when fills arrive
- Keep risk stage at 0 for new trades
- Test that new trades start with a stop at ±`risk_pct` of entry price

## Testing
- `pytest tests/test_risk.py::test_update_position_sets_initial_stop_and_trailing tests/test_risk.py::test_update_position_uses_risk_pct_for_stop tests/test_risk.py::test_on_fill_sets_initial_stop -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d41ab024832d88dbf10a1a2f3522