### PR TITLE
Track open orders per side

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -570,7 +570,7 @@ class EventDrivenBacktestEngine:
                                         else 0.0
                                     )
                                     queue_pos = min(avail, depth)
-                                svc.account.update_open_order(sym, abs(delta_qty))
+                                svc.account.update_open_order(sym, side, abs(delta_qty))
                                 order_seq += 1
                                 order = Order(
                                     exec_index,
@@ -619,7 +619,7 @@ class EventDrivenBacktestEngine:
                                         else 0.0
                                     )
                                     queue_pos = min(avail, depth)
-                                svc.account.update_open_order(sym, pending_qty)
+                                svc.account.update_open_order(sym, side, pending_qty)
                                 order_seq += 1
                                 order = Order(
                                     exec_index,
@@ -1062,7 +1062,7 @@ class EventDrivenBacktestEngine:
                         notional = qty * place_price
                         if not svc.register_order(symbol, notional):
                             continue
-                        svc.account.update_open_order(symbol, qty)
+                        svc.account.update_open_order(symbol, side, qty)
                         exchange = self.strategy_exchange[(strat_name, symbol)]
                         base_latency = self.exchange_latency.get(exchange, self.latency)
                         delay = max(1, int(base_latency * self.stress.latency))
@@ -1102,7 +1102,7 @@ class EventDrivenBacktestEngine:
                         continue
                     if sig is None or sig.side == "flat":
                         continue
-                    pending = svc.account.open_orders.get(symbol, 0.0)
+                    pending = svc.account.open_orders.get(symbol, {}).get(sig.side, 0.0)
                     atr_map = getattr(strat, "_last_atr", {})
                     tgt_map = getattr(strat, "_last_target_vol", {})
                     allowed, _reason, delta = svc.check_order(
@@ -1121,7 +1121,7 @@ class EventDrivenBacktestEngine:
                     notional = qty * place_price
                     if not svc.register_order(symbol, notional):
                         continue
-                    svc.account.update_open_order(symbol, qty)
+                    svc.account.update_open_order(symbol, side, qty)
                     exchange = self.strategy_exchange[(strat_name, symbol)]
                     base_latency = self.exchange_latency.get(exchange, self.latency)
                     delay = max(1, int(base_latency * self.stress.latency))

--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -340,7 +340,7 @@ class ExecutionRouter:
             res.setdefault("venue", venue)
             if self.risk_service is not None:
                 self.risk_service.account.update_open_order(
-                    order.symbol, float(res.get("pending_qty", 0.0))
+                    order.symbol, order.side, float(res.get("pending_qty", 0.0))
                 )
                 if filled:
                     book = self.risk_service.positions_multi.get(venue, {})
@@ -433,7 +433,7 @@ class ExecutionRouter:
         if self.risk_service is not None:
             filled = float(res.get("filled_qty") or res.get("qty") or 0.0)
             pending = float(res.get("pending_qty", 0.0))
-            self.risk_service.account.update_open_order(order.symbol, pending)
+            self.risk_service.account.update_open_order(order.symbol, order.side, pending)
             if filled:
                 book = self.risk_service.positions_multi.get(venue, {})
                 cur_qty = book.get(order.symbol, 0.0)

--- a/src/tradingbot/live/daemon.py
+++ b/src/tradingbot/live/daemon.py
@@ -361,7 +361,8 @@ class TradeBotDaemon:
                 notional = qty * (price_s + price_p)
                 if not self.risk.register_order(cfg.symbol, notional):
                     return
-                self.risk.account.update_open_order(cfg.symbol, qty * 2)
+                self.risk.account.update_open_order(cfg.symbol, spot_side, qty)
+                self.risk.account.update_open_order(cfg.symbol, perp_side, qty)
                 resp_spot, resp_perp = await asyncio.gather(
                     cfg.spot.place_order(
                         cfg.symbol,

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -200,7 +200,7 @@ async def run_live_binance(
                 )
                 filled_qty = float(resp.get("filled_qty", 0.0))
                 pending_qty = float(resp.get("pending_qty", 0.0))
-                risk.account.update_open_order(symbol, filled_qty + pending_qty)
+                risk.account.update_open_order(symbol, close_side, filled_qty + pending_qty)
                 risk.on_fill(symbol, close_side, filled_qty, venue="binance")
                 delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                 halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -229,7 +229,7 @@ async def run_live_binance(
                     )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
-                    risk.account.update_open_order(symbol, filled_qty + pending_qty)
+                    risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
                     risk.on_fill(symbol, side, filled_qty, venue="binance")
                     delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -301,7 +301,7 @@ async def run_live_binance(
         log.info("FILL live %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(symbol, filled_qty + pending_qty)
+        risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
         risk.on_fill(symbol, side, filled_qty, venue="binance")
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -108,7 +108,8 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         total_notional = size * (spot_price + perp_price)
         if not risk.register_order(cfg.symbol, total_notional):
             return
-        risk.account.update_open_order(cfg.symbol, size * 2)
+        risk.account.update_open_order(cfg.symbol, spot_side, size)
+        risk.account.update_open_order(cfg.symbol, perp_side, size)
         order_spot = Order(cfg.symbol, spot_side, "limit", size, spot_price, time_in_force="IOC")
         order_perp = Order(cfg.symbol, perp_side, "limit", size, perp_price, time_in_force="IOC")
         await asyncio.gather(

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -129,7 +129,7 @@ async def run_paper(
                     )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
-                    risk.account.update_open_order(symbol, filled_qty + pending_qty)
+                    risk.account.update_open_order(symbol, close_side, filled_qty + pending_qty)
                     risk.on_fill(symbol, close_side, filled_qty, venue="paper")
                     delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -154,7 +154,7 @@ async def run_paper(
                         )
                         filled_qty = float(resp.get("filled_qty", 0.0))
                         pending_qty = float(resp.get("pending_qty", 0.0))
-                        risk.account.update_open_order(symbol, filled_qty + pending_qty)
+                        risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
                         risk.on_fill(symbol, side, filled_qty, venue="paper")
                         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                         halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -202,7 +202,7 @@ async def run_paper(
             )
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
-            risk.account.update_open_order(symbol, filled_qty + pending_qty)
+            risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
             risk.on_fill(symbol, side, filled_qty, venue="paper")
             delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
             halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -194,7 +194,7 @@ async def _run_symbol(
                 )
                 filled_qty = float(resp.get("filled_qty", 0.0))
                 pending_qty = float(resp.get("pending_qty", 0.0))
-                risk.account.update_open_order(cfg.symbol, filled_qty + pending_qty)
+                risk.account.update_open_order(cfg.symbol, close_side, filled_qty + pending_qty)
                 risk.on_fill(
                     cfg.symbol,
                     close_side,
@@ -229,7 +229,7 @@ async def _run_symbol(
                     )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
-                    risk.account.update_open_order(cfg.symbol, filled_qty + pending_qty)
+                    risk.account.update_open_order(cfg.symbol, side, filled_qty + pending_qty)
                     risk.on_fill(
                         cfg.symbol,
                         side,
@@ -289,7 +289,7 @@ async def _run_symbol(
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(cfg.symbol, filled_qty + pending_qty)
+        risk.account.update_open_order(cfg.symbol, side, filled_qty + pending_qty)
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -192,7 +192,7 @@ async def _run_symbol(
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(cfg.symbol, filled_qty + pending_qty)
+        risk.account.update_open_order(cfg.symbol, side, filled_qty + pending_qty)
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -155,13 +155,13 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ):
                             continue
                         risk.account.update_open_order(
-                            f"{cfg.route.base}/{cfg.route.quote}", base_qty
+                            f"{cfg.route.base}/{cfg.route.quote}", "buy", base_qty
                         )
                         risk.account.update_open_order(
-                            f"{cfg.route.mid}/{cfg.route.base}", mid_qty
+                            f"{cfg.route.mid}/{cfg.route.base}", "buy", mid_qty
                         )
                         risk.account.update_open_order(
-                            f"{cfg.route.mid}/{cfg.route.quote}", mid_qty
+                            f"{cfg.route.mid}/{cfg.route.quote}", "sell", mid_qty
                         )
                         resp1 = await broker.place_limit(
                             f"{cfg.route.base}/{cfg.route.quote}",
@@ -237,13 +237,13 @@ async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None
                         ):
                             continue
                         risk.account.update_open_order(
-                            f"{cfg.route.mid}/{cfg.route.quote}", mid_qty
+                            f"{cfg.route.mid}/{cfg.route.quote}", "buy", mid_qty
                         )
                         risk.account.update_open_order(
-                            f"{cfg.route.mid}/{cfg.route.base}", mid_qty
+                            f"{cfg.route.mid}/{cfg.route.base}", "sell", mid_qty
                         )
                         risk.account.update_open_order(
-                            f"{cfg.route.base}/{cfg.route.quote}", base_qty
+                            f"{cfg.route.base}/{cfg.route.quote}", "sell", base_qty
                         )
                         resp1 = await broker.place_limit(
                             f"{cfg.route.mid}/{cfg.route.quote}",

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -571,7 +571,7 @@ class RiskService:
         """Update internal position books after a fill."""
         self.add_fill(side, qty, price=price)
         self.guard.update_position_on_order(symbol, side, qty, venue=venue)
-        self.account.update_open_order(symbol, -abs(qty))
+        self.account.update_open_order(symbol, side, -abs(qty))
         delta = qty if side == "buy" else -qty
         self.account.update_position(symbol, delta, price=price)
         if venue is not None:

--- a/tests/test_backtest_pending_orders.py
+++ b/tests/test_backtest_pending_orders.py
@@ -1,6 +1,9 @@
 import pandas as pd
 import pytest
 
+import pandas as pd
+import pytest
+
 from tradingbot.backtesting.engine import EventDrivenBacktestEngine
 from tradingbot.core import Account
 from tradingbot.strategies import STRATEGIES
@@ -30,6 +33,7 @@ class StubRisk:
     def __init__(self, account: Account):
         self.account = account
         self.rm = StubRM()
+        self.pos = self.rm.pos
 
     def get_trade(self, sym):
         return {"side": "buy"}
@@ -42,6 +46,9 @@ class StubRisk:
 
     def mark_price(self, symbol, price):
         pass
+
+    def check_limits(self, price):
+        return True
 
     def on_fill(self, symbol, side, qty, price):
         sign = 1 if side == "buy" else -1
@@ -68,4 +75,4 @@ def test_pending_order_quantity(monkeypatch):
     account.update_position("SYM", 1.0, price=100.0)
     engine.risk = {("dummy", "SYM"): StubRisk(account)}
     engine.run()
-    assert account.open_orders["SYM"] == pytest.approx(1.0)
+    assert account.open_orders["SYM"]["sell"] == pytest.approx(1.0)

--- a/tests/test_open_orders.py
+++ b/tests/test_open_orders.py
@@ -18,15 +18,15 @@ def make_service(account: Account) -> RiskService:
 
 def test_update_open_order_clears_when_offset():
     account = Account(float("inf"), cash=0.0)
-    account.update_open_order("BTC", 1.0)
-    account.update_open_order("BTC", -1.0)
+    account.update_open_order("BTC", "buy", 1.0)
+    account.update_open_order("BTC", "buy", -1.0)
     assert account.open_orders == {}
 
 
 def test_calc_position_size_accounts_for_open_orders():
     account = Account(float("inf"), cash=1000.0)
     account.mark_price("BTC", 100.0)
-    account.update_open_order("BTC", 2.0)  # reserves $200
+    account.update_open_order("BTC", "buy", 2.0)  # reserves $200
     svc = make_service(account)
     size = svc.calc_position_size(1.0, 100.0)
     assert size == pytest.approx(0.8)
@@ -40,7 +40,7 @@ def test_check_order_pending_qty_reduces_next_size():
 
     allowed, _, delta = svc.check_order("BTC", "buy", 100.0, strength=1.0)
     assert allowed
-    svc.account.update_open_order("BTC", delta)
+    svc.account.update_open_order("BTC", "buy", delta)
 
     allowed_raw, _, delta_raw = svc.check_order("BTC", "buy", 100.0, strength=1.0)
     assert allowed_raw
@@ -51,7 +51,7 @@ def test_check_order_pending_qty_reduces_next_size():
         "buy",
         100.0,
         strength=1.0,
-        pending_qty=svc.account.open_orders.get("BTC", 0.0),
+        pending_qty=svc.account.open_orders.get("BTC", {}).get("buy", 0.0),
     )
     assert not allowed2
     assert reason2 == "zero_size"
@@ -65,10 +65,10 @@ def test_check_order_pending_qty_handles_partial_fill():
 
     allowed, _, delta = svc.check_order("BTC", "buy", 100.0, strength=1.0)
     assert allowed
-    svc.account.update_open_order("BTC", delta)
+    svc.account.update_open_order("BTC", "buy", delta)
     # simulate a partial fill of half the order
     svc.on_fill("BTC", "buy", delta / 2, price=100.0)
-    pending = svc.account.open_orders.get("BTC", 0.0)
+    pending = svc.account.open_orders.get("BTC", {}).get("buy", 0.0)
     base = svc.calc_position_size(1.0, 100.0)
 
     allowed2, _, delta2 = svc.check_order(
@@ -88,6 +88,6 @@ def test_available_balance_decreases_with_pending_order():
     svc = make_service(account)
     allowed, _, delta = svc.check_order("BTC", "buy", 100.0, strength=1.0)
     assert allowed
-    account.update_open_order("BTC", delta)
+    account.update_open_order("BTC", "buy", delta)
     assert account.cash == pytest.approx(1000.0)
     assert account.get_available_balance() == pytest.approx(900.0)

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -45,7 +45,7 @@ class DummyRisk:
         self.rm = types.SimpleNamespace(allow_short=True)
         self.account = types.SimpleNamespace(
             current_exposure=lambda symbol: (0.0, 0.0),
-            update_open_order=lambda symbol, qty: None,
+            update_open_order=lambda symbol, side, qty: None,
         )
         self.trades: dict = {}
 
@@ -76,6 +76,9 @@ class DummyRisk:
 
     def daily_mark(self, broker, symbol, price, delta_rpnl):
         return False, ""
+
+    def purge(self, symbols):
+        pass
 
 
 class DummyRouter:
@@ -136,7 +139,11 @@ async def test_run_paper(monkeypatch):
     monkeypatch.setattr(rp, "PaperAdapter", DummyBroker)
     monkeypatch.setattr(rp.uvicorn, "Server", DummyServer)
     monkeypatch.setattr(rp, "_CAN_PG", False)
-    monkeypatch.setattr(rp, "settings", types.SimpleNamespace(tick_size=0.1))
+    monkeypatch.setattr(
+        rp,
+        "settings",
+        types.SimpleNamespace(tick_size=0.1, risk_purge_minutes=0),
+    )
 
     await rp.run_paper(symbol=normalize("BTC-USDT"), strategy_name="dummy")
 

--- a/tests/test_risk_register_order.py
+++ b/tests/test_risk_register_order.py
@@ -19,7 +19,7 @@ def test_register_order_blocks_on_caps(monkeypatch):
     events = []
     monkeypatch.setattr(svc, "_persist", lambda k, s, m, d: events.append(m))
     assert svc.register_order("BTC", 400.0)
-    svc.account.update_open_order("BTC", 4.0)
+    svc.account.update_open_order("BTC", "buy", 4.0)
     assert not svc.register_order("BTC", 600.0)
     assert any("per_symbol_cap_usdt" in msg for msg in events)
 


### PR DESCRIPTION
## Summary
- represent open order reservations per side with `{symbol: {"buy": qty, "sell": qty}}`
- update risk and execution flows to pass side-aware quantities
- adjust tests for side-specific pending quantities

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_adapter_class')*
- `pytest tests/test_open_orders.py tests/test_risk_register_order.py tests/test_backtest_pending_orders.py tests/test_paper_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76f174000832d9f39028e3b73130b