### PR TITLE
Improve bot status tracking and dashboard feedback

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -382,17 +382,36 @@ async function runCli(){
   }
 }
 
-async function stopBot(pid){ await fetch(api(`/bots/${pid}/stop`), {method:'POST'}); refreshBots(); }
-async function pauseBot(pid){ await fetch(api(`/bots/${pid}/pause`), {method:'POST'}); refreshBots(); }
-async function resumeBot(pid){ await fetch(api(`/bots/${pid}/resume`), {method:'POST'}); refreshBots(); }
+async function stopBot(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/stop`), {method:'POST'});
+    const j = await r.json().catch(()=>({}));
+    alert(j.status || j.detail || r.statusText);
+  }catch(e){ alert(String(e)); }
+  refreshBots();
+}
+async function pauseBot(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/pause`), {method:'POST'});
+    const j = await r.json().catch(()=>({}));
+    alert(j.status || j.detail || r.statusText);
+  }catch(e){ alert(String(e)); }
+  refreshBots();
+}
+async function resumeBot(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/resume`), {method:'POST'});
+    const j = await r.json().catch(()=>({}));
+    alert(j.status || j.detail || r.statusText);
+  }catch(e){ alert(String(e)); }
+  refreshBots();
+}
 async function haltBot(pid){ await fetch(api('/risk/halt'), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({reason:`bot ${pid}`})}); refreshBots(); }
 async function killBot(pid){
   try{
     const r = await fetch(api(`/bots/${pid}/kill`), {method:'POST'});
-    if(!r.ok){
-      const j = await r.json().catch(()=>({}));
-      alert(j.detail || r.statusText || 'error');
-    }
+    const j = await r.json().catch(()=>({}));
+    alert(j.status || j.detail || r.statusText);
   }catch(e){
     alert(String(e));
   }


### PR DESCRIPTION
## Summary
- Initialize bots with running status and track lifecycle events
- Show API action responses in bots dashboard and refresh table

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b78b9cd4832d876c21c456558fa5