### PR TITLE
Optimize ticker fetch and exchange mapping

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -191,26 +191,32 @@ async def get_tickers(exchange: str, symbols: str = Query(...)):
         raise HTTPException(status_code=404, detail="unsupported exchange")
     conn = cls()
     prices: dict[str, float | None] = {}
-    for raw in symbols.split(","):
-        sym = raw.strip()
-        if not sym:
-            continue
-        norm = normalize_symbol(sym)
-        try:
-            data = await conn.rest.fetch_ticker(sym)
-            price = (
-                data.get("last")
-                or data.get("close")
-                or data.get("price")
-                or data.get("bid")
-                or data.get("ask")
-            )
-            prices[norm] = float(price) if price is not None else None
-        except Exception as e:  # pragma: no cover - network issues
-            logger.warning("ticker_error", extra={"exchange": exchange, "symbol": sym, "err": str(e)})
-            prices[norm] = None
-    with suppress(Exception):
-        await conn.rest.close()
+    try:
+        await conn.rest.load_markets()
+        for raw in symbols.split(","):
+            sym = raw.strip()
+            if not sym:
+                continue
+            norm = normalize_symbol(sym)
+            exchange_sym = sym
+            with suppress(Exception):
+                exchange_sym = conn.rest.market(sym)["symbol"]
+            try:
+                data = await conn.rest.fetch_ticker(exchange_sym)
+                price = (
+                    data.get("last")
+                    or data.get("close")
+                    or data.get("price")
+                    or data.get("bid")
+                    or data.get("ask")
+                )
+                prices[norm] = float(price) if price is not None else None
+            except Exception as e:  # pragma: no cover - network issues
+                logger.warning("ticker_error", extra={"exchange": exchange, "symbol": sym, "err": str(e)})
+                prices[norm] = None
+    finally:
+        with suppress(Exception):
+            await conn.rest.close()
     return prices
 
 

--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -253,27 +253,34 @@ async function refreshTickers(){
   if(!body) return;
   body.innerHTML='';
   const exs=allowedExchanges.filter(ex=>localStorage.getItem('key:'+ex)&&localStorage.getItem('secret:'+ex));
-  for(const ex of exs){
-    let row='';
-    try{
-      const r=await fetch(api(`/tickers/${ex}?symbols=${tickerSymbols.join(',')}`));
-      const j=await r.json();
-      if(!r.ok||j.error){
-        console.warn('ticker_error',ex,j.error||j.detail);
-        row=tickerSymbols.map(()=>'<td>N/A</td>').join('');
-      }else{
-        for(const sym of tickerSymbols){
-          const t=j[sym]||j[sym.replace('/','')]||{};
-          const p=t.last??t.price??t.close;
-          row+=`<td>${p!=null?Number(p).toFixed(4):'N/A'}</td>`;
+  const requests = exs.map(ex => (
+    async () => {
+      let row='';
+      try{
+        const r=await fetch(api(`/tickers/${ex}?symbols=${tickerSymbols.join(',')}`));
+        const j=await r.json();
+        if(!r.ok||j.error){
+          console.warn('ticker_error',ex,j.error||j.detail);
+          row=tickerSymbols.map(()=>'<td>N/A</td>').join('');
+        }else{
+          for(const sym of tickerSymbols){
+            const t=j[sym]||j[sym.replace('/','')]||{};
+            const p=t.last??t.price??t.close;
+            row+=`<td>${p!=null?Number(p).toFixed(4):'N/A'}</td>`;
+          }
         }
+      }catch(e){
+        console.warn('ticker_fetch_error',ex,e);
+        row=tickerSymbols.map(()=>'<td>N/A</td>').join('');
       }
-    }catch(e){
-      console.warn('ticker_fetch_error',ex,e);
-      row=tickerSymbols.map(()=>'<td>N/A</td>').join('');
+      return `<td>${ex}</td>${row}`;
     }
+  )());
+
+  const rows = await Promise.all(requests);
+  for(const row of rows){
     const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${ex}</td>${row}`;
+    tr.innerHTML=row;
     body.appendChild(tr);
   }
 }


### PR DESCRIPTION
## Summary
- send ticker requests concurrently using Promise.all in dashboard
- load markets and map symbols to exchange-specific format before fetching tickers

## Testing
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d44a7f68832db85b52c68c60f52b