### PR TITLE
Restore bot parameter toggle and preload strategy params

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -109,7 +109,7 @@
       </div>
       <div id="field-toggle-params" style="display:flex;align-items:center;gap:4px">
         <span>Configurar parámetros</span>
-        <label class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
+        <label id="bot-config-toggle" class="switch"><input id="bot-toggle-params" type="checkbox"><span class="slider"></span></label>
       </div>
     </div>
       <div id="bot-param-card" style="display:none">


### PR DESCRIPTION
## Summary
- Restore `bot-config-toggle` label with checkbox for parameter configuration
- Ensure bot parameter card toggles visibility via checkbox and preload strategy params on page load

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfb01c071c832dbad3cc887436583f