### PR TITLE
feat: support atr-based initial stops

### DIFF
--- a/src/tradingbot/core/risk_manager.py
+++ b/src/tradingbot/core/risk_manager.py
@@ -128,9 +128,17 @@ class RiskManager:
     # ------------------------------------------------------------------
     # Stop management helpers
     def initial_stop(self, entry_price: float, side: str, atr: float | None = None) -> float:
-        """Return the initial stop price for a new position."""
+        """Return the initial stop price for a new position.
 
-        delta = float(entry_price) * float(self.risk_pct)
+        When ``atr`` is supplied the stop is offset by ``atr_mult * atr`` to
+        incorporate market volatility.  If ``atr`` is ``None`` the stop falls
+        back to a fixed percentage distance based on :attr:`risk_pct`.
+        """
+
+        if atr is not None:
+            delta = float(self.atr_mult) * float(atr)
+        else:
+            delta = float(entry_price) * float(self.risk_pct)
         if side.lower() in {"buy", "long"}:
             return float(entry_price) - delta
         return float(entry_price) + delta

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -49,6 +49,13 @@ def test_initial_stop_uses_risk_pct():
     assert rm.initial_stop(100.0, "sell") == pytest.approx(102.0)
 
 
+def test_initial_stop_uses_atr():
+    account = Account(float("inf"), cash=1000.0)
+    rm = CoreRiskManager(account, risk_pct=0.02, atr_mult=2.0)
+    assert rm.initial_stop(100.0, "buy", atr=1.5) == pytest.approx(97.0)
+    assert rm.initial_stop(100.0, "sell", atr=1.5) == pytest.approx(103.0)
+
+
 def test_update_trailing_advances_stop_and_stage():
     account = Account(float("inf"), cash=1000.0)
     rm = CoreRiskManager(account, risk_per_trade=0.1)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -111,6 +111,20 @@ def test_update_position_uses_risk_pct_for_stop(qty):
     assert trade["stop"] == pytest.approx(expected)
 
 
+def test_update_position_uses_atr_for_stop():
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    rs = RiskService(
+        guard, account=Account(float("inf")), risk_pct=0.02, atr_mult=2.0, risk_per_trade=1.0
+    )
+    price = 100.0
+    atr = 1.5
+    rs.update_position("X", "BTC", 1.0, entry_price=price, atr=atr)
+    trade = rs.get_trade("BTC")
+    expected = price - 2.0 * atr
+    assert trade["stop"] == pytest.approx(expected)
+    assert trade["atr"] == pytest.approx(atr)
+
+
 @pytest.mark.parametrize("side", ["buy", "sell"])
 def test_on_fill_sets_initial_stop(side):
     risk_pct = 0.02


### PR DESCRIPTION
## Summary
- allow RiskManager.initial_stop to offset by ATR when provided
- propagate ATR through RiskService.update_position and on_fill
- test ATR-based stop placement

## Testing
- `pytest tests/test_core_position_size.py tests/test_risk.py`


------
https://chatgpt.com/codex/tasks/task_e_68b76edd2c90832d9d22bdbfb9515225