### PR TITLE
Remove secrets section from bots page

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -134,18 +134,6 @@
   </div>
 
   <div class="card" style="margin-top:16px">
-    <h2>Secrets</h2>
-    <div class="grid5" style="margin-top:10px">
-      <input id="sec-key" placeholder="KEY"/>
-      <input id="sec-value" placeholder="value"/>
-      <button id="sec-set">Set</button>
-      <button id="sec-show">Show</button>
-      <button id="sec-del">Delete</button>
-    </div>
-    <pre id="sec-output" class="mono" style="margin-top:8px; white-space:pre-wrap"></pre>
-  </div>
-
-  <div class="card" style="margin-top:16px">
     <h2>Gestión de riesgo</h2>
     <div class="muted">Consultar exposiciones y eventos o ejecutar acciones</div>
     <p class="muted" style="margin-top:8px">
@@ -393,38 +381,6 @@ async function runCli(){
   }
 }
 
-async function setSecret(){
-  const key=document.getElementById('sec-key').value;
-  const value=document.getElementById('sec-value').value;
-  try{
-    await fetch(api(`/secrets/${encodeURIComponent(key)}`), {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({value})});
-    document.getElementById('sec-output').textContent='ok';
-  }catch(e){
-    document.getElementById('sec-output').textContent=String(e);
-  }
-}
-
-async function showSecret(){
-  const key=document.getElementById('sec-key').value;
-  try{
-    const r=await fetch(api(`/secrets/${encodeURIComponent(key)}`));
-    const j=await r.json();
-    document.getElementById('sec-output').textContent=j.value||'';
-  }catch(e){
-    document.getElementById('sec-output').textContent=String(e);
-  }
-}
-
-async function delSecret(){
-  const key=document.getElementById('sec-key').value;
-  try{
-    await fetch(api(`/secrets/${encodeURIComponent(key)}`), {method:'DELETE'});
-    document.getElementById('sec-output').textContent='deleted';
-  }catch(e){
-    document.getElementById('sec-output').textContent=String(e);
-  }
-}
-
 async function stopBot(pid){
   try{
     const r = await fetch(api(`/bots/${pid}/stop`), {method:'POST'});
@@ -539,27 +495,24 @@ async function resetRisk(){
   }
 }
 
-document.getElementById('bot-start').onclick = startBot;
-document.getElementById('bot-strategy').addEventListener('change', updateForm);
-document.getElementById('bot-venue').addEventListener('change', updateVenueFields);
-document.getElementById('bot-env').addEventListener('change', updateEnvFields);
-document.getElementById('bot-toggle-params').addEventListener('change', e => {
-  document.getElementById('bot-param-card').style.display = e.target.checked ? 'block' : 'none';
-});
-loadStrategies();
-loadStrategyParams(document.getElementById('bot-strategy').value);
-updateVenueFields();
-updateEnvFields();
-refreshBots();
-setInterval(refreshBots,5000);
-document.getElementById('cli-run').addEventListener('click', runCli);
-document.getElementById('sec-set').addEventListener('click', setSecret);
-document.getElementById('sec-show').addEventListener('click', showSecret);
-document.getElementById('sec-del').addEventListener('click', delSecret);
-document.getElementById('risk-refresh').addEventListener('click', refreshRisk);
-document.getElementById('risk-halt').addEventListener('click', haltRisk);
-document.getElementById('risk-reset').addEventListener('click', resetRisk);
-refreshRisk();
+  document.getElementById('bot-start').onclick = startBot;
+  document.getElementById('bot-strategy').addEventListener('change', updateForm);
+  document.getElementById('bot-venue').addEventListener('change', updateVenueFields);
+  document.getElementById('bot-env').addEventListener('change', updateEnvFields);
+  document.getElementById('bot-toggle-params').addEventListener('change', e => {
+    document.getElementById('bot-param-card').style.display = e.target.checked ? 'block' : 'none';
+  });
+  loadStrategies();
+  loadStrategyParams(document.getElementById('bot-strategy').value);
+  updateVenueFields();
+  updateEnvFields();
+  refreshBots();
+  setInterval(refreshBots,5000);
+  document.getElementById('cli-run').addEventListener('click', runCli);
+  document.getElementById('risk-refresh').addEventListener('click', refreshRisk);
+  document.getElementById('risk-halt').addEventListener('click', haltRisk);
+  document.getElementById('risk-reset').addEventListener('click', resetRisk);
+  refreshRisk();
 
 let logSource=null;
 function showLogs(pid){

--- a/tests/test_api_secrets.py
+++ b/tests/test_api_secrets.py
@@ -27,10 +27,10 @@ def test_api_secret_crud(tmp_path, monkeypatch):
     assert resp.status_code == 200
 
 
-def test_bots_html_has_secrets_form(tmp_path, monkeypatch):
+def test_bots_html_has_no_secrets_section(tmp_path, monkeypatch):
     main = reload_app(tmp_path, monkeypatch)
     client = TestClient(main.app)
 
     resp = client.get("/static/bots.html", auth=("u", "p"))
     assert resp.status_code == 200
-    assert "Secrets" in resp.text
+    assert "Secrets" not in resp.text


### PR DESCRIPTION
## Summary
- remove Secrets card and related JavaScript from bots page
- update API tests to reflect UI change

## Testing
- `curl -s http://localhost:8000/bots.html | grep Secrets`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c24738e29c832dbdd8dec133ddcb52