### PR TITLE
feat: configurate log level and startup logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ exportarlas en la terminal antes de ejecutar el bot.
 
 ## Variables de entorno
 
+El nivel de logging puede ajustarse mediante la variable de entorno `LOG_LEVEL`:
+
+```bash
+export LOG_LEVEL=DEBUG
+```
+
 De forma predeterminada, Binance Futures opera contra el entorno real. Para
 volver a utilizar la testnet es necesario indicar explícitamente:
 

--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -39,6 +39,9 @@ def run_bot(
     daily_max_drawdown_pct: float = typer.Option(
         0.05, "--daily-max-drawdown-pct", help="Intraday max drawdown limit"
     ),
+    log_level: str = typer.Option(
+        "INFO", "--log-level", help="Logging level (e.g., INFO, DEBUG)"
+    ),
     config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
     param: list[str] = typer.Option(
         [], "--param", help="Override strategy parameters as key=value pairs"
@@ -46,7 +49,7 @@ def run_bot(
 ) -> None:
     """Run the live trading bot with configurable venue and symbols."""
 
-    setup_logging()
+    setup_logging(log_level)
     params = _parse_params(param) if isinstance(param, list) else {}
     from ...core.account import Account
     from ...risk.portfolio_guard import PortfolioGuard, GuardConfig

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -106,6 +106,7 @@ async def run_live_binance(
     Pipeline en vivo:
       WS Binance -> agregador 3m -> strategy -> Risk -> PaperAdapter
     """
+    log.info("Connecting to Binance WS for %s", symbol)
     adapter = BinanceWSAdapter()
     broker = PaperAdapter(fee_bps=fee_bps)
     strat_cls = STRATEGIES.get(strategy_name)

--- a/src/tradingbot/live/runner_cross_exchange.py
+++ b/src/tradingbot/live/runner_cross_exchange.py
@@ -41,6 +41,7 @@ async def run_cross_exchange(cfg: CrossArbConfig, risk: RiskService | None = Non
         Configuration with symbol, adapters and trading params.
     """
 
+    log.info("Starting cross exchange runner for %s", getattr(cfg, "symbol", ""))
     router = ExecutionRouter([cfg.spot, cfg.perp])
     bus = EventBus()
     adapter = PaperAdapter()

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -47,7 +47,7 @@ async def run_paper(
     params: dict | None = None,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
-
+    log.info("Connecting to Binance WS in paper mode for %s", symbol)
     adapter = BinanceWSAdapter()
     broker = PaperAdapter()
 

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -104,6 +104,7 @@ async def _run_symbol(
     config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
+    log.info("Connecting to %s %s for %s", exchange, market, cfg.symbol)
     api_key, api_secret = _get_keys(exchange)
     exec_kwargs: Dict[str, Any] = {"api_key": api_key, "api_secret": api_secret}
     if market == "futures":
@@ -322,6 +323,7 @@ async def run_live_real(
     params: dict | None = None,
 ) -> None:
     """Run a simple live loop on a real crypto exchange."""
+    log.info("Starting real runner for %s %s", exchange, market)
 
     if not i_know_what_im_doing:
         raise ValueError("Real trading requires --i-know-what-im-doing flag")

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -71,6 +71,9 @@ async def _run_symbol(
     config_path: str | None = None,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
+    log.info(
+        "Connecting to %s %s testnet for %s", exchange, market, cfg.symbol
+    )
     ws_kwargs: Dict[str, Any] = {"testnet": True}
     exec_kwargs: Dict[str, Any] = {"testnet": True}
     if market == "futures":
@@ -222,6 +225,7 @@ async def run_live_testnet(
     params: dict | None = None,
 ) -> None:
     """Run a simple live loop on a crypto exchange testnet."""
+    log.info("Starting testnet runner for %s %s", exchange, market)
     if (exchange, market) not in ADAPTERS:
         raise ValueError(f"Unsupported combination {exchange} {market}")
     symbols = symbols or ["BTC/USDT"]

--- a/src/tradingbot/live/runner_triangular.py
+++ b/src/tradingbot/live/runner_triangular.py
@@ -42,6 +42,7 @@ class TriConfig:
     persist_pg: bool = False  # <-- nuevo flag
 
 async def run_triangular_binance(cfg: TriConfig, risk: RiskService | None = None):
+    log.info("Connecting to Binance WS for triangular route %s", cfg.route)
     syms = make_symbols(cfg.route)
     streams = [_stream_name(syms.bq), _stream_name(syms.mq), _stream_name(syms.mb)]
     url = BINANCE_WS + "/".join(streams)

--- a/src/tradingbot/logging_conf.py
+++ b/src/tradingbot/logging_conf.py
@@ -13,8 +13,8 @@ except Exception:
     jsonlogger = None
 
 
-def setup_logging():
-    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+def setup_logging(level: str | None = None):
+    level = getattr(logging, (level or settings.log_level).upper(), logging.INFO)
 
     handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
 


### PR DESCRIPTION
## Summary
- add `--log-level` option to `run-bot` and allow overriding `setup_logging`
- emit initial `log.info` messages across live runners for quicker feedback
- document `LOG_LEVEL` environment variable

## Testing
- `pytest` *(killed: signal)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2b0aaf74832d812491dedbdb8c02