### PR TITLE
feat: add clamping option to position sizing

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -540,7 +540,7 @@ class EventDrivenBacktestEngine:
                         decision = svc.manage_position(trade)
                         if decision in {"scale_in", "scale_out"}:
                             target = svc.calc_position_size(
-                                trade.get("strength", 1.0), price
+                                trade.get("strength", 1.0), price, clamp=False
                             )
                             delta_qty = target - abs(pos_qty)
                             if abs(delta_qty) > self.min_order_qty:
@@ -1044,7 +1044,9 @@ class EventDrivenBacktestEngine:
                         if decision == "close":
                             delta_qty = -pos_qty
                         elif decision in {"scale_in", "scale_out"}:
-                            target = svc.calc_position_size(sig.strength, place_price)
+                            target = svc.calc_position_size(
+                                sig.strength, place_price, clamp=False
+                            )
                             delta_qty = target - abs(pos_qty)
                         else:
                             continue
@@ -1113,6 +1115,7 @@ class EventDrivenBacktestEngine:
                         pending_qty=pending,
                         volatility=atr_map.get(symbol),
                         target_volatility=tgt_map.get(symbol),
+                        clamp=False,
                     )
                     if not allowed or abs(delta) < self.min_order_qty:
                         continue

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -209,7 +209,9 @@ async def run_live_binance(
                     break
                 continue
             if decision in {"scale_in", "scale_out"}:
-                target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                target = risk.calc_position_size(
+                    trade.get("strength", 1.0), px, clamp=False
+                )
                 delta_qty = target - abs(pos_qty)
                 if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -138,7 +138,9 @@ async def run_paper(
                         break
                     continue
                 if decision in {"scale_in", "scale_out"}:
-                    target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                    target = risk.calc_position_size(
+                        trade.get("strength", 1.0), px, clamp=False
+                    )
                     delta_qty = target - abs(pos_qty)
                     if abs(delta_qty) > risk.min_order_qty:
                         side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -208,7 +208,9 @@ async def _run_symbol(
                     break
                 continue
             if decision in {"scale_in", "scale_out"}:
-                target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                target = risk.calc_position_size(
+                    trade.get("strength", 1.0), px, clamp=False
+                )
                 delta_qty = target - abs(pos_qty)
                 if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else (

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -311,12 +311,14 @@ class RiskService:
         *,
         volatility: float | None = None,
         target_volatility: float | None = None,
+        clamp: bool = True,
     ) -> float:
         return self.rm.calc_position_size(
             signal_strength,
             price,
             volatility=volatility,
             target_volatility=target_volatility,
+            clamp=clamp,
         )
 
     def check_global_exposure(self, symbol: str, new_alloc: float) -> bool:
@@ -354,6 +356,7 @@ class RiskService:
         pending_qty: float = 0.0,
         volatility: float | None = None,
         target_volatility: float | None = None,
+        clamp: bool = True,
     ) -> tuple[bool, str, float]:
         """Check limits and compute sized order before submitting.
 
@@ -368,6 +371,8 @@ class RiskService:
         target_volatility:
             Desired volatility level.  Position size is scaled by
             ``target_volatility / volatility`` when both values are supplied.
+        clamp:
+            Whether to clamp ``strength`` to ``[0, 1]`` before sizing.
 
         Returns
         -------
@@ -388,6 +393,7 @@ class RiskService:
             price,
             volatility=volatility,
             target_volatility=target_volatility,
+            clamp=clamp,
         )
         delta = unsigned if side.lower() == "buy" else -unsigned
 


### PR DESCRIPTION
## Summary
- allow clamping of position sizing signals
- forward clamp option through risk service
- disable clamping for scaling logic in backtesting and live runners

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_adapter_class')*


------
https://chatgpt.com/codex/tasks/task_e_68b76f19f48c832d8992118521ceca45