### PR TITLE
refactor: unify Binance adapter import

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -10,7 +10,7 @@ import time
 
 import pandas as pd
 
-from ..adapters.binance_ws import BinanceWSAdapter
+from ..adapters.binance import BinanceWSAdapter
 from ..execution.paper import PaperAdapter
 from ..execution.router import ExecutionRouter
 from ..strategies import STRATEGIES

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -7,7 +7,7 @@ import time
 import uvicorn
 
 from .runner import BarAggregator
-from ..adapters.binance_ws import BinanceWSAdapter
+from ..adapters.binance import BinanceWSAdapter
 from ..execution.paper import PaperAdapter
 from ..execution.router import ExecutionRouter
 from ..broker.broker import Broker

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -37,7 +37,7 @@ from ..broker.broker import Broker
 
 from ..adapters.binance_spot_ws import BinanceSpotWSAdapter
 from ..adapters.binance_spot import BinanceSpotAdapter
-from ..adapters.binance_ws import BinanceWSAdapter
+from ..adapters.binance import BinanceWSAdapter
 from ..adapters.binance_futures import BinanceFuturesAdapter
 from ..adapters.bybit_spot import BybitSpotAdapter as BybitSpotWSAdapter, BybitSpotAdapter
 from ..adapters.okx_spot import OKXSpotAdapter as OKXSpotWSAdapter, OKXSpotAdapter

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -23,7 +23,7 @@ from ..broker.broker import Broker
 
 from ..adapters.binance_spot_ws import BinanceSpotWSAdapter
 from ..adapters.binance_spot import BinanceSpotAdapter
-from ..adapters.binance_ws import BinanceWSAdapter
+from ..adapters.binance import BinanceWSAdapter
 from ..adapters.binance_futures import BinanceFuturesAdapter
 from ..adapters.bybit_spot import BybitSpotAdapter as BybitSpotWSAdapter, BybitSpotAdapter
 from ..adapters.okx_spot import OKXSpotAdapter as OKXSpotWSAdapter, OKXSpotAdapter

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -5,12 +5,14 @@ from types import SimpleNamespace
 import importlib, sys, types
 
 # runner_testnet indirectly imports a module missing in tests; inject a stub
-binance_ws_stub = types.ModuleType("tradingbot.adapters.binance_ws")
-binance_ws_stub.BinanceWSAdapter = object
-sys.modules.setdefault("tradingbot.adapters.binance_ws", binance_ws_stub)
+binance_stub = types.ModuleType("tradingbot.adapters.binance")
+binance_stub.BinanceWSAdapter = object
+sys.modules.setdefault("tradingbot.adapters.binance", binance_stub)
 
 from tradingbot.live import runner_testnet as rt
 from tradingbot.core import normalize, Account
+
+sys.modules.pop("tradingbot.adapters.binance", None)
 
 
 class DummyWS:

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -6,12 +6,14 @@ from types import SimpleNamespace
 import types, sys
 
 # runner_paper indirectly imports a module missing in tests; inject a stub
-binance_ws_stub = types.ModuleType("tradingbot.adapters.binance_ws")
-binance_ws_stub.BinanceWSAdapter = object
-sys.modules.setdefault("tradingbot.adapters.binance_ws", binance_ws_stub)
+binance_stub = types.ModuleType("tradingbot.adapters.binance")
+binance_stub.BinanceWSAdapter = object
+sys.modules.setdefault("tradingbot.adapters.binance", binance_stub)
 
 from tradingbot.live import runner_paper as rp
 from tradingbot.core import normalize
+
+sys.modules.pop("tradingbot.adapters.binance", None)
 
 
 class DummyWS:


### PR DESCRIPTION
## Summary
- use `tradingbot.adapters.binance` for BinanceWSAdapter in all live runners
- update tests to stub the new Binance adapter module

## Testing
- `pytest tests/test_live_runner.py tests/test_paper_runner.py tests/test_binance_ws_adapter.py`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf19e5cba4832d8ec094c99356d13f