### PR TITLE
Refactor composite signal price handling

### DIFF
--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -47,20 +47,17 @@ class CompositeSignals(Strategy):
                 buys += 1
             elif sig.side == "sell":
                 sells += 1
+
+        result = None
         if buys >= 2 and buys > sells:
-            sig = Signal("buy", 1.0)
-            sig.limit_price = price
-            return sig
-        if sells >= 2 and sells > buys:
-            sig = Signal("sell", 1.0)
-            sig.limit_price = price
-            return sig
-        if buys > len(self.sub_strategies) / 2:
-            sig = Signal("buy", 1.0)
-            sig.limit_price = price
-            return sig
-        if sells > len(self.sub_strategies) / 2:
-            sig = Signal("sell", 1.0)
-            sig.limit_price = price
-            return sig
-        return None
+            result = Signal("buy", 1.0)
+        elif sells >= 2 and sells > buys:
+            result = Signal("sell", 1.0)
+        elif buys > len(self.sub_strategies) / 2:
+            result = Signal("buy", 1.0)
+        elif sells > len(self.sub_strategies) / 2:
+            result = Signal("sell", 1.0)
+
+        if result is not None:
+            result.limit_price = price
+        return result


### PR DESCRIPTION
## Summary
- Extract price from `bar['window']['close']` and abort if not available
- Apply limit price to any signal returned by `CompositeSignals`

## Testing
- `pytest` *(fails: TypeError in strategies without risk_service)*

------
https://chatgpt.com/codex/tasks/task_e_68b602442968832da2f1830b8a5f5b5f