### PR TITLE
Incorporate slippage and queue metrics in venue selection

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -65,6 +65,15 @@ class Settings(BaseSettings):
     limit_expiry_sec: float = 1.0
     requote_attempts: int = 5
 
+    # Venue selection weights
+    router_price_weight: float = 1.0
+    router_fee_weight: float = 1.0
+    router_spread_weight: float = 1.0
+    router_latency_weight: float = 1e-6
+    router_slippage_weight: float = 1.0
+    router_queue_weight: float = 1.0
+    router_max_book_age_ms: float = 1000.0
+
     # Risk manager defaults
     risk_pct: float = 0.0
     max_symbol_exposure: float | None = None


### PR DESCRIPTION
## Summary
- Extend settings with weights for price, fee, spread, latency, slippage, queue and a max order book age
- Enhance router.best_venue to skip stale books and use slippage & queue position when scoring venues
- Add tests covering slippage influence, queue effects, and stale book filtering

## Testing
- `pytest tests/test_execution_router_slippage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7573b03dc832d94672aff10548791