### PR TITLE
Skip Binance spot fee update on testnet

### DIFF
--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -85,6 +85,10 @@ class BinanceSpotAdapter(ExchangeAdapter):
         self._start_fee_updater()
 
     async def update_fees(self, symbol: str | None = None) -> None:
+        client = getattr(self, "client", self.rest)
+        if client.options.get("testnet"):
+            return
+
         params: Dict[str, Any] = {}
         if symbol:
             params["symbol"] = symbol.replace("/", "")


### PR DESCRIPTION
## Summary
- avoid calling Binance API for fees when running in testnet

## Testing
- `pytest tests/test_adapter_base.py tests/test_execution_router_fee_update.py -q`
- ⚠️ `pytest` *(full suite killed by environment)*


------
https://chatgpt.com/codex/tasks/task_e_68c363e3a9cc832d8f86dc3ff28f8b28