### PR TITLE
feat: autocalibrate breakout thresholds

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -3,23 +3,32 @@ from .base import Strategy, Signal, record_signal_metrics
 
 PARAM_INFO = {
     "lookback": "Ventana para medias y desviación estándar",
-    "mult": "Multiplicador aplicado a la desviación",
     "volatility_factor": "Factor para dimensionar según volatilidad",
-    "min_volatility": "Volatilidad mínima reciente en bps",
 }
 
 
 class BreakoutVol(Strategy):
-    """Volatility breakout strategy using rolling standard deviation."""
+    """Ruptura por volatilidad con umbrales autocalibrados.
+
+    El multiplicador del canal y la volatilidad mínima se estiman como
+    percentiles recientes, de modo que la estrategia se adapta a las
+    condiciones cambiantes del mercado sin necesidad de ajustar parámetros
+    manualmente.
+    """
 
     name = "breakout_vol"
 
+    # Percentil para mínimos de volatilidad y dimensionar el multiplicador.
+    _VOL_QUANTILE = 0.2
+    _MULT_QUANTILE = 0.8
+
     def __init__(self, **kwargs):
         self.lookback = kwargs.get("lookback", 10)
-        self.mult = kwargs.get("mult", 1.5)
         self.volatility_factor = kwargs.get("volatility_factor", 0.02)
-        self.min_volatility = kwargs.get("min_volatility", 0.0)
         self.risk_service = kwargs.get("risk_service")
+        # Valores dinámicos calculados en ``on_bar``.
+        self.mult = 1.0
+        self.min_volatility = 0.0
 
     @record_signal_metrics
     def on_bar(self, bar: dict) -> Signal | None:
@@ -28,20 +37,42 @@ class BreakoutVol(Strategy):
             return None
         closes = df["close"]
         mean = closes.rolling(self.lookback).mean().iloc[-1]
-        std = closes.rolling(self.lookback).std().iloc[-1]
+        std_series = closes.rolling(self.lookback).std().dropna()
+        std = float(std_series.iloc[-1])
+        window = min(len(std_series), self.lookback * 5)
+        if window >= self.lookback and std > 0.0:
+            mult_quant = float(
+                std_series.rolling(window).quantile(self._MULT_QUANTILE).iloc[-1]
+            )
+            self.mult = mult_quant / std
+        else:
+            self.mult = 1.0
+
         last = float(closes.iloc[-1])
         upper = mean + self.mult * std
         lower = mean - self.mult * std
 
         returns = closes.pct_change().dropna()
-        vol = (
-            returns.rolling(self.lookback).std().iloc[-1]
-            if len(returns) >= self.lookback
-            else 0.0
-        )
+        vol_series = returns.rolling(self.lookback).std().dropna()
+        vol = float(vol_series.iloc[-1]) if len(vol_series) else 0.0
         vol_bps = vol * 10000
-        if vol_bps < self.min_volatility:
-            return None
+        window = min(len(vol_series), self.lookback * 5)
+        if window >= self.lookback * 2:
+            vol_quant = float(
+                vol_series.rolling(window).quantile(self._VOL_QUANTILE).iloc[-1]
+            )
+            vol_bps_quant = float(
+                (vol_series * 10000)
+                .rolling(window)
+                .quantile(self._VOL_QUANTILE)
+                .iloc[-1]
+            )
+            self.min_volatility = vol_bps_quant
+            if vol < vol_quant or vol_bps < vol_bps_quant:
+                return None
+        else:
+            self.min_volatility = 0.0
+
         size = max(0.0, min(1.0, vol_bps * self.volatility_factor))
 
         side: str | None = None
@@ -52,4 +83,16 @@ class BreakoutVol(Strategy):
         if side is None:
             return self.finalize_signal(bar, last, None)
         sig = Signal(side, size)
+
+        if self.risk_service is not None:
+            qty = self.risk_service.calc_position_size(size, last)
+            stop = self.risk_service.initial_stop(last, side, vol)
+            self.trade = {
+                "side": side,
+                "entry_price": last,
+                "qty": qty,
+                "stop": stop,
+                "atr": vol,
+            }
+
         return self.finalize_signal(bar, last, sig)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -13,17 +13,17 @@ from tradingbot.data.features import keltner_channels, atr
 
 
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell):
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0)
+    strat = BreakoutATR(ema_n=2, atr_n=2)
 
-    upper, lower = keltner_channels(breakout_df_buy, 2, 2, 1.0)
-    atr_buy = atr(breakout_df_buy, 2).dropna().iloc[-1]
     sig_buy = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
+    atr_buy = atr(breakout_df_buy, 2).dropna().iloc[-1]
+    upper, lower = keltner_channels(breakout_df_buy, 2, 2, strat.mult)
     assert sig_buy.side == "buy"
     assert sig_buy.limit_price == pytest.approx(upper.iloc[-1] + 0.1 * atr_buy)
 
-    upper, lower = keltner_channels(breakout_df_sell, 2, 2, 1.0)
-    atr_sell = atr(breakout_df_sell, 2).dropna().iloc[-1]
     sig_sell = strat.on_bar({"window": breakout_df_sell, "volatility": 0.0})
+    atr_sell = atr(breakout_df_sell, 2).dropna().iloc[-1]
+    upper, lower = keltner_channels(breakout_df_sell, 2, 2, strat.mult)
     assert sig_sell.side == "sell"
     assert sig_sell.limit_price == pytest.approx(lower.iloc[-1] - 0.1 * atr_sell)
 
@@ -39,7 +39,7 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = BreakoutATR(ema_n=2, atr_n=2, mult=1.0, **{"risk_service": svc})
+    strat = BreakoutATR(ema_n=2, atr_n=2, **{"risk_service": svc})
     sig = strat.on_bar({"window": breakout_df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
     trade = strat.trade
@@ -127,7 +127,7 @@ def test_breakout_vol_risk_service_handles_stop_and_size():
         risk_pct=0.02,
     )
     svc.account.update_cash(1000.0)
-    strat = BreakoutVol(lookback=2, mult=0.5, **{"risk_service": svc})
+    strat = BreakoutVol(lookback=2, **{"risk_service": svc})
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
     assert sig.limit_price == pytest.approx(df_buy["close"].iloc[-1])


### PR DESCRIPTION
## Summary
- adapt breakout ATR and volatility strategies to compute channel multipliers and volatility floors from rolling quantiles
- remove configuration options for fixed thresholds
- update strategy tests for self-calibrating behavior

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_signals tests/test_strategies.py::test_breakout_atr_risk_service_handles_stop_and_size tests/test_strategies.py::test_breakout_vol_risk_service_handles_stop_and_size tests/test_risk_pct_validation.py::test_engine_normalizes_percentage tests/test_risk_pct_validation.py::test_engine_rejects_invalid_risk_pct -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fd653acc832dbde78f07948f6ed3