### PR TITLE
feat: clamp signal strength

### DIFF
--- a/docs/risk.md
+++ b/docs/risk.md
@@ -9,8 +9,9 @@ símbolo. Su API expone:
 
 - `check_order(symbol, side, price, strength)`: valida la orden y devuelve la
   cantidad recomendada.
-- `calc_position_size(strength, price)`: dimensiona la posición según la fuerza
-  de la señal y el riesgo configurado.
+- `calc_position_size(strength, price, clamp=True)`: dimensiona la posición según
+  la fuerza de la señal y el riesgo configurado. ``clamp=False`` permite valores
+  de ``strength`` fuera del rango ``[0, 1]``.
 - `update_trailing(trade, current_price, fees_slip=0.0)`: aplica un trailing
   stop adaptativo en tres etapas.
 - `manage_position(trade, signal=None)`: decide si mantener o cerrar una
@@ -38,7 +39,9 @@ if allowed and delta > 0:
     pass
 ```
 
-`signal["strength"]` acepta valores continuos y escala el tamaño de la orden.
+`signal["strength"]` acepta valores continuos y, por defecto, se acota al rango
+``[0, 1]``.  Establezca ``clamp=False`` al calcular el tamaño de la posición
+para permitir valores fuera de ese rango.
 El método `update_trailing` mueve el stop a *break-even*, asegura 1 USD neto y
 luego sigue al precio a `2 × ATR`. `manage_position` decide si mantener o cerrar
 la operación y `check_order` valida el límite global por símbolo.
@@ -52,11 +55,13 @@ cancelar la orden o caer a *market* cuando la ventaja desaparece.
 ## Asignación por señal
 
 Cada señal trae un `strength` que define el tamaño según la fórmula
-`notional = equity * strength`. Un valor de `1.0` utiliza todo el capital
-disponible, valores mayores piramidan la posición y menores la reducen.
-Por ejemplo, `strength = 1.5` incrementa la exposición un 50 %, mientras que
-`strength = 0.5` la reduce a la mitad. El campo `risk_pct` establece la pérdida
-máxima permitida.
+`notional = equity * strength`. Por defecto `strength` se acota a `[0, 1]`, pero
+puede desactivarse esta limitación pasando ``clamp=False`` a
+`calc_position_size` o a `check_order`.  Un valor de `1.0` utiliza todo el
+capital disponible, valores mayores (con el clamp deshabilitado) piramidan la
+posición y menores la reducen.  Por ejemplo, con el clamp desactivado,
+`strength = 1.5` incrementa la exposición un 50 %, mientras que `strength = 0.5`
+la reduce a la mitad. El campo `risk_pct` establece la pérdida máxima permitida.
 
 El parámetro `risk_pct` debe estar entre 0 y 1. Los valores de 1 a 100 se
 interpretan como porcentajes y se convierten dividiéndolos entre 100 (por

--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -540,7 +540,7 @@ class EventDrivenBacktestEngine:
                         decision = svc.manage_position(trade)
                         if decision in {"scale_in", "scale_out"}:
                             target = svc.calc_position_size(
-                                trade.get("strength", 1.0), price
+                                trade.get("strength", 1.0), price, clamp=False
                             )
                             delta_qty = target - abs(pos_qty)
                             if abs(delta_qty) > self.min_order_qty:
@@ -1044,7 +1044,7 @@ class EventDrivenBacktestEngine:
                         if decision == "close":
                             delta_qty = -pos_qty
                         elif decision in {"scale_in", "scale_out"}:
-                            target = svc.calc_position_size(sig.strength, place_price)
+                            target = svc.calc_position_size(sig.strength, place_price, clamp=False)
                             delta_qty = target - abs(pos_qty)
                         else:
                             continue

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -209,7 +209,7 @@ async def run_live_binance(
                     break
                 continue
             if decision in {"scale_in", "scale_out"}:
-                target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                target = risk.calc_position_size(trade.get("strength", 1.0), px, clamp=False)
                 delta_qty = target - abs(pos_qty)
                 if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -138,7 +138,7 @@ async def run_paper(
                         break
                     continue
                 if decision in {"scale_in", "scale_out"}:
-                    target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                    target = risk.calc_position_size(trade.get("strength", 1.0), px, clamp=False)
                     delta_qty = target - abs(pos_qty)
                     if abs(delta_qty) > risk.min_order_qty:
                         side = trade["side"] if delta_qty > 0 else ("sell" if trade["side"] == "buy" else "buy")

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -208,7 +208,7 @@ async def _run_symbol(
                     break
                 continue
             if decision in {"scale_in", "scale_out"}:
-                target = risk.calc_position_size(trade.get("strength", 1.0), px)
+                target = risk.calc_position_size(trade.get("strength", 1.0), px, clamp=False)
                 delta_qty = target - abs(pos_qty)
                 if abs(delta_qty) > risk.min_order_qty:
                     side = trade["side"] if delta_qty > 0 else (

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -326,12 +326,14 @@ class RiskService:
         *,
         volatility: float | None = None,
         target_volatility: float | None = None,
+        clamp: bool = True,
     ) -> float:
         return self.rm.calc_position_size(
             signal_strength,
             price,
             volatility=volatility,
             target_volatility=target_volatility,
+            clamp=clamp,
         )
 
     def check_global_exposure(self, symbol: str, new_alloc: float) -> bool:
@@ -412,6 +414,7 @@ class RiskService:
             price,
             volatility=volatility,
             target_volatility=target_volatility,
+            clamp=False,
         )
         delta = unsigned if side.lower() == "buy" else -unsigned
 


### PR DESCRIPTION
## Summary
- limit `calc_position_size` to [0,1] by default via `clamp` flag
- allow unbounded sizing for scaling logic in runners and backtesting
- document signal strength clamping behaviour

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_adapter_class' from 'tradingbot.cli.main')*

------
https://chatgpt.com/codex/tasks/task_e_68b77adaa2b0832da1309de23367da90