### PR TITLE
feat: configurable ping and backoff per adapter

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -69,6 +69,12 @@ class Settings(BaseSettings):
     risk_pct: float = 0.0
     max_symbol_exposure: float | None = None
 
+    # Websocket behaviour
+    adapter_ping_interval: float = 20.0
+    adapter_max_backoff: float = 30.0
+    connector_ping_interval: float = 20.0
+    connector_max_backoff: float = 60.0
+
     # Binance Spot
     binance_spot_maker_fee_bps: float = 7.5
     binance_spot_taker_fee_bps: float = 7.5


### PR DESCRIPTION
## Summary
- allow adapters and connectors to configure ping_interval and max_backoff via settings or per-adapter overrides
- track websocket reconnections and failures for connectors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7577446b0832d8de6ba5e5f44ec02