### PR TITLE
Block unauthorized short orders

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -397,6 +397,9 @@ class RiskService:
             elif delta < 0:
                 delta = min(delta + pending_qty, 0.0)
 
+        if delta < 0 and not self.allow_short:
+            return False, "short_not_allowed", 0.0
+
         qty = abs(delta)
         alloc = qty * price
         if not self.check_global_exposure(symbol, alloc):


### PR DESCRIPTION
## Summary
- respect `allow_short` flag in `RiskService.check_order`

## Testing
- `pytest` (fails: ImportError: cannot import name 'get_adapter_class')

------
https://chatgpt.com/codex/tasks/task_e_68b76efac2f0832da791f30054899c3d