### PR TITLE
Avoid global ping tweaks in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -84,13 +84,11 @@ async def run_paper(
     if ws_cls is None:
         raise ValueError(f"unsupported venue: {venue}")
     log.info("Connecting to %s %s WS in paper mode for %s", exchange.capitalize(), market, symbol)
-    # Allow slight delays without dropping the connection
-    settings.adapter_ping_interval = max(
-        getattr(settings, "adapter_ping_interval", 20.0), 30.0
-    )
-    ping_timeout = max(getattr(settings, "ping_timeout", 20.0), 30.0)
+    # Allow slight delays without dropping the connection without mutating
+    # global settings. Configure per-adapter ping timing instead.
     adapter = ws_cls()
-    adapter.ping_timeout = ping_timeout
+    adapter.ping_interval = max(getattr(adapter, "ping_interval", 20.0), 30.0)
+    adapter.ping_timeout = max(getattr(adapter, "ping_timeout", 20.0), 30.0)
     broker = PaperAdapter()
     broker.state.cash = initial_cash
     if hasattr(broker.account, "update_cash"):


### PR DESCRIPTION
## Summary
- Configure websocket ping interval/timeout per adapter instance in paper runner
- Stop mutating global settings for ping timing

## Testing
- `pytest` (killed)

------
https://chatgpt.com/codex/tasks/task_e_68c1ba0e481c832d991b7bfc74bc681e