### PR TITLE
Respect signal limit_price in backtesting engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -916,7 +916,11 @@ class EventDrivenBacktestEngine:
                     else:
                         bar_arrays = {col: arrs[col][start_idx:i] for col in arrs}
                         sig = strat.on_bar(bar_arrays)
-                    limit_price = getattr(sig, "limit_price", None)
+                    limit_price = (
+                        sig.get("limit_price")
+                        if isinstance(sig, dict)
+                        else getattr(sig, "limit_price", None)
+                    )
                     place_price = (
                         float(limit_price)
                         if limit_price is not None
@@ -929,7 +933,11 @@ class EventDrivenBacktestEngine:
                         trade["current_price"] = place_price
                         sig_obj = sig.__dict__ if hasattr(sig, "__dict__") else sig
                         decision = svc.manage_position(trade, sig_obj)
-                        limit_price = getattr(sig, "limit_price", None)
+                        limit_price = (
+                            sig.get("limit_price")
+                            if isinstance(sig, dict)
+                            else getattr(sig, "limit_price", None)
+                        )
                         place_price = (
                             float(limit_price)
                             if limit_price is not None


### PR DESCRIPTION
## Summary
- Allow backtest engine to read `limit_price` from dict-based signals
- Re-evaluate limit price for position management using dict signals

## Testing
- `python -m black src/tradingbot/backtesting/engine.py`
- `pytest tests/test_backtest_limit_price.py -q`
- `pytest --maxfail=1` *(fails: AlwaysBuyStrategy() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d45c62dc832d97f096e1531767ad