### PR TITLE
Track paper trading metrics and surface via API/UI

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -357,6 +357,9 @@ async function refreshBots(){
   <button class="icon-btn" onclick="showLogs(${b.pid})" title="Logs">
     <i class="fa-solid fa-file-lines"></i>
   </button>
+  <button class="icon-btn" onclick="showTrades(${b.pid})" title="Trades">
+    <i class="fa-solid fa-list"></i>
+  </button>
   <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause">
     <i class="fa-solid fa-pause"></i>
   </button>
@@ -568,12 +571,41 @@ function closeLogs(){
   if(logSource){ logSource.close(); logSource=null; }
   document.getElementById('logs-dialog').close();
 }
+
+async function showTrades(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/trades`));
+    const j = await r.json();
+    const tbody=document.querySelector('#trades-dialog tbody');
+    tbody.innerHTML='';
+    (j.trades||[]).forEach(t=>{
+      const tr=document.createElement('tr');
+      const ts=new Date((t.ts||0)*1000).toLocaleTimeString();
+      tr.innerHTML=`<td>${ts}</td><td>${t.side||''}</td><td>${t.price||0}</td><td>${t.qty||0}</td><td>${(t.fee||0).toFixed? (t.fee||0).toFixed(2) : t.fee||0}</td>`;
+      tbody.appendChild(tr);
+    });
+    document.getElementById('trades-dialog').showModal();
+  }catch(e){}
+}
+function closeTrades(){
+  document.getElementById('trades-dialog').close();
+}
 </script>
 
 <dialog id="logs-dialog">
   <pre id="logs-content" class="mono"></pre>
   <div style="text-align:right;margin-top:8px">
     <button onclick="closeLogs()">Cerrar</button>
+  </div>
+</dialog>
+
+<dialog id="trades-dialog">
+  <table class="mono">
+    <thead><tr><th>Time</th><th>Side</th><th>Price</th><th>Qty</th><th>Fee</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <div style="text-align:right;margin-top:8px">
+    <button onclick="closeTrades()">Cerrar</button>
   </div>
 </dialog>
 </body>

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -1,0 +1,14 @@
+import tradingbot.apps.api.main as api_main
+
+
+def test_update_bot_stats_events():
+    api_main._BOTS.clear()
+    api_main._BOTS[1] = {"stats": {}}
+    api_main.update_bot_stats(1, {"event": "order"})
+    api_main.update_bot_stats(1, {"event": "fill", "qty": 1, "fee": 0.2, "slippage_bps": 5, "maker": True, "price": 100})
+    stats = api_main._BOTS[1]["stats"]
+    assert stats["orders_sent"] == 1
+    assert stats["fills"] == 1
+    assert stats["fees_usd"] == 0.2
+    assert stats["hit_rate"] == 1.0
+    assert stats["slippage_bps"] == 5


### PR DESCRIPTION
## Summary
- log trade, order, and fill metrics in the paper runner
- accumulate metrics and recent trades in API with new `/bots/{pid}/trades` endpoint
- show trade history in the bots dashboard and test metrics aggregation

## Testing
- `pytest`
- `pytest tests/test_metrics_accumulation.py`


------
https://chatgpt.com/codex/tasks/task_e_68c217b635b0832d8a824878e426874e