### PR TITLE
feat: add dynamic OFI z-score thresholds

### DIFF
--- a/tests/test_order_flow_timeframes.py
+++ b/tests/test_order_flow_timeframes.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from tradingbot.strategies.order_flow import OrderFlow
+
+
+def test_order_flow_signal_1m():
+    df = pd.DataFrame({
+        "bid_qty": [1, 2, 3, 4, 10],
+        "ask_qty": [5, 4, 3, 2, 1],
+        "close": [100, 101, 100, 102, 101],
+    })
+    strat = OrderFlow(window=3, buy_threshold=10.0, sell_threshold=10.0)
+    sig = strat.on_bar({"window": df, "timeframe": "1m", "symbol": "X", "volatility": 0.0})
+    assert sig is not None and sig.side == "buy"
+
+
+def test_order_flow_signal_15m():
+    df = pd.DataFrame({
+        "bid_qty": [10, 4, 3, 2, 1],
+        "ask_qty": [1, 2, 3, 4, 10],
+        "close": [101, 100, 102, 99, 98],
+    })
+    strat = OrderFlow(window=3, buy_threshold=10.0, sell_threshold=10.0)
+    sig = strat.on_bar({"window": df, "timeframe": "15m", "symbol": "X", "volatility": 0.0})
+    assert sig is not None and sig.side == "sell"
+

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -64,23 +64,25 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy, timefr
 def test_order_flow_signals():
     df_buy = pd.DataFrame(
         {
-            "bid_qty": [1, 2, 3, 5],
-            "ask_qty": [5, 4, 3, 2],
+            "bid_qty": [1, 2, 3, 4, 10],
+            "ask_qty": [5, 4, 3, 2, 1],
+            "close": [100, 101, 100, 102, 101],
         }
     )
     df_sell = pd.DataFrame(
         {
-            "bid_qty": [5, 4, 3, 2],
-            "ask_qty": [1, 2, 3, 5],
+            "bid_qty": [10, 4, 3, 2, 1],
+            "ask_qty": [1, 2, 3, 4, 10],
+            "close": [101, 100, 102, 99, 98],
         }
     )
-    strat = OrderFlow(window=3, buy_threshold=1.0, sell_threshold=1.0)
-    sig_buy = strat.on_bar({"window": df_buy, "close": 100.0})
-    assert sig_buy.side == "buy"
-    assert sig_buy.limit_price == 100.0
-    sig_sell = strat.on_bar({"window": df_sell, "close": 100.0})
-    assert sig_sell.side == "sell"
-    assert sig_sell.limit_price == 100.0
+    strat = OrderFlow(window=3, buy_threshold=10.0, sell_threshold=10.0)
+    sig_buy = strat.on_bar({"window": df_buy, "timeframe": "1m", "symbol": "X", "volatility": 0.0})
+    assert sig_buy and sig_buy.side == "buy"
+    assert sig_buy.limit_price == pytest.approx(df_buy["close"].iloc[-1])
+    sig_sell = strat.on_bar({"window": df_sell, "timeframe": "1m", "symbol": "X", "volatility": 0.0})
+    assert sig_sell and sig_sell.side == "sell"
+    assert sig_sell.limit_price == pytest.approx(df_sell["close"].iloc[-1])
 
 
 def test_mean_rev_ofi_signals():


### PR DESCRIPTION
## Summary
- scale order flow signals using OFI z-score and volatility-based bps thresholds
- auto-derive minimum volatility when unspecified
- cover order flow strategy at 1m and 15m with simulated data

## Testing
- `PYTHONPATH=src pytest tests/test_strategies.py::test_order_flow_signals tests/test_strategies.py::test_order_flow_buy_property tests/test_strategies.py::test_order_flow_sell_property tests/test_order_flow_timeframes.py::test_order_flow_signal_1m tests/test_order_flow_timeframes.py::test_order_flow_signal_15m -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73b3fd06c832d9bfe6462cf8c1b0b