### PR TITLE
Add configurable timeframe support for live trading bots

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -917,6 +917,7 @@ class BotConfig(BaseModel):
     perp: str | None = None
     threshold: float | None = None
     config: str | None = None
+    timeframe: str | None = None
 
 
 _BOTS: dict[int, dict] = {}
@@ -963,6 +964,8 @@ def _build_bot_args(cfg: BotConfig, params: dict | None = None) -> list[str]:
         args.extend(["--daily-max-loss-pct", str(cfg.daily_max_loss_pct)])
     if cfg.daily_max_drawdown_pct is not None:
         args.extend(["--daily-max-drawdown-pct", str(cfg.daily_max_drawdown_pct)])
+    if cfg.timeframe is not None:
+        args.extend(["--timeframe", cfg.timeframe])
     if cfg.testnet is not None:
         args.append("--testnet" if cfg.testnet else "--no-testnet")
     if cfg.dry_run is not None:

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -86,6 +86,14 @@
         <input id="bot-daily-max-drawdown-pct" type="number" step="0.0001"/>
       </div>
       <div>
+        <label for="bot-timeframe">Timeframe</label>
+        <select id="bot-timeframe">
+          <option value="1m" selected>1m</option>
+          <option value="5m">5m</option>
+          <option value="15m">15m</option>
+        </select>
+      </div>
+      <div>
         <label for="bot-env">Entorno</label>
         <select id="bot-env">
           <option value="live">Live</option>
@@ -244,6 +252,7 @@ async function startBot(){
   const testnet = env === 'testnet';
   const dry_run = env === 'paper';
   const config = document.getElementById('bot-config').value;
+  const timeframe = document.getElementById('bot-timeframe').value;
     const spot = document.getElementById('bot-spot').value;
     const perp = document.getElementById('bot-perp').value;
     const threshold = document.getElementById('bot-threshold').value;
@@ -257,7 +266,7 @@ async function startBot(){
       else if(t.includes('float') || t.includes('number')) v=parseFloat(v);
       params[el.dataset.name]=v;
     });
-    const payload = {strategy, pairs, exchange, market, testnet, dry_run};
+    const payload = {strategy, pairs, exchange, market, testnet, dry_run, timeframe};
     if(config) payload.config = config;
     if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);

--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -27,6 +27,7 @@ def run_bot(
     testnet: bool = typer.Option(True, help="Use testnet endpoints"),
     leverage: int = typer.Option(1, help="Leverage for futures"),
     dry_run: bool = typer.Option(False, help="Dry run for futures testnet"),
+    timeframe: str = typer.Option("1m", "--timeframe", help="Bar timeframe (e.g., 1m,5m,15m)"),
     risk_pct: float = typer.Option(
         0.0,
         "--risk-pct",
@@ -74,6 +75,7 @@ def run_bot(
                 strategy_name=strategy,
                 config_path=config,
                 params=params,
+                timeframe=timeframe,
             )
         )
     else:
@@ -88,6 +90,7 @@ def run_bot(
                 strategy_name=strategy,
                 config_path=config,
                 params=params,
+                timeframe=timeframe,
             )
         )
 
@@ -107,6 +110,7 @@ def paper_run(
         callback=_parse_risk_pct,
         help="Risk manager loss percentage (0-1 or 0-100)",
     ),
+    timeframe: str = typer.Option("1m", "--timeframe", help="Bar timeframe (e.g., 1m,5m,15m)"),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
@@ -130,6 +134,7 @@ def paper_run(
             metrics_port=metrics_port,
             risk_pct=risk_pct,
             params=params,
+            timeframe=timeframe,
         )
     )
 
@@ -157,6 +162,7 @@ def real_run(
     daily_max_drawdown_pct: float = typer.Option(
         0.05, "--daily-max-drawdown-pct", help="Intraday max drawdown limit"
     ),
+    timeframe: str = typer.Option("1m", "--timeframe", help="Bar timeframe (e.g., 1m,5m,15m)"),
     i_know_what_im_doing: bool = typer.Option(
         False,
         "--i-know-what-im-doing",
@@ -190,6 +196,7 @@ def real_run(
             dry_run=dry_run,
             daily_max_loss_pct=daily_max_loss_pct,
             daily_max_drawdown_pct=daily_max_drawdown_pct,
+            timeframe=timeframe,
             i_know_what_im_doing=i_know_what_im_doing,
         )
     )

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -45,6 +45,7 @@ async def run_paper(
     corr_threshold: float = 0.8,
     risk_pct: float = 0.0,
     params: dict | None = None,
+    timeframe: str = "1m",
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
     log.info("Connecting to Binance WS in paper mode for %s", symbol)
@@ -86,7 +87,7 @@ async def run_paper(
 
     server = await _start_metrics(metrics_port)
 
-    agg = BarAggregator()
+    agg = BarAggregator(timeframe=timeframe)
     tick = getattr(settings, "tick_size", 0.0)
     purge_interval = settings.risk_purge_minutes * 60.0
     last_purge = time.time()

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -102,6 +102,7 @@ async def _run_symbol(
     strategy_name: str,
     params: dict | None = None,
     config_path: str | None = None,
+    timeframe: str = "1m",
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     log.info("Connecting to %s %s for %s", exchange, market, cfg.symbol)
@@ -113,7 +114,7 @@ async def _run_symbol(
     exec_adapter = exec_cls(**exec_kwargs)
     cfg_app = load_config()
     tick_size = float(cfg_app.exchange_configs.get(venue, {}).get("tick_size", 0.0))
-    agg = BarAggregator()
+    agg = BarAggregator(timeframe=timeframe)
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
@@ -321,6 +322,7 @@ async def run_live_real(
     strategy_name: str = "breakout_atr",
     config_path: str | None = None,
     params: dict | None = None,
+    timeframe: str = "1m",
 ) -> None:
     """Run a simple live loop on a real crypto exchange."""
     log.info("Starting real runner for %s %s", exchange, market)
@@ -354,6 +356,7 @@ async def run_live_real(
             strategy_name=strategy_name,
             params=params,
             config_path=config_path,
+            timeframe=timeframe,
         )
         for c in cfgs
     ]

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -69,6 +69,7 @@ async def _run_symbol(
     strategy_name: str,
     params: dict | None = None,
     config_path: str | None = None,
+    timeframe: str = "1m",
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     log.info(
@@ -92,7 +93,7 @@ async def _run_symbol(
             exec_adapter = exec_cls()
     cfg_app = load_config()
     tick_size = float(cfg_app.exchange_configs.get(venue, {}).get("tick_size", 0.0))
-    agg = BarAggregator()
+    agg = BarAggregator(timeframe=timeframe)
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
@@ -223,6 +224,7 @@ async def run_live_testnet(
     strategy_name: str = "breakout_atr",
     config_path: str | None = None,
     params: dict | None = None,
+    timeframe: str = "1m",
 ) -> None:
     """Run a simple live loop on a crypto exchange testnet."""
     log.info("Starting testnet runner for %s %s", exchange, market)
@@ -250,6 +252,7 @@ async def run_live_testnet(
             strategy_name=strategy_name,
             params=params,
             config_path=config_path,
+            timeframe=timeframe,
         )
         for c in cfgs
     ]


### PR DESCRIPTION
## Summary
- allow specifying bar timeframe from CLI for live, paper, and real runners
- propagate timeframe through backend `/bots` API and UI dashboard
- make `BarAggregator` accept configurable timeframes

## Testing
- `pytest` *(killed: process out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2b033c10832db2651340d174dab2