### PR TITLE
Ensure bot subprocesses inherit environment

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -981,10 +981,14 @@ async def start_bot(cfg: BotConfig):
 
     params = _strategy_params.get(cfg.strategy, {})
     args = _build_bot_args(cfg, params)
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[3]
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}" + env.get("PYTHONPATH", "")
     proc = await asyncio.create_subprocess_exec(
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=env,
     )
     _BOTS[proc.pid] = {"process": proc, "config": cfg.dict()}
     return {"pid": proc.pid, "status": "started"}

--- a/tests/test_bot_env.py
+++ b/tests/test_bot_env.py
@@ -1,0 +1,48 @@
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from tradingbot.apps.api import main as api_main
+
+
+class DummyProc:
+    def __init__(self):
+        self.pid = 999
+        self.returncode = None
+        self.stdout = None
+        self.stderr = None
+
+    async def wait(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_start_bot_inherits_env_and_running(monkeypatch):
+    monkeypatch.setenv("PGUSER", "alice")
+
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return DummyProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(api_main, "_build_bot_args", lambda cfg, params=None: ["echo", "hi"])
+
+    api_main._BOTS.clear()
+
+    cfg = api_main.BotConfig(strategy="dummy")
+    await api_main.start_bot(cfg)
+
+    env = captured["env"]
+    assert env["PGUSER"] == "alice"
+    repo_root = Path(api_main.__file__).resolve().parents[3]
+    assert env["PYTHONPATH"].startswith(str(repo_root))
+
+    class DummyReq:
+        headers = {}
+
+    status = api_main.list_bots(DummyReq())
+    assert status["bots"][0]["status"] == "running"


### PR DESCRIPTION
## Summary
- Copy parent environment and prefix repo path to PYTHONPATH when starting bots
- Pass environment to bot subprocesses so DB credentials are inherited
- Add regression test verifying PGUSER propagation and running status

## Testing
- `pytest tests/test_api_bots.py tests/test_bot_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb80413668832daf1bb9519459a03c