### PR TITLE
feat: adapt strategies for intraday timeframes

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -73,6 +73,9 @@ servicio de riesgo.
 Aprovecha diferencias de precio entre el mercado spot y los futuros para
 capturar rendimientos sin exposición direccional.
 
+En marcos intradía (segundos, minutos u horas) el umbral `threshold` se
+reduce a la mitad para poder reaccionar a bases más pequeñas.
+
 ### Arbitraje (`arbitrage`)
 Busca beneficios cuando un mismo activo tiene precios distintos en dos
 mercados.
@@ -84,3 +87,9 @@ las tasas de cambio.
 ### Arbitraje entre Exchanges (`cross_exchange_arbitrage`)
 Compara el precio entre un mercado spot y uno de futuros (perpetuo) y opera
 cuando la diferencia supera un umbral.
+
+### Composite Signals (`composite_signals`)
+Combina múltiples subestrategias y emite una señal cuando hay consenso.
+En timeframes intradía exige al menos 20 velas en la ventana de precios y las
+estrategias secundarias aportan solo la mitad del peso de la principal para
+mitigar el ruido de marcos muy cortos.

--- a/tests/test_cash_and_carry.py
+++ b/tests/test_cash_and_carry.py
@@ -42,6 +42,16 @@ def test_cash_and_carry_strategy():
     assert sig_flat and sig_flat.side == "flat"
 
 
+def test_cash_and_carry_intraday_threshold():
+    cfg = CashCarryConfig(symbol="BTCUSDT", threshold=0.01)
+    strat = CashAndCarry(cfg)
+    bar = {"spot": 100.0, "perp": 101.0, "funding": 0.001, "timeframe": "1m"}
+    sig = strat.on_bar(bar)
+    assert sig and sig.side == "buy"
+    sig_no_tf = strat.on_bar({"spot": 100.0, "perp": 101.0, "funding": 0.001})
+    assert sig_no_tf and sig_no_tf.side == "flat"
+
+
 def test_cash_and_carry_risk_closes_position():
     class DummyRisk:
         updated = False


### PR DESCRIPTION
## Summary
- scale cash and carry threshold based on bar timeframe
- require longer windows and apply secondary weights in composite signals during intraday sessions
- document intraday behavior for cash_and_carry and composite_signals

## Testing
- `pytest tests/test_cash_and_carry.py::test_cash_and_carry_intraday_threshold tests/test_composite_signals.py::test_intraday_secondary_weights tests/test_composite_signals.py::test_intraday_requires_longer_window -q`


------
https://chatgpt.com/codex/tasks/task_e_68b735736294832d88732ab6607d2cfb