### PR TITLE
Handle balance refresh errors gracefully

### DIFF
--- a/src/tradingbot/apps/api/static/index.html
+++ b/src/tradingbot/apps/api/static/index.html
@@ -254,25 +254,25 @@ async function refreshBalances(){
   const exs=Object.keys(balCells);
   const promises=exs.map(async ex=>{
     const cells=balCells[ex];
-    cells.usdt.textContent='...';
-    cells.btc.textContent='...';
     cells.usdt.classList.add('muted');
     cells.btc.classList.add('muted');
     try{
       const r=await fetch(api(`/balances/${ex}`));
       const j=await r.json();
-      if(!r.ok||j.error||j.USDT==null||j.BTC==null){
+      if(!r.ok||j.error){
         console.warn('balance_error',ex,j.error||j.detail);
-        cells.usdt.textContent='N/A';
-        cells.btc.textContent='N/A';
+        cells.usdt.classList.add('error');
+        cells.btc.classList.add('error');
       }else{
-        cells.usdt.textContent=Number(j.USDT).toFixed(2);
-        cells.btc.textContent=Number(j.BTC).toFixed(6);
+        cells.usdt.classList.remove('error');
+        cells.btc.classList.remove('error');
+        cells.usdt.textContent=j.USDT!=null?Number(j.USDT).toFixed(2):'0';
+        cells.btc.textContent=j.BTC!=null?Number(j.BTC).toFixed(6):'0';
       }
     }catch(e){
       console.warn('balance_fetch_error',ex,e);
-      cells.usdt.textContent='N/A';
-      cells.btc.textContent='N/A';
+      cells.usdt.classList.add('error');
+      cells.btc.classList.add('error');
     }finally{
       cells.usdt.classList.remove('muted');
       cells.btc.classList.remove('muted');

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -121,7 +121,7 @@ nav a:hover{
 }
 .kv:hover{ background:#1a2941 }
 .kv .k{ font-size:12px; color:var(--muted) }
-.kv .v{ font-size:20px; margin-top:4px; font-weight:600 }
+.kv .v{ font-size:20px; margin-top:4px; font-weight:600; transition: color .25s ease }
 
 /* Grids responsivas */
 .grid3{ display:grid; grid-template-columns: repeat(3,1fr); gap:12px }
@@ -201,7 +201,7 @@ nav a:hover{
 
 /* ====== Tablas ====== */
 table{ width:100%; border-collapse:collapse; font-size:12px }
-th,td{ padding:4px 6px; border-bottom:1px solid #253346 }
+th,td{ padding:4px 6px; border-bottom:1px solid #253346; transition: color .25s ease }
 th{
   background:#0f1622;
   position:sticky; top:0; z-index:1;
@@ -321,6 +321,7 @@ button.btn-xs{ padding: 4px 8px; font-size: 12px }
 .sell{ color:var(--danger) }
 .ok{ color:var(--success) }
 .warn{ color:var(--warning) }
+.error{ color:var(--danger) }
 .muted{ color:var(--muted) }
 .bot-meta{ font-size:12px; }
 .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace }


### PR DESCRIPTION
## Summary
- Keep previous balance values until responses arrive
- Highlight balance errors with `.error` class and show `0` for missing assets
- Add error styling and smooth text transitions in CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1dcd441b8832db84a062eb97eaa84