### PR TITLE
Ensure current price passed to risk manager

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -440,6 +440,7 @@ class EventDrivenBacktestEngine:
                     trade = svc.get_trade(sym)
                     if trade and abs(pos_qty) > self.min_order_qty:
                         svc.update_trailing(trade, price)
+                        trade["current_price"] = price
                         decision = svc.manage_position(trade)
                         if decision in {"scale_in", "scale_out"}:
                             target = svc.calc_position_size(
@@ -905,6 +906,7 @@ class EventDrivenBacktestEngine:
                     if equity < 0:
                         continue
                     if trade:
+                        trade["current_price"] = place_price
                         sig_obj = sig.__dict__ if hasattr(sig, "__dict__") else sig
                         decision = svc.manage_position(trade, sig_obj)
                         if decision == "close":


### PR DESCRIPTION
## Summary
- Track current price in trades before invoking `manage_position` to correctly process stops
- Test that stop orders trigger and fill on the bar where price breaches the stop

## Testing
- `pytest tests/test_backtest_close_order.py::test_stop_triggers_close -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4debf02ec832d8e4ed78b96907b4c