### PR TITLE
feat: allow configuring websocket ping timeout

### DIFF
--- a/src/tradingbot/adapters/binance.py
+++ b/src/tradingbot/adapters/binance.py
@@ -55,7 +55,7 @@ class BinanceWSAdapter(ExchangeAdapter):
     async def stream_trades(self, symbol: str) -> AsyncIterator[dict]:
         stream = _binance_symbol_stream(normalize(symbol))
         url = self.ws_base + stream
-        async for raw in self._ws_messages(url):
+        async for raw in self._ws_messages(url, ping_timeout=self.ping_timeout):
             msg = json.loads(raw)
             d = msg.get("data") or {}
             price = float(d.get("p")) if d.get("p") is not None else None
@@ -70,7 +70,7 @@ class BinanceWSAdapter(ExchangeAdapter):
     async def stream_order_book(self, symbol: str, depth: int = 10) -> AsyncIterator[dict]:
         stream = _binance_symbol_stream(normalize(symbol)).replace("@trade", f"@depth{depth}@100ms")
         url = self.ws_base + stream
-        async for raw in self._ws_messages(url):
+        async for raw in self._ws_messages(url, ping_timeout=self.ping_timeout):
             msg = json.loads(raw)
             d = msg.get("data") or msg
             bids = d.get("bids") or d.get("b") or []

