### PR TITLE
Clarify risk percentage handling and add boundary tests

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -33,14 +33,14 @@ def _validate_risk_pct(value: float) -> float:
     """Ensure ``risk_pct`` is a fraction in [0, 1].
 
     Values greater than 1 and up to 100 are interpreted as percentages and
-    converted by dividing by 100. Values outside these ranges raise a
-    :class:`ValueError`.
+    converted by dividing by 100. A value of 1 represents 100% and is returned
+    unchanged. Values outside these ranges raise a :class:`ValueError`.
     """
 
     val = float(value)
     if val < 0:
         raise ValueError("risk_pct must be non-negative")
-    if val >= 1:
+    if val > 1:
         if val <= 100:
             return val / 100
         raise ValueError("risk_pct must be between 0 and 1")

--- a/tests/test_risk_pct_validation.py
+++ b/tests/test_risk_pct_validation.py
@@ -15,15 +15,21 @@ def dummy_data():
     })}
 
 
-def test_engine_normalizes_percentage(dummy_data):
-    eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=5)
-    assert eng._risk_pct == pytest.approx(0.05)
-    eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=1)
-    assert eng._risk_pct == pytest.approx(0.01)
+@pytest.mark.parametrize(
+    "risk_pct,expected",
+    [
+        (0.5, 0.5),  # already a fraction
+        (1, 1.0),  # 100%
+        (5, 0.05),  # percentage expressed as integer
+        (50, 0.5),  # percentage conversion boundary
+    ],
+)
+def test_engine_normalizes_percentage(dummy_data, risk_pct, expected):
+    eng = EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=risk_pct)
+    assert eng._risk_pct == pytest.approx(expected)
 
 
-def test_engine_rejects_invalid_risk_pct(dummy_data):
+@pytest.mark.parametrize("risk_pct", [-0.1, 120])
+def test_engine_rejects_invalid_risk_pct(dummy_data, risk_pct):
     with pytest.raises(ValueError):
-        EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=-0.1)
-    with pytest.raises(ValueError):
-        EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=150)
+        EventDrivenBacktestEngine(dummy_data, [("breakout_atr", "BTC/USDT")], risk_pct=risk_pct)


### PR DESCRIPTION
## Summary
- ensure `_validate_risk_pct` treats `1` as 100% and only converts values greater than 1
- expand risk percentage tests with boundary and invalid values

## Testing
- `pytest tests/test_risk_pct_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4e2a80468832db8e9c9a3461fc7d3