### PR TITLE
Track market latency and order metrics in paper runner

### DIFF
--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -22,6 +22,7 @@ from ..utils.metrics import (
     SIGNAL_CONFIRM_LATENCY,
     ROUTER_SELECTED_VENUE,
     ROUTER_STALE_BOOK,
+    ORDER_REJECTS,
 )
 from ..storage import timescale
 from ..utils.logging import get_logger
@@ -268,6 +269,7 @@ class ExecutionRouter:
 
         if self.risk_service is not None and not self.risk_service.enabled:
             log.warning("Risk manager disabled; rejecting order %s", order)
+            ORDER_REJECTS.inc()
             return {"status": "rejected", "reason": "risk_disabled"}
 
         if algo:
@@ -304,6 +306,7 @@ class ExecutionRouter:
             cur_qty, _ = self.risk_service.account.current_exposure(order.symbol)
             if cur_qty <= 0:
                 log.warning("Short not allowed; rejecting order %s", order)
+                ORDER_REJECTS.inc()
                 return {"status": "rejected", "reason": "short_not_allowed"}
             if order.qty > cur_qty:
                 order.qty = cur_qty
@@ -344,6 +347,7 @@ class ExecutionRouter:
             adj = adjust_order(order.price, order.qty, float(mark_price or 0.0), rules, order.side)
             if not adj.ok:
                 log.warning("Order %s rejected by adjust_order: %s", order, adj.reason)
+                ORDER_REJECTS.inc()
                 return {"status": "rejected", "reason": adj.reason}
             order.price = adj.price
             order.qty = adj.qty
@@ -381,6 +385,7 @@ class ExecutionRouter:
             res = await adapter.place_order(**kwargs)
         except Exception as exc:  # pragma: no cover - logging only
             log.exception("Order placement failed on %s", venue)
+            ORDER_REJECTS.inc()
             return {"status": "error", "reason": str(exc), "venue": venue}
 
         latency = time.monotonic() - start
@@ -397,6 +402,8 @@ class ExecutionRouter:
         res.setdefault("fee_type", "maker" if maker else "taker")
         res.setdefault("fee_bps", fee_bps)
         status = res.get("status")
+        if status == "rejected":
+            ORDER_REJECTS.inc()
         if status in {"partial", "expired"}:
             filled = float(res.get("filled_qty", 0.0))
             order.pending_qty = max((order.pending_qty or order.qty) - filled, 0.0)

--- a/src/tradingbot/utils/metrics.py
+++ b/src/tradingbot/utils/metrics.py
@@ -167,6 +167,12 @@ MARKET_LATENCY = Histogram(
     "Latency of market data processing in seconds",
 )
 
+# Completed bars accumulated by the bar aggregator
+AGG_COMPLETED = Gauge(
+    "aggregated_bars",
+    "Number of completed bars accumulated by the bar aggregator",
+)
+
 # End-to-end order processing latency
 E2E_LATENCY = Histogram(
     "e2e_latency_seconds",

--- a/tests/test_order_metrics.py
+++ b/tests/test_order_metrics.py
@@ -1,0 +1,43 @@
+import pytest
+
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.broker.broker import Broker
+from tradingbot.utils.metrics import ORDER_SENT, ORDER_REJECTS
+
+
+class DummyAdapter:
+    name = "dummy"
+    maker_fee_bps = 0.0
+
+    def __init__(self, status="filled"):
+        self.status = status
+
+    async def place_order(self, *args, **kwargs):
+        return {
+            "status": self.status,
+            "order_id": "1",
+            "filled_qty": kwargs.get("qty", 0.0),
+            "price": kwargs.get("price"),
+        }
+
+
+@pytest.mark.asyncio
+async def test_order_sent_counter_incremented():
+    ORDER_SENT._value.set(0)
+    adapter = DummyAdapter()
+    router = ExecutionRouter(adapter)
+    broker = Broker(router)
+    await broker.place_limit("BTC/USDT", "buy", 100.0, 1.0)
+    assert ORDER_SENT._value.get() == 1.0
+
+
+@pytest.mark.asyncio
+async def test_order_rejects_counter_incremented():
+    ORDER_SENT._value.set(0)
+    ORDER_REJECTS._value.set(0)
+    adapter = DummyAdapter(status="rejected")
+    router = ExecutionRouter(adapter)
+    broker = Broker(router)
+    await broker.place_limit("BTC/USDT", "buy", 100.0, 1.0)
+    assert ORDER_SENT._value.get() == 1.0
+    assert ORDER_REJECTS._value.get() == 1.0


### PR DESCRIPTION
## Summary
- observe market latency and aggregated bar count in paper runner
- track submitted orders via ORDER_SENT and expose place_market helper
- count order rejections in ExecutionRouter

## Testing
- `pytest tests/test_order_metrics.py tests/test_metrics.py tests/broker/test_place_limit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c191ae05c4832dbbe52f9110b2f0f7