### PR TITLE
Pass risk service into strategies

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -331,7 +331,6 @@ class EventDrivenBacktestEngine:
             if strat_cls is None:
                 raise ValueError(f"unknown strategy: {strat_name}")
             key = (strat_name, symbol)
-            self.strategies[key] = strat_cls()
             allow_short = self.exchange_mode.get(exchange, "perp") != "spot"
             guard = PortfolioGuard(GuardConfig(venue=exchange))
             account = CoreAccount(float("inf"), cash=self.initial_equity)
@@ -345,6 +344,7 @@ class EventDrivenBacktestEngine:
             svc.rm.min_order_qty = self.min_order_qty
             self.risk[key] = svc
             self.strategy_exchange[key] = exchange
+            self.strategies[key] = strat_cls(risk_service=svc)
 
         # Internal flag to avoid repeated on_bar calls per bar index
         self._last_on_bar_i: int = -1

--- a/src/tradingbot/strategies/arbitrage.py
+++ b/src/tradingbot/strategies/arbitrage.py
@@ -22,8 +22,12 @@ class Arbitrage(Strategy):
 
     name = "arbitrage"
 
-    def __init__(self, **_: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """Accept arbitrary parameters for future extensions."""
+
+        # ``risk_service`` is accepted to keep a uniform signature across
+        # strategies even though this placeholder does not use it.
+        self.risk_service = kwargs.get("risk_service")
 
         # No configuration required for the placeholder implementation.
 

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -111,6 +111,8 @@ class TriangularArb(Strategy):
         self.taker_fee_bps = kwargs.get("taker_fee_bps", 0.0)
         self.buffer_bps = kwargs.get("buffer_bps", 0.0)
         self.min_edge = kwargs.get("min_edge", 0.0)
+        # Accept optional ``risk_service`` for interface compatibility.
+        self.risk_service = kwargs.get("risk_service")
 
     @record_signal_metrics
     def on_bar(self, bar: Dict[str, Dict[str, float]]) -> Optional[Signal]:

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -61,6 +61,7 @@ class CashAndCarry(Strategy):
         argumento o, alternativamente, los parámetros vía ``**kwargs``.
         """
 
+        self.risk_service = kwargs.pop("risk_service", None)
         self.cfg = cfg or CashCarryConfig(**kwargs)
         self.engine = get_engine() if (self.cfg.persist_pg and _CAN_PG) else None
 

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -27,7 +27,7 @@ _RiskManager.complete_order = lambda self: None  # type: ignore
 class DummyStrategy:
     name = "dummy"
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.i = 0
 
     def on_bar(self, bar):

--- a/tests/test_depth_imbalance.py
+++ b/tests/test_depth_imbalance.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
 from tradingbot.strategies.depth_imbalance import DepthImbalance
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+from tradingbot.core.account import Account as CoreAccount
+from unittest.mock import MagicMock
 
 
 def test_depth_imbalance_strategy_buy():
@@ -15,3 +19,24 @@ def test_depth_imbalance_strategy_sell():
     strat = DepthImbalance(window=2, threshold=0.1)
     sig = strat.on_bar({"window": df})
     assert sig is not None and sig.side == "sell"
+
+
+def test_depth_imbalance_trailing_close():
+    df = pd.DataFrame({"bid_qty": [5, 7, 9], "ask_qty": [5, 5, 3]})
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    account = CoreAccount(float("inf"), cash=1000.0)
+    svc = RiskService(guard, account=account, risk_per_trade=1.0, risk_pct=0.01)
+    svc.update_trailing = MagicMock(wraps=svc.update_trailing)
+    svc.manage_position = MagicMock(wraps=svc.manage_position)
+    strat = DepthImbalance(window=2, threshold=0.1, risk_service=svc)
+
+    sig = strat.on_bar({"window": df, "close": 100.0})
+    assert sig is not None and sig.side == "buy"
+    assert svc.update_trailing.call_count == 1
+    stop = strat.trade["stop"]
+
+    sig2 = strat.on_bar({"window": df, "close": stop - 1})
+    assert svc.update_trailing.call_count == 2
+    assert svc.manage_position.call_count == 1
+    assert sig2 is not None and sig2.side == "sell"
+    assert strat.trade is None


### PR DESCRIPTION
## Summary
- inject `RiskService` into strategies in backtesting engine
- allow built-in strategies to accept optional `risk_service`
- add test verifying DepthImbalance closes via risk service

## Testing
- `pytest tests/test_depth_imbalance.py::test_depth_imbalance_trailing_close -q`
- `pytest tests/test_arbitrage_triangular.py -q`
- `pytest tests/test_cash_and_carry.py -q`
- `pytest tests/test_composite_signals.py -q`
- `pytest tests/test_backtest_engine.py::test_pnl_with_and_without_slippage -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dec1800c832da2ed86d4b6f56405