### PR TITLE
feat: add tools dropdown to navigation menu

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -24,11 +24,27 @@
     <a href="/stats" class="">Estadísticas operativas</a>
     <a href="/data" class="">Datos históricos</a>
     <a href="/backtest" class="active">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
-
+    <div class="dropdown">
+      <a class="dropbtn" href="#">Herramientas</a>
+      <div class="dropdown-content">
+        <a href="http://localhost:3000/" target="_blank">Grafana</a>
+        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+        <a href="http://localhost:8081/" target="_blank">Adminer</a>
+        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+        <!-- Agregar aquí otros enlaces necesarios -->
+      </div>
+    </div>
   </div>
 </nav>
+
+<script>
+document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
+  btn.addEventListener('click', function(e){
+    e.preventDefault();
+    this.parentElement.classList.toggle('open');
+  });
+});
+</script>
 
 </header>
   <h1>Backtest</h1>

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -20,10 +20,27 @@
     <a href="/stats" class="">Estadísticas operativas</a>
     <a href="/data" class="">Datos históricos</a>
     <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
+    <div class="dropdown">
+      <a class="dropbtn" href="#">Herramientas</a>
+      <div class="dropdown-content">
+        <a href="http://localhost:3000/" target="_blank">Grafana</a>
+        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+        <a href="http://localhost:8081/" target="_blank">Adminer</a>
+        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+        <!-- Agregar aquí otros enlaces necesarios -->
+      </div>
+    </div>
   </div>
 </nav>
+
+<script>
+document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
+  btn.addEventListener('click', function(e){
+    e.preventDefault();
+    this.parentElement.classList.toggle('open');
+  });
+});
+</script>
 
 </header>
   <h1>Bots</h1>

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -24,10 +24,27 @@
     <a href="/stats" class="">Estadísticas operativas</a>
     <a href="/data" class="active">Datos históricos</a>
     <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
+    <div class="dropdown">
+      <a class="dropbtn" href="#">Herramientas</a>
+      <div class="dropdown-content">
+        <a href="http://localhost:3000/" target="_blank">Grafana</a>
+        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+        <a href="http://localhost:8081/" target="_blank">Adminer</a>
+        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+        <!-- Agregar aquí otros enlaces necesarios -->
+      </div>
+    </div>
   </div>
 </nav>
+
+<script>
+document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
+  btn.addEventListener('click', function(e){
+    e.preventDefault();
+    this.parentElement.classList.toggle('open');
+  });
+});
+</script>
 
 </header>
   <h1>Datos históricos</h1>

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -20,10 +20,27 @@
     <a href="/stats" class="">Estadísticas operativas</a>
     <a href="/data" class="">Datos históricos</a>
     <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
+    <div class="dropdown">
+      <a class="dropbtn" href="#">Herramientas</a>
+      <div class="dropdown-content">
+        <a href="http://localhost:3000/" target="_blank">Grafana</a>
+        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+        <a href="http://localhost:8081/" target="_blank">Adminer</a>
+        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+        <!-- Agregar aquí otros enlaces necesarios -->
+      </div>
+    </div>
   </div>
 </nav>
+
+<script>
+document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
+  btn.addEventListener('click', function(e){
+    e.preventDefault();
+    this.parentElement.classList.toggle('open');
+  });
+});
+</script>
 
 </header>
   <h1>Monitoreo</h1>

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -20,10 +20,27 @@
     <a href="/stats" class="active">Estadísticas operativas</a>
     <a href="/data" class="">Datos históricos</a>
     <a href="/backtest" class="">Backtest</a>
-    <a href="http://localhost:3000/" target="_blank" class="">Grafana</a>
-    <a href="http://localhost:9090/" target="_blank" class="">Prometheus</a>
+    <div class="dropdown">
+      <a class="dropbtn" href="#">Herramientas</a>
+      <div class="dropdown-content">
+        <a href="http://localhost:3000/" target="_blank">Grafana</a>
+        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+        <a href="http://localhost:8081/" target="_blank">Adminer</a>
+        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+        <!-- Agregar aquí otros enlaces necesarios -->
+      </div>
+    </div>
   </div>
 </nav>
+
+<script>
+document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
+  btn.addEventListener('click', function(e){
+    e.preventDefault();
+    this.parentElement.classList.toggle('open');
+  });
+});
+</script>
 
 </header>
 

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -533,3 +533,36 @@ button.icon-btn.warn:hover {
   border-color: rgba(250,204,21,.6);
   background: rgba(250,204,21,.08);
 }
+
+/* Dropdown menu */
+.dropdown { position: relative; }
+.dropbtn { cursor: pointer; }
+.dropdown-content {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #0f1622;
+  border: 1px solid #263041;
+  border-radius: 8px;
+  min-width: 160px;
+  box-shadow: 0 8px 16px rgba(0,0,0,.3);
+  z-index: 10;
+}
+.dropdown-content a {
+  display: block;
+  padding: 8px 12px;
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.dropdown-content a:hover {
+  color: var(--text);
+  background: rgba(255,255,255,.04);
+}
+.dropdown:hover .dropdown-content,
+.dropdown.open .dropdown-content {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- replace Grafana and Prometheus links with a Herramientas dropdown on all static pages
- style dropdown and submenu links
- add simple script to toggle dropdown on click

## Testing
- `pytest` *(fails: tests/integration/test_recorded_flow.py, tests/integration/test_stress_resilience.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b633349f04832daebf9dae7e95825b