### PR TITLE
Expose secrets subcommand in main CLI

### DIFF
--- a/src/tradingbot/cli/main.py
+++ b/src/tradingbot/cli/main.py
@@ -39,7 +39,7 @@ app = typer.Typer(add_completion=False, help="Utilities for running TradingBot")
 app.add_typer(data.app)
 app.add_typer(backtesting.app)
 app.add_typer(live.app)
-app.add_typer(secrets.app)
+app.add_typer(secrets.app, name="secrets")
 
 
 def main() -> int:

--- a/tests/test_cli_secrets.py
+++ b/tests/test_cli_secrets.py
@@ -1,6 +1,7 @@
 from typer.testing import CliRunner
 
 from tradingbot.cli.commands import secrets as cli_secrets
+from tradingbot.cli import main as cli_main
 
 
 def test_cli_set_show_delete(tmp_path):
@@ -18,3 +19,14 @@ def test_cli_set_show_delete(tmp_path):
     result = runner.invoke(cli_secrets.app, ["delete", "FOO", "--env-file", str(env_file)])
     assert result.exit_code == 0
     assert env_file.read_text() == ""
+
+
+def test_cli_main_exposes_secrets(tmp_path):
+    runner = CliRunner()
+    env_file = tmp_path / ".env"
+
+    result = runner.invoke(
+        cli_main.app, ["secrets", "set", "FOO", "bar", "--env-file", str(env_file)]
+    )
+    assert result.exit_code == 0
+    assert "FOO=bar" in env_file.read_text()


### PR DESCRIPTION
## Summary
- name the `secrets` Typer app when registering in the main CLI
- test that `tradingbot.cli.main` exposes the `secrets` commands

## Testing
- `pytest tests/test_cli_secrets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d1fb4674832d82c555c6ed499ad5