### PR TITLE
Use window close price in DepthImbalance strategy

### DIFF
--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -39,7 +39,12 @@ class DepthImbalance(Strategy):
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
 
-        price = bar.get("close")
+        price: float | None = None
+        if "close" in df.columns and len(df):
+            last_close = df["close"].iloc[-1]
+            if pd.notna(last_close):
+                price = float(last_close)
+
         if self.trade and self.risk_service and price is not None:
             self.risk_service.update_trailing(self.trade, price)
             trade_state = {**self.trade, "current_price": price}


### PR DESCRIPTION
## Summary
- derive trade price from the latest `close` in the windowed DataFrame
- avoid creating signals when price is missing

## Testing
- `pytest tests/integration/test_recorded_flow.py tests/integration/test_stress_resilience.py tests/test_account_cash_backtesting.py -q` *(fails: AlwaysBuyStrategy() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdc9c940832d87e2871cdece0944