### PR TITLE
chore: remove explicit compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   timescaledb:
     image: timescale/timescaledb:latest-pg16


### PR DESCRIPTION
## Summary
- remove explicit Compose spec version from docker-compose.yml

## Testing
- `pytest -q` *(killed)*
- `docker compose version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c191b20aac832d881cba2510249e50