### PR TITLE
feat: track signal latency

### DIFF
--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -37,6 +37,15 @@ groups:
           summary: High end-to-end latency
           description: 95th percentile E2E latency above 2s for 5m
 
+      - alert: HighSignalLatency
+        expr: histogram_quantile(0.95, sum(rate(signal_confirmation_latency_seconds_bucket[5m])) by (le)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High signal confirmation latency
+          description: 95th percentile signal confirmation latency above 1s for 5m
+
       - alert: WebsocketDisconnects
         expr: increase(ws_failures_total[5m]) > 0
         for: 5m

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -23,6 +23,7 @@ from tradingbot.utils.metrics import (
     OPEN_POSITIONS,
     MARKET_LATENCY,
     E2E_LATENCY,
+    SIGNAL_CONFIRM_LATENCY,
     FUNDING_RATE,
     BASIS,
     OPEN_INTEREST,

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -6,6 +6,7 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Deque, Dict, Optional
+import time
 
 import pandas as pd
 
@@ -255,6 +256,7 @@ async def run_live_binance(
         signal = strat.on_bar(bar)
         if signal is None:
             continue
+        signal_ts = getattr(signal, "signal_ts", time.time())
 
         pending = getattr(strat, "pending_qty", {}).get(symbol, 0.0)
         allowed, reason, delta = risk.check_order(
@@ -281,6 +283,7 @@ async def run_live_binance(
             abs(delta),
             on_partial_fill=strat.on_partial_fill,
             on_order_expiry=strat.on_order_expiry,
+            signal_ts=signal_ts,
         )
         fills += 1
         log.info("FILL live %s", resp)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
+import time
 
 import uvicorn
 
@@ -166,6 +167,7 @@ async def run_paper(
             signal = strat.on_bar(bar)
             if signal is None:
                 continue
+            signal_ts = getattr(signal, "signal_ts", time.time())
             allowed, _reason, delta = risk.check_order(
                 symbol,
                 signal.side,
@@ -187,6 +189,7 @@ async def run_paper(
                 abs(delta),
                 on_partial_fill=strat.on_partial_fill,
                 on_order_expiry=strat.on_order_expiry,
+                signal_ts=signal_ts,
             )
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -18,6 +18,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Tuple
+import time
 
 import pandas as pd
 
@@ -250,6 +251,7 @@ async def _run_symbol(
         sig = strat.on_bar(bar)
         if sig is None:
             continue
+        signal_ts = getattr(sig, "signal_ts", time.time())
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
@@ -278,6 +280,7 @@ async def _run_symbol(
             tif=tif,
             on_partial_fill=lambda *_: "re_quote",
             on_order_expiry=lambda *_: "re_quote",
+            signal_ts=signal_ts,
         )
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from typing import Dict, Callable, Tuple, Type, List, Any
+import time
 
 import pandas as pd
 
@@ -152,6 +153,7 @@ async def _run_symbol(
         sig = strat.on_bar(bar)
         if sig is None:
             continue
+        signal_ts = getattr(sig, "signal_ts", time.time())
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
@@ -181,6 +183,7 @@ async def _run_symbol(
             tif=tif,
             on_partial_fill=lambda *_: "re_quote",
             on_order_expiry=lambda *_: "re_quote",
+            signal_ts=signal_ts,
         )
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -26,6 +26,7 @@ class Signal:
     strength: float = 1.0  # fraction of the base equity allocation
     reduce_only: bool = False
     limit_price: float | None = None
+    signal_ts: float | None = None
 
 class Strategy(ABC):
     name: str
@@ -175,6 +176,9 @@ def record_signal_metrics(fn):
             return None
         start = time.monotonic()
         sig = fn(self, bar)
+        gen_ts = time.time()
+        if sig is not None:
+            sig.signal_ts = gen_ts
         duration = time.monotonic() - start
         REQUEST_LATENCY.labels(method=self.name, endpoint="on_bar").observe(duration)
 

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -160,6 +160,12 @@ E2E_LATENCY = Histogram(
     "End-to-end order processing latency in seconds",
 )
 
+# Latency from signal generation to order confirmation
+SIGNAL_CONFIRM_LATENCY = Histogram(
+    "signal_confirmation_latency_seconds",
+    "Latency from signal generation to order confirmation in seconds",
+)
+
 # Order book persistence failures
 ORDERBOOK_INSERT_FAILURES = Counter(
     "orderbook_insert_failures_total",


### PR DESCRIPTION
## Summary
- timestamp strategy signals and forward to broker
- measure signal-to-confirmation latency in execution router
- export Prometheus metric and alert on high latency

## Testing
- `pytest` *(fails: event loop stopped before Future completed; 19 passed, 3 skipped, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7577f10b4832d96120bac4767b3ac