### PR TITLE
Add 3m and 30m timeframes to bot UI

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -85,8 +85,10 @@
         <label for="bot-timeframe">Timeframe</label>
         <select id="bot-timeframe">
           <option value="1m" selected>1m</option>
+          <option value="3m">3m</option>
           <option value="5m">5m</option>
           <option value="15m">15m</option>
+          <option value="30m">30m</option>
         </select>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- extend timeframe options in bot creation form to include 3m and 30m

## Testing
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9d54cc4832d8c9b1cb7bcca9699