### PR TITLE
Remove per-bot halt control

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -351,9 +351,6 @@ async function refreshBots(){
   <button class="icon-btn" onclick="resumeBot(${b.pid})" title="Resume">
     <i class="fa-solid fa-play"></i>
   </button>
-  <button class="icon-btn warn" onclick="haltBot(${b.pid})" title="Halt">
-    <i class="fa-solid fa-ban"></i>
-  </button>
   <button class="icon-btn" onclick="stopBot(${b.pid})" title="Stop">
     <i class="fa-solid fa-stop"></i>
   </button>
@@ -408,11 +405,6 @@ async function resumeBot(pid){
   }catch(e){
     console.log('resumeBot error', e);
   }
-  refreshBots();
-}
-async function haltBot(pid){
-  await fetch(api('/risk/halt'), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({reason:`bot ${pid}`})});
-  console.log('haltBot', pid);
   refreshBots();
 }
 async function killBot(pid){


### PR DESCRIPTION
## Summary
- Remove Halt button from individual bot rows in dashboard
- Drop unused haltBot helper

## Testing
- `node - <<'NODE' ...` (simulated refreshBots)
- `PYTHONPATH=src python - <<'PY' ...` (risk/halt endpoint)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c19f9ac4f4832dabc25b9644015163