### PR TITLE
Adjust bots table UI layout

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -119,7 +119,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Error</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -336,10 +336,7 @@ async function refreshBots(){
       tr.innerHTML=`<td>${b.pid}</td>
         <td>
           <div>${b.config?.strategy || ''}</div>
-          <div class="muted bot-meta">
-            ${venue} • ${timeframe}
-            <span class="env-dot env-${env}" title="${env}"></span>
-          </div>
+          <div class="muted bot-meta"><span class="env-dot env-${env}" title="${env}"></span> ${venue} • ${timeframe}</div>
         </td>
         <td>${pairs}</td><td>${b.status}</td>
         <td>${stats.orders_sent||0}/${stats.fills||0}</td>
@@ -352,7 +349,6 @@ async function refreshBots(){
         <td>${(stats.inventory||0).toFixed(4)}</td>
         <td>${(stats.leverage||0).toFixed(2)}</td>
         <td>${((b.risk_pct ?? 0)*100).toFixed(2)}%</td>
-        <td>${b.last_error||''}</td>
         <td>
   <button class="icon-btn" onclick="showLogs(${b.pid})" title="Logs">
     <i class="fa-solid fa-file-lines"></i>
@@ -433,6 +429,16 @@ async function stopBot(pid){
     console.log('stopBot', pid, r.status);
   }catch(e){
     console.log('stopBot error', e);
+  }
+  refreshBots();
+}
+
+async function haltBot(pid){
+  try{
+    const r = await fetch(api(`/bots/${pid}/halt`), {method:'POST'});
+    console.log('haltBot', pid, r.status);
+  }catch(e){
+    console.log('haltBot error', e);
   }
   refreshBots();
 }

--- a/src/tradingbot/apps/api/static/styles.css
+++ b/src/tradingbot/apps/api/static/styles.css
@@ -229,6 +229,13 @@ th{
 tbody tr{ transition: background .15s }
 tbody tr:hover{ background: rgba(255,255,255,.03) }
 
+#tbl-bots th, #tbl-bots td{
+  text-align:center;
+}
+#tbl-bots th:nth-child(2), #tbl-bots td:nth-child(2){
+  text-align:left;
+}
+
 #bal-table td:nth-child(n+2), #bal-table th:nth-child(n+2),
 #tick-table td:nth-child(n+2), #tick-table th:nth-child(n+2){
   text-align:right;
@@ -619,7 +626,7 @@ button.icon-btn.warn:hover {
   display:inline-block;
   width:8px;height:8px;
   border-radius:50%;
-  margin-left:4px;
+  margin-right:4px;
 }
 .env-live{ background:var(--success); }
 .env-testnet{ background:var(--warning); }


### PR DESCRIPTION
## Summary
- Reposition environment status dot to the left of strategy meta info
- Remove obsolete Error column and center columns in active bots table
- Add missing haltBot handler for completeness

## Testing
- `pytest tests/test_api_bots.py::test_dashboard_bot_controls -q`


------
https://chatgpt.com/codex/tasks/task_e_68c21f594a84832db8bf5b69644fef9a