### PR TITLE
chore: load env file in bot service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     volumes:
       - ./src:/app/src
       - ./monitoring:/app/monitoring
+    env_file:
+      - .env
     environment:
       - SENTRY_ENABLED=${SENTRY_ENABLED:-false}
       - SENTRY_DSN=${SENTRY_DSN:-}


### PR DESCRIPTION
## Summary
- mount `.env` for bot-running service via `env_file` to expose API credentials

## Testing
- `docker run --rm --env-file .env alpine:3.18 sh -c 'echo $BINANCE_API_KEY'` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3535213ac832d83a346bc8efd70b4