### PR TITLE
Preserve trade stage for existing positions

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -228,12 +228,16 @@ class RiskService:
             self.trades.pop(symbol, None)
             return
         side = "buy" if qty > 0 else "sell"
-        trade = self.trades.get(symbol, {})
+        trade = self.trades.get(symbol)
+        is_new = trade is None
+        if is_new:
+            trade = {}
         trade.update({"side": side, "qty": abs(qty)})
         if entry_price is not None:
             trade["entry_price"] = entry_price
             trade.setdefault("stop", self.initial_stop(entry_price, side))
-        trade["stage"] = 0
+        if is_new:
+            trade["stage"] = 0
         self.trades[symbol] = trade
 
     def aggregate_positions(self) -> Dict[str, float]:


### PR DESCRIPTION
## Summary
- avoid resetting a trade's stage when adjusting an already-open position

## Testing
- `pytest` (fails: ImportError: cannot import name 'get_adapter_class' from 'tradingbot.cli.main')

------
https://chatgpt.com/codex/tasks/task_e_68b76ee50124832da677d093ab8dce18