### PR TITLE
feat: add configurable profit lock

### DIFF
--- a/src/tradingbot/core/risk_manager.py
+++ b/src/tradingbot/core/risk_manager.py
@@ -14,7 +14,7 @@ Main features
     * Progressively tighten stops as a trade becomes profitable using four stages:
       1. cut the initial risk in half,
       2. move the stop to break‑even once price moves the full initial risk,
-      3. lock in one dollar of net profit (after fees and slippage),
+      3. lock in a configurable amount of net profit (after fees and slippage),
       4. afterwards trail the stop at ``2 × ATR``.
     * Check global exposure limits before submitting new orders.
 """
@@ -62,6 +62,7 @@ class RiskManager:
     risk_per_trade: float = 0.1
     atr_mult: float = 2.0
     risk_pct: float = 0.01
+    profit_lock_usd: float = 1.0
 
     # ------------------------------------------------------------------
     # Volatility adjustment
@@ -135,7 +136,13 @@ class RiskManager:
             return float(entry_price) - delta
         return float(entry_price) + delta
 
-    def update_trailing(self, trade: Any, current_price: float, fees_slip: float = 0.0) -> None:
+    def update_trailing(
+        self,
+        trade: Any,
+        current_price: float,
+        fees_slip: float = 0.0,
+        profit_lock_usd: float | None = None,
+    ) -> None:
         """Update ``trade`` stop according to the four stop stages."""
 
         side = _get(trade, "side")
@@ -162,10 +169,11 @@ class RiskManager:
             _set(trade, "stage", 2)
             return
 
-        # Stage 2 -> 3: lock in +1 USD net after fees/slippage
+        # Stage 2 -> 3: lock in configurable net profit after fees/slippage
+        lock = self.profit_lock_usd if profit_lock_usd is None else float(profit_lock_usd)
         net = move * qty - float(fees_slip)
-        if stage <= 2 and net >= 1.0:
-            price_shift = (1.0 + float(fees_slip)) / qty
+        if stage <= 2 and net >= lock:
+            price_shift = (lock + float(fees_slip)) / qty
             new_stop = entry + price_shift if side in {"buy", "long"} else entry - price_shift
             _set(trade, "stop", new_stop)
             _set(trade, "stage", 3)

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -47,6 +47,7 @@ class RiskService:
         risk_per_trade: float = 0.01,
         atr_mult: float = 2.0,
         risk_pct: float = 0.01,
+        profit_lock_usd: float = 1.0,
     ) -> None:
         self.guard = guard
         self.daily = daily
@@ -59,6 +60,7 @@ class RiskService:
             risk_per_trade=risk_per_trade,
             atr_mult=atr_mult,
             risk_pct=risk_pct,
+            profit_lock_usd=profit_lock_usd,
         )
         self.trades: Dict[str, dict] = {}
 
@@ -328,9 +330,18 @@ class RiskService:
         return self.rm.initial_stop(entry_price, side, atr)
 
     def update_trailing(
-        self, trade: dict | object, current_price: float, fees_slip: float = 0.0
+        self,
+        trade: dict | object,
+        current_price: float,
+        fees_slip: float = 0.0,
+        profit_lock_usd: float | None = None,
     ) -> None:
-        self.rm.update_trailing(trade, current_price, fees_slip)
+        self.rm.update_trailing(
+            trade,
+            current_price,
+            fees_slip,
+            profit_lock_usd=profit_lock_usd,
+        )
 
     def manage_position(self, trade: dict | object, signal: dict | None = None) -> str:
         return self.rm.manage_position(trade, signal)


### PR DESCRIPTION
## Summary
- allow configuring profit lock amount in RiskManager
- pipe profit lock setting through RiskService and trailing update calls

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_adapter_class' from 'tradingbot.cli.main')*


------
https://chatgpt.com/codex/tasks/task_e_68b76f0aea74832d84075175cec59192