### PR TITLE
Enable automatic liquidity filter calibration

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -32,9 +32,9 @@ balance:
   assets: []
 
 filters:
-  max_spread: 0.5
-  min_volume: 1000.0
-  max_volatility: 0.05
+  max_spread: .inf
+  min_volume: 0.0
+  max_volatility: .inf
 
 execution:
   limit_offset_ticks: 1.0


### PR DESCRIPTION
## Summary
- Remove hard-coded liquidity thresholds so filters can auto-calibrate from market data
- Verified liquidity filter already infers spread, volume and volatility bounds when thresholds are neutral

## Testing
- `PYTHONPATH=src python backtest_snippet.py` *(demonstrates backtest at 30m & 15m with generated fills)*
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7234fa484832d9227eb50460f0d4b