### PR TITLE
Add periodic purge of inactive symbols in risk service and runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ El riesgo por operación se controla mediante `risk_pct` (equivalente a
 `--risk-pct` en la CLI). Para limitar la exposición global pueden utilizarse
 los parámetros `total_cap_pct` y `per_symbol_cap_pct` de `PortfolioGuard`.
 
+### Purga de símbolos inactivos
+
+Los runners limpian periódicamente los registros de símbolos que ya no se
+operan invocando `RiskService.purge`. El intervalo (en minutos) se configura
+mediante la variable de entorno `RISK_PURGE_MINUTES` y por defecto es `10`:
+
+```bash
+export RISK_PURGE_MINUTES=30
+```
+
 ### Ejemplo
 
 ```python

--- a/src/tradingbot/risk/correlation_service.py
+++ b/src/tradingbot/risk/correlation_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Iterable
 import math
 
 import pandas as pd
@@ -61,3 +61,14 @@ class CorrelationService:
                 if not pd.isna(val):
                     result[(a, b)] = float(val)
         return result
+
+    def purge(self, symbols_active: Iterable[str]) -> None:
+        """Remove tracking for symbols not present in ``symbols_active``."""
+
+        active = set(symbols_active)
+        for sym in list(self._last_price.keys()):
+            if sym not in active:
+                self._last_price.pop(sym, None)
+        if not self._returns.empty:
+            cols = [c for c in self._returns.columns if c in active]
+            self._returns = self._returns[cols]

--- a/tests/test_risk_purge.py
+++ b/tests/test_risk_purge.py
@@ -1,0 +1,17 @@
+from tradingbot.risk.service import RiskService
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.core.account import Account
+
+
+def test_purge_removes_inactive_symbols():
+    guard = PortfolioGuard(GuardConfig(venue="X"))
+    account = Account(float("inf"))
+    rs = RiskService(guard, account=account, risk_pct=0.0)
+    rs.update_position("X", "AAA", 1.0, entry_price=10.0)
+    rs.update_position("X", "BBB", 2.0, entry_price=20.0)
+    assert "AAA" in rs.trades and "BBB" in rs.trades
+    rs.purge({"AAA"})
+    assert set(rs.trades.keys()) == {"AAA"}
+    assert "BBB" not in rs.account.positions
+    assert "BBB" not in guard.st.positions
+    assert "BBB" not in rs.positions_multi["X"]


### PR DESCRIPTION
## Summary
- implement `RiskService.purge` to drop inactive symbol data
- call purge periodically from live runners based on `RISK_PURGE_MINUTES`
- document purge interval configuration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b757851b38832da170e0b0f0ec7dc0