### PR TITLE
refactor: centralize header with herramientas menu

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -12,25 +12,7 @@
   </style>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="active">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-
-  </div>
-</nav>
-
-</header>
+<div id="header"></div>
   <h1>Backtest</h1>
 
   <div class="card">
@@ -134,7 +116,9 @@
     <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+<script src="/static/header.js"></script>
 <script>
+loadHeader('backtest');
 const api = (path) => `${location.origin}${path}`;
 
 function normalizeSymbol(sym) {

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -9,23 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="active">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-  </div>
-</nav>
-
-</header>
+<div id="header"></div>
   <h1>Bots</h1>
 
   <div class="card">
@@ -149,7 +133,9 @@
     <pre id="risk-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+<script src="/static/header.js"></script>
 <script>
+loadHeader('bots');
 const api = (path) => `${location.origin}${path}`;
 
   async function loadStrategies(){

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -12,24 +12,7 @@
   </style>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="active">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-  </div>
-</nav>
-
-</header>
+<div id="header"></div>
   <h1>Datos históricos</h1>
 
   <div class="card">
@@ -159,7 +142,9 @@
     <pre id="cli-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
   </div>
 
+<script src="/static/header.js"></script>
 <script>
+loadHeader('data');
 const api = (path) => `${location.origin}${path}`;
 function normalizeSymbol(sym) {
   return sym.replace(/[^A-Za-z0-9]/g, "");

--- a/src/tradingbot/apps/api/static/header.html
+++ b/src/tradingbot/apps/api/static/header.html
@@ -1,0 +1,17 @@
+<header class="center" style="margin-bottom:8px">
+  <div class="logo-wrap">
+    <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
+  </div>
+  <nav>
+    <div class="menu">
+      <a href="/" data-page="index">Monitoreo</a>
+      <a href="/bots" data-page="bots">Bots</a>
+      <a href="/stats" data-page="stats">Estadísticas operativas</a>
+      <a href="/data" data-page="data">Datos históricos</a>
+      <a href="/backtest" data-page="backtest">Backtest</a>
+      <a href="/tools" data-page="tools">Herramientas</a>
+      <a href="http://localhost:3000/" target="_blank">Grafana</a>
+      <a href="http://localhost:9090/" target="_blank">Prometheus</a>
+    </div>
+  </nav>
+</header>

--- a/src/tradingbot/apps/api/static/header.js
+++ b/src/tradingbot/apps/api/static/header.js
@@ -1,0 +1,13 @@
+async function loadHeader(active){
+  try {
+    const resp = await fetch('/static/header.html');
+    const html = await resp.text();
+    document.getElementById('header').innerHTML = html;
+    if (active) {
+      const link = document.querySelector(`.menu a[data-page="${active}"]`);
+      if (link) link.classList.add('active');
+    }
+  } catch (e) {
+    console.error('Failed to load header:', e);
+  }
+}

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -8,24 +8,7 @@
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="active">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-  </div>
-</nav>
-
-</header>
+<div id="header"></div>
   <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
   <div class="grid5" style="margin:14px 0 10px">
@@ -86,7 +69,9 @@
     <pre id="logs" class="mono" style="overflow:auto; max-height:60vh"></pre>
   </div>
 
+<script src="/static/header.js"></script>
 <script>
+loadHeader('index');
 const api = (path) => `${location.origin}${path}`;
 const allowedExchanges = [
   'binance_spot',

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -8,24 +8,7 @@
   <link rel="stylesheet" href="/static/styles.css"/>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="active">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-  </div>
-</nav>
-
-</header>
+<div id="header"></div>
 
   <h1>Estadísticas operativas</h1>
   <div class="grid5" style="margin:14px 0 10px">
@@ -146,7 +129,9 @@
       </table>
     </div>
   </div>
+<script src="/static/header.js"></script>
 <script>
+loadHeader('stats');
 async function refreshMetrics(){
   try{
     const r = await fetch('/metrics');


### PR DESCRIPTION
## Summary
- extract common header into shared fragment and add "Herramientas" menu link
- load header dynamically on index, bots, stats, data and backtest pages

## Testing
- `pytest tests/test_smoke.py::test_smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63335a720832dbab1e40b647f8e72