### PR TITLE
feat(ui): show bot environment

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -317,11 +317,16 @@ async function refreshBots(){
       const pairs=(b.config?.pairs||[]).join(',');
       const venue = b.config?.venue || '';
       const timeframe = b.config?.timeframe || '';
+      const env = b.config?.dry_run ? 'paper'
+                 : (b.config?.testnet ? 'testnet' : 'live');
       const tr=document.createElement('tr');
       tr.innerHTML=`<td>${b.pid}</td>
         <td>
           <div>${b.config?.strategy || ''}</div>
-          <div class="muted bot-meta">${venue} • ${timeframe}</div>
+          <div class="muted bot-meta">
+            ${venue} • ${timeframe}
+            <span class="env-dot env-${env}" title="${env}"></span>
+          </div>
         </td>
         <td>${pairs}</td><td>${b.status}</td>
         <td>${stats.orders_sent||0}/${stats.fills||0}</td>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -583,3 +583,13 @@ button.icon-btn.warn:hover {
   font-weight: 600;
   color: var(--text);
 }
+
+.env-dot{
+  display:inline-block;
+  width:8px;height:8px;
+  border-radius:50%;
+  margin-left:4px;
+}
+.env-live{ background:var(--success); }
+.env-testnet{ background:var(--warning); }
+.env-paper{ background:var(--primary); }


### PR DESCRIPTION
## Summary
- show running bot environment with dot indicator
- add env-dot styles for live/testnet/paper status

## Testing
- `pytest` *(fails: KeyboardInterrupt after 19 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c0772f1270832d99f94db396a4d145