### PR TITLE
Load strategy params after strategies load

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -433,6 +433,7 @@ document.getElementById('bot-toggle-params').addEventListener('change', e => {
   document.getElementById('bot-param-card').style.display = e.target.checked ? 'block' : 'none';
 });
 loadStrategies();
+loadStrategyParams(document.getElementById('bot-strategy').value);
 updateVenueFields();
 updateEnvFields();
 refreshBots();


### PR DESCRIPTION
## Summary
- Load strategy params on bots page after strategies fetch

## Testing
- `pytest tests/test_api_bots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa210dc4832d978a913b67fa7533