### PR TITLE
Select Binance testnet WebSocket when enabled

### DIFF
--- a/src/tradingbot/connectors/binance.py
+++ b/src/tradingbot/connectors/binance.py
@@ -27,8 +27,17 @@ from ..execution.venue_adapter import translate_order_flags
 class BinanceConnector(ExchangeConnector):
     name = "binance"
 
+    WS_BASE = "wss://stream.binance.com:9443/ws"
+    WS_BASE_TESTNET = "wss://testnet.binance.vision/ws"
+
+    def _ws_base(self) -> str:
+        """Return websocket base depending on CCXT testnet option."""
+        client = getattr(self, "rest", None)
+        options = getattr(client, "options", {}) if client else {}
+        return self.WS_BASE_TESTNET if options.get("testnet") else self.WS_BASE
+
     def _ws_url(self, symbol: str) -> str:
-        return f"wss://stream.binance.com:9443/ws/{symbol.lower()}@depth"
+        return f"{self._ws_base()}/{symbol.lower()}@depth"
 
     def _ws_subscribe(self, symbol: str) -> str:
         return json.dumps(
@@ -48,7 +57,7 @@ class BinanceConnector(ExchangeConnector):
         )
 
     def _ws_trades_url(self, symbol: str) -> str:
-        return f"wss://stream.binance.com:9443/ws/{symbol.lower()}@trade"
+        return f"{self._ws_base()}/{symbol.lower()}@trade"
 
     def _ws_trades_subscribe(self, symbol: str) -> str:
         return json.dumps(

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -54,6 +54,15 @@ class DummyWS:
         self.pings += 1
 
 
+def test_binance_connector_uses_testnet_ws_base():
+    c = BinanceConnector()
+    c.rest.options["testnet"] = True
+    url = c._ws_url("BTCUSDT")
+    trade_url = c._ws_trades_url("BTCUSDT")
+    assert url.startswith("wss://testnet.binance.vision/ws/")
+    assert trade_url.startswith("wss://testnet.binance.vision/ws/")
+
+
 @pytest.mark.parametrize(
     "connector_cls",
     [BinanceConnector, BybitConnector, OKXConnector],


### PR DESCRIPTION
## Summary
- allow BinanceConnector to switch WS host when CCXT testnet option is set
- cover testnet WebSocket selection with unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c363e788d0832d9ffd3894a240dc81