### PR TITLE
doc: update backtest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,35 @@ predeterminado es la constante `MIN_FILL_QTY = 1e-3`, pero puede ajustarse
 al crear `EventDrivenBacktestEngine` o mediante los campos `backtest.min_fill_qty`
 y `exchange_configs.<exchange>.min_fill_qty` en la configuración YAML.
 
+### Backtesting con datos de nivel 1
+
+Para reproducir un entorno sin profundidad de libro (L2) se recomienda:
+
+- Ejecutar con `use_l2=False`.
+- Definir `min_fill_qty=0` y `exchange_configs.<exchange>.min_fill_qty=0`.
+- Eliminar o ignorar las columnas `ask_size` y `bid_size` del CSV.
+
+Ejemplo de configuración:
+
+```yaml
+backtest:
+  data: data/examples/btcusdt_3m.csv
+  symbol: BTC/USDT
+  strategy: breakout_atr
+  use_l2: false
+  min_fill_qty: 0
+
+exchange_configs:
+  binance_spot:
+    min_fill_qty: 0
+```
+
+Ejecución desde la CLI:
+
+```bash
+python -m tradingbot.cli backtest-cfg config.yaml
+```
+
 ## Solución de problemas
 
 Si se muestra el mensaje `System clock offset`, indica que el reloj del

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -200,6 +200,33 @@ backtest:
     base_spread: 0.1  # spread fijo si faltan columnas bid/ask o tienen NaN
 ```
 
+Para backtests con datos de nivel 1 (sin profundidad de libro) se recomienda:
+
+- Ejecutar con `use_l2=False`.
+- Definir `min_fill_qty=0` y `exchange_min_fill_qty=0`.
+- Eliminar o ignorar las columnas `ask_size` y `bid_size` del CSV.
+
+Ejemplo de YAML completo:
+
+```yaml
+backtest:
+  data: data/examples/btcusdt_3m.csv
+  symbol: BTC/USDT
+  strategy: breakout_atr
+  use_l2: false
+  min_fill_qty: 0
+
+exchange_configs:
+  binance_spot:
+    min_fill_qty: 0
+```
+
+Ejemplo en la CLI:
+
+```bash
+python -m tradingbot.cli backtest-cfg config.yaml
+```
+
 Si se especifica `--fills-csv`, se genera un archivo con las columnas
 `timestamp, reason, side, price, qty, strategy, symbol, exchange, fee_cost, slippage_pnl, realized_pnl, realized_pnl_total, equity_after`.
 La columna `price` refleja el precio final de ejecución con spread y slippage aplicados.


### PR DESCRIPTION
## Summary
- document running backtests with Level 1 data only
- outline required `min_fill_qty` settings and ignoring `ask_size`/`bid_size`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b750e7aec8832dab89990b13029466