### PR TITLE
Auto-clean finished bots and configurable log retention

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1019,6 +1019,11 @@ class BotConfig(BaseModel):
 _BOTS: dict[int, dict] = {}
 _launch_lock = asyncio.Lock()
 
+# Seconds to retain finished bot info and logs before purging.
+# Allows a short window for clients to fetch final logs or status.
+# Set ``BOT_LOG_RETENTION`` environment variable to override.
+BOT_LOG_RETENTION: float = float(os.getenv("BOT_LOG_RETENTION", "1"))
+
 # Regex para detectar líneas de métricas en logs: "METRICS {json}"
 _METRIC_LINE = re.compile(r"METRICS?\s+(\{.*\})")
 
@@ -1102,6 +1107,43 @@ async def _capture_stderr(
                 queue.put_nowait(text)
             except asyncio.QueueFull:
                 pass
+
+
+async def _monitor_bot(pid: int, proc: asyncio.subprocess.Process, retention: float | None = None) -> None:
+    """Monitor a bot process and purge its record once finished.
+
+    Parameters
+    ----------
+    pid:
+        Process identifier for lookup in ``_BOTS``.
+    proc:
+        The subprocess running the bot.
+    retention:
+        Optional override for how many seconds to keep the bot's info
+        after it finishes. Defaults to ``BOT_LOG_RETENTION``.
+    """
+
+    try:
+        await proc.wait()
+    finally:
+        info = _BOTS.get(pid)
+        if not info:
+            return
+        # Preserve existing status if stop/kill updated it already
+        if info.get("status") == "running":
+            info["status"] = "finished"
+        info["returncode"] = proc.returncode
+        # Cancel log scraping tasks
+        for name in ("metrics_task", "stderr_task"):
+            task = info.get(name)
+            if task:
+                task.cancel()
+                with suppress(Exception):
+                    await task
+        wait_secs = BOT_LOG_RETENTION if retention is None else retention
+        if wait_secs > 0:
+            await asyncio.sleep(wait_secs)
+        _BOTS.pop(pid, None)
 
 
 def _build_bot_args(cfg: BotConfig, params: dict | None = None) -> list[str]:
@@ -1229,6 +1271,9 @@ async def start_bot(cfg: BotConfig, request: Request = None):
         stderr_task = asyncio.create_task(
             _capture_stderr(proc.pid, proc, log_buffer)
         )
+        monitor_task = asyncio.create_task(
+            _monitor_bot(proc.pid, proc)
+        )
         _BOTS[proc.pid] = {
             "process": proc,
             "config": cfg.dict(),
@@ -1236,6 +1281,7 @@ async def start_bot(cfg: BotConfig, request: Request = None):
             "status": "running",
             "metrics_task": stdout_task,
             "stderr_task": stderr_task,
+             "monitor_task": monitor_task,
             "log_buffer": log_buffer,
         }
         return {"pid": proc.pid, "status": "running"}
@@ -1385,5 +1431,8 @@ async def delete_bot(pid: int):
     err_task = info.get("stderr_task")
     if err_task:
         err_task.cancel()
+    mon_task = info.get("monitor_task")
+    if mon_task:
+        mon_task.cancel()
     return {"pid": pid, "status": "deleted", "returncode": proc.returncode}
 

--- a/tests/test_bot_env.py
+++ b/tests/test_bot_env.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from pathlib import Path
 
 import pytest
@@ -8,25 +7,32 @@ from tradingbot.apps.api import main as api_main
 
 
 class DummyProc:
-    def __init__(self):
+    def __init__(self, done: bool = False):
         self.pid = 999
         self.returncode = None
         self.stdout = None
         self.stderr = None
+        self._done = asyncio.Event()
+        if done:
+            self.returncode = 0
+            self._done.set()
 
     async def wait(self):
-        return None
+        await self._done.wait()
+        return self.returncode
 
 
 @pytest.mark.asyncio
 async def test_start_bot_inherits_env_and_running(monkeypatch):
     monkeypatch.setenv("PGUSER", "alice")
 
-    captured = {}
+    captured: dict[str, object] = {}
 
     async def fake_exec(*args, **kwargs):
         captured["env"] = kwargs.get("env")
-        return DummyProc()
+        proc = DummyProc()
+        captured["proc"] = proc
+        return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(api_main, "_build_bot_args", lambda cfg, params=None: ["echo", "hi"])
@@ -49,11 +55,19 @@ async def test_start_bot_inherits_env_and_running(monkeypatch):
     assert bot["status"] == "running"
     assert bot["stats"] == {}
 
+    # cleanup
+    captured["proc"]._done.set()  # type: ignore[index]
+    await asyncio.sleep(0)
+
 
 @pytest.mark.asyncio
 async def test_update_bot_stats(monkeypatch):
+    captured: dict[str, object] = {}
+
     async def fake_exec(*args, **kwargs):
-        return DummyProc()
+        proc = DummyProc()
+        captured["proc"] = proc
+        return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(api_main, "_build_bot_args", lambda cfg, params=None: ["echo", "hi"])
@@ -72,3 +86,35 @@ async def test_update_bot_stats(monkeypatch):
     assert stats["orders_sent"] == 5
     assert stats["fills"] == 2
     assert stats["inventory"] == 1.5
+
+    # cleanup
+    captured["proc"]._done.set()  # type: ignore[index]
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_finished_bot_removed(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_exec(*args, **kwargs):
+        proc = DummyProc(done=True)
+        captured["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(api_main, "_build_bot_args", lambda cfg, params=None: ["echo", "hi"])
+    # remove quickly for test
+    monkeypatch.setattr(api_main, "BOT_LOG_RETENTION", 0)
+
+    api_main._BOTS.clear()
+
+    cfg = api_main.BotConfig(strategy="dummy")
+    await api_main.start_bot(cfg)
+
+    await asyncio.sleep(0.05)
+
+    class DummyReq:
+        headers = {}
+
+    data = api_main.list_bots(DummyReq())
+    assert data["bots"] == []


### PR DESCRIPTION
## Summary
- remove finished bots from `/bots` by monitoring processes and purging their info
- allow configurable log retention via `BOT_LOG_RETENTION`
- test cleanup of finished bots

## Testing
- `pytest -q`
- `pytest tests/test_bot_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d34399bc832d9f74e2b7c10e2869