### PR TITLE
Align dropdown button with nav links

### DIFF
--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -364,6 +364,7 @@ nav{
 nav .menu{
   display:inline-flex;
   gap:20px;
+  align-items:center;
 }
 
 nav a{
@@ -537,6 +538,14 @@ button.icon-btn.warn:hover {
 /* Dropdown menu */
 .dropdown { position: relative; }
 .dropbtn { cursor: pointer; }
+.dropdown .dropbtn {
+  font-weight:600;
+  font-size:15px;
+  padding:8px 4px;
+  color:var(--muted);
+  transition: color .15s ease;
+  display:inline-block;
+}
 .dropdown-content {
   display: none;
   position: absolute;


### PR DESCRIPTION
## Summary
- vertically center nav menu items
- style dropdown button to match nav links

## Testing
- `pytest` *(fails: assert 104.07283406244801 == 103.86715654853998; assert 0.0 > 0.0; KeyboardInterrupt)*
- `node -e ...` *(fails: Failed to launch the browser process, libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b647d95bf4832d87c2108b6136aeff