### PR TITLE
Implement arbitrage risk service and net edge checks

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -88,7 +88,10 @@ las tasas de cambio.
 
 ### Arbitraje entre Exchanges (`cross_exchange_arbitrage`)
 Compara el precio entre un mercado spot y uno de futuros (perpetuo) y opera
-cuando la diferencia supera un umbral.
+cuando la diferencia neta –descontando comisiones y slippage– supera un umbral.
+Un servicio de riesgo específico limita la exposición de cada operación y
+permite inyectar una latencia simulada para evaluar el deterioro de la
+oportunidad.
 
 ### Composite Signals (`composite_signals`)
 Combina múltiples subestrategias y emite una señal cuando hay consenso.

--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -24,6 +24,25 @@ class Broker:
         )
         self.passive_rebate_bps = getattr(settings, "passive_rebate_bps", 0.0)
 
+    def update_last_price(self, symbol: str, px: float) -> None:
+        """Update last price on the underlying adapter if supported."""
+        upd = getattr(self.adapter, "update_last_price", None)
+        if upd:
+            upd(symbol, px)
+
+    def equity(self) -> float:
+        """Return account equity if the adapter exposes it."""
+        eq = getattr(self.adapter, "equity", None)
+        if callable(eq):
+            try:
+                return float(eq())
+            except Exception:
+                return 0.0
+        bal = getattr(self.adapter, "account", None)
+        if bal is not None and hasattr(bal, "equity"):
+            return float(getattr(bal, "equity", 0.0))
+        return 0.0
+
     async def place_limit(
         self,
         symbol: str,

--- a/src/tradingbot/risk/__init__.py
+++ b/src/tradingbot/risk/__init__.py
@@ -1,6 +1,7 @@
 """Risk package public API."""
 
 from .exceptions import StopLossExceeded
+from .arbitrage_service import ArbitrageRiskService, ArbGuardConfig
 
-__all__ = ["StopLossExceeded"]
+__all__ = ["StopLossExceeded", "ArbitrageRiskService", "ArbGuardConfig"]
 

--- a/src/tradingbot/risk/arbitrage_service.py
+++ b/src/tradingbot/risk/arbitrage_service.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Simple risk utilities dedicated to arbitrage strategies.
+
+The generic :mod:`tradingbot.risk.service` module contains a rather heavyweight
+risk manager tailored for directional strategies.  The arbitrage strategies in
+this repository only need a lightweight component that validates whether an
+opportunity remains profitable after accounting for fees and slippage and that
+keeps track of a few exposure caps.  This module purposely implements just that
+subset so triangular and cross‑exchange arbitrage can operate without pulling in
+all the machinery from :class:`RiskService`.
+"""
+
+from dataclasses import dataclass, field
+import asyncio
+from collections import defaultdict
+from typing import Dict, Tuple
+
+
+@dataclass
+class ArbGuardConfig:
+    """Configuration for :class:`ArbitrageRiskService`.
+
+    Parameters
+    ----------
+    max_position_usd:
+        Upper bound for the notional allocated to a single trade.
+    max_open_trades:
+        Maximum number of simultaneous open arbitrage trades.
+    min_edge:
+        Minimum net edge required to deploy capital.
+    slippage_buffer_bps:
+        Additional buffer to subtract from the edge to account for
+        unexpected slippage.  Expressed in basis points.
+    """
+
+    max_position_usd: float = float("inf")
+    max_open_trades: int = 1
+    min_edge: float = 0.0
+    slippage_buffer_bps: float = 0.0
+
+
+class ArbitrageRiskService:
+    """Lightweight risk helper for arbitrage strategies.
+
+    The service exposes a minimal async API that guards capital allocation and
+    keeps track of open exposures.  It deliberately avoids the complexity of the
+    generic risk engine while still providing basic limits and validations that
+    are relevant for arbitrage where trades are expected to be hedged quickly.
+    """
+
+    def __init__(self, cfg: ArbGuardConfig | None = None) -> None:
+        self.cfg = cfg or ArbGuardConfig()
+        self._open_trades = 0
+        self._lock = asyncio.Lock()
+        self._positions: Dict[str, float] = defaultdict(float)
+
+    async def evaluate(
+        self,
+        symbol: str,
+        edge: float,
+        price_ref: float,
+        account_equity: float,
+        *,
+        fees: float = 0.0,
+        slippage: float = 0.0,
+    ) -> Tuple[float, float]:
+        """Validate an opportunity and return the allowed notional.
+
+        Parameters
+        ----------
+        symbol:
+            Market symbol being evaluated.
+        edge:
+            Raw edge expressed as a decimal (e.g. ``0.001`` for 10 bps).
+        price_ref:
+            Reference price used to translate notional into quantity.
+        account_equity:
+            Equity available for arbitrage expressed in quote currency.
+        fees:
+            Sum of fees across all legs expressed as a decimal.
+        slippage:
+            Expected slippage across all legs expressed as a decimal.
+
+        Returns
+        -------
+        tuple
+            ``(notional, net_edge)`` where ``notional`` is the capital to
+            allocate (0 if the trade is rejected) and ``net_edge`` is the edge
+            after deductions.
+        """
+
+        async with self._lock:
+            net_edge = edge - fees - slippage - self.cfg.slippage_buffer_bps / 10000.0
+            if net_edge <= self.cfg.min_edge:
+                return 0.0, net_edge
+            if self._open_trades >= self.cfg.max_open_trades:
+                return 0.0, net_edge
+            notional = min(self.cfg.max_position_usd, account_equity * abs(net_edge))
+            if notional <= 0:
+                return 0.0, net_edge
+            self._open_trades += 1
+            return notional, net_edge
+
+    async def on_fill(self, symbol: str, side: str, qty: float) -> None:
+        """Record a fill and release an open trade slot."""
+        async with self._lock:
+            signed = float(qty) if side == "buy" else -float(qty)
+            self._positions[symbol] += signed
+            if self._open_trades > 0:
+                self._open_trades -= 1
+
+    def exposure(self, symbol: str) -> float:
+        """Return current net position for ``symbol``."""
+        return self._positions.get(symbol, 0.0)
+
+
+__all__ = ["ArbitrageRiskService", "ArbGuardConfig"]

--- a/tests/test_arbitrage_risk_service.py
+++ b/tests/test_arbitrage_risk_service.py
@@ -1,0 +1,18 @@
+import pytest
+from tradingbot.risk.arbitrage_service import ArbitrageRiskService, ArbGuardConfig
+
+
+@pytest.mark.asyncio
+async def test_risk_service_rejects_negative_edge():
+    risk = ArbitrageRiskService(ArbGuardConfig(min_edge=0.0))
+    notional, net = await risk.evaluate("BTC/USDT", edge=0.01, price_ref=100.0, account_equity=1000.0, fees=0.02)
+    assert notional == 0.0
+    assert net < 0
+
+
+@pytest.mark.asyncio
+async def test_risk_service_caps_position_size():
+    cfg = ArbGuardConfig(max_position_usd=50.0)
+    risk = ArbitrageRiskService(cfg)
+    notional, _ = await risk.evaluate("BTC/USDT", edge=0.05, price_ref=100.0, account_equity=1000.0)
+    assert notional == pytest.approx(50.0)

--- a/tests/test_cross_exchange_arbitrage_rebalance.py
+++ b/tests/test_cross_exchange_arbitrage_rebalance.py
@@ -17,10 +17,10 @@ class MockAdapter:
         for t in self._trades:
             yield t
 
-    async def place_order(self, symbol, side, type_, qty):
+    async def place_order(self, symbol, side, type_, qty, price=None, **kwargs):
         self.orders.append({"symbol": symbol, "side": side, "qty": qty})
-        price = self._trades[0]["price"]
-        return {"status": "filled", "price": price}
+        px = price if price is not None else self._trades[0]["price"]
+        return {"status": "filled", "price": px}
 
     async def fetch_balance(self):
         return self._balances


### PR DESCRIPTION
## Summary
- add dedicated `ArbitrageRiskService` with configurable limits
- account for fees and slippage in cross-exchange arbitrage
- document new arbitrage risk considerations and latency simulation

## Testing
- `pytest tests/test_arbitrage_risk_service.py tests/test_cross_exchange_arbitrage.py tests/test_cross_exchange_arbitrage_rebalance.py tests/test_arbitrage_triangular.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c72bb64832d8ebc140e7d00124d