### PR TITLE
Enhance breakout and momentum strategies

### DIFF
--- a/src/tradingbot/core/risk_manager.py
+++ b/src/tradingbot/core/risk_manager.py
@@ -152,16 +152,26 @@ class RiskManager:
 
     # ------------------------------------------------------------------
     # Stop management helpers
-    def initial_stop(self, entry_price: float, side: str, atr: float | None = None) -> float:
+    def initial_stop(
+        self,
+        entry_price: float,
+        side: str,
+        atr: float | None = None,
+        *,
+        atr_mult: float | None = None,
+    ) -> float:
         """Return the initial stop price for a new position.
 
         When ``atr`` is supplied the stop is offset by ``atr_mult * atr`` to
-        incorporate market volatility.  If ``atr`` is ``None`` the stop falls
-        back to a fixed percentage distance based on :attr:`risk_pct`.
+        incorporate market volatility.  ``atr_mult`` defaults to the instance's
+        configured multiplier but can be overridden per-call to adapt stops to
+        different timeframes.  If ``atr`` is ``None`` the stop falls back to a
+        fixed percentage distance based on :attr:`risk_pct`.
         """
 
         if atr is not None:
-            delta = float(self.atr_mult) * float(atr)
+            mult = float(atr_mult) if atr_mult is not None else float(self.atr_mult)
+            delta = mult * float(atr)
         else:
             delta = float(entry_price) * float(self.risk_pct)
         if side.lower() in {"buy", "long"}:

--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -1,7 +1,7 @@
 import math
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
-from ..data.features import rsi, returns
+from ..data.features import rsi, returns, atr
 from ..utils.rolling_quantile import RollingQuantileCache
 from ..filters.liquidity import LiquidityFilterManager
 
@@ -31,7 +31,13 @@ class Momentum(Strategy):
     name = "momentum"
 
     def __init__(self, **kwargs):
+        self.fast_ema = kwargs.get("fast_ema", 10)
+        self.slow_ema = kwargs.get("slow_ema", 30)
         self.rsi_n = kwargs.get("rsi_n", 14)
+        self.atr_n = kwargs.get("atr_n", 14)
+        self.use_rsi = kwargs.get("use_rsi", True)
+        self.use_roc = kwargs.get("use_roc", False)
+        self.roc_n = kwargs.get("roc_n", 10)
         # Optional market activity filters
         self.min_volume = kwargs.get("min_volume")
         self.min_volatility = kwargs.get("min_volatility")
@@ -71,17 +77,32 @@ class Momentum(Strategy):
         df: pd.DataFrame = bar["window"]
 
         tf_min = self._tf_to_minutes(bar.get("timeframe"))
+        fast_n = max(2, int(math.ceil(self.fast_ema / tf_min)))
+        slow_n = max(2, int(math.ceil(self.slow_ema / tf_min)))
         rsi_n = max(2, int(math.ceil(self.rsi_n / tf_min)))
+        atr_n = max(2, int(math.ceil(self.atr_n / tf_min)))
         vol_window = max(2, int(math.ceil(self.vol_window / tf_min)))
 
-        if len(df) < rsi_n + 2:
+        if len(df) < max(slow_n, rsi_n, atr_n) + 2:
             return None
 
         closes = df["close"]
         price = float(closes.iloc[-1])
+
+        fast_ema = closes.ewm(span=fast_n, adjust=False).mean()
+        slow_ema = closes.ewm(span=slow_n, adjust=False).mean()
+        prev_fast, prev_slow = fast_ema.iloc[-2], slow_ema.iloc[-2]
+        last_fast, last_slow = float(fast_ema.iloc[-1]), float(slow_ema.iloc[-1])
+        slope = float(slow_ema.iloc[-1] - slow_ema.iloc[-2])
+
         rsi_series = rsi(df, rsi_n)
-        prev_rsi = rsi_series.iloc[-2]
         last_rsi = float(rsi_series.iloc[-1])
+
+        roc_val = float(closes.pct_change(self.roc_n).iloc[-1]) if self.use_roc else 0.0
+
+        atr_series = atr(df, atr_n)
+        atr_val = float(atr_series.iloc[-1])
+        bar["atr"] = atr_val
 
         # Optional inactivity filters
         min_vol = self.min_volume
@@ -116,18 +137,53 @@ class Momentum(Strategy):
             if pd.isna(vol) or vol < min_volatility:
                 return None
 
-        threshold = self.auto_threshold(symbol, last_rsi, rsi_n)
-        upper = threshold
-        lower = 100 - threshold
+        # Determinar reglas según timeframe
+        require_confirm = tf_min >= 15
         side: str | None = None
-        if prev_rsi <= upper and last_rsi > upper:
-            side = "buy"
-        elif prev_rsi >= lower and last_rsi < lower:
-            side = "sell"
+        if prev_fast <= prev_slow and last_fast > last_slow:
+            cond = slope > 0
+            if require_confirm and self.use_rsi:
+                cond = cond and last_rsi > 50
+            if require_confirm and self.use_roc:
+                cond = cond and roc_val > 0
+            if cond:
+                side = "buy"
+        elif prev_fast >= prev_slow and last_fast < last_slow:
+            cond = slope < 0
+            if require_confirm and self.use_rsi:
+                cond = cond and last_rsi < 50
+            if require_confirm and self.use_roc:
+                cond = cond and roc_val < 0
+            if cond:
+                side = "sell"
         if side is None:
             return None
+
+        if symbol:
+            if not hasattr(self, "_last_atr"):
+                self._last_atr: dict[str, float] = {}
+            self._last_atr[symbol] = atr_val
+
         strength = 1.0
         sig = Signal(side, strength)
+
+        if self.risk_service is not None:
+            stop_mult = 1.5 if tf_min <= 5 else 2.0
+            qty = self.risk_service.calc_position_size(strength, price)
+            stop = self.risk_service.initial_stop(
+                price, side, atr_val, atr_mult=stop_mult
+            )
+            max_hold = 10 if tf_min <= 5 else 20
+            self.trade = {
+                "side": side,
+                "entry_price": price,
+                "qty": qty,
+                "stop": stop,
+                "atr": atr_val,
+                "bars_held": 0,
+                "max_hold": max_hold,
+            }
+
         return self.finalize_signal(bar, price, sig)
 
 


### PR DESCRIPTION
## Summary
- Tune BreakoutATR lookbacks and stops by timeframe, add volume filter and max hold logic
- Rework Momentum strategy using EMA cross with optional RSI/ROC confirmation and ATR-based risk
- Allow per-call ATR multipliers and bar-based exit management in risk service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86a314e1c832dbc20b8d4a1f20d49