### PR TITLE
feat: auto thresholds for core strategies

### DIFF
--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -4,7 +4,7 @@ from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
 def test_mean_reversion_on_bar_signals():
     df_down = pd.DataFrame({"close": list(range(20, 0, -1))})
     df_up = pd.DataFrame({"close": list(range(1, 21))})
-    strat = MeanReversion(rsi_n=5, upper=70, lower=30)
+    strat = MeanReversion(rsi_n=5)
     sig_buy = strat.on_bar({"window": df_down, "volatility": 0.0})
     sig_sell = strat.on_bar({"window": df_up, "volatility": 0.0})
     assert sig_buy.side == "buy"

--- a/tests/test_momentum_limit_price.py
+++ b/tests/test_momentum_limit_price.py
@@ -3,7 +3,7 @@ from tradingbot.strategies.momentum import Momentum
 
 def test_momentum_sets_limit_price():
     df = pd.DataFrame({"close": [1, 2, 1, 2]})
-    strat = Momentum(rsi_n=2, rsi_threshold=55.0)
+    strat = Momentum(rsi_n=2)
     sig = strat.on_bar({"window": df, "close": df["close"].iloc[-1], "volatility": 0.0})
     assert sig is not None and sig.side == "buy"
     assert sig.limit_price == df["close"].iloc[-1]

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -37,7 +37,7 @@ def test_walk_forward_optimize(tmp_path):
     csv_path = tmp_path / "data.csv"
     df.to_csv(csv_path, index=False)
 
-    params = [{"rsi_n": 2, "rsi_threshold": 55}, {"rsi_n": 2, "rsi_threshold": 65}]
+    params = [{"rsi_n": 2}, {"rsi_n": 3}]
 
     results = walk_forward_optimize(
         str(csv_path),
@@ -68,7 +68,7 @@ def test_walk_forward_mlflow(tmp_path):
     csv_path = tmp_path / "data.csv"
     df.to_csv(csv_path, index=False)
 
-    params = [{"rsi_n": 2, "rsi_threshold": 55}, {"rsi_n": 2, "rsi_threshold": 65}]
+    params = [{"rsi_n": 2}, {"rsi_n": 3}]
 
     mlflow.set_tracking_uri(str(tmp_path))
     exp_name = "wf_test"


### PR DESCRIPTION
## Summary
- derive momentum RSI threshold from recent percentiles
- add volatility-based threshold to trend following strategy and include trade info
- compute mean reversion bands from rolling RSI deviation
- drop explicit threshold params and adjust strategy tests

## Testing
- `pytest tests/test_momentum_limit_price.py tests/test_trend_following.py tests/test_mean_reversion.py tests/test_walk_forward.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fd6a1754832d8d0ae8d7629be9fb