### PR TITLE
feat: periodic risk purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ o superiores a 100 generan un error.
 superan los límites configurados, detiene el bot o cierra las posiciones
 abiertas.
 
+### Purga periódica de símbolos
+
+`RiskService` elimina periódicamente la información de símbolos que ya no
+están activos para mantener un estado limpio. El intervalo se controla mediante
+la variable de entorno `RISK_PURGE_MINUTES` (valor por defecto: `60`).
+
+```bash
+export RISK_PURGE_MINUTES=15  # purga cada 15 minutos
+```
+
 ### Ejemplo para cuenta pequeña
 
 Las configuraciones de ejemplo utilizan velas de 3 minutos.

--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -78,6 +78,9 @@ class Settings(BaseSettings):
     risk_pct: float = 0.0
     max_symbol_exposure: float | None = None
 
+    # Risk maintenance
+    risk_purge_minutes: float = 60.0
+
     # Websocket behaviour
     adapter_ping_interval: float = 20.0
     adapter_max_backoff: float = 30.0

--- a/tests/test_risk_purge.py
+++ b/tests/test_risk_purge.py
@@ -1,0 +1,19 @@
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+from tradingbot.core.account import Account
+
+
+def test_risk_service_purge_removes_inactive_symbols():
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    account = Account(float("inf"))
+    rs = RiskService(guard, account=account)
+
+    rs.update_position("v", "AAA", 1.0)
+    rs.update_position("v", "BBB", 2.0)
+
+    rs.purge(["AAA"])
+
+    assert "BBB" not in rs.trades
+    assert "BBB" not in rs.positions_multi.get("v", {})
+    assert "BBB" not in rs.account.positions
+    assert "BBB" not in guard.st.positions


### PR DESCRIPTION
## Summary
- add `RiskService.purge` to clean stale symbols
- schedule periodic purge from runners via configurable interval
- document `RISK_PURGE_MINUTES` env setting

## Testing
- `pytest tests/test_risk_purge.py tests/test_risk.py tests/test_daemon_integration.py tests/test_paper_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b76894cd34832d8b8503ed2b6bc216