### PR TITLE
Expose bot metrics via API

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -307,7 +307,7 @@ async function refreshBots(){
       <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
       <td>${(stats.inventory||0).toFixed(4)}</td>
       <td>${(stats.leverage||0).toFixed(2)}</td>
-      <td>${stats.risk_triggers||0}</td>
+      <td>${((stats.risk_pct||0)*100).toFixed(2)}%</td>
       <td>${b.last_error||''}</td>
       <td>
   <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause">


### PR DESCRIPTION
## Summary
- track per-bot metrics by scraping process logs
- expose runtime stats through `/bots` and dashboard
- test bot stats update path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf436875e0832d9fc9569d5d03c3c9