### PR TITLE
feat: adapt risk to volatility

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1014,12 +1014,16 @@ class EventDrivenBacktestEngine:
                     if sig is None or sig.side == "flat":
                         continue
                     pending = svc.account.open_orders.get(symbol, 0.0)
+                    atr_map = getattr(strat, "_last_atr", {})
+                    tgt_map = getattr(strat, "_last_target_vol", {})
                     allowed, _reason, delta = svc.check_order(
                         symbol,
                         sig.side,
                         place_price,
                         strength=sig.strength,
                         pending_qty=pending,
+                        volatility=atr_map.get(symbol),
+                        target_volatility=tgt_map.get(symbol),
                     )
                     if not allowed or abs(delta) < self.min_order_qty:
                         continue

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -263,6 +263,8 @@ async def run_live_binance(
             closed.c,
             strength=signal.strength,
             pending_qty=pending,
+            volatility=bar.get("atr") or bar.get("volatility"),
+            target_volatility=bar.get("target_volatility"),
         )
         if not allowed or abs(delta) <= 1e-9:
             if not allowed:

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -162,7 +162,8 @@ async def run_paper(
             df = agg.last_n_bars_df(200)
             if len(df) < 140:
                 continue
-            signal = strat.on_bar({"window": df, "symbol": symbol})
+            bar = {"window": df, "symbol": symbol}
+            signal = strat.on_bar(bar)
             if signal is None:
                 continue
             allowed, _reason, delta = risk.check_order(
@@ -170,6 +171,8 @@ async def run_paper(
                 signal.side,
                 closed.c,
                 strength=signal.strength,
+                volatility=bar.get("atr") or bar.get("volatility"),
+                target_volatility=bar.get("target_volatility"),
             )
             if not allowed or abs(delta) <= 0:
                 continue

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -246,7 +246,8 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        sig = strat.on_bar({"window": df, "symbol": symbol})
+        bar = {"window": df, "symbol": symbol}
+        sig = strat.on_bar(bar)
         if sig is None:
             continue
         allowed, reason, delta = risk.check_order(
@@ -254,6 +255,8 @@ async def _run_symbol(
             sig.side,
             closed.c,
             strength=sig.strength,
+            volatility=bar.get("atr") or bar.get("volatility"),
+            target_volatility=bar.get("target_volatility"),
         )
         if not allowed or abs(delta) <= 0:
             if reason:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -148,7 +148,8 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        sig = strat.on_bar({"window": df, "symbol": symbol})
+        bar = {"window": df, "symbol": symbol}
+        sig = strat.on_bar(bar)
         if sig is None:
             continue
         allowed, reason, delta = risk.check_order(
@@ -157,6 +158,8 @@ async def _run_symbol(
             closed.c,
             strength=sig.strength,
             corr_threshold=corr_threshold,
+            volatility=bar.get("atr") or bar.get("volatility"),
+            target_volatility=bar.get("target_volatility"),
         )
         if not allowed or abs(delta) <= 0:
             if reason:


### PR DESCRIPTION
## Summary
- expose ATR and target volatility in BreakoutATR signals
- propagate volatility data to RiskService so risk_pct scales with market conditions
- support volatility-aware sizing in backtests and live runners

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61da99d94832da454333937f11634