### PR TITLE
Expose risk percentage for bots

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1012,7 +1012,22 @@ def list_bots(request: Request):
     for pid, info in _BOTS.items():
         proc = info["process"]
         status = "running" if proc.returncode is None else f"stopped:{proc.returncode}"
-        items.append({"pid": pid, "status": status, "config": info["config"]})
+        cfg = info["config"]
+        stats = info.get("stats")
+        risk_pct = cfg.get("risk_pct")
+        if risk_pct is None and stats:
+            risk_pct = stats.get("risk_pct")
+        item = {
+            "pid": pid,
+            "status": status,
+            "config": cfg,
+            "risk_pct": risk_pct,
+        }
+        if stats:
+            item["stats"] = stats
+        if "last_error" in info:
+            item["last_error"] = info["last_error"]
+        items.append(item)
     return {"bots": items}
 
 

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -307,7 +307,7 @@ async function refreshBots(){
       <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
       <td>${(stats.inventory||0).toFixed(4)}</td>
       <td>${(stats.leverage||0).toFixed(2)}</td>
-      <td>${stats.risk_triggers||0}</td>
+      <td>${((b.risk_pct||0)*100).toFixed(2)}%</td>
       <td>${b.last_error||''}</td>
       <td>
   <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause">

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -51,7 +51,10 @@ def test_bot_endpoints(monkeypatch):
 
     lst = client.get("/bots", auth=("admin", "admin"))
     assert lst.status_code == 200
-    assert any(b["pid"] == pid for b in lst.json()["bots"])
+    data = lst.json()["bots"]
+    assert any(b["pid"] == pid for b in data)
+    bot = next(b for b in data if b["pid"] == pid)
+    assert bot.get("risk_pct") == payload["risk_pct"]
 
     assert client.post(f"/bots/{pid}/pause", auth=("admin", "admin")).status_code == 200
     assert client.post(f"/bots/{pid}/resume", auth=("admin", "admin")).status_code == 200


### PR DESCRIPTION
## Summary
- Include `risk_pct` in `/bots` API responses pulled from config or stats
- Display risk percentage in bots dashboard
- Test `/bots` endpoint for risk percent field

## Testing
- `pytest tests/test_api_bots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf436c4300832d950df5d9efb34be8