### PR TITLE
feat: allow configuring initial cash for paper trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ python -m tradingbot.cli --help
 
 Para una guía detallada de cada comando, consulte [docs/commands.md](docs/commands.md).
 
+## Modo paper trading
+
+Para probar estrategias sin riesgo se puede utilizar el modo *paper trading*.
+Este permite simular operaciones con un saldo virtual configurable mediante
+`--initial-cash`:
+
+```bash
+python -m tradingbot.cli live paper-run --initial-cash 5000
+```
+
+El ejemplo anterior inicia el bot con un balance virtual de `5000` unidades.
+
 ## Modo testnet en el CLI
 
 Para operar contra los entornos de prueba de los exchanges se puede

--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -111,6 +111,9 @@ def paper_run(
         help="Risk manager loss percentage (0-1 or 0-100)",
     ),
     timeframe: str = typer.Option("1m", "--timeframe", help="Bar timeframe (e.g., 1m,5m,15m)"),
+    initial_cash: float = typer.Option(
+        1000.0, "--initial-cash", help="Initial cash for paper trading"
+    ),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
@@ -135,6 +138,7 @@ def paper_run(
             risk_pct=risk_pct,
             params=params,
             timeframe=timeframe,
+            initial_cash=initial_cash,
         )
     )
 

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -46,14 +46,16 @@ async def run_paper(
     risk_pct: float = 0.0,
     params: dict | None = None,
     timeframe: str = "1m",
+    initial_cash: float = 1000.0,
 ) -> None:
     """Run a simple live pipeline entirely in paper mode."""
     log.info("Connecting to Binance WS in paper mode for %s", symbol)
     adapter = BinanceWSAdapter()
     broker = PaperAdapter()
+    broker.state.cash = initial_cash
 
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
-    guard.refresh_usd_caps(1000.0)
+    guard.refresh_usd_caps(initial_cash)
     corr = CorrelationService()
     risk = RiskService(
         guard,


### PR DESCRIPTION
## Summary
- allow specifying initial cash in `run_paper` and CLI `paper-run`
- document `--initial-cash` for running the bot with a virtual balance

## Testing
- `python -m tradingbot.cli.main paper-run --help`
- `pytest` *(killed: container out of memory?)*

------
https://chatgpt.com/codex/tasks/task_e_68bf98be2554832da8c50edea8465cb9