### PR TITLE
Track average trade duration

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1247,6 +1247,18 @@ def update_bot_stats(pid: int, stats: dict | None = None, **kwargs) -> None:
     elif event == "trade":
         trades_buf = info.setdefault("trades", deque(maxlen=100))
         trade_payload = dict(data)
+        duration = data.get("duration")
+        if duration is not None:
+            try:
+                dur = float(duration)
+            except (TypeError, ValueError):
+                dur = None
+            if dur is not None:
+                tot = buf.get("_dur_tot", 0.0) + dur
+                cnt = buf.get("_dur_cnt", 0) + 1
+                buf["_dur_tot"] = tot
+                buf["_dur_cnt"] = cnt
+                buf["avg_trade_duration"] = tot / cnt
         if pnl_val is not None:
             trade_payload["pnl"] = pnl_val
         trades_buf.append(trade_payload)


### PR DESCRIPTION
## Summary
- track and expose average trade duration when receiving trade events

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c32c400f44832daf7858c18df4b0b4