### PR TITLE
Handle close decision immediately

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -473,6 +473,7 @@ class EventDrivenBacktestEngine:
                                         else 0.0
                                     )
                                     queue_pos = min(avail, depth)
+                                svc.account.update_open_order(sym, abs(delta_qty))
                                 order_seq += 1
                                 order = Order(
                                     exec_index,
@@ -519,6 +520,7 @@ class EventDrivenBacktestEngine:
                                         else 0.0
                                     )
                                     queue_pos = min(avail, depth)
+                                svc.account.update_open_order(sym, pending_qty)
                                 order_seq += 1
                                 order = Order(
                                     exec_index,

--- a/tests/test_backtest_close_order.py
+++ b/tests/test_backtest_close_order.py
@@ -47,4 +47,5 @@ def test_stop_triggers_close(monkeypatch):
     monkeypatch.setattr(svc.rm, "check_limits", lambda price: None)
 
     res = engine.run()
-    assert any(o["side"] == "sell" and pytest.approx(o["qty"]) == 1.0 for o in res["orders"])
+    assert res["orders"][0]["side"] == "sell"
+    assert res["orders"][0]["qty"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- reserve `open_orders` when scaling existing positions
- immediately enqueue opposite order and update `open_orders` on close decisions
- test stop-loss closes position without waiting for new signal

## Testing
- `python -m pytest tests/test_backtest_close_order.py -q`
- `python -m pytest tests/test_open_orders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d7d80718832da17bcc5d848c4fc4