### PR TITLE
Handle gaps in Binance depth streams

### DIFF
--- a/src/tradingbot/adapters/binance_futures_ws.py
+++ b/src/tradingbot/adapters/binance_futures_ws.py
@@ -95,15 +95,39 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
         stream = _stream_name(normalize(symbol), f"depth{depth}@100ms")
         url = self.ws_base + stream
         messages = self._ws_messages(url)
+        last_uid: int | None = None
         while True:
             try:
                 raw = await asyncio.wait_for(messages.__anext__(), 15)
             except asyncio.TimeoutError:
                 log.warning("No message received on %s for 15s", stream)
                 messages = self._ws_messages(url)
+                last_uid = None
                 continue
             msg = json.loads(raw)
             d = msg.get("data") or msg
+            pu = d.get("pu")
+            u = d.get("u") or d.get("lastUpdateId")
+            if last_uid is not None and pu is not None and pu != last_uid:
+                log.warning("Gap in depthUpdate for %s: expected %s, got %s", stream, last_uid, pu)
+                if self.rest:
+                    try:
+                        snap = await self.rest.fetch_order_book(normalize(symbol), depth)
+                        bids_n = [[float(b[0]), float(b[1])] for b in snap.get("bids", [])]
+                        asks_n = [[float(a[0]), float(a[1])] for a in snap.get("asks", [])]
+                        ts = datetime.now(timezone.utc)
+                        self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
+                        last_uid = snap.get("lastUpdateId")
+                        yield {
+                            **self.normalize_order_book(symbol, ts, bids_n, asks_n),
+                            "last_update_id": last_uid,
+                            "resync": True,
+                        }
+                    except Exception as e:  # pragma: no cover - logging only
+                        log.warning("Failed to resync order book: %s", e)
+                messages = self._ws_messages(url)
+                last_uid = None
+                continue
             bids = d.get("b") or d.get("bids") or []
             asks = d.get("a") or d.get("asks") or []
             ts_ms = d.get("T") or d.get("E")
@@ -111,7 +135,11 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
             asks_n = [[float(a[0]), float(a[1])] for a in asks]
             ts = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc) if ts_ms else datetime.now(timezone.utc)
             self.state.order_book[symbol] = {"bids": bids_n, "asks": asks_n}
-            yield self.normalize_order_book(symbol, ts, bids_n, asks_n)
+            last_uid = u if u is not None else last_uid
+            yield {
+                **self.normalize_order_book(symbol, ts, bids_n, asks_n),
+                "last_update_id": last_uid,
+            }
 
     stream_orderbook = stream_order_book
 
@@ -135,6 +163,8 @@ class BinanceFuturesWSAdapter(ExchangeAdapter):
 
         prev: dict | None = None
         async for ob in self.stream_order_book(symbol, depth):
+            if ob.get("resync"):
+                prev = None
             curr_bids = list(zip(ob.get("bid_px", []), ob.get("bid_qty", [])))
             curr_asks = list(zip(ob.get("ask_px", []), ob.get("ask_qty", [])))
             if prev is None:

--- a/tests/test_binance_depth_resync.py
+++ b/tests/test_binance_depth_resync.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+import pytest
+
+from tradingbot.adapters.binance_spot_ws import BinanceSpotWSAdapter
+from tradingbot.adapters.binance_futures_ws import BinanceFuturesWSAdapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls", [BinanceSpotWSAdapter, BinanceFuturesWSAdapter])
+async def test_depth_update_gap_resync(monkeypatch, cls):
+    adapter = cls()
+    calls = {"ws": 0, "rest": 0}
+
+    first_msgs = [
+        json.dumps({"data": {"b": [["1", "1"]], "a": [["2", "1"]], "pu": 9, "u": 10, "T": 0}}),
+        json.dumps({"data": {"b": [["1", "1"]], "a": [["2", "1"]], "pu": 12, "u": 13, "T": 1}}),
+    ]
+    second_msgs = [
+        json.dumps({"data": {"b": [["1", "1"]], "a": [["2", "1"]], "pu": 20, "u": 21, "T": 2}})
+    ]
+
+    async def fake_ws_messages(url):
+        calls["ws"] += 1
+        msgs = first_msgs if calls["ws"] == 1 else second_msgs
+        for m in msgs:
+            yield m
+        while True:
+            await asyncio.sleep(0.01)
+
+    class DummyRest:
+        async def fetch_order_book(self, symbol, depth=10):
+            calls["rest"] += 1
+            return {"lastUpdateId": 20, "bids": [["1", "1"]], "asks": [["2", "1"]]}
+
+    adapter._ws_messages = fake_ws_messages
+    adapter.rest = DummyRest()
+
+    gen = adapter.stream_book_delta("BTC/USDT", depth=10)
+    first = await gen.__anext__()
+    second = await gen.__anext__()
+    third = await gen.__anext__()
+    await gen.aclose()
+
+    assert calls["ws"] >= 2
+    assert calls["rest"] == 1
+    assert first["bid_px"] == [1.0]
+    assert second["bid_px"] == [1.0]
+    assert third["bid_px"] == []


### PR DESCRIPTION
## Summary
- detect gaps in Binance `depthUpdate` messages and resync using REST snapshots
- reset book delta calculations after resync
- test websocket reconnection and snapshot retrieval on gaps

## Testing
- `pytest tests/test_binance_depth_resync.py tests/test_adapters.py::test_binance_futures_ws_stream_funding -q`

------
https://chatgpt.com/codex/tasks/task_e_68b75751d304832db39c8b3f83c3f5f6