### PR TITLE
feat: vectorized backtesting support

### DIFF
--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -354,7 +354,8 @@ def test_run_vectorbt_basic():
 
     class MAStrategy:
         @staticmethod
-        def signal(close, fast, slow):
+        def signal(df, fast, slow):
+            close = df["close"]
             fast_ma = vbt_local.MA.run(close, fast)
             slow_ma = vbt_local.MA.run(close, slow)
             entries = fast_ma.ma_crossed_above(slow_ma)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -61,6 +61,16 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy, timefr
     assert trade["stop"] == pytest.approx(expected_stop)
 
 
+def test_breakout_atr_vector_signal(breakout_df_buy):
+    data = breakout_df_buy.copy()
+    data["volume"] = 100
+    entries, exits = BreakoutATR.signal(
+        data, ema_n=2, atr_n=2, mult=1.0, volume_factor=0
+    )
+    assert entries.iloc[-1]
+    assert not exits.iloc[-1]
+
+
 def test_order_flow_signals():
     df_buy = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- add vectorized strategy interface and data-first run_vectorbt helper
- expose vectorized breakout_atr signals to avoid per-bar recalculation
- cover vectorized path with focused tests

## Testing
- `pytest tests/test_strategies.py::test_breakout_atr_vector_signal tests/test_backtest_engine.py::test_run_vectorbt_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4d315ac832d8860a95a7115da67