### PR TITLE
feat: add dynamic OFI z-score thresholds

### DIFF
--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -2,12 +2,13 @@ import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import calc_ofi
+from ..data.features import returns
 
 
 PARAM_INFO = {
     "window": "Ventana para promediar el OFI",
-    "buy_threshold": "Umbral de compra para OFI",
-    "sell_threshold": "Umbral de venta para OFI",
+    "buy_threshold": "Multiplicador del umbral de compra (z-score)",
+    "sell_threshold": "Multiplicador del umbral de venta (z-score)",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
 
@@ -26,13 +27,16 @@ class OrderFlow(Strategy):
         window: int = 3,
         buy_threshold: float = 1.0,
         sell_threshold: float = 1.0,
-        min_volatility: float = 0.0,
+        min_volatility: float | None = None,
         **kwargs,
     ):
         self.window = window
         self.buy_threshold = buy_threshold
         self.sell_threshold = sell_threshold
         self.min_volatility = min_volatility
+        self.buy_threshold_bps = 0.0
+        self.sell_threshold_bps = 0.0
+        self._min_volatility = 0.0
         self.risk_service = kwargs.get("risk_service")
 
     @record_signal_metrics
@@ -41,37 +45,59 @@ class OrderFlow(Strategy):
         needed = {"bid_qty", "ask_qty"}
         if not needed.issubset(df.columns) or len(df) < self.window:
             return None
+
         price = bar.get("close")
         if price is None:
             if "close" in df.columns:
                 price = float(df["close"].iloc[-1])
             elif "price" in df.columns:
                 price = float(df["price"].iloc[-1])
+        if price is None:
+            return None
 
-        vol_bps = float("inf")
         price_col = "close" if "close" in df.columns else None
+        vol_bps = 0.0
         if price_col:
             closes = df[price_col]
-            returns = closes.pct_change().dropna()
+            rets = closes.pct_change().dropna()
             vol = (
-                returns.rolling(self.window).std().iloc[-1]
-                if len(returns) >= self.window
+                rets.rolling(self.window).std().iloc[-1]
+                if len(rets) >= self.window
                 else 0.0
             )
             vol_bps = vol * 10000
-        if vol_bps < self.min_volatility:
+            if self.min_volatility is None:
+                vol_series = rets.rolling(self.window).std().dropna()
+                window = min(len(vol_series), self.window * 5)
+                if window >= self.window:
+                    self._min_volatility = float(
+                        (vol_series * 10000).rolling(window).quantile(0.2).iloc[-1]
+                    )
+                else:
+                    self._min_volatility = 0.0
+            else:
+                self._min_volatility = self.min_volatility
+        if vol_bps < self._min_volatility:
             return None
 
         ofi_series = calc_ofi(df[list(needed)])
-        ofi_mean = ofi_series.iloc[-self.window :].mean()
-        if ofi_mean > self.buy_threshold:
+        rolling_mean = ofi_series.rolling(self.window).mean()
+        rolling_std = ofi_series.rolling(self.window).std(ddof=0).replace(0, pd.NA)
+        ofi_z = ((ofi_series - rolling_mean) / rolling_std).iloc[-1]
+        if pd.isna(ofi_z):
+            return None
+
+        ofi_bps = ofi_z * vol_bps
+        self.buy_threshold_bps = self.buy_threshold * vol_bps
+        self.sell_threshold_bps = self.sell_threshold * vol_bps
+
+        if ofi_bps > self.buy_threshold_bps:
             side = "buy"
-        elif ofi_mean < -self.sell_threshold:
+        elif ofi_bps < -self.sell_threshold_bps:
             side = "sell"
         else:
-            return self.finalize_signal(bar, price or 0.0, None)
-        if price is None:
-            return None
+            return self.finalize_signal(bar, price, None)
+
         strength = 1.0
         sig = Signal(side, strength)
         return self.finalize_signal(bar, price, sig)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -50,22 +50,34 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy):
     assert trade["stop"] == pytest.approx(expected_stop)
 
 
-def test_order_flow_signals():
-    df_buy = pd.DataFrame({
-        "bid_qty": [1, 2, 3, 5],
-        "ask_qty": [5, 4, 3, 2],
-    })
-    df_sell = pd.DataFrame({
-        "bid_qty": [5, 4, 3, 2],
-        "ask_qty": [1, 2, 3, 5],
-    })
-    strat = OrderFlow(window=3, buy_threshold=1.0, sell_threshold=1.0)
-    sig_buy = strat.on_bar({"window": df_buy, "close": 100.0})
-    assert sig_buy.side == "buy"
-    assert sig_buy.limit_price == 100.0
-    sig_sell = strat.on_bar({"window": df_sell, "close": 100.0})
-    assert sig_sell.side == "sell"
-    assert sig_sell.limit_price == 100.0
+def test_order_flow_signal_1m():
+    idx = pd.date_range("2024-01-01", periods=6, freq="1min")
+    df_buy = pd.DataFrame(
+        {
+            "bid_qty": [10, 12, 15, 20, 25, 30],
+            "ask_qty": [30, 25, 20, 18, 15, 12],
+            "close": [100, 100.1, 99.9, 100.3, 100.0, 100.5],
+        },
+        index=idx,
+    )
+    strat = OrderFlow(window=3, buy_threshold=0.5, sell_threshold=0.5)
+    sig_buy = strat.on_bar({"window": df_buy})
+    assert sig_buy and sig_buy.side == "buy"
+
+
+def test_order_flow_signal_15m():
+    idx = pd.date_range("2024-01-01", periods=6, freq="15min")
+    df_sell = pd.DataFrame(
+        {
+            "bid_qty": [30, 25, 20, 18, 15, 12],
+            "ask_qty": [10, 12, 15, 20, 25, 30],
+            "close": [100, 99.8, 100.2, 99.7, 100.1, 99.6],
+        },
+        index=idx,
+    )
+    strat = OrderFlow(window=3, buy_threshold=0.5, sell_threshold=0.5)
+    sig_sell = strat.on_bar({"window": df_sell})
+    assert sig_sell and sig_sell.side == "sell"
 
 
 def test_mean_rev_ofi_signals():


### PR DESCRIPTION
## Summary
- compute z-score of order flow imbalance and scale thresholds by current volatility
- auto-derive minimum volatility floor when not supplied
- add 1m and 15m tests for order flow signals with simulated data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73569455c832dad344f299c7b6ada