### PR TITLE
Add bot kill endpoint and improve dashboard error handling

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1207,6 +1207,22 @@ async def stop_bot(pid: int):
     return {"pid": pid, "status": "stopped", "returncode": proc.returncode}
 
 
+@app.post("/bots/{pid}/kill")
+async def kill_bot(pid: int):
+    """Forcefully kill a running bot process."""
+
+    info = _BOTS.get(pid)
+    if not info:
+        raise HTTPException(status_code=404, detail="bot not found")
+    proc: asyncio.subprocess.Process = info["process"]
+    if proc.returncode is not None:
+        raise HTTPException(status_code=400, detail="bot not running")
+    proc.kill()
+    await proc.wait()
+    info["status"] = f"killed:{proc.returncode}"
+    return {"pid": pid, "status": info["status"]}
+
+
 @app.post("/bots/{pid}/pause")
 def pause_bot(pid: int):
     """Send SIGSTOP to a running bot process."""

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -386,7 +386,18 @@ async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST
 async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
 async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
 async function haltBot(pid){ await fetch(api('/risk/halt'), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({reason:`bot ${pid}`})}); refreshBots(); }
-async function killBot(pid){ await fetch(api(`/bots/${pid}/kill`), {method:'POST'}); refreshBots(); }
+async function killBot(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/kill`), {method:'POST'});
+    if(!r.ok){
+      const j = await r.json().catch(()=>({}));
+      alert(j.detail || r.statusText || 'error');
+    }
+  }catch(e){
+    alert(String(e));
+  }
+  refreshBots();
+}
 async function deleteBot(pid){ await fetch(api(`/bots/${pid}`), {method:'DELETE'}); refreshBots(); }
 
 function renderExposure(data){


### PR DESCRIPTION
## Summary
- add `/bots/{pid}/kill` endpoint to forcefully terminate bot processes
- handle errors when killing bots in `bots.html`

## Testing
- `pytest tests/test_bot_env.py -q`
- `pytest tests/test_cli_venues.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08f81a388832da9334d3b092f9f12