### PR TITLE
Track trade open timestamp in RiskService

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, List, Tuple
 from dataclasses import dataclass
 from collections import defaultdict
 from threading import Lock
+import time
 
 import pandas as pd
 import numpy as np
@@ -685,6 +686,7 @@ class RiskService:
                     "entry_price": self._entry_price,
                 }
             )
+            trade.setdefault("opened_at", time.time())
             if atr is not None:
                 trade["atr"] = float(atr)
             entry_price = trade.get("entry_price")


### PR DESCRIPTION
## Summary
- record a trade's `opened_at` time in `RiskService.on_fill`
- import `time` module for timestamping trades

## Testing
- `MLFLOW_ENABLE_TELEMETRY=0 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c32c3ab230832dbbaf7f7609ec005b