### PR TITLE
feat: recalibrate ofi volatility filter

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -50,7 +50,9 @@ precio cae por debajo del promedio y vende cuando lo supera.
 
 ### Mean Reversion con OFI (`mean_rev_ofi`)
 Variación de mean reversion que utiliza el desequilibrio de flujo de órdenes
-(Order Flow Imbalance) para estimar el regreso al promedio.
+(Order Flow Imbalance) para estimar el regreso al promedio. Filtra señales
+cuando la volatilidad reciente, medida en bps, supera un percentil móvil y la
+ventana de cálculo se adapta automáticamente al timeframe de las velas.
 
 ### Depth Imbalance (`depth_imbalance`)
 Evalúa el desequilibrio entre órdenes de compra y venta en el libro de

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -12,7 +12,7 @@ strategies:
       ofi_window: 20
       zscore_threshold: 1.0
       vol_window: 20
-      vol_threshold: 0.01
+      vol_threshold: 0.8
 
 backtest:
   data: data/examples/btcusdt_3m.csv

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -74,29 +74,30 @@ def test_mean_rev_ofi_signals():
 ofi_window: 2
 zscore_threshold: 0.5
 vol_window: 2
-vol_threshold: 1.0
+vol_threshold: 0.9
 """
     )
+    closes = [100, 110, 100, 105, 100, 101]
     df_sell = pd.DataFrame(
         {
-            "bid_qty": [1, 2, 10],
-            "ask_qty": [3, 1, 0],
-            "close": [100, 100, 100],
+            "bid_qty": [1, 2, 3, 4, 5, 10],
+            "ask_qty": [5, 4, 3, 2, 1, 0],
+            "close": closes,
         }
     )
     strat = MeanRevOFI(**cfg)
-    sig_sell = strat.on_bar({"window": df_sell, "volatility": 0.0})
+    sig_sell = strat.on_bar({"window": df_sell, "volatility": 0.0, "timeframe": "3m"})
     assert sig_sell.side == "sell"
 
     df_buy = pd.DataFrame(
         {
-            "bid_qty": [3, 1, 0],
-            "ask_qty": [1, 2, 10],
-            "close": [100, 100, 100],
+            "bid_qty": [5, 4, 3, 2, 1, 0],
+            "ask_qty": [1, 2, 3, 4, 5, 10],
+            "close": closes,
         }
     )
     strat = MeanRevOFI(**cfg)
-    sig_buy = strat.on_bar({"window": df_buy, "volatility": 0.0})
+    sig_buy = strat.on_bar({"window": df_buy, "volatility": 0.0, "timeframe": "3m"})
     assert sig_buy.side == "buy"
 
 


### PR DESCRIPTION
## Summary
- scale mean reversion OFI volatility window by bar timeframe
- auto-tune volatility filter using rolling percentile in bps
- document and test dynamic threshold behaviour

## Testing
- `pytest tests/test_strategies.py::test_mean_rev_ofi_signals tests/test_strategies.py::test_mean_rev_ofi_trailing_stop_uses_atr -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7356c8258832dbacd00413fa35437