### PR TITLE
Use CorrelationService.get_correlations in runners and tests

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -141,7 +141,7 @@ async def run_paper(
             if time.time() - last_purge >= purge_interval:
                 risk.purge([symbol])
                 last_purge = time.time()
-            risk.update_correlation(corr._returns.corr(), corr_threshold)
+            risk.update_correlation(corr.get_correlations(), corr_threshold)
             pos_qty, _ = risk.account.current_exposure(symbol)
             trade = risk.get_trade(symbol)
             if trade and abs(pos_qty) > risk.min_order_qty:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -169,7 +169,7 @@ async def _run_symbol(
         qty: float = float(t.get("qty") or 0.0)
         broker.update_last_price(cfg.symbol, px)
         risk.mark_price(cfg.symbol, px)
-        risk.update_correlation(corr._returns.corr(), corr_threshold)
+        risk.update_correlation(corr.get_correlations(), corr_threshold)
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, 0.0)
         if halted:
             log.error("[HALT] motivo=%s", reason)

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -143,7 +143,7 @@ async def _run_symbol(
         qty: float = float(t.get("qty") or 0.0)
         broker.update_last_price(cfg.symbol, px)
         risk.mark_price(cfg.symbol, px)
-        risk.update_correlation(corr._returns.corr(), corr_threshold)
+        risk.update_correlation(corr.get_correlations(), corr_threshold)
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, 0.0)
         if halted:
             log.error("[HALT] motivo=%s", reason)

--- a/tests/test_risk_service_correlation.py
+++ b/tests/test_risk_service_correlation.py
@@ -44,8 +44,8 @@ async def test_risk_service_correlation_limits_and_sizing():
     svc.account.cash = 1000.0
 
     _feed_correlated_prices(corr)
-    corr_df = corr._returns.corr()
-    exceeded = svc.update_correlation(corr_df, 0.8)
+    corr_pairs = corr.get_correlations()
+    exceeded = svc.update_correlation(corr_pairs, 0.8)
     await asyncio.sleep(0)
     assert exceeded == [("AAA", "BBB")]
 


### PR DESCRIPTION
## Summary
- replace direct `_returns.corr()` usage with `CorrelationService.get_correlations` in live runners
- update risk service correlation test to use dictionary-based correlations

## Testing
- `pytest tests/test_risk_service_correlation.py tests/test_correlation_service.py tests/test_risk_manager_limits.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06429a530832d9e387e98e60eafb8