### PR TITLE
refactor: drop legacy _RiskManager

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -343,8 +343,8 @@ class EventDrivenBacktestEngine:
                 risk_per_trade=self.risk_per_trade,
                 risk_pct=self._risk_pct,
             )
-            svc.rm.allow_short = allow_short
-            svc.rm.min_order_qty = self.min_order_qty
+            svc.allow_short = allow_short
+            svc.min_order_qty = self.min_order_qty
             self.risk[key] = svc
             self.strategy_exchange[key] = exchange
             try:
@@ -694,7 +694,7 @@ class EventDrivenBacktestEngine:
 
                 trade_value = fill_qty * price
                 fee_cost = fee_model.calculate(trade_value, maker=maker)
-                prev_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                prev_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 if order.side == "buy":
                     cash -= trade_value + fee_cost
                 else:
@@ -702,11 +702,11 @@ class EventDrivenBacktestEngine:
                 sync_cash()
                 prev_qty = svc.account.current_exposure(order.symbol)[0]
                 svc.on_fill(order.symbol, order.side, fill_qty, price)
-                new_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 realized_pnl = new_rpnl - prev_rpnl - fee_cost - slip_cash
                 slippage_pnl = -slip_cash
                 realized_pnl_total += realized_pnl
-                svc.rm.pos.realized_pnl = prev_rpnl + realized_pnl
+                svc.pos.realized_pnl = prev_rpnl + realized_pnl
                 new_qty = svc.account.current_exposure(order.symbol)[0]
                 key = (order.strategy, order.symbol)
                 prev_sign = 1 if prev_qty > 0 else -1 if prev_qty < 0 else 0
@@ -791,7 +791,7 @@ class EventDrivenBacktestEngine:
                         order.side,
                         f"{fill_qty:.8f}",
                         price,
-                        getattr(svc.rm.pos, "realized_pnl", 0.0),
+                        getattr(svc.pos, "realized_pnl", 0.0),
                     )
                 if order.remaining_qty > 1e-9 and not self.cancel_unfilled:
                     order.execute_index = i + 1
@@ -839,7 +839,7 @@ class EventDrivenBacktestEngine:
                     fee_model = self.exchange_fees.get(exchange, self.default_fee)
                     trade_value = exit_qty * exit_price
                     fee_cost = fee_model.calculate(trade_value, maker=False)
-                    prev_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                    prev_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                     if side == "sell":
                         cash += trade_value - fee_cost
                     else:
@@ -847,11 +847,11 @@ class EventDrivenBacktestEngine:
                     sync_cash()
                     prev_qty = svc.account.current_exposure(symbol)[0]
                     svc.on_fill(symbol, side, exit_qty, exit_price)
-                    new_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                    new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                     realized_pnl = new_rpnl - prev_rpnl - fee_cost
                     slippage_pnl = 0.0
                     realized_pnl_total += realized_pnl
-                    svc.rm.pos.realized_pnl = prev_rpnl + realized_pnl
+                    svc.pos.realized_pnl = prev_rpnl + realized_pnl
                     position_levels.pop((strat_name, symbol), None)
                     mtm_after = 0.0
                     for (strat_s, sym_s), svc_s in self.risk.items():
@@ -1099,7 +1099,7 @@ class EventDrivenBacktestEngine:
                 elif pos_qty < 0 and "high" in arrs:
                     check_price = float(arrs["high"][i])
                 try:
-                    svc.rm.check_limits(check_price)
+                    svc.check_limits(check_price)
                 except StopLossExceeded:
                     delta = -svc.account.current_exposure(symbol)[0]
                     if abs(delta) > self.min_order_qty:
@@ -1163,13 +1163,13 @@ class EventDrivenBacktestEngine:
                 fee_model = self.exchange_fees.get(exchange, self.default_fee)
                 trade_value = qty * last_price
                 fee_cost = fee_model.calculate(trade_value, maker=False)
-                prev_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                prev_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 svc.on_fill(symbol, side, qty, last_price)
-                new_rpnl = getattr(svc.rm.pos, "realized_pnl", 0.0)
+                new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 slippage_pnl = 0.0
                 realized_pnl = new_rpnl - prev_rpnl - fee_cost - slippage_pnl
                 realized_pnl_total += realized_pnl
