### PR TITLE
Handle None ping timeout in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -89,7 +89,8 @@ async def run_paper(
     # global settings. Configure per-adapter ping timing instead.
     adapter = ws_cls()
     adapter.ping_interval = max(getattr(adapter, "ping_interval", 20.0), 30.0)
-    adapter.ping_timeout = max(getattr(adapter, "ping_timeout", 20.0), 30.0)
+    timeout = getattr(adapter, "ping_timeout", 20.0) or 20.0
+    adapter.ping_timeout = max(timeout, 30.0)
     broker = PaperAdapter()
     broker.state.cash = initial_cash
     if hasattr(broker.account, "update_cash"):


### PR DESCRIPTION
## Summary
- guard against `None` ping timeout in `runner_paper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1d3418f48832db737eaa22cabf374