### PR TITLE
Log leverage metric in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -159,7 +159,9 @@ async def run_paper(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    params = params or {}
+    params = dict(params or {})
+    leverage_value = params.pop("leverage", 1)
+    log.info("METRICS %s", json.dumps({"leverage": leverage_value}))
     strat = (
         strat_cls(config_path=config_path, **params)
         if (config_path or params)
@@ -200,6 +202,8 @@ async def run_paper(
         agg = BarAggregator(timeframe=timeframe)
     except TypeError:
         agg = BarAggregator()
+    if not hasattr(agg, "completed"):
+        agg.completed = []
 
     if rest is not None and warmup_total > 0:
         try:


### PR DESCRIPTION
## Summary
- log leverage value at startup of paper runner
- ensure bar aggregator exposes `completed` list when missing

## Testing
- `pytest tests/test_iceberg_translation.py::test_binance_translates_iceberg -q`
- `pytest tests/test_paper_runner.py::test_run_paper -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c32c44df70832db0c56d5af18d0d61