### PR TITLE
fix: ensure Settings loads env from project root

### DIFF
--- a/src/tradingbot/config/__init__.py
+++ b/src/tradingbot/config/__init__.py
@@ -4,7 +4,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
 
-BASE_DIR = Path(__file__).resolve().parents[2]
+# Project root directory
+BASE_DIR = Path(__file__).resolve().parents[3]
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=BASE_DIR / ".env", extra="ignore")


### PR DESCRIPTION
## Summary
- point config.BASE_DIR to project root so .env is resolved correctly
- note project base path in config for clarity

## Testing
- `PYTHONPATH=./src python - <<'PY'
from tradingbot.config import Settings
print(Settings().binance_api_key)
PY`
- `pytest tests/test_account_cash_backtesting.py::test_account_cash_updates_after_each_fill -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33446e388832d811e0a83e63437b2