### PR TITLE
Reserve cash for pending orders in backtests

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -447,6 +447,7 @@ class EventDrivenBacktestEngine:
                             )
                             delta_qty = target - abs(pos_qty)
                             if abs(delta_qty) > self.min_order_qty:
+                                svc.account.update_open_order(sym, abs(delta_qty))
                                 side = (
                                     trade["side"]
                                     if delta_qty > 0
@@ -495,8 +496,10 @@ class EventDrivenBacktestEngine:
                                 orders.append(order)
                                 heapq.heappush(order_queue, order)
                         elif decision == "close":
-                            pending_qty = abs(pos_qty)
+                            delta_qty = -pos_qty
+                            pending_qty = abs(delta_qty)
                             if pending_qty > self.min_order_qty:
+                                svc.account.update_open_order(sym, pending_qty)
                                 side = "sell" if pos_qty > 0 else "buy"
                                 exchange = self.strategy_exchange[(strat, sym)]
                                 base_latency = self.exchange_latency.get(
@@ -923,6 +926,7 @@ class EventDrivenBacktestEngine:
                         notional = qty * place_price
                         if not svc.register_order(notional):
                             continue
+                        svc.account.update_open_order(symbol, qty)
                         exchange = self.strategy_exchange[(strat_name, symbol)]
                         base_latency = self.exchange_latency.get(exchange, self.latency)
                         delay = max(1, int(base_latency * self.stress.latency))

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -480,7 +480,7 @@ def test_funding_payment(tmp_path, monkeypatch):
     )
     assert pytest.approx(res["funding"], rel=1e-9) == 1.0
     # El costo de la operación incluye la comisión por defecto (0.001)
-    assert pytest.approx(res["equity"], rel=1e-9) == 198.9
+    assert pytest.approx(res["equity"], rel=1e-9) == 198.8
 
 
 class AlwaysBuyStrategy:
@@ -516,7 +516,7 @@ def test_stop_on_equity_depletion(tmp_path, monkeypatch, caplog):
     )
 
     df = pd.read_csv(out)
-    assert len(df) == 1
+    assert len(df) == 0
     assert any("Equity depleted" in m for m in caplog.messages)
 
 

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -88,3 +88,13 @@ def test_check_order_pending_qty_handles_partial_fill():
     )
     assert allowed2
     assert delta2 == pytest.approx(base - pending)
+
+
+def test_available_balance_decreases_with_pending_order():
+    account = Account(float("inf"), cash=1000.0)
+    account.mark_price("BTC", 100.0)
+    svc = make_service(account)
+    allowed, _, delta = svc.check_order("BTC", "buy", 100.0, strength=1.0)
+    assert allowed
+    assert account.cash == pytest.approx(1000.0)
+    assert account.get_available_balance() == pytest.approx(900.0)


### PR DESCRIPTION
## Summary
- reserve account balance when scaling in/out or closing positions during backtests
- cover reserved-balance behavior with unit tests
- update backtest expectations affected by reserved cash

## Testing
- `pytest tests/test_open_orders.py tests/test_backtest_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4d7dd0774832dafa729a0a505f59c