### PR TITLE
Filtrar parámetros internos en strategy_schema

### DIFF
--- a/tests/test_strategy_schema.py
+++ b/tests/test_strategy_schema.py
@@ -1,5 +1,6 @@
 import pytest
 from tradingbot.apps.api.main import strategy_schema
+from tradingbot.strategies import STRATEGIES
 
 
 def test_triangular_arb_schema_returns_params():
@@ -12,3 +13,20 @@ def test_cross_arbitrage_schema_returns_params():
     res = strategy_schema("cross_arbitrage")
     names = [p["name"] for p in res["params"]]
     assert "threshold" in names
+
+
+def test_strategy_schema_filters_internal_params():
+    internal = {
+        "config_path",
+        "risk_service",
+        "spot_exchange",
+        "perp_exchange",
+        "persist_pg",
+        "rebalance_assets",
+        "rebalance_threshold",
+        "latency",
+    }
+    for name in list(STRATEGIES) + ["cross_arbitrage"]:
+        res = strategy_schema(name)
+        names = {p["name"] for p in res["params"]}
+        assert not (internal & names), f"{name} exposes internal params: {internal & names}"


### PR DESCRIPTION
## Summary
- oculta parámetros internos al construir el esquema de estrategias
- expande `cfg` únicamente con campos documentados y filtrados
- prueba que ninguna estrategia exponga parámetros internos

## Testing
- `pytest tests/test_strategy_schema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7126ef894832dba744de3f3c0cb1a