### PR TITLE
Backtesting L2 queue handling fix

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -563,12 +563,13 @@ class EventDrivenBacktestEngine:
                     continue
                 vol_key = "ask_size" if order.side == "buy" else "bid_size"
                 vol_arr = arrs.get(vol_key)
-                avail = (
-                    float(vol_arr[i]) if vol_arr is not None else order.remaining_qty
-                )
                 if self.use_l2:
+                    avail = float(vol_arr[i]) if vol_arr is not None else 0.0
                     depth = self.exchange_depth.get(order.exchange, self.default_depth)
                     order.queue_pos = min(order.queue_pos + avail, depth)
+                else:
+                    avail = order.remaining_qty
+                    order.queue_pos = 0.0
                 if "bid" in arrs and "ask" in arrs:
                     market_price = float(
                         arrs["ask"][i] if order.side == "buy" else arrs["bid"][i]


### PR DESCRIPTION
## Summary
- Ensure Level 2 availability and queue position are handled correctly when executing orders
- Reset queue position when Level 2 data is disabled

## Testing
- `pre-commit run --files src/tradingbot/backtesting/engine.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68b750d3b480832da859e6526ef46555