### PR TITLE
feat: adjust risk percent handling

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -67,19 +67,19 @@
       </div>
       <div>
         <label for="bot-risk-pct">Risk %</label>
-        <input id="bot-risk-pct" type="number" step="0.0001" required/>
+        <input id="bot-risk-pct" type="number" step="0.01" required/>
       </div>
       <div>
         <label for="bot-daily-max-loss-pct">Daily max loss %
           <span class="help-icon" title="Pérdida diaria máxima permitida (porcentaje del equity)">?</span>
         </label>
-        <input id="bot-daily-max-loss-pct" type="number" step="0.0001"/>
+        <input id="bot-daily-max-loss-pct" type="number" step="0.01"/>
       </div>
       <div>
         <label for="bot-daily-max-drawdown-pct">Daily max drawdown %
           <span class="help-icon" title="Drawdown diario máximo relativo al pico intradía">?</span>
         </label>
-        <input id="bot-daily-max-drawdown-pct" type="number" step="0.0001"/>
+        <input id="bot-daily-max-drawdown-pct" type="number" step="0.01"/>
       </div>
       <div>
         <label for="bot-timeframe">Timeframe</label>
@@ -274,9 +274,9 @@ async function startBot(){
     const payload = {strategy, pairs, venue, testnet, dry_run, timeframe};
     if(env==='paper' && initial_cash) payload.initial_cash = Number(initial_cash);
     if(config) payload.config = config;
-    if(risk_pct) payload.risk_pct = Number(risk_pct);
-    if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct);
-    if(daily_max_drawdown_pct) payload.daily_max_drawdown_pct = Number(daily_max_drawdown_pct);
+    if(risk_pct) payload.risk_pct = Number(risk_pct) / 100;
+    if(daily_max_loss_pct) payload.daily_max_loss_pct = Number(daily_max_loss_pct) / 100;
+    if(daily_max_drawdown_pct) payload.daily_max_drawdown_pct = Number(daily_max_drawdown_pct) / 100;
     if(leverage) payload.leverage = Number(leverage);
   if(strategy==='cross_arbitrage'){
     payload.spot = spot;


### PR DESCRIPTION
## Summary
- allow percentage inputs with two decimal precision
- convert percentage fields from whole numbers to decimals before sending payload

## Testing
- `pytest tests/test_api_bots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfa9d728fc832d9bea7b45e14d5156