### PR TITLE
fix(api): update adapter utility import

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -37,7 +37,7 @@ from monitoring.dashboard import router as dashboard_router
 from ...storage.timescale import select_recent_fills
 from ...utils.metrics import REQUEST_COUNT, REQUEST_LATENCY
 from ...config import settings
-from ...cli.main import get_adapter_class, get_supported_kinds
+from ...cli.utils import get_adapter_class, get_supported_kinds
 from ...exchanges import SUPPORTED_EXCHANGES
 from ...core.symbols import normalize as normalize_symbol
 


### PR DESCRIPTION
## Summary
- fix import in API main to reference cli.utils module

## Testing
- `pytest` *(killed)*
- `docker-compose build api` *(command not found: docker-compose)*
- `docker-compose up -d api` *(command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68b782afe61c832d9df1fb58359dfbcb