### PR TITLE
feat: make BreakoutATR vol filter configurable

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -50,6 +50,41 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
     assert trade["stop"] == pytest.approx(expected_stop)
 
 
+def test_breakout_atr_vol_filter_can_be_disabled():
+    close = 100.0
+    data = []
+    for _ in range(8):
+        data.append({
+            "open": close,
+            "high": close + 1,
+            "low": close - 1,
+            "close": close,
+            "volume": 1,
+        })
+    data.append({
+        "open": close,
+        "high": close + 0.02,
+        "low": close - 0.02,
+        "close": close,
+        "volume": 1,
+    })
+    data.append({
+        "open": close,
+        "high": close + 0.03,
+        "low": close - 0.02,
+        "close": close + 0.03,
+        "volume": 1,
+    })
+    df = pd.DataFrame(data)
+
+    strat = BreakoutATR(ema_n=2, atr_n=2, mult=0.2)
+    assert strat.on_bar({"window": df}) is None
+
+    strat_nofilter = BreakoutATR(ema_n=2, atr_n=2, mult=0.2, vol_quantile=0)
+    sig = strat_nofilter.on_bar({"window": df})
+    assert sig and sig.side == "buy"
+
+
 def test_order_flow_signals():
     df_buy = pd.DataFrame({
         "bid_qty": [1, 2, 3, 5],


### PR DESCRIPTION
## Summary
- allow configuring volatility quantile in BreakoutATR (default 0.05)
- skip volatility filter when vol_quantile=0
- test that disabling filter emits signals on low-vol data

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_signals tests/test_strategies.py::test_breakout_atr_risk_service_handles_stop_and_size tests/test_strategies.py::test_breakout_atr_vol_filter_can_be_disabled -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e3718e40832d9f92fda844b6c3f2