### PR TITLE
Track liquidity metrics per timeframe

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -171,7 +171,7 @@ def record_signal_metrics(fn):
     """
 
     def wrapper(self: Strategy, bar: dict[str, Any]) -> Signal | None:  # type: ignore[misc]
-        if not liquidity_passes(bar):
+        if not liquidity_passes(bar, bar.get("timeframe")):
             return None
         start = time.monotonic()
         sig = fn(self, bar)


### PR DESCRIPTION
## Summary
- maintain historical liquidity metrics per symbol and timeframe and compute thresholds via percentiles
- allow `record_signal_metrics` to forward bar timeframe to liquidity filter
- test that thresholds adjust when switching from 1h to 1m data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7356f704c832dbc4fc05351a3af05