### PR TITLE
Fix duplicate open-order tracking in backtesting engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -450,7 +450,6 @@ class EventDrivenBacktestEngine:
                             )
                             delta_qty = target - abs(pos_qty)
                             if abs(delta_qty) > self.min_order_qty:
-                                svc.account.update_open_order(sym, abs(delta_qty))
                                 side = (
                                     trade["side"]
                                     if delta_qty > 0
@@ -503,7 +502,6 @@ class EventDrivenBacktestEngine:
                             delta_qty = -pos_qty
                             pending_qty = abs(delta_qty)
                             if pending_qty > self.min_order_qty:
-                                svc.account.update_open_order(sym, pending_qty)
                                 side = "sell" if pos_qty > 0 else "buy"
                                 exchange = self.strategy_exchange[(strat, sym)]
                                 base_latency = self.exchange_latency.get(

--- a/tests/test_backtest_pending_orders.py
+++ b/tests/test_backtest_pending_orders.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import pytest
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.core import Account
+from tradingbot.strategies import STRATEGIES
+
+
+class DummyStrategy:
+    def __init__(self, risk_service=None):
+        self.risk_service = risk_service
+
+    def on_bar(self, data):
+        return None
+
+
+class StubPos:
+    realized_pnl = 0.0
+
+
+class StubRM:
+    def __init__(self):
+        self.pos = StubPos()
+
+    def check_limits(self, price):
+        return True
+
+
+class StubRisk:
+    def __init__(self, account: Account):
+        self.account = account
+        self.rm = StubRM()
+
+    def get_trade(self, sym):
+        return {"side": "buy"}
+
+    def update_trailing(self, trade, price):
+        pass
+
+    def manage_position(self, trade):
+        return "close"
+
+    def mark_price(self, symbol, price):
+        pass
+
+    def on_fill(self, symbol, side, qty, price):
+        sign = 1 if side == "buy" else -1
+        self.account.update_position(symbol, sign * qty, price)
+
+    def complete_order(self):
+        pass
+
+
+def test_pending_order_quantity(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "timestamp": [0],
+            "open": [100.0],
+            "high": [100.0],
+            "low": [100.0],
+            "close": [100.0],
+            "volume": [1000],
+        }
+    )
+    monkeypatch.setitem(STRATEGIES, "dummy", DummyStrategy)
+    engine = EventDrivenBacktestEngine({"SYM": df}, [("dummy", "SYM")], latency=2, window=1)
+    account = Account(float("inf"), cash=0.0)
+    account.update_position("SYM", 1.0, price=100.0)
+    engine.risk = {("dummy", "SYM"): StubRisk(account)}
+    engine.run()
+    assert account.open_orders["SYM"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- avoid double-counting open orders during scale and close decisions
- add regression test ensuring pending order quantity is correct

## Testing
- `pytest tests/test_backtest_pending_orders.py::test_pending_order_quantity -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e2a8ee68832d9bca16bcbc30d438