### PR TITLE
Add venue and timeframe info in bot list

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -119,7 +119,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Estrategia</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Error</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Error</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -315,20 +315,27 @@ async function refreshBots(){
     (j.bots||[]).forEach(b=>{
       const stats=b.stats||{};
       const pairs=(b.config?.pairs||[]).join(',');
+      const venue = b.config?.venue || '';
+      const timeframe = b.config?.timeframe || '';
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${b.pid}</td><td>${b.config?.strategy||''}</td><td>${pairs}</td><td>${b.status}</td>
-      <td>${stats.orders_sent||0}/${stats.fills||0}</td>
-      <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
-      <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>
-      <td>${(stats.fees_usd||0).toFixed(2)}</td>
-      <td>${(stats.slippage_bps||0).toFixed(2)}</td>
-      <td>${((stats.hit_rate||0)*100).toFixed(1)}%</td>
-      <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
-      <td>${(stats.inventory||0).toFixed(4)}</td>
-      <td>${(stats.leverage||0).toFixed(2)}</td>
-      <td>${((b.risk_pct ?? 0)*100).toFixed(2)}%</td>
-      <td>${b.last_error||''}</td>
-      <td>
+      tr.innerHTML=`<td>${b.pid}</td>
+        <td>
+          <div>${b.config?.strategy || ''}</div>
+          <div class="muted bot-meta">${venue} • ${timeframe}</div>
+        </td>
+        <td>${pairs}</td><td>${b.status}</td>
+        <td>${stats.orders_sent||0}/${stats.fills||0}</td>
+        <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
+        <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>
+        <td>${(stats.fees_usd||0).toFixed(2)}</td>
+        <td>${(stats.slippage_bps||0).toFixed(2)}</td>
+        <td>${((stats.hit_rate||0)*100).toFixed(1)}%</td>
+        <td>${(stats.avg_trade_duration||0).toFixed(1)}</td>
+        <td>${(stats.inventory||0).toFixed(4)}</td>
+        <td>${(stats.leverage||0).toFixed(2)}</td>
+        <td>${((b.risk_pct ?? 0)*100).toFixed(2)}%</td>
+        <td>${b.last_error||''}</td>
+        <td>
   <button class="icon-btn" onclick="showLogs(${b.pid})" title="Logs">
     <i class="fa-solid fa-file-lines"></i>
   </button>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -311,6 +311,7 @@ button.btn-xs{ padding: 4px 8px; font-size: 12px }
 .ok{ color:var(--success) }
 .warn{ color:var(--warning) }
 .muted{ color:var(--muted) }
+.bot-meta{ font-size:12px; }
 .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace }
 
 /* ====== Helpers ====== */


### PR DESCRIPTION
## Summary
- Rename Estrategia column to Bot
- Show venue and timeframe under bot strategy in bots list
- Add CSS helper class for bot meta info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c074148020832da0a0780fe3037b2d