### PR TITLE
chore: remove deprecated sym_vols references

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -387,9 +387,6 @@ class EventDrivenBacktestEngine:
             for sym, df in self.data.items()
         }
         data_lengths = {sym: len(df) for sym, df in self.data.items()}
-        # Rolling volatility arrays (previously stored in ``sym_vols``) have been
-        # removed. Strategies and risk modules should compute any required
-        # volatility metrics internally as needed.
 
         order_seq = 0
 


### PR DESCRIPTION
## Summary
- clean up backtesting engine by removing obsolete comment about `sym_vols` rolls

## Testing
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'get')*
- `pytest tests/test_backtest_engine.py::test_sharpe_is_annualised -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'get')*


------
https://chatgpt.com/codex/tasks/task_e_68b4d446dbac832d881d15374e937ffd