### PR TITLE
Parallelize dashboard data refresh and add loading indicators

### DIFF
--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -106,6 +106,44 @@ const allowedExchanges = [
   'bybit_futures_testnet',
 ];
 
+const tickerSymbols = ['BTC/USDT', 'ETH/USDT', 'XRP/USDT'];
+const balanceCells = {};
+const tickerCells = {};
+
+function initTables(){
+  const balBody = document.getElementById('bal-body');
+  const tickBody = document.getElementById('tick-body');
+  for(const ex of allowedExchanges){
+    // Balance rows
+    const bRow = document.createElement('tr');
+    const bEx = document.createElement('td');
+    bEx.textContent = ex;
+    const bUsdt = document.createElement('td');
+    bUsdt.textContent = '—';
+    const bBtc = document.createElement('td');
+    bBtc.textContent = '—';
+    bRow.appendChild(bEx);
+    bRow.appendChild(bUsdt);
+    bRow.appendChild(bBtc);
+    balBody.appendChild(bRow);
+    balanceCells[ex] = {USDT: bUsdt, BTC: bBtc};
+
+    // Ticker rows
+    const tRow = document.createElement('tr');
+    const tEx = document.createElement('td');
+    tEx.textContent = ex;
+    tRow.appendChild(tEx);
+    tickerCells[ex] = {};
+    for(const sym of tickerSymbols){
+      const td = document.createElement('td');
+      td.textContent = '—';
+      tickerCells[ex][sym] = td;
+      tRow.appendChild(td);
+    }
+    tickBody.appendChild(tRow);
+  }
+}
+
 // Track whether the backend has emitted any trading events. If no events have
 // occurred yet (orders_sent, fills, etc.), metrics returning 0 are rendered as
 // "N/A" to indicate insufficient data.
@@ -222,47 +260,50 @@ async function refreshMarket(){
 }
 
 async function refreshBalances(){
-  const body=document.getElementById('bal-body');
-  if(!body) return;
-  body.innerHTML='';
-  for(const ex of allowedExchanges){
-    let usdt='—';
-    let btc='—';
+  await Promise.all(allowedExchanges.map(async ex => {
+    const cells = balanceCells[ex];
+    cells.USDT.textContent = '…';
+    cells.BTC.textContent = '…';
+    cells.USDT.classList.add('muted');
+    cells.BTC.classList.add('muted');
     try{
-      const r=await fetch(api(`/balances/${ex}`));
-      const j=await r.json();
-      if(j && j.USDT!=null) usdt=Number(j.USDT).toFixed(2);
-      if(j && j.BTC!=null) btc=Number(j.BTC).toFixed(6);
-    }catch(e){}
-    const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${ex}</td><td>${usdt}</td><td>${btc}</td>`;
-    body.appendChild(tr);
-  }
+      const r = await fetch(api(`/balances/${ex}`));
+      const j = await r.json();
+      cells.USDT.textContent = (j && j.USDT!=null) ? Number(j.USDT).toFixed(2) : '—';
+      cells.BTC.textContent = (j && j.BTC!=null) ? Number(j.BTC).toFixed(6) : '—';
+    }catch(e){
+      cells.USDT.textContent = '—';
+      cells.BTC.textContent = '—';
+    }
+    cells.USDT.classList.remove('muted');
+    cells.BTC.classList.remove('muted');
+  }));
 }
 
-const tickerSymbols=['BTC/USDT','ETH/USDT','XRP/USDT'];
-
 async function refreshTickers(){
-  const body=document.getElementById('tick-body');
-  if(!body) return;
-  body.innerHTML='';
-  for(const ex of allowedExchanges){
-    let row='';
+  await Promise.all(allowedExchanges.map(async ex => {
+    const cells = tickerCells[ex];
+    for(const sym of tickerSymbols){
+      cells[sym].textContent = '…';
+      cells[sym].classList.add('muted');
+    }
     try{
-      const r=await fetch(api(`/tickers/${ex}?symbols=${tickerSymbols.join(',')}`));
-      const j=await r.json();
+      const r = await fetch(api(`/tickers/${ex}?symbols=${tickerSymbols.join(',')}`));
+      const j = await r.json();
       for(const sym of tickerSymbols){
-        const t=j[sym]||j[sym.replace('/','')]||{};
-        const p=t.last??t.price??t.close;
-        row+=`<td>${p!=null?Number(p).toFixed(4):'—'}</td>`;
+        const t = j[sym] || j[sym.replace('/','')] || {};
+        const p = t.last ?? t.price ?? t.close;
+        cells[sym].textContent = p != null ? Number(p).toFixed(4) : '—';
       }
     }catch(e){
-      row=tickerSymbols.map(()=>'<td>—</td>').join('');
+      for(const sym of tickerSymbols){
+        cells[sym].textContent = '—';
+      }
     }
-    const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${ex}</td>${row}`;
-    body.appendChild(tr);
-  }
+    for(const sym of tickerSymbols){
+      cells[sym].classList.remove('muted');
+    }
+  }));
 }
 
 async function saveConfig(){
@@ -293,6 +334,7 @@ refreshMetrics();
 setInterval(refreshMetrics, 5000);
 refreshMarket();
 setInterval(refreshMarket, 5000);
+initTables();
 refreshBalances();
 setInterval(refreshBalances, 5000);
 refreshTickers();


### PR DESCRIPTION
## Summary
- Pre-build exchange rows for balances and tickers and keep cell references
- Refresh balances and tickers concurrently with Promise.all
- Display loading indicators while data is fetched

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1d1e3e6a0832da3a64d77ffb1e02e