### PR TITLE
Remove trade count column and update metrics

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1136,7 +1136,7 @@ def update_bot_stats(pid: int, stats: dict | None = None, **kwargs) -> None:
     elif event == "trade":
         trades_buf = info.setdefault("trades", deque(maxlen=100))
         trades_buf.append(data)
-        buf["trades_processed"] = buf.get("trades_processed", 0) + 1
+        info["market_trades"] = info.get("market_trades", 0) + 1
         pnl_val = data.get("pnl")
         if pnl_val is None:
             pnl_val = TRADING_PNL._value.get()

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -119,7 +119,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>Trades</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -340,7 +340,6 @@ async function refreshBots(){
         </td>
         <td>${pairs}</td><td>${b.status}</td>
         <td>${stats.orders_sent||0}/${stats.fills||0}</td>
-        <td>${stats.trades_processed||0}</td>
         <td>${(stats.pnl||0).toFixed(2)}</td>
         <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
         <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>
@@ -354,9 +353,6 @@ async function refreshBots(){
         <td>
   <button class="icon-btn" onclick="showLogs(${b.pid})" title="Logs">
     <i class="fa-solid fa-file-lines"></i>
-  </button>
-  <button class="icon-btn" onclick="showTrades(${b.pid})" title="Trades">
-    <i class="fa-solid fa-list"></i>
   </button>
   <button class="icon-btn" onclick="pauseBot(${b.pid})" title="Pause">
     <i class="fa-solid fa-pause"></i>
@@ -579,41 +575,12 @@ function closeLogs(){
   if(logSource){ logSource.close(); logSource=null; }
   document.getElementById('logs-dialog').close();
 }
-
-async function showTrades(pid){
-  try{
-    const r = await fetch(api(`/bots/${pid}/trades`));
-    const j = await r.json();
-    const tbody=document.querySelector('#trades-dialog tbody');
-    tbody.innerHTML='';
-    (j.trades||[]).forEach(t=>{
-      const tr=document.createElement('tr');
-      const ts=new Date((t.ts||0)*1000).toLocaleTimeString();
-      tr.innerHTML=`<td>${ts}</td><td>${t.side||''}</td><td>${t.price||0}</td><td>${t.qty||0}</td><td>${(t.fee||0).toFixed? (t.fee||0).toFixed(2) : t.fee||0}</td>`;
-      tbody.appendChild(tr);
-    });
-    document.getElementById('trades-dialog').showModal();
-  }catch(e){}
-}
-function closeTrades(){
-  document.getElementById('trades-dialog').close();
-}
 </script>
 
 <dialog id="logs-dialog">
   <pre id="logs-content" class="mono"></pre>
   <div style="text-align:right;margin-top:8px">
     <button onclick="closeLogs()">Cerrar</button>
-  </div>
-</dialog>
-
-<dialog id="trades-dialog">
-  <table class="mono">
-    <thead><tr><th>Time</th><th>Side</th><th>Price</th><th>Qty</th><th>Fee</th></tr></thead>
-    <tbody></tbody>
-  </table>
-  <div style="text-align:right;margin-top:8px">
-    <button onclick="closeTrades()">Cerrar</button>
   </div>
 </dialog>
 </body>

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -14,5 +14,5 @@ def test_update_bot_stats_events():
     assert stats["fees_usd"] == 0.2
     assert stats["hit_rate"] == 1.0
     assert stats["slippage_bps"] == 5
-    assert stats["trades_processed"] == 2
     assert stats["pnl"] == 7
+    assert "trades_processed" not in stats


### PR DESCRIPTION
## Summary
- Stop exposing processed trade counts and track market trades internally
- Remove trades column and modal from bots table
- Update metrics tests for new behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c247485e88832db20b9f96d5410779