### PR TITLE
Include Chart.js in stats page

### DIFF
--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -6,6 +6,7 @@
   <title>DMI - TradingBot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="stylesheet" href="/static/styles.css"/>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="/static/header.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load Chart.js from CDN on statistics page

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c36ac9f83c832d97d498974759b4cd