### PR TITLE
Use window close price for composite signal limit price

### DIFF
--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -33,9 +33,12 @@ class CompositeSignals(Strategy):
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
+        window = bar.get("window")
+        if window is None or "close" not in window:
+            return None
+        price = float(window["close"].iloc[-1])
         buys = 0
         sells = 0
-        price = float(bar.get("close") or bar.get("price") or 0.0)
         for strat in self.sub_strategies:
             sig = strat.on_bar(bar)
             if sig is None:


### PR DESCRIPTION
## Summary
- derive composite signal limit price from latest close in `bar['window']`
- abort signal creation when `window` or `close` column missing

## Testing
- `pytest -q` *(fails: AlwaysBuyStrategy() takes no arguments, BuyOnceStrategy.__init__() got an unexpected keyword argument 'risk_service', test_account_cash_updates_after_each_fill.<locals>.BuySell.__init__() got an unexpected keyword argument 'risk_service')*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdd9e6a8832dba82ceb8e21ae12c