### PR TITLE
refactor: consolidate venue selection

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -23,19 +23,15 @@
         <label for="bot-pairs">Pares (coma)</label>
         <input id="bot-pairs" placeholder="BTC/USDT,ETH/USDT"/>
       </div>
-      <div id="field-exchange">
-        <label for="bot-exchange">Exchange</label>
-        <select id="bot-exchange">
-          <option value="binance">Binance</option>
-          <option value="bybit">Bybit</option>
-          <option value="okx">OKX</option>
-        </select>
-      </div>
-      <div id="field-market">
-        <label for="bot-market">Mercado</label>
-        <select id="bot-market">
-          <option value="spot">Spot</option>
-          <option value="futures">Futuros</option>
+      <div id="field-venue">
+        <label for="bot-venue">Venue</label>
+        <select id="bot-venue">
+          <option value="binance_spot">Binance Spot</option>
+          <option value="binance_futures">Binance Futures</option>
+          <option value="bybit_spot">Bybit Spot</option>
+          <option value="bybit_futures">Bybit Futures</option>
+          <option value="okx_spot">OKX Spot</option>
+          <option value="okx_futures">OKX Futures</option>
         </select>
       </div>
       <div id="field-leverage">
@@ -218,32 +214,31 @@ async function loadStrategyParams(name){
 }
 
 
-  function updateMarketFields(){
-    const market=document.getElementById('bot-market').value;
+  function updateVenueFields(){
+    const venue=document.getElementById('bot-venue').value;
     const strat=document.getElementById('bot-strategy').value;
     const cross=strat==='cross_arbitrage';
     const lev=document.getElementById('field-leverage');
-    lev.style.display = (!cross && market==='futures') ? '' : 'none';
+    lev.style.display = (!cross && venue.endsWith('_futures')) ? '' : 'none';
   }
 
   async function updateForm(){
     const strat=document.getElementById('bot-strategy').value;
     const cross=strat==='cross_arbitrage';
-    ['field-exchange','field-market','field-risk-pct'].forEach(id=>{
+    ['field-venue','field-risk-pct'].forEach(id=>{
       document.getElementById(id).style.display = cross ? 'none' : '';
     });
     ['field-spot','field-perp','field-threshold'].forEach(id=>{
       document.getElementById(id).style.display = cross ? '' : 'none';
     });
     await loadStrategyParams(strat);
-    updateMarketFields();
+    updateVenueFields();
   }
 
 async function startBot(){
   const strategy = document.getElementById('bot-strategy').value;
   const pairs = document.getElementById('bot-pairs').value.split(',').map(s=>s.trim()).filter(Boolean);
-  const exchange = document.getElementById('bot-exchange').value;
-  const market = document.getElementById('bot-market').value;
+  const venue = document.getElementById('bot-venue').value;
   const risk_pct = document.getElementById('bot-risk-pct').value;
   const daily_max_loss_pct = document.getElementById('bot-daily-max-loss-pct').value;
   const daily_max_drawdown_pct = document.getElementById('bot-daily-max-drawdown-pct').value;
@@ -266,7 +261,7 @@ async function startBot(){
       else if(t.includes('float') || t.includes('number')) v=parseFloat(v);
       params[el.dataset.name]=v;
     });
-    const payload = {strategy, pairs, exchange, market, testnet, dry_run, timeframe};
+    const payload = {strategy, pairs, venue, testnet, dry_run, timeframe};
     if(config) payload.config = config;
     if(risk_pct) payload.risk_pct = Number(risk_pct);
     if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);
@@ -418,12 +413,12 @@ async function resetRisk(){
 
 document.getElementById('bot-start').addEventListener('click', startBot);
 document.getElementById('bot-strategy').addEventListener('change', updateForm);
-document.getElementById('bot-market').addEventListener('change', updateMarketFields);
+document.getElementById('bot-venue').addEventListener('change', updateVenueFields);
 document.getElementById('bot-toggle-params').addEventListener('change', e => {
   document.getElementById('bot-param-card').style.display = e.target.checked ? 'block' : 'none';
 });
 loadStrategies();
-updateMarketFields();
+updateVenueFields();
 refreshBots();
 setInterval(refreshBots,5000);
 document.getElementById('cli-run').addEventListener('click', runCli);


### PR DESCRIPTION
## Summary
- replace exchange/market fields with a single venue selector in bots dashboard
- send venue in bot start payload and adjust form logic
- allow API to derive venue from legacy exchange/market fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf43651918832db7463cd31e151af0