### PR TITLE
Scale mean reversion trend windows with timeframe

### DIFF
--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from tradingbot.strategies import mean_reversion as mr
 from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
 
 def test_mean_reversion_on_bar_signals():
@@ -16,3 +17,27 @@ def test_mean_reversion_generate_signals():
     res = generate_signals(df, params)
     assert {"signal", "position", "fee", "slippage"} <= set(res.columns)
     assert len(res) == len(df)
+
+
+def _const_rsi(val: float):
+    def fn(df: pd.DataFrame, n: int):  # noqa: ANN001
+        return pd.Series([val] * len(df), index=df.index)
+    return fn
+
+
+def test_trend_detection_1m(monkeypatch):
+    df = pd.DataFrame({"close": list(range(1, 100))})
+    monkeypatch.setattr(mr, "rsi", _const_rsi(56))
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (55, 45))
+    strat = MeanReversion(timeframe="1m")
+    sig = strat.on_bar({"window": df})
+    assert sig is None
+
+
+def test_trend_detection_5m(monkeypatch):
+    df = pd.DataFrame({"close": list(range(1, 100))})
+    monkeypatch.setattr(mr, "rsi", _const_rsi(56))
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (55, 45))
+    strat = MeanReversion(timeframe="5m")
+    sig = strat.on_bar({"window": df})
+    assert sig is None


### PR DESCRIPTION
## Summary
- Adapt mean reversion strategy to convert trend windows from minutes to bars based on timeframe
- Scale trend strength threshold with timeframe for consistent sensitivity
- Add tests covering trend detection for 1m and 5m windows

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_mean_reversion.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7356361cc832dbc73043cb336557c