### PR TITLE
Remove bot output JSON display from bots page

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -102,7 +102,6 @@
         <div id="bot-strategy-params" class="param-grid"></div>
       </div>
       <button id="bot-start" style="margin-top:10px">Start</button>
-      <pre id="bot-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
     </div>
 
   <div class="card" style="margin-top:16px">
@@ -264,13 +263,12 @@ async function startBot(){
     if(Object.keys(params).length){
       try{ await fetch(api(`/strategies/${strategy}/params`), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(params)}); }catch(e){}
     }
-    try{
-      const r = await fetch(api('/bots'), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
-      const j = await r.json();
-      document.getElementById('bot-output').textContent = JSON.stringify(j,null,2);
-      refreshBots();
-  }catch(e){ document.getElementById('bot-output').textContent = String(e); }
-}
+      try{
+        const r = await fetch(api('/bots'), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
+        await r.json();
+        refreshBots();
+    }catch(e){ console.error(e); }
+  }
 
 async function refreshBots(){
   try{


### PR DESCRIPTION
## Summary
- drop unused `<pre id="bot-output">` element from bots.html
- stop `startBot` from writing API response or errors to removed element

## Testing
- `pytest tests/test_adapter_base.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb742a0660832d8773d1e65e91afd5