### PR TITLE
refactor static pages to use shared header

### DIFF
--- a/src/tradingbot/apps/api/static/backtest.html
+++ b/src/tradingbot/apps/api/static/backtest.html
@@ -10,43 +10,9 @@
   @keyframes blink{0%,100%{opacity:.2;}50%{opacity:1;}}
   #bt-working{animation:blink 1s linear infinite;display:none;margin-left:8px;}
   </style>
+  <script src="/static/header.js" defer></script>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="active">Backtest</a>
-    <div class="dropdown">
-      <a class="dropbtn" href="#">Herramientas</a>
-      <div class="dropdown-content">
-        <a href="http://localhost:3000/" target="_blank">Grafana</a>
-        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
-        <a href="http://localhost:8081/" target="_blank">Adminer</a>
-        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
-        <!-- Agregar aquí otros enlaces necesarios -->
-      </div>
-    </div>
-  </div>
-</nav>
-
-<script>
-document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
-  btn.addEventListener('click', function(e){
-    e.preventDefault();
-    this.parentElement.classList.toggle('open');
-  });
-});
-</script>
-
-</header>
   <h1>Backtest</h1>
 
   <div class="card">

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -7,42 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+  <script src="/static/header.js" defer></script>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="active">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <div class="dropdown">
-      <a class="dropbtn" href="#">Herramientas</a>
-      <div class="dropdown-content">
-        <a href="http://localhost:3000/" target="_blank">Grafana</a>
-        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
-        <a href="http://localhost:8081/" target="_blank">Adminer</a>
-        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
-        <!-- Agregar aquí otros enlaces necesarios -->
-      </div>
-    </div>
-  </div>
-</nav>
-
-<script>
-document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
-  btn.addEventListener('click', function(e){
-    e.preventDefault();
-    this.parentElement.classList.toggle('open');
-  });
-});
-</script>
-
-</header>
   <h1>Bots</h1>
 
   <div class="card">

--- a/src/tradingbot/apps/api/static/data.html
+++ b/src/tradingbot/apps/api/static/data.html
@@ -10,43 +10,9 @@
   @keyframes blink{0%,100%{opacity:.2;}50%{opacity:1;}}
   #dm-working{animation:blink 1s linear infinite;display:none;margin-left:8px;}
   </style>
+  <script src="/static/header.js" defer></script>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="active">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <div class="dropdown">
-      <a class="dropbtn" href="#">Herramientas</a>
-      <div class="dropdown-content">
-        <a href="http://localhost:3000/" target="_blank">Grafana</a>
-        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
-        <a href="http://localhost:8081/" target="_blank">Adminer</a>
-        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
-        <!-- Agregar aquí otros enlaces necesarios -->
-      </div>
-    </div>
-  </div>
-</nav>
-
-<script>
-document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
-  btn.addEventListener('click', function(e){
-    e.preventDefault();
-    this.parentElement.classList.toggle('open');
-  });
-});
-</script>
-
-</header>
   <h1>Datos históricos</h1>
 
   <div class="card">

--- a/src/tradingbot/apps/api/static/header.html
+++ b/src/tradingbot/apps/api/static/header.html
@@ -1,0 +1,24 @@
+<header class="center" style="margin-bottom:8px">
+  <div class="logo-wrap">
+    <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
+  </div>
+  <nav>
+    <div class="menu">
+      <a href="/">Monitoreo</a>
+      <a href="/bots">Bots</a>
+      <a href="/stats">Estadísticas operativas</a>
+      <a href="/data">Datos históricos</a>
+      <a href="/backtest">Backtest</a>
+      <div class="dropdown">
+        <a class="dropbtn" href="#">Herramientas</a>
+        <div class="dropdown-content">
+          <a href="http://localhost:3000/" target="_blank">Grafana</a>
+          <a href="http://localhost:9090/" target="_blank">Prometeus</a>
+          <a href="http://localhost:8081/" target="_blank">Adminer</a>
+          <a href="http://localhost:9093/" target="_blank">AlertManager</a>
+          <!-- Agregar aquí otros enlaces necesarios -->
+        </div>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/src/tradingbot/apps/api/static/header.js
+++ b/src/tradingbot/apps/api/static/header.js
@@ -1,0 +1,25 @@
+async function loadHeader(){
+  try{
+    const resp = await fetch('/static/header.html');
+    const html = await resp.text();
+    document.body.insertAdjacentHTML('afterbegin', html);
+
+    const path = location.pathname;
+    document.querySelectorAll('header .menu > a').forEach(link => {
+      if(link.getAttribute('href') === path){
+        link.classList.add('active');
+      }
+    });
+
+    document.querySelectorAll('header .dropdown .dropbtn').forEach(btn => {
+      btn.addEventListener('click', function(e){
+        e.preventDefault();
+        this.parentElement.classList.toggle('open');
+      });
+    });
+  }catch(err){
+    console.error('Failed to load header:', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadHeader);

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -6,43 +6,9 @@
   <title>DMI - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
+  <script src="/static/header.js" defer></script>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="active">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <div class="dropdown">
-      <a class="dropbtn" href="#">Herramientas</a>
-      <div class="dropdown-content">
-        <a href="http://localhost:3000/" target="_blank">Grafana</a>
-        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
-        <a href="http://localhost:8081/" target="_blank">Adminer</a>
-        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
-        <!-- Agregar aquí otros enlaces necesarios -->
-      </div>
-    </div>
-  </div>
-</nav>
-
-<script>
-document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
-  btn.addEventListener('click', function(e){
-    e.preventDefault();
-    this.parentElement.classList.toggle('open');
-  });
-});
-</script>
-
-</header>
   <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
   <div class="grid5" style="margin:14px 0 10px">

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -6,43 +6,9 @@
   <title>DMI - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
+  <script src="/static/header.js" defer></script>
 </head>
 <body>
-<header class="center" style="margin-bottom:8px">
-  <div class="logo-wrap">
-  <img src="/static/logo.png" alt="DMI Bot Trading" class="logo">
-</div>
-
-  <nav>
-  <div class="menu">
-    <a href="/" class="">Monitoreo</a>
-    <a href="/bots" class="">Bots</a>
-    <a href="/stats" class="active">Estadísticas operativas</a>
-    <a href="/data" class="">Datos históricos</a>
-    <a href="/backtest" class="">Backtest</a>
-    <div class="dropdown">
-      <a class="dropbtn" href="#">Herramientas</a>
-      <div class="dropdown-content">
-        <a href="http://localhost:3000/" target="_blank">Grafana</a>
-        <a href="http://localhost:9090/" target="_blank">Prometeus</a>
-        <a href="http://localhost:8081/" target="_blank">Adminer</a>
-        <a href="http://localhost:9093/" target="_blank">AlertManager</a>
-        <!-- Agregar aquí otros enlaces necesarios -->
-      </div>
-    </div>
-  </div>
-</nav>
-
-<script>
-document.querySelectorAll('.dropdown .dropbtn').forEach(btn => {
-  btn.addEventListener('click', function(e){
-    e.preventDefault();
-    this.parentElement.classList.toggle('open');
-  });
-});
-</script>
-
-</header>
 
   <h1>Estadísticas operativas</h1>
   <div class="grid5" style="margin:14px 0 10px">


### PR DESCRIPTION
## Summary
- extract common header with new "Herramientas" menu into `header.html`
- add `header.js` to load the shared header and mark active section
- update index, bots, stats, data and backtest pages to load the shared header

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b63762bf44832d905bf72ad097ff36