### PR TITLE
Ensure default orders use bar close as limit price

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -921,11 +921,12 @@ class EventDrivenBacktestEngine:
                         if isinstance(sig, dict)
                         else getattr(sig, "limit_price", None)
                     )
-                    place_price = (
-                        float(limit_price)
-                        if limit_price is not None
-                        else float(arrs["close"][i])
-                    )
+                    if limit_price is None:
+                        place_price = float(arrs["close"][i])
+                        limit_price = place_price
+                    else:
+                        place_price = float(limit_price)
+                        limit_price = place_price
                     svc.mark_price(symbol, place_price)
                     if equity < 0:
                         continue
@@ -938,11 +939,12 @@ class EventDrivenBacktestEngine:
                             if isinstance(sig, dict)
                             else getattr(sig, "limit_price", None)
                         )
-                        place_price = (
-                            float(limit_price)
-                            if limit_price is not None
-                            else float(arrs["close"][i])
-                        )
+                        if limit_price is None:
+                            place_price = float(arrs["close"][i])
+                            limit_price = place_price
+                        else:
+                            place_price = float(limit_price)
+                            limit_price = place_price
                         svc.mark_price(symbol, place_price)
                         if decision == "close":
                             delta_qty = -pos_qty


### PR DESCRIPTION
## Summary
- When signals omit a limit price, default to using the bar's close for both `place_price` and `limit_price`
- Add regression test to confirm orders without explicit limits are stored and filled at the bar close

## Testing
- `pytest tests/test_backtest_limit_price.py -q`
- `pytest tests/test_backtest_engine.py -q` *(fails: FlipStrategy.__init__() missing risk_service and similar for other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e095ea70832d8b344fafe36bb497