### PR TITLE
Fix OKX symbol formatting in paper runner preload

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -209,6 +209,8 @@ async def run_paper(
                 if hasattr(rest, "normalize_symbol")
                 else symbol
             )
+            if isinstance(rest, (OKXSpotAdapter, OKXFuturesAdapter)):
+                sym_norm = sym_norm.replace("-", "/")
             client = rest.rest if hasattr(rest, "rest") else rest
             bars = await client.fetch_ohlcv(
                 sym_norm, timeframe=timeframe, limit=warmup_total


### PR DESCRIPTION
## Summary
- Detect OKX REST adapters during warm-up bar preload
- Convert OKX symbols to slash-delimited format before fetch_ohlcv

## Testing
- `pytest` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c326fd2d80832dbca7b85297d0b3d1