### PR TITLE
feat: add relative ATR threshold

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -22,6 +22,12 @@ en una orden de mercado cuando la ventaja desaparece.
 ### Breakout con ATR (`breakout_atr`)
 Compra cuando el precio supera el canal superior calculado con el indicador
 ATR y vende cuando cae por debajo del canal inferior.
+Parámetros clave:
+
+- `min_atr`: umbral mínimo del ATR en unidades de precio, independiente del
+  tamaño de la vela.
+- `min_atr_bps`: exige un ATR relativo mínimo expresado en puntos básicos del
+  precio.
 
 ### Breakout por Volumen (`breakout_vol`)
 Detecta rupturas de precio acompañadas de incrementos de volumen.

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -20,6 +20,12 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
     assert sig_sell.side == "sell"
 
 
+def test_breakout_atr_min_atr_bps_filter(breakout_df_buy):
+    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, min_atr_bps=2000)
+    sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
+    assert sig is None
+
+
 def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
     account = Account(float("inf"))
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))


### PR DESCRIPTION
## Summary
- allow BreakoutATR to filter signals using a relative ATR in bps
- document `min_atr` independence from candle size and expose `min_atr_bps`
- cover ATR bps filter with tests

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_signals tests/test_strategies.py::test_breakout_atr_min_atr_bps_filter tests/test_strategies.py::test_breakout_atr_risk_service_handles_stop_and_size -q`
- `pytest` *(fails: tests/integration/test_recorded_flow.py, tests/integration/test_stress_resilience.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b637a6888c832da468a20fdc3b2b9f