### PR TITLE
Reflect paper cash in account during paper run

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -71,6 +71,7 @@ async def run_paper(
     adapter = BinanceWSAdapter()
     broker = PaperAdapter()
     broker.state.cash = initial_cash
+    broker.account.update_cash(initial_cash)
 
     guard = PortfolioGuard(GuardConfig(total_cap_pct=1.0, per_symbol_cap_pct=0.5, venue="paper"))
     guard.refresh_usd_caps(initial_cash)


### PR DESCRIPTION
## Summary
- Sync paper account's cash with initial balance so risk/accounting stay in sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0399e0294832da85b542acce0aedc