### PR TITLE
Hide config_path from strategy parameter UI

### DIFF
--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -5,7 +5,6 @@ from ..data.features import atr, keltner_channels
 PARAM_INFO = {
     "ema_n": "Periodo de la EMA para la línea central",
     "atr_n": "Periodo del ATR usado en los canales",
-    "config_path": "Ruta opcional al archivo de configuración",
 }
 
 

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -11,7 +11,6 @@ PARAM_INFO = {
     "vol_window": "Ventana para volatilidad de retornos",
     "vol_threshold": "Volatilidad máxima permitida",
     "min_volatility": "Volatilidad mínima reciente en bps",
-    "config_path": "Ruta opcional de configuración",
 }
 
 

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -16,7 +16,6 @@ PARAM_INFO = {
     "trend_ma": "Ventana para la media móvil de tendencia",
     "trend_rsi_n": "Ventana del RSI para medir tendencia",
     "trend_threshold": "Umbral para considerar la tendencia fuerte",
-    "config_path": "Ruta opcional al archivo de configuración",
 }
 
 

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -11,7 +11,6 @@ PARAM_INFO = {
     "lower_pct": "Porcentaje de barrera inferior",
     "training_window": "Ventana para entrenamiento del modelo",
     "meta_model": "Modelo para meta etiquetado",
-    "config_path": "Ruta opcional al archivo de configuración",
 }
 
 


### PR DESCRIPTION
## Summary
- Remove `config_path` from `PARAM_INFO` dictionaries of BreakoutATR, ScalpPingPong, MeanRevOFI, and TripleBarrier strategies so it's no longer exposed in the UI.
- Keep `config_path` as an optional `__init__` argument for advanced configuration.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7126db1d4832dbe57268c3f92bf65