### PR TITLE
Handle None expected price in slippage calculation

### DIFF
--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -406,7 +406,7 @@ class ExecutionRouter:
         expected = order.price
         if expected is None:
             expected = getattr(getattr(adapter, "state", None), "last_px", {}).get(order.symbol)
-        if exec_price is not None and expected:
+        if exec_price is not None and expected is not None:
             bps = (exec_price - expected) / expected * 10000
             if bps != 0:
                 SLIPPAGE.labels(symbol=order.symbol, side=order.side).observe(bps)


### PR DESCRIPTION
## Summary
- avoid computing slippage when expected price is missing

## Testing
- `pytest` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ef16d38832d815dfbfb04d03721