### PR TITLE
chore: remove unused bot controls

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -301,15 +301,6 @@ async function refreshBots(){
   <button class="icon-btn" onclick="resumeBot(${b.pid})" title="Resume">
     <i class="fa-solid fa-play"></i>
   </button>
-  <button class="icon-btn warn" onclick="haltBot(${b.pid})" title="Halt">
-    <i class="fa-solid fa-hand"></i>
-  </button>
-  <button class="icon-btn danger" onclick="flattenBot(${b.pid})" title="Flatten">
-    <i class="fa-solid fa-bomb"></i>
-  </button>
-  <button class="icon-btn" onclick="reloadBot(${b.pid})" title="Reload">
-    <i class="fa-solid fa-rotate-right"></i>
-  </button>
   <button class="icon-btn" onclick="stopBot(${b.pid})" title="Stop">
     <i class="fa-solid fa-stop"></i>
   </button>
@@ -340,9 +331,6 @@ async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST
 async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
 async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
 async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
-async function haltBot(pid){ await fetch(api(`/bots/${pid}/halt`), {method:'POST'}); refreshBots(); }
-async function flattenBot(pid){ await fetch(api(`/bots/${pid}/flatten`), {method:'POST'}); refreshBots(); }
-async function reloadBot(pid){ await fetch(api(`/bots/${pid}/reload`), {method:'POST'}); refreshBots(); }
 
 async function refreshRisk(){
   try{

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -97,3 +97,15 @@ def test_cross_arbitrage_start(monkeypatch):
     assert "binance_spot" in argv and "binance_futures" in argv
     assert "--notional" not in argv
 
+
+def test_dashboard_missing_bot_controls():
+    client = TestClient(app)
+    resp = client.get("/bots", headers={"Accept": "text/html"}, auth=("admin", "admin"))
+    assert resp.status_code == 200
+    html = resp.text
+    assert "haltBot" not in html
+    assert "flattenBot" not in html
+    assert "reloadBot" not in html
+    for path in ["halt", "flatten", "reload"]:
+        r = client.post(f"/bots/123/{path}", auth=("admin", "admin"))
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary
- remove unused halt/flatten/reload controls from bots dashboard
- add tests asserting dashboard and API lack those controls

## Testing
- `pytest tests/test_api_bots.py::test_bot_endpoints tests/test_api_bots.py::test_cross_arbitrage_start tests/test_api_bots.py::test_dashboard_missing_bot_controls -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb74738a8c832dbb97f29582c0118d