### PR TITLE
Track order/fill metrics and expose in dashboard

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -119,7 +119,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders/Fills</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders</th><th>Fills</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -327,7 +327,8 @@ async function refreshBots(){
           <div class="muted bot-meta"><span class="env-dot env-${env}" title="${env}"></span> ${venue} • ${timeframe}</div>
         </td>
         <td>${pairs}</td><td>${b.status}</td>
-        <td>${stats.orders_sent||0}/${stats.fills||0}</td>
+        <td>${stats.orders_sent||0}</td>
+        <td>${stats.fills||0}</td>
         <td>${(stats.pnl||0).toFixed(2)}</td>
         <td>${((stats.cancel_ratio||0)*100).toFixed(1)}%</td>
         <td>${(stats.maker_taker_ratio||0).toFixed(2)}</td>

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -5,7 +5,18 @@ def test_update_bot_stats_events():
     api_main._BOTS.clear()
     api_main._BOTS[1] = {"stats": {}}
     api_main.update_bot_stats(1, {"event": "order"})
-    api_main.update_bot_stats(1, {"event": "fill", "qty": 1, "fee": 0.2, "slippage_bps": 5, "maker": True, "price": 100})
+    api_main.update_bot_stats(
+        1,
+        {
+            "event": "fill",
+            "qty": 1,
+            "fee": 0.2,
+            "slippage_bps": 5,
+            "maker": True,
+            "price": 100,
+            "pnl": 2,
+        },
+    )
     api_main.update_bot_stats(1, {"event": "trade", "pnl": 5})
     api_main.update_bot_stats(1, {"event": "trade", "pnl": 7})
     stats = api_main._BOTS[1]["stats"]
@@ -14,5 +25,5 @@ def test_update_bot_stats_events():
     assert stats["fees_usd"] == 0.2
     assert stats["hit_rate"] == 1.0
     assert stats["slippage_bps"] == 5
-    assert stats["pnl"] == 7
+    assert stats["pnl"] == 9
     assert "trades_processed" not in stats


### PR DESCRIPTION
## Summary
- log order and fill events with fee and realized PnL in paper runner
- accumulate orders, fills, fees and PnL in API stats buffer
- display orders, fills and PnL separately in bots dashboard

## Testing
- `pytest tests/test_metrics_accumulation.py -q`
- `pytest tests/test_bot_env.py -q`
- `pytest tests/test_paper_runner.py::test_run_paper -q` *(fails: KeyboardInterrupt, server task did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e738885c832dab35c757f311c685