### PR TITLE
Expose metrics port range for bots

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - API_PASS=securepassword
     ports:
       - "8000:8000"
+      - "8001-8010:8001-8010"
     depends_on:
       - timescaledb
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,7 +150,8 @@ Ejecuta el bot en modo en vivo (testnet o real).
 Corre una estrategia en modo paper (sin dinero real) y expone métricas.
 - `--symbol`: par a operar (por defecto `BTC/USDT`).
 - `--strategy`: nombre de la estrategia (`breakout_atr`).
-- `--metrics-port`: puerto para las métricas (8000).
+- `--metrics-port`: puerto para las métricas (8000; los bots adicionales usan el
+  primer puerto libre del rango `8001-8010`).
 - `--config`: ruta a un archivo YAML con parámetros opcionales.
 
 ## `real-run`

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -4,6 +4,10 @@ TradeBot incluye paneles de Grafana para visualizar el estado del bot y los
 resultados de las operaciones. Los archivos de cada dashboard se encuentran
 en `monitoring/grafana/dashboards`.
 
+Por defecto, la API expone sus métricas en `http://localhost:8000/metrics`.
+Si se ejecutan varios bots, cada uno tomará el primer puerto libre del rango
+`8001-8010`, quedando accesibles desde `http://localhost:<puerto>/metrics`.
+
 ## Variables de consulta
 Para los paneles que acceden a datos de mercado desde PostgreSQL se añadieron
 variables que permiten filtrar las consultas:


### PR DESCRIPTION
## Summary
- map ports 8001-8010 for api service so multiple bots can expose metrics
- document new metrics port range in dashboards and command reference

## Testing
- `pytest tests/test_smoke.py -q`
- `docker compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c038c375c4832da89bd4366651f9f9