### PR TITLE
feat: enforce exposure limits on pending orders

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -970,7 +970,7 @@ class EventDrivenBacktestEngine:
                             )
                         qty = abs(delta_qty)
                         notional = qty * place_price
-                        if not svc.register_order(notional):
+                        if not svc.register_order(symbol, notional):
                             continue
                         svc.account.update_open_order(symbol, qty)
                         exchange = self.strategy_exchange[(strat_name, symbol)]
@@ -1029,8 +1029,9 @@ class EventDrivenBacktestEngine:
                     side = "buy" if delta > 0 else "sell"
                     qty = abs(delta)
                     notional = qty * place_price
-                    if not svc.register_order(notional):
+                    if not svc.register_order(symbol, notional):
                         continue
+                    svc.account.update_open_order(symbol, qty)
                     exchange = self.strategy_exchange[(strat_name, symbol)]
                     base_latency = self.exchange_latency.get(exchange, self.latency)
                     delay = max(1, int(base_latency * self.stress.latency))

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -344,6 +344,10 @@ class TradeBotDaemon:
                     return
                 price_s = last["spot"] * (1.001 if spot_side == "buy" else 0.999)
                 price_p = last["perp"] * (1.001 if perp_side == "buy" else 0.999)
+                notional = qty * (price_s + price_p)
+                if not self.risk.register_order(cfg.symbol, notional):
+                    return
+                self.risk.account.update_open_order(cfg.symbol, qty * 2)
                 resp_spot, resp_perp = await asyncio.gather(
                     cfg.spot.place_order(
                         cfg.symbol,

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -105,6 +105,10 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         tick = getattr(settings, "tick_size", 0.0)
         spot_price = last["spot"] + tick if spot_side == "buy" else last["spot"] - tick
         perp_price = last["perp"] + tick if perp_side == "buy" else last["perp"] - tick
+        total_notional = size * (spot_price + perp_price)
+        if not risk.register_order(cfg.symbol, total_notional):
+            return
+        risk.account.update_open_order(cfg.symbol, size * 2)
         order_spot = Order(cfg.symbol, spot_side, "limit", size, spot_price, time_in_force="IOC")
         order_perp = Order(cfg.symbol, perp_side, "limit", size, perp_price, time_in_force="IOC")
         await asyncio.gather(

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -177,14 +177,18 @@ async def run_paper(
             if not allowed or abs(delta) <= 0:
                 continue
             side = "buy" if delta > 0 else "sell"
-            prev_rpnl = broker.state.realized_pnl
+            qty = abs(delta)
             price = getattr(signal, "limit_price", None)
             price = price if price is not None else _limit_price(side)
+            notional = qty * price
+            if not risk.register_order(symbol, notional):
+                continue
+            prev_rpnl = broker.state.realized_pnl
             resp = await exec_broker.place_limit(
                 symbol,
                 side,
                 price,
-                abs(delta),
+                qty,
                 on_partial_fill=strat.on_partial_fill,
                 on_order_expiry=strat.on_order_expiry,
             )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -11,6 +11,7 @@ from .runner import BarAggregator
 from ..config import settings
 from ..config.hydra_conf import load_config
 from ..strategies import STRATEGIES
+from ..strategies.breakout_atr import BreakoutATR
 from ..risk.service import load_positions
 from ..risk.daily_guard import DailyGuard, GuardLimits
 from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
@@ -93,7 +94,6 @@ async def _run_symbol(
         raise ValueError(f"unknown strategy: {strategy_name}")
     params = params or {}
     strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
-    strat.risk_service = risk
     guard = PortfolioGuard(GuardConfig(
         total_cap_pct=total_cap_pct,
         per_symbol_cap_pct=per_symbol_cap_pct,
@@ -117,6 +117,7 @@ async def _run_symbol(
         risk_pct=cfg.risk_pct,
     )
     risk.allow_short = market != "spot"
+    strat.risk_service = risk
     limit_offset = settings.limit_offset_ticks * tick_size
     tif = f"GTD:{settings.limit_expiry_sec}|PO"
     try:
@@ -148,7 +149,7 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": cfg.symbol}
         sig = strat.on_bar(bar)
         if sig is None:
             continue
@@ -172,6 +173,9 @@ async def _run_symbol(
             if sig.limit_price is not None
             else (closed.c - limit_offset if side == "buy" else closed.c + limit_offset)
         )
+        notional = qty * price
+        if not risk.register_order(cfg.symbol, notional):
+            continue
         prev_rpnl = broker.state.realized_pnl
         resp = await exec_broker.place_limit(
             cfg.symbol,
@@ -185,6 +189,7 @@ async def _run_symbol(
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
+        risk.account.update_open_order(cfg.symbol, filled_qty + pending_qty)
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -145,6 +145,24 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         price1 = last["bq"] + tick
                         price2 = last["mb"] + tick
                         price3 = last["mq"] - tick
+                        not1 = base_qty * price1
+                        not2 = mid_qty * price2
+                        not3 = mid_qty * price3
+                        if not (
+                            risk.register_order(f"{cfg.route.base}/{cfg.route.quote}", not1)
+                            and risk.register_order(f"{cfg.route.mid}/{cfg.route.base}", not2)
+                            and risk.register_order(f"{cfg.route.mid}/{cfg.route.quote}", not3)
+                        ):
+                            continue
+                        risk.account.update_open_order(
+                            f"{cfg.route.base}/{cfg.route.quote}", base_qty
+                        )
+                        risk.account.update_open_order(
+                            f"{cfg.route.mid}/{cfg.route.base}", mid_qty
+                        )
+                        risk.account.update_open_order(
+                            f"{cfg.route.mid}/{cfg.route.quote}", mid_qty
+                        )
                         resp1 = await broker.place_limit(
                             f"{cfg.route.base}/{cfg.route.quote}",
                             "buy",
@@ -209,6 +227,24 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         price1 = last["mq"] + tick
                         price2 = last["mb"] - tick
                         price3 = last["bq"] - tick
+                        not1 = mid_qty * price1
+                        not2 = mid_qty * price2
+                        not3 = base_qty * price3
+                        if not (
+                            risk.register_order(f"{cfg.route.mid}/{cfg.route.quote}", not1)
+                            and risk.register_order(f"{cfg.route.mid}/{cfg.route.base}", not2)
+                            and risk.register_order(f"{cfg.route.base}/{cfg.route.quote}", not3)
+                        ):
+                            continue
+                        risk.account.update_open_order(
+                            f"{cfg.route.mid}/{cfg.route.quote}", mid_qty
+                        )
+                        risk.account.update_open_order(
+                            f"{cfg.route.mid}/{cfg.route.base}", mid_qty
+                        )
+                        risk.account.update_open_order(
+                            f"{cfg.route.base}/{cfg.route.quote}", base_qty
+                        )
                         resp1 = await broker.place_limit(
                             f"{cfg.route.mid}/{cfg.route.quote}",
                             "buy",

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -68,6 +68,9 @@ class DummyRisk:
         self.last_strength = strength
         return True, "", 1.0
 
+    def register_order(self, symbol, notional):
+        return True
+
     def on_fill(self, symbol, side, qty, price=None, venue=None):
         pass
 

--- a/tests/test_risk_register_order.py
+++ b/tests/test_risk_register_order.py
@@ -1,0 +1,33 @@
+import pytest
+from tradingbot.core import Account
+from tradingbot.risk.service import RiskService
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.daily_guard import DailyGuard, GuardLimits
+
+
+def _make_svc(equity=1000.0):
+    guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="X"))
+    guard.refresh_usd_caps(equity)
+    daily = DailyGuard(GuardLimits(), venue="X")
+    account = Account(float("inf"), cash=equity)
+    account.mark_price("BTC", 100.0)
+    return RiskService(guard, daily, account=account)
+
+
+def test_register_order_blocks_on_caps(monkeypatch):
+    svc = _make_svc()
+    events = []
+    monkeypatch.setattr(svc, "_persist", lambda k, s, m, d: events.append(m))
+    assert svc.register_order("BTC", 400.0)
+    svc.account.update_open_order("BTC", 4.0)
+    assert not svc.register_order("BTC", 600.0)
+    assert any("per_symbol_cap_usdt" in msg for msg in events)
+
+
+def test_register_order_respects_daily_guard(monkeypatch):
+    svc = _make_svc()
+    svc.daily._halted = True  # force halt
+    events = []
+    monkeypatch.setattr(svc, "_persist", lambda k, s, m, d: events.append(m))
+    assert not svc.register_order("BTC", 100.0)
+    assert events and events[0] == "daily_halt"


### PR DESCRIPTION
## Summary
- evaluate projected exposure in `RiskService.register_order`
- check pending orders against portfolio and daily limits
- update runners to honour `register_order`
- add tests for register order exposure handling

## Testing
- `pytest tests/test_risk_register_order.py tests/test_live_runner.py tests/test_paper_runner.py tests/test_open_orders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7573365f0832dbc82c4f3bd46521c