### PR TITLE
Enable liquidity autocalibration

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -31,11 +31,6 @@ balance:
   interval: 60.0
   assets: []
 
-filters:
-  max_spread: .inf
-  min_volume: 0.0
-  max_volatility: .inf
-
 execution:
   limit_offset_ticks: 1.0
   limit_expiry_sec: 1.0


### PR DESCRIPTION
## Summary
- Remove static liquidity thresholds from default config to allow auto-calibration
- Delay enforcing liquidity checks until enough samples are collected
- Auto-calibrate thresholds from recent bars using moving percentiles when not provided

## Testing
- `pytest tests/test_liquidity_filter.py -q`
- `pytest tests/test_backtesting_integration.py::test_event_engine_runs -q`
- `PYTHONPATH=src python - <<'PY'
import pandas as pd
from tradingbot.backtesting.engine import run_backtest_csv
from tradingbot.strategies import STRATEGIES
from types import SimpleNamespace

class DummyStrategy:
    name = "dummy"
    def on_bar(self, bar):
        return SimpleNamespace(side="buy", strength=1.0)

STRATEGIES['dummy'] = DummyStrategy

rng = pd.date_range('2021-01-01', periods=20, freq='5min')
price = pd.Series(range(100, 120))
import numpy as np
df = pd.DataFrame({
    'timestamp': rng.view('int64') // 10**9,
    'open': price,
    'high': price + 0.5,
    'low': price - 0.5,
    'close': price,
    'volume': np.full(len(price), 1000),
})
path = 'tmp_data.csv'
df.to_csv(path, index=False)

res = run_backtest_csv({'SYM': path}, [('dummy','SYM')], latency=1, window=1, initial_equity=10000, verbose_fills=True)
print('orders', len(res['orders']), 'fill_count', res['fill_count'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b742aff5b8832da01a9c6ac7f748ab