### PR TITLE
feat: add warm-up bars option to paper runner

### DIFF
--- a/src/tradingbot/cli/commands/live.py
+++ b/src/tradingbot/cli/commands/live.py
@@ -116,6 +116,12 @@ def paper_run(
     initial_cash: float = typer.Option(
         1000.0, "--initial-cash", help="Initial cash for paper trading"
     ),
+    warmup_bars: int = typer.Option(
+        140,
+        "--warmup-bars",
+        envvar="WARMUP_BARS",
+        help="Number of bars to warm up before trading",
+    ),
 ) -> None:
     """Run a strategy in paper trading mode with metrics."""
 
@@ -142,6 +148,7 @@ def paper_run(
             params=params,
             timeframe=timeframe,
             initial_cash=initial_cash,
+            warmup_bars=warmup_bars,
         )
     )
 


### PR DESCRIPTION
## Summary
- add `warmup_bars` parameter to `run_paper` and fetch initial OHLCV bars for accurate progress
- expose `--warmup-bars` CLI flag for paper mode
- adjust tests for new warm-up behaviour

## Testing
- `python -m pytest tests/test_paper_runner.py::test_run_paper -q` *(interrupted: process did not exit in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c30cd4c438832da9906ee2578a324c