### PR TITLE
Remove redundant risk setup in live run command

### DIFF
--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -52,12 +52,6 @@ def run_bot(
 
     setup_logging(log_level)
     params = _parse_params(param) if isinstance(param, list) else {}
-    from ...core.account import Account
-    from ...risk.portfolio_guard import PortfolioGuard, GuardConfig
-    from ...risk.service import RiskService
-
-    _guard = PortfolioGuard(GuardConfig(venue=venue))
-    RiskService(_guard, account=Account(float("inf")), risk_pct=risk_pct)
     exchange, market = venue.split("_", 1)
     if testnet:
         from ...live.runner_testnet import run_live_testnet


### PR DESCRIPTION
## Summary
- Drop pre-run risk service initialization from `run_bot`
- Allow live runners to manage risk internally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0655bc4c4832db1898ca157bd4e94