### PR TITLE
Add venue selection for paper trading

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1045,6 +1045,8 @@ def _build_bot_args(cfg: BotConfig, params: dict | None = None) -> list[str]:
             "--strategy",
             cfg.strategy,
         ]
+        if cfg.venue:
+            args.extend(["--venue", cfg.venue])
         if cfg.risk_pct is not None:
             args.extend(["--risk-pct", str(cfg.risk_pct)])
         if cfg.timeframe is not None:

--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -100,6 +100,7 @@ def run_bot(
 def paper_run(
     symbol: str = typer.Option("BTC/USDT", "--symbol", help="Trading symbol"),
     strategy: str = typer.Option("breakout_atr", help="Strategy name"),
+    venue: str = typer.Option("binance_spot", "--venue", help="Trading venue"),
     metrics_port: int = typer.Option(8000, help="Port to expose metrics"),
     config: str | None = typer.Option(None, "--config", help="YAML config for the strategy"),
     param: list[str] = typer.Option(
@@ -134,6 +135,7 @@ def paper_run(
         run_paper(
             symbol=symbol,
             strategy_name=strategy,
+            venue=venue,
             config_path=config,
             metrics_port=metrics_port,
             risk_pct=risk_pct,


### PR DESCRIPTION
## Summary
- include venue flag when building paper trading bot args
- allow paper-run CLI command to accept venue and pass to runner
- add venue-based websocket adapter selection for paper trading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cd174a44832d8929c1ca691d747b