### PR TITLE
feat: add quantile thresholds for liquidity filter

### DIFF
--- a/data/examples/backtest.yaml
+++ b/data/examples/backtest.yaml
@@ -9,3 +9,6 @@ slippage:
   base_spread: 0.1   # spread fijo si faltan columnas bid/ask o tienen NaN
 mlflow:
   run_name: example_backtest
+filters:
+  volume_quantile: 0.1
+  spread_quantile: 0.1

--- a/data/examples/small_account.yaml
+++ b/data/examples/small_account.yaml
@@ -8,3 +8,6 @@ backtest:
     source: bba
     base_spread: 0.1  # spread fijo si faltan columnas bid/ask o tienen NaN
   min_fill_qty: 0.001
+filters:
+  volume_quantile: 0.1
+  spread_quantile: 0.1

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -35,6 +35,8 @@ filters:
   max_spread: 0.5
   min_volume: 1000.0
   max_volatility: 0.05
+  volume_quantile: 0.5
+  spread_quantile: 0.5
 
 execution:
   limit_offset_ticks: 1.0

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -104,6 +104,8 @@ class FiltersConfig:
     max_spread: float = float("inf")
     min_volume: float = 0.0
     max_volatility: float = float("inf")
+    volume_quantile: float = 0.5
+    spread_quantile: float = 0.5
 
 
 @dataclass

--- a/src/tradingbot/filters/liquidity.py
+++ b/src/tradingbot/filters/liquidity.py
@@ -69,6 +69,8 @@ def _load_default_filter() -> LiquidityFilter:
     max_spread = float(getattr(filt_cfg, "max_spread", float("inf")))
     min_volume = float(getattr(filt_cfg, "min_volume", 0.0))
     max_volatility = float(getattr(filt_cfg, "max_volatility", float("inf")))
+    volume_quantile = float(getattr(filt_cfg, "volume_quantile", 0.5))
+    spread_quantile = float(getattr(filt_cfg, "spread_quantile", 0.5))
 
     # If some thresholds are missing, estimate them from the latest bars
     if (
@@ -87,11 +89,11 @@ def _load_default_filter() -> LiquidityFilter:
             df = pd.DataFrame()
 
         if max_spread == float("inf") and "spread" in df.columns:
-            # upper bound roughly twice the typical spread
-            max_spread = 2 * float(df["spread"].median())
+            # accept trades only when spreads are below the chosen quantile
+            max_spread = float(df["spread"].quantile(spread_quantile))
         if min_volume == 0.0 and "volume" in df.columns:
-            # require at least median traded volume
-            min_volume = float(df["volume"].median())
+            # require volumes above the selected percentile
+            min_volume = float(df["volume"].quantile(volume_quantile))
         if max_volatility == float("inf"):
             if "volatility" in df.columns:
                 max_volatility = 2 * float(df["volatility"].median())

--- a/tests/test_liquidity_filter.py
+++ b/tests/test_liquidity_filter.py
@@ -29,6 +29,8 @@ def test_default_filter_estimates_thresholds(tmp_path, monkeypatch):
             max_spread=float("inf"),
             min_volume=0.0,
             max_volatility=float("inf"),
+            volume_quantile=0.5,
+            spread_quantile=0.5,
         ),
         backtest=SimpleNamespace(data=str(csv_path), window=5),
     )
@@ -37,8 +39,8 @@ def test_default_filter_estimates_thresholds(tmp_path, monkeypatch):
     importlib.reload(liquidity)
     try:
         filt = liquidity._default_filter
-        assert filt.max_spread == pytest.approx(2 * df["spread"].median())
-        assert filt.min_volume == pytest.approx(df["volume"].median())
+        assert filt.max_spread == pytest.approx(df["spread"].quantile(0.5))
+        assert filt.min_volume == pytest.approx(df["volume"].quantile(0.5))
         assert filt.max_volatility == pytest.approx(2 * df["volatility"].median())
     finally:
         monkeypatch.undo()


### PR DESCRIPTION
## Summary
- support configurable volume and spread quantiles for liquidity thresholds
- expose volume_quantile and spread_quantile in config and example backtest YAMLs
- adjust liquidity filter test for quantile defaults

## Testing
- `pytest tests/test_liquidity_filter.py -q`
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e37ff4fc832d848a1ad9c3c1c8b4