--- a/src/tradingbot/adapters/bybit_futures.py
+++ b/src/tradingbot/adapters/bybit_futures.py
@@ -95,7 +95,9 @@ class BybitFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price = float(t.get("p"))
@@ -109,7 +111,9 @@ class BybitFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             data = msg.get("data") or {}
             if not data:

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -87,7 +87,9 @@ class BybitSpotAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price = float(t.get("p"))
@@ -101,7 +103,9 @@ class BybitSpotAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = normalize(symbol)
         sub = {"op": "subscribe", "args": [f"orderbook.1.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             data = msg.get("data") or {}
             if not data:

--- a/src/tradingbot/adapters/bybit_ws.py
+++ b/src/tradingbot/adapters/bybit_ws.py
@@ -52,7 +52,9 @@ class BybitWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"publicTrade.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price_raw = t.get("p")
@@ -83,7 +85,9 @@ class BybitWSAdapter(ExchangeAdapter):
         bids: dict[float, float] = {}
         asks: dict[float, float] = {}
 
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             data_raw = msg.get("data") or {}
             if isinstance(data_raw, list):
@@ -132,7 +136,9 @@ class BybitWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"tickers.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             data = msg.get("data") or {}
             bid_px = data.get("bid1Price")
@@ -163,7 +169,9 @@ class BybitWSAdapter(ExchangeAdapter):
         sub_depth = 50 if depth <= 50 else 200
         sub = {"op": "subscribe", "args": [f"orderbook.{sub_depth}.{sym}"]}
 
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             data_raw = msg.get("data") or {}
             if isinstance(data_raw, list):
@@ -191,7 +199,9 @@ class BybitWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"fundingRate.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             if msg.get("op") == "subscribe" and not msg.get("success", True):
                 raise NotImplementedError("fundingRate stream not supported")
@@ -215,7 +225,9 @@ class BybitWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self.normalize_symbol(symbol)
         sub = {"op": "subscribe", "args": [f"openInterest.{sym}"]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             if msg.get("op") == "subscribe" and not msg.get("success", True):
                 raise NotImplementedError("openInterest stream not supported")

--- a/src/tradingbot/adapters/deribit_ws.py
+++ b/src/tradingbot/adapters/deribit_ws.py
@@ -66,7 +66,9 @@ class DeribitWSAdapter(ExchangeAdapter):
 
         while True:
             try:
-                async for raw in self._ws_messages(self.ws_url, json.dumps(sub)):
+                async for raw in self._ws_messages(
+                    self.ws_url, json.dumps(sub), ping_timeout=self.ping_timeout
+                ):
                     msg = json.loads(raw)
                     if msg.get("error"):
                         log.error("WS subscription error: %s", msg)
@@ -122,7 +124,9 @@ class DeribitWSAdapter(ExchangeAdapter):
             "id": 1,
         }
 
-        async for raw in self._ws_messages(self.ws_url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            self.ws_url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             if msg.get("error"):
                 log.error("WS subscription error: %s", msg)

--- a/src/tradingbot/adapters/okx_futures.py
+++ b/src/tradingbot/adapters/okx_futures.py
@@ -129,7 +129,9 @@ class OKXFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price = float(t.get("px"))
@@ -158,7 +160,9 @@ class OKXFuturesAdapter(ExchangeAdapter):
         if channel is None:
             raise ValueError(f"depth must be one of {sorted(self.DEPTH_TO_CHANNEL)}")
         sub = {"op": "subscribe", "args": [{"channel": channel, "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 if channel == "bbo-tbt":
@@ -192,7 +196,9 @@ class OKXFuturesAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 bids = d.get("bids", [])

--- a/src/tradingbot/adapters/okx_spot.py
+++ b/src/tradingbot/adapters/okx_spot.py
@@ -120,7 +120,9 @@ class OKXSpotAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price = float(t.get("px"))
@@ -149,7 +151,9 @@ class OKXSpotAdapter(ExchangeAdapter):
         if channel is None:
             raise ValueError(f"depth must be one of {sorted(self.DEPTH_TO_CHANNEL)}")
         sub = {"op": "subscribe", "args": [{"channel": channel, "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 if channel == "bbo-tbt":

--- a/src/tradingbot/adapters/okx_ws.py
+++ b/src/tradingbot/adapters/okx_ws.py
@@ -72,7 +72,9 @@ class OKXWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "trades", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for t in msg.get("data", []) or []:
                 price_raw = t.get("px")
@@ -102,7 +104,9 @@ class OKXWSAdapter(ExchangeAdapter):
         if channel is None:
             raise ValueError(f"depth must be one of {sorted(self.DEPTH_TO_CHANNEL)}")
         sub = {"op": "subscribe", "args": [{"channel": channel, "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 if channel == "bbo-tbt":
@@ -128,7 +132,9 @@ class OKXWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "books5", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 bids = d.get("bids", []) or []
@@ -189,7 +195,9 @@ class OKXWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "funding-rate", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 rate = d.get("fundingRate") or d.get("fundingRate")
@@ -211,7 +219,9 @@ class OKXWSAdapter(ExchangeAdapter):
         url = self.ws_public_url
         sym = self._normalize(symbol)
         sub = {"op": "subscribe", "args": [{"channel": "open-interest", "instId": sym}]}
-        async for raw in self._ws_messages(url, json.dumps(sub)):
+        async for raw in self._ws_messages(
+            url, json.dumps(sub), ping_timeout=self.ping_timeout
+        ):
             msg = json.loads(raw)
             for d in msg.get("data", []) or []:
                 oi = d.get("oi") or d.get("openInterest")

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -4,10 +4,7 @@ import errno
 import logging
 from datetime import datetime, timezone
 import time
-import functools
-
 import uvicorn
-import websockets
 
 from sqlalchemy.exc import OperationalError
 
@@ -88,10 +85,12 @@ async def run_paper(
         raise ValueError(f"unsupported venue: {venue}")
     log.info("Connecting to %s %s WS in paper mode for %s", exchange.capitalize(), market, symbol)
     # Allow slight delays without dropping the connection
-    settings.adapter_ping_interval = max(getattr(settings, "adapter_ping_interval", 20.0), 30.0)
+    settings.adapter_ping_interval = max(
+        getattr(settings, "adapter_ping_interval", 20.0), 30.0
+    )
     ping_timeout = max(getattr(settings, "ping_timeout", 20.0), 30.0)
-    websockets.connect = functools.partial(websockets.connect, ping_timeout=ping_timeout)
     adapter = ws_cls()
+    adapter.ping_timeout = ping_timeout
     broker = PaperAdapter()
     broker.state.cash = initial_cash
     if hasattr(broker.account, "update_cash"):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -290,7 +290,7 @@ async def test_binance_futures_ws_stream_funding():
 
     msg = json.dumps({"data": {"r": "0.01", "i": "100", "E": 0}})
 
-    async def _fake_messages(url):
+    async def _fake_messages(url, subscribe=None, ping_timeout=None):
         yield msg
 
     ws._ws_messages = _fake_messages
@@ -309,7 +309,7 @@ async def test_binance_futures_ws_open_interest_timeout_recovery(monkeypatch, ca
     msg = json.dumps({"data": {"oi": "100", "E": 0, "s": "BTCUSDT"}})
     calls = {"per": 0, "arr": 0}
 
-    async def _fake_messages(url):
+    async def _fake_messages(url, subscribe=None, ping_timeout=None):
         if "!openInterest@arr@" in url:
             calls["arr"] += 1
             yield msg
@@ -419,7 +419,7 @@ async def test_okx_stream_bba(monkeypatch, adapter_cls):
         adapter.ws_public_url = "wss://example"
         msg = json.dumps({"data": [{"bids": [["1", "2"]], "asks": [["3", "4"]], "ts": "0"}]})
 
-        async def fake_messages(url, sub):
+        async def fake_messages(url, sub, ping_timeout=None):
             yield msg
 
         adapter._ws_messages = fake_messages
@@ -454,7 +454,7 @@ async def test_okx_stream_bba_handles_empty(monkeypatch, adapter_cls):
         msg1 = json.dumps({"data": [{"bids": [], "asks": [], "ts": "0"}]})
         msg2 = json.dumps({"data": [{"bids": [["1", "2"]], "asks": [["3", "4"]], "ts": "1"}]})
 
-        async def fake_messages(url, sub):
+        async def fake_messages(url, sub, ping_timeout=None):
             yield msg1
             yield msg2
 

--- a/tests/test_binance_depth_resync.py
+++ b/tests/test_binance_depth_resync.py
@@ -20,7 +20,7 @@ async def test_depth_update_gap_resync(monkeypatch, cls):
         json.dumps({"data": {"b": [["1", "1"]], "a": [["2", "1"]], "pu": 20, "u": 21, "T": 2}})
     ]
 
-    async def fake_ws_messages(url):
+    async def fake_ws_messages(url, subscribe=None, ping_timeout=None):
         calls["ws"] += 1
         msgs = first_msgs if calls["ws"] == 1 else second_msgs
         for m in msgs:

--- a/tests/test_deribit_connector.py
+++ b/tests/test_deribit_connector.py
@@ -202,7 +202,7 @@ async def test_deribit_ws_adapter_parsing(monkeypatch, caplog):
 async def test_deribit_ws_adapter_channel_mismatch():
     adapter = DeribitWSAdapter()
 
-    async def fake_messages(url, sub):
+    async def fake_messages(url, sub, ping_timeout=None):
         yield json.dumps({"params": {"channel": "other", "data": []}})
 
     adapter._ws_messages = fake_messages

--- a/tests/test_okx_futures_streams.py
+++ b/tests/test_okx_futures_streams.py
@@ -15,7 +15,7 @@ async def test_stream_order_book_ignores_zero_or_none(caplog):
     adapter.state = type("S", (), {"order_book": {}, "last_px": {}})()
     adapter.ws_public_url = "wss://example"
 
-    async def fake_messages(url, sub):
+    async def fake_messages(url, sub, ping_timeout=None):
         yield json.dumps(
             {"data": [{"bidPx": None, "askPx": "3", "bidSz": "1", "askSz": "1", "ts": "0"}]}
         )
@@ -47,7 +47,7 @@ async def test_stream_bba_skips_missing_sides():
     msg1 = json.dumps({"data": [{"bids": [], "asks": [["3", "4"]], "ts": "0"}]})
     msg2 = json.dumps({"data": [{"bids": [["1", "2"]], "asks": [["3", "4"]], "ts": "1"}]})
 
-    async def fake_messages(url, sub):
+    async def fake_messages(url, sub, ping_timeout=None):
         yield msg1
         yield msg2
 

--- a/tests/test_okx_ws_adapter.py
+++ b/tests/test_okx_ws_adapter.py
@@ -114,7 +114,7 @@ async def test_subscription_format(method, args, channel, msg):
     adapter = OKXWSAdapter()
     captured: dict[str, dict] = {}
 
-    async def fake_messages(url, sub):
+    async def fake_messages(url, sub, ping_timeout=None):
         captured["sub"] = json.loads(sub)
         yield msg
 
@@ -140,7 +140,7 @@ async def test_stream_bba_discard_invalid(caplog):
         json.dumps({"data": [{"bids": [["1", "2"]], "asks": [["3", "4"]], "ts": "0"}]})
     ]
 
-    async def fake_messages(url, sub):
+    async def fake_messages(url, sub, ping_timeout=None):
         for e in events:
             yield e
 


### PR DESCRIPTION
## Summary
- add optional `ping_timeout` to websocket helpers
- remove monkey-patching of `websockets.connect` in paper runner
- pass configured timeout from adapters

## Testing
- `pytest tests/test_adapters.py`
- `pytest tests/test_okx_futures_streams.py`
- `pytest tests/test_okx_ws_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1ab2f223c832db2cca38d4bb8edbc