-                svc.rm.pos.realized_pnl = prev_rpnl + realized_pnl
+                svc.pos.realized_pnl = prev_rpnl + realized_pnl
                 if side == "sell":
                     cash += trade_value - fee_cost
                 else:

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -158,7 +158,7 @@ class ExecutionRouter:
             Result(s) from the adapter or algorithm.
         """
 
-        if self.risk_service is not None and not self.risk_service.rm.enabled:
+        if self.risk_service is not None and not self.risk_service.enabled:
             log.warning("Risk manager disabled; rejecting order %s", order)
             return {"status": "rejected", "reason": "risk_disabled"}
 
@@ -284,7 +284,7 @@ class ExecutionRouter:
                     order.symbol, float(res.get("pending_qty", 0.0))
                 )
                 if filled:
-                    book = self.risk_service.rm.positions_multi.get(venue, {})
+                    book = self.risk_service.positions_multi.get(venue, {})
                     cur_qty = book.get(order.symbol, 0.0)
                     delta = filled if order.side == "buy" else -filled
                     self.risk_service.update_position(
@@ -374,7 +374,7 @@ class ExecutionRouter:
             pending = float(res.get("pending_qty", 0.0))
             self.risk_service.account.update_open_order(order.symbol, pending)
             if filled:
-                book = self.risk_service.rm.positions_multi.get(venue, {})
+                book = self.risk_service.positions_multi.get(venue, {})
                 cur_qty = book.get(order.symbol, 0.0)
                 delta = filled if order.side == "buy" else -filled
                 self.risk_service.update_position(

--- a/tests/test_backtest_close_order.py
+++ b/tests/test_backtest_close_order.py
@@ -35,7 +35,7 @@ def test_stop_triggers_close(monkeypatch):
     svc.update_position("default", "SYM", 1.0, entry_price=100.0)
     trade = svc.get_trade("SYM")
     trade["stop"] = 95.0
-    monkeypatch.setattr(svc.rm, "check_limits", lambda price: None)
+    monkeypatch.setattr(svc, "check_limits", lambda price: None)
 
     res = engine.run()
     assert res["orders"][0]["side"] == "sell"

--- a/tests/test_backtest_db_cli.py
+++ b/tests/test_backtest_db_cli.py
@@ -71,8 +71,8 @@ def test_backtest_db_futures_config(monkeypatch):
         cfg["taker_fee_bps"] / 10000.0
     )
     assert eng.exchange_tick_size["binance_futures"] == cfg["tick_size"]
-    rm = eng.risk[("dummy", "BTCUSDT")].rm
-    assert rm.allow_short is True
+    rs = eng.risk[("dummy", "BTCUSDT")]
+    assert rs.allow_short is True
 
 
 def test_backtest_db_spot_config(monkeypatch):
@@ -86,8 +86,8 @@ def test_backtest_db_spot_config(monkeypatch):
         cfg["taker_fee_bps"] / 10000.0
     )
     assert eng.exchange_tick_size["binance_spot"] == cfg["tick_size"]
-    rm = eng.risk[("dummy", "BTCUSDT")].rm
-    assert rm.allow_short is False
+    rs = eng.risk[("dummy", "BTCUSDT")]
+    assert rs.allow_short is False
 
 
 def test_backtest_db_normalizes_symbol(monkeypatch):

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -73,5 +73,5 @@ def test_update_correlation_uses_guard_for_global_cap():
         ("ETH", "SOL"): 0.85,
         ("XRP", "DOGE"): 0.7,  # below threshold
     }
-    exceeded = rs.rm.update_correlation(pairs, 0.8)
+    exceeded = rs.update_correlation(pairs, 0.8)
     assert set(exceeded) == {("BTC", "ETH"), ("ETH", "SOL")}

--- a/tests/test_risk_api.py
+++ b/tests/test_risk_api.py
@@ -37,10 +37,9 @@ def test_risk_reset_resets_and_auth(monkeypatch):
     app = get_app()
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=1.0, venue="X"))
     rs = RiskService(guard, account=Account(float("inf")))
-    rm = rs.rm
-    rm.enabled = False
-    rm.last_kill_reason = "dd"
-    app.state.risk_manager = rm
+    rs.enabled = False
+    rs.last_kill_reason = "dd"
+    app.state.risk_service = rs
     client = TestClient(app)
 
     resp = client.post("/risk/reset")
@@ -51,4 +50,4 @@ def test_risk_reset_resets_and_auth(monkeypatch):
     data = resp.json()
     assert data["risk"]["enabled"] is True
     assert data["risk"]["last_kill_reason"] is None
-    assert rm.enabled is True
+    assert rs.enabled is True

--- a/tests/test_risk_manager_extra.py
+++ b/tests/test_risk_manager_extra.py
@@ -18,27 +18,27 @@ def _make_rs() -> RiskService:
 def test_covariance_and_aggregation():
     rs = _make_rs()
     returns = {"A": [0.1, 0.2, 0.15], "B": [0.05, 0.07, 0.06]}
-    cov = rs.rm.covariance_matrix(returns)
+    cov = rs.covariance_matrix(returns)
     assert pytest.approx(cov[("A", "A")]) == np.var(returns["A"], ddof=1)
     assert pytest.approx(cov[("A", "B")]) == np.cov(returns["A"], returns["B"])[0, 1]
 
-    rs.rm.update_position("ex1", "BTC", 1.0)
-    rs.rm.update_position("ex2", "BTC", -0.3)
-    agg = rs.rm.aggregate_positions()
+    rs.update_position("ex1", "BTC", 1.0)
+    rs.update_position("ex2", "BTC", -0.3)
+    agg = rs.aggregate_positions()
     assert agg["BTC"] == pytest.approx(0.7)
 
 
 def test_adjust_size_and_portfolio_risk():
     rs = _make_rs()
     corr = {("A", "B"): 0.9}
-    size = rs.rm.adjust_size_for_correlation("A", 2.0, corr, 0.8)
+    size = rs.adjust_size_for_correlation("A", 2.0, corr, 0.8)
     assert size == pytest.approx(1.0)
-    size2 = rs.rm.adjust_size_for_correlation("A", 2.0, corr, 0.95)
+    size2 = rs.adjust_size_for_correlation("A", 2.0, corr, 0.95)
     assert size2 == 2.0
 
     cov = {("BTC", "BTC"): 0.04}
-    assert rs.rm.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
-    assert not rs.rm.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
-    assert rs.rm.enabled is False
-    assert rs.rm.last_kill_reason == "covariance_limit"
+    assert rs.check_portfolio_risk({"BTC": 0.5}, cov, 1.0)
+    assert not rs.check_portfolio_risk({"BTC": 0.5}, cov, 0.001)
+    assert rs.enabled is False
+    assert rs.last_kill_reason == "covariance_limit"
 

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -18,26 +18,26 @@ def test_stop_loss_sets_reason():
     from tradingbot.risk.exceptions import StopLossExceeded
 
     svc = _make_service(risk_pct=0.05)
-    svc.rm.add_fill("buy", 1.0, price=100.0)
-    assert svc.rm.check_limits(100.0)
+    svc.add_fill("buy", 1.0, price=100.0)
+    assert svc.check_limits(100.0)
     with pytest.raises(StopLossExceeded):
-        svc.rm.check_limits(94.0)
-    assert svc.rm.enabled is True
-    assert svc.rm.last_kill_reason == "stop_loss"
-    assert svc.rm.pos.qty == pytest.approx(1.0)
+        svc.check_limits(94.0)
+    assert svc.enabled is True
+    assert svc.last_kill_reason == "stop_loss"
+    assert svc.pos.qty == pytest.approx(1.0)
 
 
 def test_stop_loss_multiple_fills_weighted_average():
     from tradingbot.risk.exceptions import StopLossExceeded
 
     svc = _make_service(risk_pct=0.1)
-    svc.rm.add_fill("buy", 1, price=100)
-    svc.rm.add_fill("buy", 1, price=120)
-    assert svc.rm._entry_price == pytest.approx(110.0)
-    assert svc.rm.pos.qty == pytest.approx(2.0)
-    assert svc.rm.check_limits(105)
+    svc.add_fill("buy", 1, price=100)
+    svc.add_fill("buy", 1, price=120)
+    assert svc._entry_price == pytest.approx(110.0)
+    assert svc.pos.qty == pytest.approx(2.0)
+    assert svc.check_limits(105)
     with pytest.raises(StopLossExceeded):
-        svc.rm.check_limits(98)
+        svc.check_limits(98)
 
 
 def test_risk_service_updates_and_persists(monkeypatch):
@@ -61,8 +61,8 @@ def test_risk_service_updates_and_persists(monkeypatch):
         risk_pct=100.0,
     )
     svc.account.cash = 100.0
-    svc.rm.enabled = False
-    svc.rm.last_kill_reason = "manual"
+    svc.enabled = False
+    svc.last_kill_reason = "manual"
     allowed, _, _delta = svc.check_order("BTC", "buy", 1.0, strength=1.0)
     assert not allowed
     assert events and events[0]["kind"] == "VIOLATION"
@@ -78,7 +78,7 @@ def test_risk_service_stop_loss_triggers_close():
         risk_pct=0.05,
     )
     svc.account.cash = 100.0
-    svc.rm.add_fill("buy", 1.0, price=100.0)
+    svc.add_fill("buy", 1.0, price=100.0)
     svc.update_position("X", "BTC", 1.0, entry_price=100.0)
     allowed, reason, delta = svc.check_order("BTC", "buy", 94.0)
     assert allowed is True
@@ -90,7 +90,7 @@ def test_risk_service_stop_loss_triggers_close():
 async def test_update_correlation_returns_pairs():
     svc = _make_service()
     pairs = {("BTC", "ETH"): 0.9}
-    exceeded = svc.rm.update_correlation(pairs, 0.8)
+    exceeded = svc.update_correlation(pairs, 0.8)
     assert exceeded == [("BTC", "ETH")]
 
 
@@ -102,7 +102,7 @@ async def test_update_covariance_returns_pairs():
         ("ETH", "ETH"): 0.04,
         ("BTC", "ETH"): 0.039,
     }
-    exceeded = svc.rm.update_covariance(cov, 0.8)
+    exceeded = svc.update_covariance(cov, 0.8)
     assert exceeded == [("BTC", "ETH")]
 
 

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -40,7 +40,7 @@ async def test_risk_service_correlation_limits_and_sizing():
         atr_mult=2.0,
         risk_pct=100.0,
     )
-    svc.rm.bus = bus
+    svc.bus = bus
     svc.account.cash = 1000.0
 
     _feed_correlated_prices(corr)
@@ -72,7 +72,7 @@ async def test_risk_service_covariance_limit():
         atr_mult=2.0,
         risk_pct=100.0,
     )
-    svc.rm.bus = bus
+    svc.bus = bus
     cov_df = pd.DataFrame(
         [[0.04, 0.039], [0.039, 0.04]], index=["AAA", "BBB"], columns=["AAA", "BBB"]
     )

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -113,11 +113,11 @@ def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
         svc.corr,
         engine=engine,
         account=svc.account,
-        risk_per_trade=svc.core.risk_per_trade,
-        atr_mult=svc.core.atr_mult,
-        risk_pct=svc.core.risk_pct,
+        risk_per_trade=svc.rm.risk_per_trade,
+        atr_mult=svc.rm.atr_mult,
+        risk_pct=svc.rm.risk_pct,
     )
-    cheat.rm.add_fill("buy", 1.0, price=100.0)
+    cheat.add_fill("buy", 1.0, price=100.0)
     cheat.update_position("default", "SYM", 1.0, entry_price=100.0)
     engine.risk[("sell_once", "SYM")] = cheat
     with pytest.raises(AssertionError, match="position went negative"):


### PR DESCRIPTION
## Summary
- replace bespoke `_RiskManager` with direct use of `CoreRiskManager`
- move risk tracking and limit checks into `RiskService`
- update router, engine and tests to work with new risk manager API

## Testing
- `pytest tests/test_risk.py tests/test_risk_manager_limits.py tests/test_risk_manager_extra.py tests/test_correlation_service.py tests/test_risk_service_correlation.py tests/test_risk_api.py tests/test_backtest_engine.py::test_pnl_with_and_without_slippage tests/test_backtest_engine.py::test_fills_csv_export tests/test_backtest_engine.py::test_spot_long_only_enforced tests/test_backtest_db_cli.py::test_backtest_db_spot_config tests/test_backtest_close_order.py tests/test_spot_balance_assertions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74e69812c832d90ac2c498a1dd104