### PR TITLE
Log inventory metrics after paper fills

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -300,6 +300,8 @@ async def run_paper(
                     risk.on_fill(
                         symbol, close_side, filled_qty, price=exec_price, venue="paper"
                     )
+                    cur_qty = risk.account.current_exposure(symbol)[0]
+                    log.info("METRICS %s", json.dumps({"inventory": cur_qty}))
                     delta_rpnl = (
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
@@ -378,6 +380,8 @@ async def run_paper(
                         risk.on_fill(
                             symbol, side, filled_qty, price=exec_price, venue="paper"
                         )
+                        cur_qty = risk.account.current_exposure(symbol)[0]
+                        log.info("METRICS %s", json.dumps({"inventory": cur_qty}))
                         delta_rpnl = (
                             resp.get("realized_pnl", broker.state.realized_pnl)
                             - prev_rpnl
@@ -500,6 +504,8 @@ async def run_paper(
             risk.on_fill(
                 symbol, side, filled_qty, price=exec_price, venue="paper"
             )
+            cur_qty = risk.account.current_exposure(symbol)[0]
+            log.info("METRICS %s", json.dumps({"inventory": cur_qty}))
             delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
             if filled_qty > 0:
                 slippage = ((exec_price - price) / price) * 10000 if price else 0.0


### PR DESCRIPTION
## Summary
- Log current inventory metrics after every paper fill to track exposure

## Testing
- `pytest` *(fails: KeyboardInterrupt after 19 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c32c347fc0832d9e46c8517dc54eb2