### PR TITLE
Reorder balance and ticker tables with compact cards

### DIFF
--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -11,6 +11,27 @@
 <body>
   <h1>Monitoreo</h1>
   <div class="muted" id="health">Comprobando estado…</div>
+  <div class="grid2" style="margin:14px 0 10px">
+    <div class="card card-sm">
+      <h2>Balances</h2>
+      <table id="bal-table">
+        <thead>
+          <tr><th>Exchange</th><th>USDT</th><th>BTC</th></tr>
+        </thead>
+        <tbody id="bal-body"></tbody>
+      </table>
+    </div>
+
+    <div class="card card-sm">
+      <h2>Tickers</h2>
+      <table id="tick-table">
+        <thead>
+          <tr><th>Exchange</th><th>BTC/USDT</th><th>ETH/USDT</th><th>XRP/USDT</th></tr>
+        </thead>
+        <tbody id="tick-body"></tbody>
+      </table>
+    </div>
+  </div>
   <div class="grid5" style="margin:14px 0 10px">
     <div class="kv"><div class="k">Reject Rate</div><div class="v" id="m-reject">—</div></div>
     <div class="kv"><div class="k">Latency p90 (s)</div><div class="v" id="m-lat90">—</div></div>
@@ -42,26 +63,6 @@
     <div class="kv"><div class="k">Funding</div><div class="v" id="m-funding-now">—</div></div>
     <div class="kv"><div class="k">Próx Funding</div><div class="v" id="m-funding-next">—</div></div>
     <div class="kv"><div class="k">Basis</div><div class="v" id="m-basis">—</div></div>
-  </div>
-
-  <div class="card" style="margin-top:16px">
-    <h2>Balances</h2>
-    <table id="bal-table">
-      <thead>
-        <tr><th>Exchange</th><th>USDT</th><th>BTC</th></tr>
-      </thead>
-      <tbody id="bal-body"></tbody>
-    </table>
-  </div>
-
-  <div class="card" style="margin-top:16px">
-    <h2>Tickers</h2>
-    <table id="tick-table">
-      <thead>
-        <tr><th>Exchange</th><th>BTC/USDT</th><th>ETH/USDT</th><th>XRP/USDT</th></tr>
-      </thead>
-      <tbody id="tick-body"></tbody>
-    </table>
   </div>
 
   <div class="card" style="margin-top:16px">

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -106,6 +106,10 @@ nav a:hover{
   box-shadow: 0 16px 30px rgba(0,0,0,.45);
   border-color: #3b4a63;
 }
+.card-sm{
+  padding:8px;
+  margin-top:8px;
+}
 
 /* pequeñas tarjetas KPI */
 .kv{
@@ -123,9 +127,11 @@ nav a:hover{
 .grid3{ display:grid; grid-template-columns: repeat(3,1fr); gap:12px }
 .grid4{ display:grid; grid-template-columns: repeat(4,1fr); gap:12px }
 .grid5{ display:grid; grid-template-columns: repeat(5,1fr); gap:12px }
+.grid2{ display:grid; grid-template-columns: repeat(2,1fr); gap:12px }
 @media (max-width: 1200px){ .grid5{ grid-template-columns: repeat(3,1fr) } }
 @media (max-width: 900px){ .grid4, .grid3, .grid5{ grid-template-columns: repeat(2,1fr) } }
-@media (max-width: 600px){ .grid4, .grid3, .grid5{ grid-template-columns: 1fr } }
+@media (max-width: 900px){ .grid2{ grid-template-columns: 1fr } }
+@media (max-width: 600px){ .grid4, .grid3, .grid5, .grid2{ grid-template-columns: 1fr } }
 
 
 /* Grid compacto */
@@ -194,8 +200,8 @@ nav a:hover{
 
 
 /* ====== Tablas ====== */
-table{ width:100%; border-collapse:collapse; font-size:14px }
-th,td{ padding:10px 8px; border-bottom:1px solid #253346 }
+table{ width:100%; border-collapse:collapse; font-size:12px }
+th,td{ padding:4px 6px; border-bottom:1px solid #253346 }
 th{
   background:#0f1622;
   position:sticky; top:0; z-index:1;


### PR DESCRIPTION
## Summary
- Move Balances and Tickers tables to the top of the monitor page
- Add compact `card-sm` style and responsive grid to show tables side by side
- Reduce table padding and font size for denser display

## Testing
- ⚠️ `pytest` (terminates early after ~3% of tests)


------
https://chatgpt.com/codex/tasks/task_e_68c1d1e29410832d93a8dc92660b2f66