### PR TITLE
Default exchange min fill quantity to zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ El motor de backtesting ignora ejecuciones cuya cantidad sea menor a
 `min_fill_qty` para evitar registrar residuos irrelevantes. El umbral
 predeterminado es la constante `MIN_FILL_QTY = 1e-3`, pero puede ajustarse
 al crear `EventDrivenBacktestEngine` o mediante los campos `backtest.min_fill_qty`
-y `exchange_configs.<exchange>.min_fill_qty` en la configuración YAML.
+y `exchange_configs.<exchange>.min_fill_qty` en la configuración YAML. Si un
+exchange no define `min_fill_qty`, ahora se asume `0.0` como valor por defecto.
 
 ## Solución de problemas
 

--- a/data/examples/small_account.yaml
+++ b/data/examples/small_account.yaml
@@ -7,4 +7,4 @@ backtest:
   slippage:
     source: bba
     base_spread: 0.1  # spread fijo si faltan columnas bid/ask o tienen NaN
-  min_fill_qty: 0.001
+  min_fill_qty: 0.0

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -295,9 +295,7 @@ class EventDrivenBacktestEngine:
             self.exchange_fees[exch] = FeeModel(maker_bps, taker_bps)
             self.exchange_depth[exch] = float(cfg.get("depth", float("inf")))
             self.exchange_tick_size[exch] = float(cfg.get("tick_size", 0.0))
-            self.exchange_min_fill_qty[exch] = float(
-                cfg.get("min_fill_qty", self.min_fill_qty)
-            )
+            self.exchange_min_fill_qty[exch] = float(cfg.get("min_fill_qty", 0.0))
             market_type = cfg.get("market_type")
             if market_type is None:
                 if exch.endswith("_spot"):

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -56,13 +56,13 @@ exchange_configs:
     maker_fee_bps: 7.5
     taker_fee_bps: 7.5
     tick_size: 0.01
-    min_fill_qty: 0.001
+    min_fill_qty: 0.0
   binance_futures:
     market_type: perp
     maker_fee_bps: 2.0
     taker_fee_bps: 4.0
     tick_size: 0.01
-    min_fill_qty: 0.001
+    min_fill_qty: 0.0
   okx_spot:
     market_type: spot
     maker_fee_bps: 8.0
@@ -73,4 +73,4 @@ exchange_configs:
     maker_fee_bps: 7.5
     taker_fee_bps: 7.5
     tick_size: 0.1
-    min_fill_qty: 0.001
+    min_fill_qty: 0.0


### PR DESCRIPTION
## Summary
- default per-exchange min fill quantity to 0 when not specified
- adjust example configs to use new zero min fill qty
- document that unspecified exchange min fill qty assumes 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b750ddcc00832dac3492251bed4ce8