### PR TITLE
Scale ScalpPingPong params by timeframe

### DIFF
--- a/tests/test_scalp_pingpong.py
+++ b/tests/test_scalp_pingpong.py
@@ -39,3 +39,19 @@ def test_scalp_pingpong_emits_limit_price():
     sig = strat.on_bar({"window": df, "close": df["close"].iloc[-1], "volatility": 0.0})
     assert sig is not None
     assert sig.limit_price == df["close"].iloc[-1]
+
+
+@pytest.mark.parametrize(
+    "timeframe,closes",
+    [
+        (1, list(range(100, 115)) + [100]),
+        (5, [100, 105, 110, 100]),
+    ],
+)
+def test_scalp_pingpong_generates_trades_across_timeframes(timeframe, closes):
+    df = pd.DataFrame({"close": closes})
+    cfg = ScalpPingPongConfig(volatility_factor=0.02, min_volatility=0.0)
+    strat = ScalpPingPong(cfg=cfg)
+    sig = strat.on_bar({"window": df, "timeframe": timeframe})
+    assert sig is not None
+    assert 0 < sig.strength <= 1.0


### PR DESCRIPTION
## Summary
- scale ScalpPingPong lookback and trend windows according to bar timeframe
- size positions by volatility or ATR fraction instead of raw multiplier
- test ScalpPingPong on 1m and 5m bars to show more trades with bounded risk

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73566d498832db0dc95f25a7a300d