### PR TITLE
Enforce limit prices in strategies to guarantee limit-order backtests

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -38,10 +38,14 @@ class BreakoutVol(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = last
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = last
+                return sig
             return None
         upper = mean + self.mult * std
         lower = mean - self.mult * std
@@ -72,4 +76,6 @@ class BreakoutVol(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, last)
             self.trade = trade
-        return Signal(side, size)
+        sig = Signal(side, size)
+        sig.limit_price = last
+        return sig

--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -25,9 +25,7 @@ class CompositeSignals(Strategy):
         self.sub_strategies = []
         for cls, params in strategies:
             try:
-                self.sub_strategies.append(
-                    cls(risk_service=risk_service, **params)
-                )
+                self.sub_strategies.append(cls(risk_service=risk_service, **params))
             except TypeError:
                 # Sub-strategy may not accept ``risk_service``; fall back to
                 # instantiating without it to preserve backward compatibility.
@@ -37,6 +35,17 @@ class CompositeSignals(Strategy):
     def on_bar(self, bar: dict) -> Signal | None:
         buys = 0
         sells = 0
+        df = bar.get("window")
+        if df is None:
+            return None
+        col = (
+            "close"
+            if "close" in df.columns
+            else "price" if "price" in df.columns else None
+        )
+        if col is None:
+            return None
+        price = float(df[col].iloc[-1])
         for strat in self.sub_strategies:
             sig = strat.on_bar(bar)
             if sig is None:
@@ -46,11 +55,19 @@ class CompositeSignals(Strategy):
             elif sig.side == "sell":
                 sells += 1
         if buys >= 2 and buys > sells:
-            return Signal("buy", 1.0)
+            sig = Signal("buy", 1.0)
+            sig.limit_price = price
+            return sig
         if sells >= 2 and sells > buys:
-            return Signal("sell", 1.0)
+            sig = Signal("sell", 1.0)
+            sig.limit_price = price
+            return sig
         if buys > len(self.sub_strategies) / 2:
-            return Signal("buy", 1.0)
+            sig = Signal("buy", 1.0)
+            sig.limit_price = price
+            return sig
         if sells > len(self.sub_strategies) / 2:
-            return Signal("sell", 1.0)
+            sig = Signal("sell", 1.0)
+            sig.limit_price = price
+            return sig
         return None

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -40,17 +40,30 @@ class DepthImbalance(Strategy):
             return None
 
         price = bar.get("close")
-        if self.trade and self.risk_service and price is not None:
+        if price is None:
+            col = (
+                "close"
+                if "close" in df.columns
+                else "price" if "price" in df.columns else None
+            )
+            if col is None:
+                return None
+            price = float(df[col].iloc[-1])
+        if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
             trade_state = {**self.trade, "current_price": price}
             decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         di_series = depth_imbalance(df[list(needed)])
@@ -62,13 +75,22 @@ class DepthImbalance(Strategy):
         else:
             return None
         strength = 1.0
-        if self.risk_service and price is not None:
+        if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            trade = {
+                "side": side,
+                "entry_price": price,
+                "qty": qty,
+                "strength": strength,
+            }
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        if price is None:
+            return None
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -77,10 +77,14 @@ class LiquidityEvents(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = float(last_price)
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = float(last_price)
+                return sig
             return None
 
         vac_thresh = self._vol_adjust(mid, self.vacuum_threshold)
@@ -90,27 +94,41 @@ class LiquidityEvents(Strategy):
             strength = 1.0
             if self.risk_service:
                 qty = self.risk_service.calc_position_size(strength, last_price)
-                trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
+                trade = {
+                    "side": side,
+                    "entry_price": float(last_price),
+                    "qty": qty,
+                    "strength": strength,
+                }
                 atr = bar.get("atr") or bar.get("volatility")
                 trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         if vac < 0:
             side = "sell"
             strength = 1.0
             if self.risk_service:
                 qty = self.risk_service.calc_position_size(strength, last_price)
-                trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
+                trade = {
+                    "side": side,
+                    "entry_price": float(last_price),
+                    "qty": qty,
+                    "strength": strength,
+                }
                 atr = bar.get("atr") or bar.get("volatility")
                 trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
 
         gap_thresh = self._vol_adjust(mid, self.gap_threshold)
         gap = liquidity_gap(df[["bid_px", "ask_px"]], gap_thresh).iloc[-1]
@@ -119,25 +137,39 @@ class LiquidityEvents(Strategy):
             strength = 1.0
             if self.risk_service:
                 qty = self.risk_service.calc_position_size(strength, last_price)
-                trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
+                trade = {
+                    "side": side,
+                    "entry_price": float(last_price),
+                    "qty": qty,
+                    "strength": strength,
+                }
                 atr = bar.get("atr") or bar.get("volatility")
                 trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         if gap < 0:
             side = "sell"
             strength = 1.0
             if self.risk_service:
                 qty = self.risk_service.calc_position_size(strength, last_price)
-                trade = {"side": side, "entry_price": float(last_price), "qty": qty, "strength": strength}
+                trade = {
+                    "side": side,
+                    "entry_price": float(last_price),
+                    "qty": qty,
+                    "strength": strength,
+                }
                 atr = bar.get("atr") or bar.get("volatility")
                 trade["stop"] = self.risk_service.initial_stop(last_price, side, atr)
                 if atr is not None:
                     trade["atr"] = atr
                 self.risk_service.update_trailing(trade, last_price)
                 self.trade = trade
-            return Signal(side, strength)
+            sig = Signal(side, strength)
+            sig.limit_price = float(last_price)
+            return sig
         return None

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -49,10 +49,14 @@ class MeanReversion(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
         rsi_series = rsi(df, self.rsi_n)
         last_rsi = rsi_series.iloc[-1]
@@ -95,7 +99,12 @@ class MeanReversion(Strategy):
             return None
         if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            trade = {
+                "side": side,
+                "entry_price": price,
+                "qty": qty,
+                "strength": strength,
+            }
             atr = bar.get("atr") or bar.get("volatility") or 0.0
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             trade["atr"] = atr

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -17,6 +17,7 @@ PARAM_INFO = {
     "margin": "Margen de probabilidad sobre 0.5",
 }
 
+
 class MLStrategy(Strategy):
     """Machine learning based strategy using scikit-learn models.
 
@@ -90,7 +91,19 @@ class MLStrategy(Strategy):
         except NotFittedError:
             return None
         proba = max(0.0, min(1.0, proba))
-        price = float(bar.get("close") or bar.get("price") or 0.0)
+        price = bar.get("close") or bar.get("price")
+        if price is None and "window" in bar:
+            df = bar["window"]
+            col = (
+                "close"
+                if "close" in df.columns
+                else "price" if "price" in df.columns else None
+            )
+            if col is not None:
+                price = float(df[col].iloc[-1])
+        if price is None:
+            return None
+        price = float(price)
         if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
             trade_state = {**self.trade, "current_price": price}
@@ -98,10 +111,14 @@ class MLStrategy(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         if proba > 0.5 + self.margin:
@@ -115,14 +132,21 @@ class MLStrategy(Strategy):
 
         if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            trade = {
+                "side": side,
+                "entry_price": price,
+                "qty": qty,
+                "strength": strength,
+            }
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig
 
 
 __all__ = ["MLStrategy"]

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -43,17 +43,30 @@ class OrderFlow(Strategy):
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
         price = bar.get("close")
-        if self.trade and self.risk_service and price is not None:
+        if price is None:
+            col = (
+                "close"
+                if "close" in df.columns
+                else "price" if "price" in df.columns else None
+            )
+            if col is None:
+                return None
+            price = float(df[col].iloc[-1])
+        if self.trade and self.risk_service:
             self.risk_service.update_trailing(self.trade, price)
             trade_state = {**self.trade, "current_price": price}
             decision = self.risk_service.manage_position(trade_state)
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         vol_bps = float("inf")
@@ -71,7 +84,7 @@ class OrderFlow(Strategy):
             return None
 
         ofi_series = calc_ofi(df[list(needed)])
-        ofi_mean = ofi_series.iloc[-self.window:].mean()
+        ofi_mean = ofi_series.iloc[-self.window :].mean()
         if ofi_mean > self.buy_threshold:
             side = "buy"
         elif ofi_mean < -self.sell_threshold:
@@ -79,13 +92,22 @@ class OrderFlow(Strategy):
         else:
             return None
         strength = 1.0
-        if self.risk_service and price is not None:
+        if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, price)
-            trade = {"side": side, "entry_price": price, "qty": qty, "strength": strength}
+            trade = {
+                "side": side,
+                "entry_price": price,
+                "qty": qty,
+                "strength": strength,
+            }
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             if atr is not None:
                 trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
+        if price is None:
+            return None
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -99,10 +99,14 @@ class ScalpPingPong(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
 
         vol = (
@@ -153,10 +157,10 @@ class ScalpPingPong(Strategy):
             qty = self.risk_service.calc_position_size(size, price)
             trade = {"side": side, "entry_price": price, "qty": qty, "strength": size}
             atr = bar.get("atr") or bar.get("volatility")
-            trade["stop"] = self.risk_service.initial_stop(
-                price, side, atr
-            )
+            trade["stop"] = self.risk_service.initial_stop(price, side, atr)
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, size)
+        sig = Signal(side, size)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -44,10 +44,14 @@ class TrendFollowing(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = price
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = price
+                return sig
             return None
         returns = prices.pct_change().dropna()
         vol = returns.rolling(self.vol_lookback).std().iloc[-1] * 10000
@@ -78,5 +82,6 @@ class TrendFollowing(Strategy):
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, price)
             self.trade = trade
-        return Signal(side, strength)
-
+        sig = Signal(side, strength)
+        sig.limit_price = price
+        return sig

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -84,7 +84,7 @@ def triple_barrier_labels(
         upper = start * (1 + upper_pct)
         lower = start * (1 - lower_pct)
         end = min(i + 1 + horizon, n)
-        future = prices.iloc[i + 1:end]
+        future = prices.iloc[i + 1 : end]
         hit_upper = future[future >= upper]
         hit_lower = future[future <= lower]
         if not hit_upper.empty and not hit_lower.empty:
@@ -156,10 +156,14 @@ class TripleBarrier(Strategy):
             if decision == "close":
                 side = "sell" if self.trade["side"] == "buy" else "buy"
                 self.trade = None
-                return Signal(side, 1.0)
+                sig = Signal(side, 1.0)
+                sig.limit_price = float(last)
+                return sig
             if decision in {"scale_in", "scale_out"}:
                 self.trade["strength"] = trade_state.get("strength", 1.0)
-                return Signal(self.trade["side"], self.trade["strength"])
+                sig = Signal(self.trade["side"], self.trade["strength"])
+                sig.limit_price = float(last)
+                return sig
             return None
 
         features = self._prepare_features(df)
@@ -194,10 +198,17 @@ class TripleBarrier(Strategy):
         strength = 1.0
         if self.risk_service:
             qty = self.risk_service.calc_position_size(strength, last)
-            trade = {"side": side, "entry_price": float(last), "qty": qty, "strength": strength}
+            trade = {
+                "side": side,
+                "entry_price": float(last),
+                "qty": qty,
+                "strength": strength,
+            }
             atr = bar.get("atr") or bar.get("volatility")
             trade["stop"] = self.risk_service.initial_stop(last, side, atr)
             trade["atr"] = atr
             self.risk_service.update_trailing(trade, float(last))
             self.trade = trade
-        return Signal(side, strength)
+        sig = Signal(side, strength)
+        sig.limit_price = float(last)
+        return sig


### PR DESCRIPTION
## Summary
- derive entry price from data windows in order flow, depth imbalance, composite signals, and ML strategies
- assign `limit_price` unconditionally and abort when price is missing

## Testing
- `python -m black src/tradingbot/backtesting/engine.py src/tradingbot/strategies/order_flow.py src/tradingbot/strategies/depth_imbalance.py src/tradingbot/strategies/composite_signals.py src/tradingbot/strategies/ml_models.py`
- `pytest tests/test_backtest_limit_price.py -q`
- `pytest --maxfail=1` *(fails: AlwaysBuyStrategy() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d45c62dc832d97f096e1531767ad