### PR TITLE
Respect pre-set limit prices in finalize_signal

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -90,7 +90,7 @@ class Strategy(ABC):
         ``limit_price`` and returns the signal unchanged.
         """
 
-        if signal is not None:
+        if signal is not None and signal.limit_price is None:
             signal.limit_price = price
         rs = getattr(self, "risk_service", None)
         if rs is None:

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -9,15 +9,21 @@ from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.risk.service import RiskService
 import pytest
 from hypothesis import given, strategies as st, settings
+from tradingbot.data.features import keltner_channels
 
 
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0)
 
+    upper, lower = keltner_channels(breakout_df_buy, 2, 2, 1.0)
     sig_buy = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
     assert sig_buy.side == "buy"
+    assert sig_buy.limit_price == pytest.approx(upper.iloc[-1])
+
+    upper, lower = keltner_channels(breakout_df_sell, 2, 2, 1.0)
     sig_sell = strat.on_bar({"window": breakout_df_sell, "volatility": 0.0})
     assert sig_sell.side == "sell"
+    assert sig_sell.limit_price == pytest.approx(lower.iloc[-1])
 
 
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):


### PR DESCRIPTION
## Summary
- Avoid overwriting a signal's existing limit price when finalizing
- Test BreakoutATR strategy keeps its channel-based limit price

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_signals -q`
- `pytest tests/test_momentum_limit_price.py::test_momentum_sets_limit_price -q`


------
https://chatgpt.com/codex/tasks/task_e_68b637a27a0c832da2629b8aeeb7d51c