### PR TITLE
Ensure strategies return limit-priced signals

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -38,10 +38,14 @@ class BreakoutVol(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = last
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = last
+                return sig
             return None
         upper = mean + self.mult * std
         lower = mean - self.mult * std
@@ -72,4 +76,6 @@ class BreakoutVol(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, last)
             self.trade = trade
-        return Signal(side, size)
+        sig = Signal(side, size)
+        sig.limit_price = last
+        return sig

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -47,10 +47,14 @@ class DepthImbalance(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         di_series = depth_imbalance(df[list(needed)])
@@ -71,4 +75,6 @@ class DepthImbalance(Strategy):
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -77,10 +77,14 @@ class LiquidityEvents(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = float(last_price)
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = float(last_price)
+                return sig
             return None
 
         vac_thresh = self._vol_adjust(mid, self.vacuum_threshold)
@@ -97,7 +101,9 @@ class LiquidityEvents(Strategy):
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         if vac < 0:
             side = "sell"
             strength = 1.0
@@ -110,7 +116,9 @@ class LiquidityEvents(Strategy):
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
 
         gap_thresh = self._vol_adjust(mid, self.gap_threshold)
         gap = liquidity_gap(df[["bid_px", "ask_px"]], gap_thresh).iloc[-1]
@@ -126,7 +134,9 @@ class LiquidityEvents(Strategy):
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         if gap < 0:
             side = "sell"
             strength = 1.0
@@ -139,5 +149,7 @@ class LiquidityEvents(Strategy):
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         return None

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -53,10 +53,14 @@ class Momentum(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
         rsi_series = rsi(df, self.rsi_n)
         prev_rsi = rsi_series.iloc[-2]
@@ -89,7 +93,9 @@ class Momentum(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig
 
 
 def generate_signals(data: pd.DataFrame, params: dict) -> pd.DataFrame:

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -50,10 +50,14 @@ class OrderFlow(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         vol_bps = float("inf")
@@ -88,4 +92,6 @@ class OrderFlow(Strategy):
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -99,10 +99,14 @@ class ScalpPingPong(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         vol = (
@@ -159,4 +163,6 @@ class ScalpPingPong(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, size)
+        sig = Signal(side, size)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -44,10 +44,14 @@ class TrendFollowing(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
         returns = prices.pct_change().dropna()
         vol = returns.rolling(self.vol_lookback).std().iloc[-1] * 10000
@@ -78,5 +82,7 @@ class TrendFollowing(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig
 

--- a/tests/test_depth_imbalance.py
+++ b/tests/test_depth_imbalance.py
@@ -10,15 +10,17 @@ from unittest.mock import MagicMock
 def test_depth_imbalance_strategy_buy():
     df = pd.DataFrame({"bid_qty": [5, 7, 9], "ask_qty": [5, 5, 3]})
     strat = DepthImbalance(window=2, threshold=0.1)
-    sig = strat.on_bar({"window": df})
+    sig = strat.on_bar({"window": df, "close": 100.0})
     assert sig is not None and sig.side == "buy"
+    assert sig.limit_price == 100.0
 
 
 def test_depth_imbalance_strategy_sell():
     df = pd.DataFrame({"bid_qty": [5, 4, 3], "ask_qty": [5, 6, 7]})
     strat = DepthImbalance(window=2, threshold=0.1)
-    sig = strat.on_bar({"window": df})
+    sig = strat.on_bar({"window": df, "close": 100.0})
     assert sig is not None and sig.side == "sell"
+    assert sig.limit_price == 100.0
 
 
 def test_depth_imbalance_trailing_close():

--- a/tests/test_liquidity_events.py
+++ b/tests/test_liquidity_events.py
@@ -33,6 +33,7 @@ def test_liquidity_events_strategy_buy_vacuum():
     strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=2, dynamic_thresholds=False)
     sig = strat.on_bar({"window": df})
     assert sig is not None and sig.side == "buy"
+    assert sig.limit_price == pytest.approx(100.5)
 
 
 def test_liquidity_events_strategy_sell_gap():
@@ -45,6 +46,7 @@ def test_liquidity_events_strategy_sell_gap():
     strat = LiquidityEvents(vacuum_threshold=0.5, gap_threshold=5, dynamic_thresholds=False)
     sig = strat.on_bar({"window": df})
     assert sig is not None and sig.side == "sell"
+    assert sig.limit_price == pytest.approx(100.5)
 
 
 def test_liquidity_events_no_signal_returns_none():

--- a/tests/test_momentum_limit_price.py
+++ b/tests/test_momentum_limit_price.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from tradingbot.strategies.momentum import Momentum
+
+def test_momentum_sets_limit_price():
+    df = pd.DataFrame({"close": [1, 2, 1, 2]})
+    strat = Momentum(rsi_n=2, rsi_threshold=55.0)
+    sig = strat.on_bar({"window": df, "close": df["close"].iloc[-1], "volatility": 0.0})
+    assert sig is not None and sig.side == "buy"
+    assert sig.limit_price == df["close"].iloc[-1]

--- a/tests/test_scalp_pingpong.py
+++ b/tests/test_scalp_pingpong.py
@@ -1,7 +1,8 @@
+import pandas as pd
 import yaml
 import pytest
 from tradingbot.core import Account, RiskManager as CoreRiskManager
-from tradingbot.strategies.scalp_pingpong import ScalpPingPong
+from tradingbot.strategies.scalp_pingpong import ScalpPingPong, ScalpPingPongConfig
 
 
 def test_config_path_overrides(tmp_path):
@@ -29,3 +30,12 @@ def test_scalp_pingpong_trailing_stop_uses_atr():
     }
     rm.update_trailing(trade, 110.0)
     assert trade["stop"] == pytest.approx(110.0 - 2 * trade["atr"])
+
+
+def test_scalp_pingpong_emits_limit_price():
+    df = pd.DataFrame({"close": [1, 2, 1]})
+    cfg = ScalpPingPongConfig(lookback=2, z_threshold=0.1, volatility_factor=1.0, min_volatility=0.0)
+    strat = ScalpPingPong(cfg=cfg)
+    sig = strat.on_bar({"window": df, "close": df["close"].iloc[-1], "volatility": 0.0})
+    assert sig is not None
+    assert sig.limit_price == df["close"].iloc[-1]

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -52,10 +52,12 @@ def test_order_flow_signals():
         "ask_qty": [1, 2, 3, 5],
     })
     strat = OrderFlow(window=3, buy_threshold=1.0, sell_threshold=1.0)
-    sig_buy = strat.on_bar({"window": df_buy})
+    sig_buy = strat.on_bar({"window": df_buy, "close": 100.0})
     assert sig_buy.side == "buy"
-    sig_sell = strat.on_bar({"window": df_sell})
+    assert sig_buy.limit_price == 100.0
+    sig_sell = strat.on_bar({"window": df_sell, "close": 100.0})
     assert sig_sell.side == "sell"
+    assert sig_sell.limit_price == 100.0
 
 
 def test_mean_rev_ofi_signals():
@@ -120,6 +122,7 @@ def test_breakout_vol_risk_service_handles_stop_and_size():
     strat = BreakoutVol(lookback=2, mult=0.5, **{"risk_service": svc})
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
+    assert sig.limit_price == pytest.approx(df_buy["close"].iloc[-1])
     trade = strat.trade
     assert trade is not None
     expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])

--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -37,6 +37,7 @@ def test_trend_following_risk_service_handles_stop_and_size():
     strat = TrendFollowing(rsi_n=2, **{"risk_service": svc})
     sig = strat.on_bar({"window": df, "atr": 1.0, "volatility": 0.0})
     assert sig and sig.side == "buy"
+    assert sig.limit_price == pytest.approx(df["close"].iloc[-1])
     trade = strat.trade
     assert trade is not None
     expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])


### PR DESCRIPTION
## Summary
- Set `limit_price` on signals across strategies (trend following, momentum, order flow, breakout vol, scalp pingpong, liquidity events, depth imbalance)
- Added tests verifying that generated signals include a limit price

## Testing
- `pytest tests/test_trend_following.py::test_trend_following_risk_service_handles_stop_and_size tests/test_strategies.py::test_order_flow_signals tests/test_strategies.py::test_breakout_vol_risk_service_handles_stop_and_size tests/test_liquidity_events.py::test_liquidity_events_strategy_buy_vacuum tests/test_liquidity_events.py::test_liquidity_events_strategy_sell_gap tests/test_depth_imbalance.py::test_depth_imbalance_strategy_buy tests/test_depth_imbalance.py::test_depth_imbalance_strategy_sell tests/test_scalp_pingpong.py::test_scalp_pingpong_emits_limit_price tests/test_momentum_limit_price.py::test_momentum_sets_limit_price -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5e094b09c832d8a2def115376ce5b