### PR TITLE
Allow short selling on futures markets

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -105,7 +105,7 @@ async def run_paper(
         account=broker.account,
         risk_pct=risk_pct,
     )
-    risk.allow_short = False
+    risk.allow_short = market != "spot"
     engine = None
     if _CAN_PG:
         while True:


### PR DESCRIPTION
## Summary
- Allow short trades on non-spot venues in paper and live runners
- Parse market type from the `venue` parameter

## Testing
- `pytest` *(killed)*
- `PYTHONPATH=src python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c1e02c9810832d8b5fce160257f35c