### PR TITLE
Add metrics port option to bot runners

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -920,6 +920,7 @@ class BotConfig(BaseModel):
     config: str | None = None
     timeframe: str | None = None
     initial_cash: float | None = None
+    metrics_port: int | None = None
 
 
 _BOTS: dict[int, dict] = {}
@@ -1045,6 +1046,8 @@ def _build_bot_args(cfg: BotConfig, params: dict | None = None) -> list[str]:
                 args.extend(["--param", f"{k}={v}"])
         if cfg.initial_cash is not None:
             args.extend(["--initial-cash", str(cfg.initial_cash)])
+        if cfg.metrics_port is not None:
+            args.extend(["--metrics-port", str(cfg.metrics_port)])
         return args
 
     args = [
@@ -1078,6 +1081,8 @@ def _build_bot_args(cfg: BotConfig, params: dict | None = None) -> list[str]:
     if params:
         for k, v in params.items():
             args.extend(["--param", f"{k}={v}"])
+    if cfg.metrics_port is not None:
+        args.extend(["--metrics-port", str(cfg.metrics_port)])
     return args
 
 
@@ -1100,6 +1105,7 @@ async def start_bot(cfg: BotConfig, request: Request = None):
             if exchange and market:
                 cfg.venue = f"{exchange}_{market}"
 
+        cfg.metrics_port = cfg.metrics_port or 0
         params = _strategy_params.get(cfg.strategy, {})
         args = _build_bot_args(cfg, params)
         env = os.environ.copy()

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -298,6 +298,7 @@ async function startBot(){
     if(Object.keys(params).length){
       try{ await fetch(api(`/strategies/${strategy}/params`), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(params)}); }catch(e){}
     }
+    payload.metrics_port = 0;
       try{
         const r = await fetch(api('/bots'), {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
         await r.json();

--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -47,6 +47,7 @@ def run_bot(
     param: list[str] = typer.Option(
         [], "--param", help="Override strategy parameters as key=value pairs"
     ),
+    metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
 ) -> None:
     """Run the live trading bot with configurable venue and symbols."""
 
@@ -69,6 +70,7 @@ def run_bot(
                 config_path=config,
                 params=params,
                 timeframe=timeframe,
+                metrics_port=metrics_port,
             )
         )
     else:
@@ -89,6 +91,7 @@ def run_bot(
                 timeframe=timeframe,
                 strategy_name=strategy,
                 i_know_what_im_doing=True,
+                metrics_port=metrics_port,
             )
         )
 


### PR DESCRIPTION
## Summary
- allow API bot config and CLI to set an explicit metrics port
- default bots from dashboard to bind metrics on an ephemeral port
- harden paper runner metric startup and account init for tests

## Testing
- `pytest tests/test_bot_env.py tests/test_live_runner.py tests/test_paper_runner.py`
- `pytest` *(fails: killed by OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bcc13254832db1cdaa83b9c9a710