### PR TITLE
Honor limit prices when recalculating place price

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -927,6 +927,10 @@ class EventDrivenBacktestEngine:
                         trade["current_price"] = place_price
                         sig_obj = sig.__dict__ if hasattr(sig, "__dict__") else sig
                         decision = svc.manage_position(trade, sig_obj)
+                        limit_price = getattr(sig, "limit_price", None)
+                        place_price = float(arrs["close"][i])
+                        if limit_price is not None:
+                            place_price = float(limit_price)
                         if decision == "close":
                             delta_qty = -pos_qty
                         elif decision in {"scale_in", "scale_out"}:
@@ -956,7 +960,9 @@ class EventDrivenBacktestEngine:
                         queue_pos = 0.0
                         if self.use_l2:
                             vol_key = "ask_size" if side == "buy" else "bid_size"
-                            depth = self.exchange_depth.get(exchange, self.default_depth)
+                            depth = self.exchange_depth.get(
+                                exchange, self.default_depth
+                            )
                             vol_arr = arrs.get(vol_key)
                             avail = float(vol_arr[i]) if vol_arr is not None else 0.0
                             queue_pos = min(avail, depth)


### PR DESCRIPTION
## Summary
- Recompute `place_price` after `manage_position` to account for updated `sig.limit_price`
- Ensure resulting `place_price` is used for position sizing and order placement

## Testing
- `pytest` *(fails: TypeError in AlwaysBuyStrategy/BuyOnceStrategy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fad68ae8832d92c94822622bb784