### PR TITLE
Auto-tune liquidity filter thresholds via moving percentiles

### DIFF
--- a/tests/test_liquidity_filter.py
+++ b/tests/test_liquidity_filter.py
@@ -11,16 +11,27 @@ import pytest
 from tradingbot.filters import liquidity
 
 
-def test_default_filter_estimates_thresholds(tmp_path, monkeypatch):
-    """When no thresholds are provided the filter adapts to recent data."""
+@pytest.mark.parametrize(
+    "spreads, volumes, vols",
+    [
+        (
+            [1.0, 2.0, 1.5, 2.5, 2.0],
+            [100, 150, 200, 120, 180],
+            [0.01, 0.02, 0.015, 0.03, 0.025],
+        ),
+        (
+            [0.3, 0.4, 0.35, 0.5, 0.45],
+            [500, 550, 520, 580, 560],
+            [0.005, 0.006, 0.0055, 0.007, 0.0065],
+        ),
+    ],
+    ids=["BTC-1m", "ETH-5m"],
+)
 
-    df = pd.DataFrame(
-        {
-            "spread": [1.0, 2.0, 1.5, 2.5, 2.0],
-            "volume": [100, 150, 200, 120, 180],
-            "volatility": [0.01, 0.02, 0.015, 0.03, 0.025],
-        }
-    )
+def test_default_filter_estimates_percentiles(tmp_path, monkeypatch, spreads, volumes, vols):
+    """Filter derives thresholds from moving percentiles when unset."""
+
+    df = pd.DataFrame({"spread": spreads, "volume": volumes, "volatility": vols})
     csv_path = tmp_path / "bars.csv"
     df.to_csv(csv_path, index=False)
 
@@ -30,17 +41,65 @@ def test_default_filter_estimates_thresholds(tmp_path, monkeypatch):
             min_volume=0.0,
             max_volatility=float("inf"),
         ),
-        backtest=SimpleNamespace(data=str(csv_path), window=5),
+        backtest=SimpleNamespace(data=str(csv_path), window=len(df)),
     )
 
     monkeypatch.setattr("tradingbot.config.hydra_conf.load_config", lambda path=None: cfg)
     importlib.reload(liquidity)
     try:
         filt = liquidity._default_filter
-        assert filt.max_spread == pytest.approx(2 * df["spread"].median())
-        assert filt.min_volume == pytest.approx(df["volume"].median())
-        assert filt.max_volatility == pytest.approx(2 * df["volatility"].median())
+        assert filt.max_spread == pytest.approx(df["spread"].quantile(0.95))
+        assert filt.min_volume == pytest.approx(df["volume"].quantile(0.05))
+        assert filt.max_volatility == pytest.approx(df["volatility"].quantile(0.95))
     finally:
         monkeypatch.undo()
         importlib.reload(liquidity)
 
+
+def test_filter_thresholds_vary_by_dataset(tmp_path, monkeypatch):
+    """Different datasets yield different automatic thresholds."""
+
+    df1 = pd.DataFrame(
+        {
+            "spread": [1.0, 2.0, 1.5, 2.5, 2.0],
+            "volume": [100, 150, 200, 120, 180],
+            "volatility": [0.01, 0.02, 0.015, 0.03, 0.025],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "spread": [0.3, 0.4, 0.35, 0.5, 0.45],
+            "volume": [500, 550, 520, 580, 560],
+            "volatility": [0.005, 0.006, 0.0055, 0.007, 0.0065],
+        }
+    )
+
+    csv1 = tmp_path / "btc.csv"
+    csv2 = tmp_path / "eth.csv"
+    df1.to_csv(csv1, index=False)
+    df2.to_csv(csv2, index=False)
+
+    def load(path):
+        return SimpleNamespace(
+            filters=SimpleNamespace(
+                max_spread=float("inf"),
+                min_volume=0.0,
+                max_volatility=float("inf"),
+            ),
+            backtest=SimpleNamespace(data=str(path), window=5),
+        )
+
+    monkeypatch.setattr("tradingbot.config.hydra_conf.load_config", lambda path=None: load(csv1))
+    importlib.reload(liquidity)
+    filt1 = liquidity._default_filter
+
+    monkeypatch.setattr("tradingbot.config.hydra_conf.load_config", lambda path=None: load(csv2))
+    importlib.reload(liquidity)
+    filt2 = liquidity._default_filter
+
+    assert filt1.max_spread != filt2.max_spread
+    assert filt1.min_volume != filt2.min_volume
+    assert filt1.max_volatility != filt2.max_volatility
+
+    monkeypatch.undo()
+    importlib.reload(liquidity)


### PR DESCRIPTION
## Summary
- Auto-calibrate liquidity filter using rolling percentiles for spread, volume and volatility when config thresholds are missing
- Document automatic adjustment behaviour for default filter
- Test dynamic percentile thresholds across symbols and timeframes

## Testing
- `pytest tests/test_liquidity_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fd71f3e8832db4705abcb3298944