### PR TITLE
refactor: instance-based liquidity filters

### DIFF
--- a/src/tradingbot/filters/__init__.py
+++ b/src/tradingbot/filters/__init__.py
@@ -1,5 +1,5 @@
 """Filter utilities for trading strategies."""
 
-from .liquidity import LiquidityFilter, passes
+from .liquidity import LiquidityFilter, LiquidityFilterManager
 
-__all__ = ["LiquidityFilter", "passes"]
+__all__ = ["LiquidityFilter", "LiquidityFilterManager"]

--- a/src/tradingbot/strategies/arbitrage_triangular.py
+++ b/src/tradingbot/strategies/arbitrage_triangular.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 
 from .base import Strategy, Signal, record_signal_metrics
+from ..filters.liquidity import LiquidityFilterManager
 
 PARAM_INFO = {
     "taker_fee_bps": "Comisión taker por tramo en puntos básicos",
@@ -87,6 +88,9 @@ def compute_edge(
     else:
         return TriEdge(direction="m->b", gross=edge_mb, net=edge_mb, prices=prices)
 
+liquidity = LiquidityFilterManager()
+
+
 class TriangularArb(Strategy):
     """Naive triangular arbitrage strategy based on three market prices.
 
@@ -114,7 +118,7 @@ class TriangularArb(Strategy):
         # Accept optional ``risk_service`` for interface compatibility.
         self.risk_service = kwargs.get("risk_service")
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: Dict[str, Dict[str, float]]) -> Optional[Signal]:
         prices = bar.get("prices") if isinstance(bar, dict) else None
         if not prices:

--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -3,6 +3,7 @@ import pandas as pd
 from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import atr, keltner_channels
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
 PARAM_INFO = {
     "ema_n": "Periodo de la EMA para la línea central",
@@ -10,6 +11,9 @@ PARAM_INFO = {
     "vol_quantile": "Percentil base para filtrar baja volatilidad (1m)",
     "offset_frac": "Fracción base del ATR usada como offset (1m)",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class BreakoutATR(Strategy):
@@ -61,7 +65,7 @@ class BreakoutATR(Strategy):
         factors = {"s": 1 / 60, "m": 1, "h": 60, "d": 1440}
         return value * factors.get(unit, 1.0)
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < max(self.ema_n, self.atr_n) + 2:

--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -1,11 +1,15 @@
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
 PARAM_INFO = {
     "lookback": "Ventana para medias y desviación estándar",
     "volatility_factor": "Factor para dimensionar según volatilidad",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class BreakoutVol(Strategy):
@@ -40,7 +44,7 @@ class BreakoutVol(Strategy):
         self.min_volatility = 0.0
         self._rq = RollingQuantileCache()
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.lookback + 1:

--- a/src/tradingbot/strategies/cash_and_carry.py
+++ b/src/tradingbot/strategies/cash_and_carry.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .base import Strategy, Signal, record_signal_metrics
+from ..filters.liquidity import LiquidityFilterManager
 
 try:  # optional persistence
     from ..storage.timescale import get_engine, insert_cross_signal
@@ -38,6 +39,9 @@ class CashCarryConfig:
     persist_pg: bool = False
 
 
+liquidity = LiquidityFilterManager()
+
+
 class CashAndCarry(Strategy):
     """Simple cash-and-carry strategy using spot vs perpetual futures funding.
 
@@ -68,7 +72,7 @@ class CashAndCarry(Strategy):
         self.cfg = cfg or CashCarryConfig(**kwargs)
         self.engine = get_engine() if (self.cfg.persist_pg and _CAN_PG) else None
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Optional[Signal]:
         spot = bar.get("spot")
         perp = bar.get("perp")

--- a/src/tradingbot/strategies/composite_signals.py
+++ b/src/tradingbot/strategies/composite_signals.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from typing import Sequence, Type
 
 from .base import Strategy, Signal, record_signal_metrics
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
     "strategies": "Lista de subestrategias y sus parámetros",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class CompositeSignals(Strategy):
@@ -31,7 +35,7 @@ class CompositeSignals(Strategy):
                 # instantiating without it to preserve backward compatibility.
                 self.sub_strategies.append(cls(**params))
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df = bar.get("window")
         if df is None:

--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -4,6 +4,10 @@ import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import depth_imbalance
+from ..filters.liquidity import LiquidityFilterManager
+
+
+liquidity = LiquidityFilterManager()
 
 
 PARAM_INFO = {
@@ -32,7 +36,7 @@ class DepthImbalance(Strategy):
         self.percentile = percentile
         self.risk_service = kwargs.get("risk_service")
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         needed = {"bid_qty", "ask_qty"}

--- a/src/tradingbot/strategies/liquidity_events.py
+++ b/src/tradingbot/strategies/liquidity_events.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import book_vacuum, liquidity_gap
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -14,6 +15,9 @@ PARAM_INFO = {
     "vol_window": "Ventana para calcular la volatilidad",
     "dynamic_thresholds": "Ajustar umbrales según volatilidad",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class LiquidityEvents(Strategy):
@@ -67,7 +71,7 @@ class LiquidityEvents(Strategy):
                 return max(5, self.vol_window // 2)
         return self.vol_window
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         needed = {"bid_qty", "ask_qty", "bid_px", "ask_px"}

--- a/src/tradingbot/strategies/mean_rev_ofi.py
+++ b/src/tradingbot/strategies/mean_rev_ofi.py
@@ -4,6 +4,7 @@ import pandas as pd
 from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import calc_ofi, returns
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -13,6 +14,9 @@ PARAM_INFO = {
     "vol_threshold": "Percentil para volatilidad máxima en bps",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class MeanRevOFI(Strategy):
@@ -72,7 +76,7 @@ class MeanRevOFI(Strategy):
         base_min = 3.0
         return max(1, int(round(self.vol_window * base_min / tf_min)))
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         last_close = float(df["close"].iloc[-1]) if "close" in df.columns else None

--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi
+from ..filters.liquidity import LiquidityFilterManager
 
 
 def _tf_to_minutes(tf: str) -> int:
@@ -11,6 +12,8 @@ def _tf_to_minutes(tf: str) -> int:
     if tf.endswith("h"):
         return int(tf[:-1]) * 60
     raise ValueError(f"unsupported timeframe: {tf}")
+
+liquidity = LiquidityFilterManager()
 
 PARAM_INFO = {
     "rsi_n": "Ventana para el cálculo del RSI",
@@ -57,7 +60,7 @@ class MeanReversion(Strategy):
         lower = 50 - dev
         return upper, lower
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.rsi_n + 1:

--- a/src/tradingbot/strategies/ml_models.py
+++ b/src/tradingbot/strategies/ml_models.py
@@ -10,6 +10,7 @@ from sklearn.preprocessing import StandardScaler
 from joblib import dump, load
 
 from .base import Strategy, Signal, record_signal_metrics
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -17,6 +18,9 @@ PARAM_INFO = {
     "model_path": "Ruta para cargar el modelo",
     "margin": "Margen de probabilidad sobre 0.5",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class MLStrategy(Strategy):
@@ -69,7 +73,7 @@ class MLStrategy(Strategy):
         self.model.fit(X_scaled, y)
 
     # ------------------------------------------------------------------
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict[str, Any]) -> Signal | None:
         """Generate a signal for a given bar using the ML model.
 

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -3,7 +3,10 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, returns
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
+
+liquidity = LiquidityFilterManager()
 
 PARAM_INFO = {
     "rsi_n": "Ventana para el cálculo del RSI",
@@ -63,7 +66,7 @@ class Momentum(Strategy):
         thresh = rq.update(float(last_rsi))
         return 55.0 if pd.isna(thresh) else float(thresh)
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
 

--- a/src/tradingbot/strategies/order_flow.py
+++ b/src/tradingbot/strategies/order_flow.py
@@ -4,6 +4,7 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import calc_ofi
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -12,6 +13,9 @@ PARAM_INFO = {
     "sell_threshold": "Umbral de venta en bps",
     "min_volatility": "Volatilidad mínima reciente en bps",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class OrderFlow(Strategy):
@@ -39,7 +43,7 @@ class OrderFlow(Strategy):
         self.risk_service = kwargs.get("risk_service")
         self._rq = RollingQuantileCache()
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         needed = {"bid_qty", "ask_qty"}

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from .base import Strategy, Signal, load_params, record_signal_metrics
 from ..data.features import rsi
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -53,6 +54,9 @@ class ScalpPingPongConfig:
     trend_threshold: float = 10.0
 
 
+liquidity = LiquidityFilterManager()
+
+
 class ScalpPingPong(Strategy):
     """Mean-reversion scalping strategy using z-score of returns."""
 
@@ -81,7 +85,7 @@ class ScalpPingPong(Strategy):
         z = (returns.iloc[-1] - mean) / std
         return float(z)
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         tf = int(bar.get("timeframe", 1)) or 1

--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -2,6 +2,7 @@ import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, calc_ofi
 from ..utils.rolling_quantile import RollingQuantileCache
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -9,6 +10,9 @@ PARAM_INFO = {
     "min_volatility": "Volatilidad mínima requerida",
     "vol_lookback": "Ventana para calcular la volatilidad (minutos)",
 }
+
+
+liquidity = LiquidityFilterManager()
 
 
 class TrendFollowing(Strategy):
@@ -59,7 +63,7 @@ class TrendFollowing(Strategy):
         thresh = base + vol_bps * 0.5
         return max(55.0, min(90.0, thresh))
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         tf = bar.get("timeframe")

--- a/src/tradingbot/strategies/triple_barrier.py
+++ b/src/tradingbot/strategies/triple_barrier.py
@@ -3,6 +3,7 @@ from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.base import ClassifierMixin
 
 from .base import Strategy, Signal, record_signal_metrics, load_params
+from ..filters.liquidity import LiquidityFilterManager
 
 
 PARAM_INFO = {
@@ -105,6 +106,9 @@ def triple_barrier_labels(
     return labels
 
 
+liquidity = LiquidityFilterManager()
+
+
 class TripleBarrier(Strategy):
     """Strategy using triple-barrier labeling and a gradient boosting model."""
 
@@ -153,7 +157,7 @@ class TripleBarrier(Strategy):
         )
         return feat
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
         if len(df) < self.training_window:

--- a/tests/broker/test_place_limit.py
+++ b/tests/broker/test_place_limit.py
@@ -3,6 +3,7 @@ import pytest
 from tradingbot.broker import Broker
 from tradingbot.execution.paper import PaperAdapter
 from tradingbot.strategies.base import Strategy, Signal, record_signal_metrics
+from tradingbot.filters.liquidity import LiquidityFilterManager
 
 
 class DummyAdapter:
@@ -82,10 +83,13 @@ class ExpiringAdapter:
         return {"status": "canceled"}
 
 
+liquidity = LiquidityFilterManager()
+
+
 class DummyStrategy(Strategy):
     name = "dummy"
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar):
         return Signal(bar.get("side", "buy"), 1.0)
 

--- a/tests/strategies/test_execution_callbacks.py
+++ b/tests/strategies/test_execution_callbacks.py
@@ -3,12 +3,16 @@ import pytest
 from tradingbot.strategies.base import Strategy, Signal, record_signal_metrics
 from tradingbot.execution.order_types import Order
 from tradingbot.execution.router import ExecutionRouter
+from tradingbot.filters.liquidity import LiquidityFilterManager
+
+
+liquidity = LiquidityFilterManager()
 
 
 class DummyStrategy(Strategy):
     name = "dummy"
 
-    @record_signal_metrics
+    @record_signal_metrics(liquidity)
     def on_bar(self, bar):
         # Always emit the side provided in the bar for testing
         return Signal(bar.get("side", "buy"), 1.0)


### PR DESCRIPTION
## Summary
- encapsulate liquidity tracking in `LiquidityFilterManager` with thread-safe state
- use per-strategy liquidity instances via updated `record_signal_metrics`
- adjust strategies and tests to instantiate and pass liquidity managers

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'get_adapter_class' from 'tradingbot.cli.main')*
- `pytest tests/test_liquidity_filter.py tests/strategies/test_execution_callbacks.py tests/broker/test_place_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77f658020832d82bf0357e89bfae4