### PR TITLE
refactor: remove risk setup from run_bot

### DIFF
--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -52,12 +52,6 @@ def run_bot(
 
     setup_logging(log_level)
     params = _parse_params(param) if isinstance(param, list) else {}
-    from ...core.account import Account
-    from ...risk.portfolio_guard import PortfolioGuard, GuardConfig
-    from ...risk.service import RiskService
-
-    _guard = PortfolioGuard(GuardConfig(venue=venue))
-    RiskService(_guard, account=Account(float("inf")), risk_pct=risk_pct)
     if testnet:
         from ...live.runner_testnet import run_live_testnet
 


### PR DESCRIPTION
## Summary
- remove Account/PortfolioGuard/RiskService creation from run_bot command
- rely on internal risk handling within live runners

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0641ddf34832d998911ecb21ceba2