### PR TITLE
Add Binance futures connector and handle full exchange names

### DIFF
--- a/src/tradingbot/connectors/__init__.py
+++ b/src/tradingbot/connectors/__init__.py
@@ -2,6 +2,7 @@ from .base import Trade, OrderBook, Funding, Basis, OpenInterest, ExchangeConnec
 from .binance import BinanceConnector
 from .bybit import BybitConnector
 from .okx import OKXConnector
+from .binance_futures import BinanceFuturesConnector
 from .deribit import DeribitConnector
 from .kaiko import KaikoConnector
 from .coinapi import CoinAPIConnector
@@ -16,6 +17,7 @@ __all__ = [
     "BinanceConnector",
     "BybitConnector",
     "OKXConnector",
+    "BinanceFuturesConnector",
     "DeribitConnector",
     "KaikoConnector",
     "CoinAPIConnector",

--- a/src/tradingbot/connectors/binance_futures.py
+++ b/src/tradingbot/connectors/binance_futures.py
@@ -1,0 +1,42 @@
+"""Connector for Binance USD-M futures using CCXT."""
+from __future__ import annotations
+
+from .base import ExchangeConnector
+
+
+class BinanceFuturesConnector(ExchangeConnector):
+    """Minimal connector for Binance futures markets."""
+
+    # CCXT client uses the ``binanceusdm`` identifier for USD-M futures
+    name = "binanceusdm"
+
+    async def fetch_balance(self) -> dict[str, float]:
+        """Return account balances with numeric totals as floats."""
+
+        data = await self._rest_call(self.rest.fetch_balance)
+        balances: dict[str, float] = {}
+        for asset, info in (data or {}).items():
+            if isinstance(info, dict) and "total" in info:
+                try:
+                    balances[asset] = float(info["total"])
+                except (TypeError, ValueError):
+                    continue
+        return balances
+
+    async def fetch_ticker(self, symbol: str) -> float | None:
+        """Return the last traded price for ``symbol``.
+
+        The response from CCXT varies slightly between exchanges; the helper
+        normalises the common fields and returns ``None`` when no price is
+        available.
+        """
+
+        data = await self._rest_call(self.rest.fetch_ticker, symbol)
+        price = (
+            data.get("last")
+            or data.get("close")
+            or data.get("price")
+            or data.get("bid")
+            or data.get("ask")
+        )
+        return float(price) if price is not None else None


### PR DESCRIPTION
## Summary
- add BinanceFuturesConnector built on ccxt.binanceusdm with balance and ticker helpers
- export BinanceFuturesConnector and register it in API connector map
- update API balance and ticker endpoints to respect full exchange name and enable testnet mode

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_api_ccxt_exchanges.py::test_ccxt_exchanges_includes_testnet -q`
- `pytest tests/test_execution_flags.py::test_post_only_orders -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1dcda2990832d98b4640f7ad48e33