### PR TITLE
Style logs dialog using CSS

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -489,8 +489,8 @@ function closeLogs(){
 }
 </script>
 
-<dialog id="logs-dialog" style="width:80vw;max-height:80vh;">
-  <pre id="logs-content" class="mono" style="max-height:70vh;overflow:auto;white-space:pre-wrap;margin:0"></pre>
+<dialog id="logs-dialog">
+  <pre id="logs-content" class="mono"></pre>
   <div style="text-align:right;margin-top:8px">
     <button onclick="closeLogs()">Cerrar</button>
   </div>

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -593,3 +593,15 @@ button.icon-btn.warn:hover {
 .env-live{ background:var(--success); }
 .env-testnet{ background:var(--warning); }
 .env-paper{ background:var(--primary); }
+
+#logs-dialog{
+    background: var(--panel-a);
+    color: var(--text);
+    border:1px solid var(--panel-border);
+    padding:12px;
+}
+#logs-content{
+    background: #000;
+    color: var(--text);
+    padding:8px;
+}


### PR DESCRIPTION
## Summary
- apply consistent theming for logs dialog and content with CSS variables
- drop redundant inline styles in bots page to use stylesheet rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c09174c1c0832db6e01ed082aac1af