### PR TITLE
Finalize cash&carry signals via RiskManager

### DIFF
--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -81,16 +81,16 @@ class CashAndCarry(Strategy):
             self._persist_signal(basis, spot, perp)
             sig = Signal("buy", strength)
             sig.limit_price = spot
-            return sig
+            return self.finalize_signal(bar, spot, sig)
         if funding < 0 and basis < -self.cfg.threshold:
             strength = min(1.0, -basis)
             self._persist_signal(basis, spot, perp)
             sig = Signal("sell", strength)
             sig.limit_price = spot
-            return sig
+            return self.finalize_signal(bar, spot, sig)
         sig = Signal("flat", 0.0)
         sig.limit_price = spot
-        return sig
+        return self.finalize_signal(bar, spot, sig)
 
     def _persist_signal(self, basis: float, spot_px: float, perp_px: float) -> None:
         if self.engine is None:


### PR DESCRIPTION
## Summary
- Let cash & carry strategy finalize buy/sell signals so RiskManager can manage positions
- Finalize flat signals to update stops/positions even when edge disappears

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6f4d39804832dbec290adb36e550c