### PR TITLE
Handle missing REST fetch_ohlcv in paper runner warmup

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -211,10 +211,15 @@ async def run_paper(
             fetch_symbol = symbol
             if exchange == "okx" and hasattr(adapter, "normalize_symbol"):
                 fetch_symbol = adapter.normalize_symbol(symbol).replace("-", "/")
-            client = rest.rest if hasattr(rest, "rest") else rest
-            bars = await client.fetch_ohlcv(
-                fetch_symbol, timeframe=timeframe, limit=warmup_total
-            )
+            if hasattr(rest, "fetch_ohlcv"):
+                bars = await rest.fetch_ohlcv(
+                    fetch_symbol, timeframe=timeframe, limit=warmup_total
+                )
+            else:
+                client = rest.rest if hasattr(rest, "rest") else rest
+                bars = await client.fetch_ohlcv(
+                    fetch_symbol, timeframe=timeframe, limit=warmup_total
+                )
             for ts_ms, o, h, l, c, v in bars:
                 ts_bar = datetime.fromtimestamp(ts_ms / 1000, timezone.utc)
                 agg.completed.append(Bar(ts_open=ts_bar, o=o, h=h, l=l, c=c, v=v))


### PR DESCRIPTION
## Summary
- check for fetch_ohlcv on REST adapter before falling back to nested client

## Testing
- `pytest` *(killed: process terminated due to resource limits)*
- `pytest tests/test_adapter_base.py`


------
https://chatgpt.com/codex/tasks/task_e_68c363e83c5c832da842b2192be076aa