### PR TITLE
feat: adjust risk by volatility

### DIFF
--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -102,3 +102,30 @@ def test_check_global_exposure_enforces_limit():
     rm = CoreRiskManager(account)
     assert rm.check_global_exposure("BTC", 700.0)
     assert not rm.check_global_exposure("BTC", 900.0)
+
+
+def test_calc_position_size_adjusts_with_atr():
+    """Higher ATR should reduce position size and lower ATR should increase it."""
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_per_trade=0.1, risk_pct=0.02)
+    price = 100.0
+    base = rm.calc_position_size(1.0, price)
+
+    high_atr = rm.calc_position_size(1.0, price, volatility=4.0, target_volatility=2.0)
+    low_atr = rm.calc_position_size(1.0, price, volatility=1.0, target_volatility=2.0)
+
+    assert high_atr < base
+    assert low_atr > base
+
+
+def test_effective_risk_pct_varies_with_std():
+    """Effective risk pct should shrink/grow with volatility changes."""
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_pct=0.02)
+    base = rm.risk_pct
+
+    high_std = rm.effective_risk_pct(0.04, 0.02)
+    low_std = rm.effective_risk_pct(0.01, 0.02)
+
+    assert high_std < base
+    assert low_std > base


### PR DESCRIPTION
## Summary
- add `effective_risk_pct` to scale base risk by volatility ratio
- allow `calc_position_size` to use volatility to adapt position sizes
- test volatility-driven risk adjustments via ATR and standard deviation

## Testing
- `pytest tests/test_core_position_size.py -q`
- `pytest tests/test_risk.py::test_size_scales_with_equity_and_strength -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fd9f55a8832d901414e4f62935f8