### PR TITLE
Log trade duration on position close

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -330,6 +330,18 @@ async def run_paper(
                     delta_rpnl = (
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
+                    opened_at = trade.get("opened_at")
+                    duration = time.time() - opened_at if opened_at else 0.0
+                    log.info(
+                        "METRICS %s",
+                        json.dumps(
+                            {
+                                "event": "trade",
+                                "duration": duration,
+                                "pnl": delta_rpnl,
+                            }
+                        ),
+                    )
                     halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
                     if halted:
                         log.error("[HALT] motivo=%s", reason)


### PR DESCRIPTION
## Summary
- log trade duration and realized PnL when closing a position in paper runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c32c3e1a7c832d881d39a47f8d10da