### PR TITLE
Clarify Bybit spot WS adapter usage

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -15,7 +15,6 @@ from ..adapters.binance import BinanceWSAdapter
 from ..adapters.binance_spot import BinanceSpotAdapter
 from ..adapters.binance_spot_ws import BinanceSpotWSAdapter
 from ..adapters.binance_futures import BinanceFuturesAdapter
-from ..adapters.bybit_spot import BybitSpotAdapter as BybitSpotWSAdapter
 from ..adapters.bybit_spot import BybitSpotAdapter
 from ..adapters.bybit_futures import BybitFuturesAdapter
 from ..adapters.okx_spot import OKXSpotAdapter as OKXSpotWSAdapter
@@ -47,7 +46,7 @@ log = logging.getLogger(__name__)
 WS_ADAPTERS = {
     ("binance", "spot"): BinanceSpotWSAdapter,
     ("binance", "futures"): BinanceWSAdapter,
-    ("bybit", "spot"): BybitSpotWSAdapter,
+    ("bybit", "spot"): BybitSpotAdapter,
     ("bybit", "futures"): BybitFuturesAdapter,
     ("okx", "spot"): OKXSpotWSAdapter,
     ("okx", "futures"): OKXFuturesAdapter,


### PR DESCRIPTION
## Summary
- remove redundant alias for Bybit spot WS adapter
- point Bybit spot entries in WS adapter map to BybitSpotAdapter directly

## Testing
- `pytest tests/test_adapters.py::test_registered_adapters_are_subclasses -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36ac3568c832da5c65f8fe9e36f69