### PR TITLE
Handle absolute notional in risk exposure projections

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -112,11 +112,16 @@ class RiskService:
             for sym in self.account.open_orders
             if sym != symbol
         )
-        proj_sym_exp = self.guard.exposure_symbol(symbol) + pending_existing + float(
-            notional
+        proj_sym_exp = (
+            self.guard.exposure_symbol(symbol)
+            + pending_existing
+            + abs(float(notional))
         )
-        proj_total_exp = self.guard.exposure_total() + pending_other + pending_existing + float(
-            notional
+        proj_total_exp = (
+            self.guard.exposure_total()
+            + pending_other
+            + pending_existing
+            + abs(float(notional))
         )
 
         per_cap = getattr(self.guard.st, "per_symbol_cap_usdt", None)


### PR DESCRIPTION
## Summary
- ensure projected exposure calculations use absolute notional values

## Testing
- `pytest` *(fails: tests/test_api_backtest_db_stream.py, tests/test_api_bots.py, tests/test_smoke.py, tests/test_strategy_schema.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f138954832d851d38457000d387