### PR TITLE
feat: refresh router fees and track stale venues

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     router_slippage_weight: float = 1.0
     router_queue_weight: float = 1.0
     router_max_book_age_ms: float = 1000.0
+    router_fee_update_interval_sec: float = 3600.0
 
     # Risk manager defaults
     risk_pct: float = 0.0

--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -31,6 +31,8 @@ balance:
   interval: 60.0
   assets: []
 
+router_fee_update_interval_sec: 3600.0
+
 execution:
   limit_offset_ticks: 1.0
   limit_expiry_sec: 1.0

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -94,6 +94,19 @@ MAKER_TAKER_RATIO = Gauge(
     ["venue"],
 )
 
+# Venue selection metrics
+ROUTER_SELECTED_VENUE = Counter(
+    "router_selected_venue_total",
+    "Total venue selections by router",
+    ["venue", "path"],
+)
+
+ROUTER_STALE_BOOK = Counter(
+    "router_stale_book_total",
+    "Venues skipped due to stale order book data",
+    ["venue"],
+)
+
 # --- Additional high level trading metrics ---
 
 # Current profit and loss in USD

--- a/tests/test_execution_router_fee_update.py
+++ b/tests/test_execution_router_fee_update.py
@@ -1,0 +1,82 @@
+import asyncio
+import time
+
+import pytest
+
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.order_types import Order
+from tradingbot.config import settings
+from tradingbot.utils.metrics import ROUTER_SELECTED_VENUE, ROUTER_STALE_BOOK
+
+
+class FeeAdapter:
+    def __init__(self):
+        self.name = "fee"
+        self.maker_fee_bps = 0.0
+        self.taker_fee_bps = 0.0
+        self.state = type("S", (), {"order_book": {}, "last_px": {}})()
+        self.calls = 0
+
+    async def place_order(self, **kwargs):  # pragma: no cover - not used
+        return {"status": "filled", **kwargs}
+
+    async def update_fees(self, symbol: str | None = None) -> None:
+        self.calls += 1
+        self.maker_fee_bps = 1.0
+        self.taker_fee_bps = 2.0
+
+
+class MockAdapter:
+    def __init__(self, name, order_book):
+        self.name = name
+        self.state = type("S", (), {"order_book": order_book, "last_px": {}})()
+        self.maker_fee_bps = 0.0
+        self.taker_fee_bps = 0.0
+
+    async def place_order(self, **kwargs):  # pragma: no cover - not used
+        return {"status": "filled", **kwargs}
+
+    async def update_fees(self, symbol: str | None = None) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_router_periodic_fee_update(monkeypatch):
+    monkeypatch.setattr(settings, "router_fee_update_interval_sec", 0.1)
+    adapter = FeeAdapter()
+    router = ExecutionRouter(adapter)
+    await asyncio.sleep(0.15)
+    assert adapter.calls >= 1
+    assert adapter.maker_fee_bps == 1.0
+    assert adapter.taker_fee_bps == 2.0
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_best_venue_records_metrics(monkeypatch):
+    ROUTER_SELECTED_VENUE.clear()
+    ROUTER_STALE_BOOK.clear()
+    ts = time.time()
+    ob1 = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(100.0, 1.0)], "ts": ts - 10}}
+    ob2 = {"XYZ": {"bids": [(99.0, 1.0)], "asks": [(100.0, 1.0)], "ts": ts}}
+    a1 = MockAdapter("a1", ob1)
+    a2 = MockAdapter("a2", ob2)
+    monkeypatch.setattr(settings, "router_max_book_age_ms", 1000.0)
+    router = ExecutionRouter([a1, a2], prefer="taker")
+    order = Order(symbol="XYZ", side="buy", type_="market", qty=1.0)
+    sel = await router.best_venue(order)
+    assert sel is a2
+
+    samples = list(ROUTER_STALE_BOOK.collect())[0].samples
+    stale_sample = [s for s in samples if s.labels["venue"] == "a1"][0]
+    assert stale_sample.value == 1.0
+
+    samples = list(ROUTER_SELECTED_VENUE.collect())[0].samples
+    selected_sample = [
+        s
+        for s in samples
+        if s.labels["venue"] == "a2" and s.labels["path"] == "taker"
+    ][0]
+    assert selected_sample.value == 1.0
+    await router.close()
+


### PR DESCRIPTION
## Summary
- periodically refresh maker/taker fees from adapters
- skip venues with stale books and expose selection metrics
- add tests for fee updates and venue metrics

## Testing
- `pytest tests/test_execution_router_fee_update.py tests/test_execution_router_extra.py::test_best_venue_fallback tests/test_execution_router_slippage.py::test_best_venue_skips_stale_book -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77f6465dc832d8cfd42fd552ea31d