### PR TITLE
refactor: enforce limit-only execution

### DIFF
--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -261,21 +261,6 @@ class ExecutionRouter:
             res["pending_qty"] = order.pending_qty
             cb = self.on_partial_fill if status == "partial" else self.on_order_expiry
             action = cb(order, res) if cb else None
-            if action == "taker" and order.pending_qty > 0:
-                taker_order = Order(
-                    symbol=order.symbol,
-                    side=order.side,
-                    type_="market",
-                    qty=order.pending_qty,
-                    reason=getattr(order, "reason", None),
-                    reduce_only=order.reduce_only,
-                )
-                res2 = await self.execute(
-                    taker_order, fill_mode=fill_mode, slip_bps=slip_bps
-                )
-                order.pending_qty = 0.0
-                res2.setdefault("pending_qty", 0.0)
-                return res2
             if action in {"re_quote", "re-quote", "requote"} and order.pending_qty > 0:
                 new_order = Order(
                     symbol=order.symbol,

--- a/tests/broker/test_place_limit.py
+++ b/tests/broker/test_place_limit.py
@@ -112,24 +112,23 @@ async def test_place_limit_partial_fill_requotes():
 
 
 @pytest.mark.asyncio
-async def test_place_limit_partial_fill_taker():
+async def test_place_limit_partial_fill_no_fallback():
     adapter = PartialAdapter()
     broker = Broker(adapter)
 
-    def to_taker(order, res):
-        return "taker"
+    def ignore(order, res):
+        return "taker"  # any non re_quote value
 
     res = await broker.place_limit(
         "BTC/USDT",
         "buy",
         100.0,
         10.0,
-        on_partial_fill=to_taker,
+        on_partial_fill=ignore,
     )
-    assert res["status"] == "filled"
-    assert res["pending_qty"] == pytest.approx(0.0)
-    assert len(adapter.calls) == 2
-    assert adapter.calls[1]["qty"] == pytest.approx(5.0)
+    assert res["status"] == "partial"
+    assert res["pending_qty"] == pytest.approx(5.0)
+    assert len(adapter.calls) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/strategies/test_execution_callbacks.py
+++ b/tests/strategies/test_execution_callbacks.py
@@ -104,7 +104,7 @@ class FallbackStrategy(DummyStrategy):
 
 
 @pytest.mark.asyncio
-async def test_fallback_to_market_when_edge_gone():
+async def test_partial_fill_no_fallback_when_edge_gone():
     strat = FallbackStrategy()
     # record opposite last signal to indicate edge vanished
     strat.on_bar({"symbol": "XYZ", "exchange": "ex", "close": 100.0, "side": "sell"})
@@ -112,6 +112,5 @@ async def test_fallback_to_market_when_edge_gone():
     router = ExecutionRouter(adapter, on_partial_fill=strat.on_partial_fill)
     order = Order(symbol="XYZ", side="buy", type_="limit", qty=10.0, price=100.0)
     res = await router.execute(order)
-    assert res["status"] == "filled"
-    assert len(adapter.calls) == 2
-    assert adapter.calls[1]["type_"] == "market"
+    assert res["status"] == "partial"
+    assert len(adapter.calls) == 1

--- a/tests/test_router_orders.py
+++ b/tests/test_router_orders.py
@@ -121,18 +121,16 @@ class PartialFillAdapter:
 
 
 @pytest.mark.asyncio
-async def test_partial_fill_fallback_to_market():
+async def test_partial_fill_no_fallback():
     adapter = PartialFillAdapter()
     def on_pf(order, res):
         return "taker"
     router = ExecutionRouter(adapter, on_partial_fill=on_pf)
     order = Order(symbol="XYZ", side="buy", type_="limit", qty=10.0, price=100.0)
     res = await router.execute(order)
-    assert res["status"] == "filled"
-    assert len(adapter.calls) == 2
-    assert adapter.calls[1]["type_"] == "market"
-    assert adapter.calls[1]["qty"] == pytest.approx(5.0)
-    assert order.pending_qty == pytest.approx(0.0)
+    assert res["status"] == "partial"
+    assert len(adapter.calls) == 1
+    assert order.pending_qty == pytest.approx(5.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- migrate live daemon to RiskService.check_order with limit IOC orders and fill bookkeeping
- remove market-order fallbacks in execution router and broker
- adjust tests for new limit-only behaviour

## Testing
- `pytest tests/broker/test_place_limit.py tests/strategies/test_execution_callbacks.py tests/test_router_orders.py tests/test_daemon_routing.py tests/test_daemon_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68b61959028c832db48393344c639a24