### PR TITLE
Track trade counts and PnL metrics

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -119,7 +119,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Trades</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -340,6 +340,8 @@ async function refreshBots(){
         </td>
         <td>${pairs}</td><td>${b.status}</td>
         <td>${stats.orders_sent||0}/${stats.fills||0}</td>
+        <td>${stats.trades_processed||0}</td>
+        <td>${(stats.pnl||0).toFixed(2)}</td>
         <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
         <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>
         <td>${(stats.fees_usd||0).toFixed(2)}</td>

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -181,7 +181,14 @@ async def run_paper(
             qty = float(t.get("qty", 0.0))
             log.info(
                 "METRICS %s",
-                json.dumps({"event": "trade", "price": px, "qty": qty}),
+                json.dumps(
+                    {
+                        "event": "trade",
+                        "price": px,
+                        "qty": qty,
+                        "pnl": broker.state.realized_pnl,
+                    }
+                ),
             )
             broker.update_last_price(symbol, px)
             risk.mark_price(symbol, px)

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -6,9 +6,13 @@ def test_update_bot_stats_events():
     api_main._BOTS[1] = {"stats": {}}
     api_main.update_bot_stats(1, {"event": "order"})
     api_main.update_bot_stats(1, {"event": "fill", "qty": 1, "fee": 0.2, "slippage_bps": 5, "maker": True, "price": 100})
+    api_main.update_bot_stats(1, {"event": "trade", "pnl": 5})
+    api_main.update_bot_stats(1, {"event": "trade", "pnl": 7})
     stats = api_main._BOTS[1]["stats"]
     assert stats["orders_sent"] == 1
     assert stats["fills"] == 1
     assert stats["fees_usd"] == 0.2
     assert stats["hit_rate"] == 1.0
     assert stats["slippage_bps"] == 5
+    assert stats["trades_processed"] == 2
+    assert stats["pnl"] == 7


### PR DESCRIPTION
## Summary
- accumulate trade counts and PnL in API bot stats
- display processed trades and PnL on bots page
- include PnL in runner_paper trade metric logs

## Testing
- `pytest tests/test_metrics_accumulation.py tests/test_bot_env.py::test_update_bot_stats -q`
- ⚠️ `pytest tests/test_paper_runner.py::test_run_paper -q` (hangs)


------
https://chatgpt.com/codex/tasks/task_e_68c23f7e7588832d90bc1208d45dda99