### PR TITLE
Expose bot risk percentage

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1075,12 +1075,18 @@ def list_bots(request: Request):
     for pid, info in _BOTS.items():
         proc = info["process"]
         status = "running" if proc.returncode is None else f"stopped:{proc.returncode}"
+        cfg = info["config"]
+        stats = info.get("stats", {})
+        risk_pct = cfg.get("risk_pct")
+        if risk_pct is None:
+            risk_pct = stats.get("risk_pct")
         items.append(
             {
                 "pid": pid,
                 "status": status,
-                "config": info["config"],
-                "stats": info.get("stats", {}),
+                "config": cfg,
+                "stats": stats,
+                "risk_pct": risk_pct,
                 "last_error": info.get("last_error"),
             }
         )

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -302,7 +302,7 @@ async function refreshBots(){
       <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
       <td>${(stats.inventory||0).toFixed(4)}</td>
       <td>${(stats.leverage||0).toFixed(2)}</td>
-      <td>${((stats.risk_pct||0)*100).toFixed(2)}%</td>
+      <td>${((b.risk_pct ?? 0)*100).toFixed(2)}%</td>
       <td>${b.last_error||''}</td>
       <td>
   <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause">

--- a/tests/test_api_bots.py
+++ b/tests/test_api_bots.py
@@ -51,7 +51,9 @@ def test_bot_endpoints(monkeypatch):
 
     lst = client.get("/bots", auth=("admin", "admin"))
     assert lst.status_code == 200
-    assert any(b["pid"] == pid for b in lst.json()["bots"])
+    bots = lst.json()["bots"]
+    assert any(b["pid"] == pid for b in bots)
+    assert any(b["pid"] == pid and b.get("risk_pct") == 0.03 for b in bots)
 
     assert client.post(f"/bots/{pid}/pause", auth=("admin", "admin")).status_code == 200
     assert client.post(f"/bots/{pid}/resume", auth=("admin", "admin")).status_code == 200


### PR DESCRIPTION
## Summary
- Include `risk_pct` from config or stats in `/bots` endpoint responses
- Display bot risk percentage in dashboard using new top-level property
- Test that API `/bots` entries include the configured risk percentage

## Testing
- `pytest tests/test_api_bots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf4a6551e8832d8e7474215c71a855