### PR TITLE
Add secrets management via CLI and API

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -134,6 +134,18 @@
   </div>
 
   <div class="card" style="margin-top:16px">
+    <h2>Secrets</h2>
+    <div class="grid5" style="margin-top:10px">
+      <input id="sec-key" placeholder="KEY"/>
+      <input id="sec-value" placeholder="value"/>
+      <button id="sec-set">Set</button>
+      <button id="sec-show">Show</button>
+      <button id="sec-del">Delete</button>
+    </div>
+    <pre id="sec-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card" style="margin-top:16px">
     <h2>Gestión de riesgo</h2>
     <div class="muted">Consultar exposiciones y eventos o ejecutar acciones</div>
     <p class="muted" style="margin-top:8px">
@@ -380,6 +392,38 @@ async function runCli(){
   }
 }
 
+async function setSecret(){
+  const key=document.getElementById('sec-key').value;
+  const value=document.getElementById('sec-value').value;
+  try{
+    await fetch(api(`/secrets/${encodeURIComponent(key)}`), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({value})});
+    document.getElementById('sec-output').textContent='ok';
+  }catch(e){
+    document.getElementById('sec-output').textContent=String(e);
+  }
+}
+
+async function showSecret(){
+  const key=document.getElementById('sec-key').value;
+  try{
+    const r=await fetch(api(`/secrets/${encodeURIComponent(key)}`));
+    const j=await r.json();
+    document.getElementById('sec-output').textContent=j.value||'';
+  }catch(e){
+    document.getElementById('sec-output').textContent=String(e);
+  }
+}
+
+async function delSecret(){
+  const key=document.getElementById('sec-key').value;
+  try{
+    await fetch(api(`/secrets/${encodeURIComponent(key)}`), {method:'DELETE'});
+    document.getElementById('sec-output').textContent='deleted';
+  }catch(e){
+    document.getElementById('sec-output').textContent=String(e);
+  }
+}
+
 async function stopBot(pid){
   try{
     const r = await fetch(api(`/bots/${pid}/stop`), {method:'POST'});
@@ -498,6 +542,9 @@ updateEnvFields();
 refreshBots();
 setInterval(refreshBots,5000);
 document.getElementById('cli-run').addEventListener('click', runCli);
+document.getElementById('sec-set').addEventListener('click', setSecret);
+document.getElementById('sec-show').addEventListener('click', showSecret);
+document.getElementById('sec-del').addEventListener('click', delSecret);
 document.getElementById('risk-refresh').addEventListener('click', refreshRisk);
 document.getElementById('risk-halt').addEventListener('click', haltRisk);
 document.getElementById('risk-reset').addEventListener('click', resetRisk);

--- a/src/tradingbot/cli/commands/secrets.py
+++ b/src/tradingbot/cli/commands/secrets.py
@@ -1,0 +1,48 @@
+"""CLI commands for managing secrets stored in a ``.env`` file."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from ...utils import secrets as secrets_utils
+
+
+app = typer.Typer(help="Manage API secrets and other sensitive values")
+
+
+@app.command("set")
+def set_(
+    key: str,
+    value: str,
+    env_file: Path = typer.Option(Path(".env"), help="Path to .env file"),
+) -> None:
+    """Store ``key=value`` in the env file."""
+
+    secrets_utils.set_secret(key, value, env_file)
+    typer.echo(f"{key} set")
+
+
+@app.command("show")
+def show(
+    key: str,
+    env_file: Path = typer.Option(Path(".env"), help="Path to .env file"),
+) -> None:
+    """Display the value for ``key`` from the env file."""
+
+    val = secrets_utils.read_secret(key, env_file)
+    if val is None:
+        raise typer.Exit(1)
+    typer.echo(val)
+
+
+@app.command("delete")
+def delete(
+    key: str,
+    env_file: Path = typer.Option(Path(".env"), help="Path to .env file"),
+) -> None:
+    """Remove ``key`` from the env file."""
+
+    secrets_utils.delete_secret(key, env_file)
+    typer.echo(f"{key} deleted")
+

--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -15,7 +15,7 @@ from tradingbot.utils.time_sync import check_ntp_offset
 
 # Import utilities to ensure Typer patches and helpers are available
 from . import utils as _utils  # noqa: F401
-from .commands import backtesting, data, live
+from .commands import backtesting, data, live, secrets
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ app = typer.Typer(add_completion=False, help="Utilities for running TradingBot")
 app.add_typer(data.app)
 app.add_typer(backtesting.app)
 app.add_typer(live.app)
+app.add_typer(secrets.app)
 
 
 def main() -> int:

--- a/src/tradingbot/utils/secrets.py
+++ b/src/tradingbot/utils/secrets.py
@@ -21,6 +21,38 @@ def _load_env_file(path: Path) -> Dict[str, str]:
         os.environ.setdefault(k, v)
     return data
 
+
+def _write_env_file(path: Path, data: Dict[str, str]) -> None:
+    """Persist dictionary to ``path`` in ``KEY=VALUE`` format."""
+    if not data:
+        path.write_text("")
+        return
+    content = "\n".join(f"{k}={v}" for k, v in data.items()) + "\n"
+    path.write_text(content)
+
+
+def read_secret(key: str, path: Path = Path(".env")) -> Optional[str]:
+    """Read a secret value from ``path`` without falling back to ~/.secrets."""
+    data = _load_env_file(path)
+    return data.get(key)
+
+
+def set_secret(key: str, value: str, path: Path = Path(".env")) -> None:
+    """Store ``key=value`` in ``path`` and update ``os.environ``."""
+    data = _load_env_file(path)
+    data[key] = value
+    _write_env_file(path, data)
+    os.environ[key] = value
+
+
+def delete_secret(key: str, path: Path = Path(".env")) -> None:
+    """Remove ``key`` from ``path`` and ``os.environ`` if present."""
+    data = _load_env_file(path)
+    if key in data:
+        del data[key]
+        _write_env_file(path, data)
+    os.environ.pop(key, None)
+
 # Cargar .env al importar el módulo
 _load_env_file(Path(".env"))
 

--- a/tests/test_api_secrets.py
+++ b/tests/test_api_secrets.py
@@ -1,0 +1,36 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def reload_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("API_USER", "u")
+    monkeypatch.setenv("API_PASS", "p")
+    import tradingbot.apps.api.main as main
+    importlib.reload(main)
+    return main
+
+
+def test_api_secret_crud(tmp_path, monkeypatch):
+    main = reload_app(tmp_path, monkeypatch)
+    client = TestClient(main.app)
+
+    resp = client.post("/secrets/FOO", json={"value": "bar"}, auth=("u", "p"))
+    assert resp.status_code == 200
+
+    resp = client.get("/secrets/FOO", auth=("u", "p"))
+    assert resp.status_code == 200
+    assert resp.json()["value"] == "bar"
+
+    resp = client.delete("/secrets/FOO", auth=("u", "p"))
+    assert resp.status_code == 200
+
+
+def test_bots_html_has_secrets_form(tmp_path, monkeypatch):
+    main = reload_app(tmp_path, monkeypatch)
+    client = TestClient(main.app)
+
+    resp = client.get("/static/bots.html", auth=("u", "p"))
+    assert resp.status_code == 200
+    assert "Secrets" in resp.text

--- a/tests/test_cli_secrets.py
+++ b/tests/test_cli_secrets.py
@@ -1,0 +1,20 @@
+from typer.testing import CliRunner
+
+from tradingbot.cli.commands import secrets as cli_secrets
+
+
+def test_cli_set_show_delete(tmp_path):
+    runner = CliRunner()
+    env_file = tmp_path / ".env"
+
+    result = runner.invoke(cli_secrets.app, ["set", "FOO", "bar", "--env-file", str(env_file)])
+    assert result.exit_code == 0
+    assert "FOO=bar" in env_file.read_text()
+
+    result = runner.invoke(cli_secrets.app, ["show", "FOO", "--env-file", str(env_file)])
+    assert result.exit_code == 0
+    assert "bar" in result.stdout
+
+    result = runner.invoke(cli_secrets.app, ["delete", "FOO", "--env-file", str(env_file)])
+    assert result.exit_code == 0
+    assert env_file.read_text() == ""


### PR DESCRIPTION
## Summary
- add Typer `secrets` command group with set/show/delete operations
- expose `/secrets/{key}` API endpoints and UI form for managing `.env`
- introduce helper functions for updating `.env` and tests for CLI/UI

## Testing
- `pytest tests/test_cli_secrets.py tests/test_api_secrets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1c7718254832dbd062e0d8f97912b