### PR TITLE
feat(stats): make venue configurable

### DIFF
--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -41,16 +41,30 @@
   </div>
   <div class="card">
     <h2>Filtros</h2>
-    <div class="grid3" style="margin-top:10px">
+    <div class="grid4" style="margin-top:10px">
       <div>
         <label for="fl-symbol">Símbolo</label>
         <input id="fl-symbol" placeholder="BTCUSDT"/>
+      </div>
+      <div>
+        <label for="fl-venue-spot">Venue Spot</label>
+        <select id="fl-venue-spot">
+          <option value="binance_spot_testnet">Binance Spot Testnet</option>
+          <option value="binance_spot">Binance Spot</option>
+        </select>
+      </div>
+      <div>
+        <label for="fl-venue-fut">Venue Futuros</label>
+        <select id="fl-venue-fut">
+          <option value="binance_futures_um_testnet">Binance Futures UM Testnet</option>
+          <option value="binance_futures_um">Binance Futures UM</option>
+        </select>
       </div>
       <div style="display:flex;align-items:end;">
         <button id="fl-apply">Aplicar</button>
       </div>
     </div>
-  </div>  
+  </div>
   <div class="row" style="margin-top:20px">
     <div class="card">
       <h2>PnL Spot (6h)</h2>
@@ -171,6 +185,8 @@ async function refreshPositions(){
   }catch(e){}
 }
 let currentSymbol='';
+let currentVenueSpot=document.getElementById('fl-venue-spot').value;
+let currentVenueFut=document.getElementById('fl-venue-fut').value;
 const pnlCharts={};
 function renderPnlChart(canvasId, labels, upnl, rpnl, net){
   const data={labels,datasets:[{label:'UPnL',data:upnl,borderColor:'#10b981'},{label:'RPnL',data:rpnl,borderColor:'#3b82f6'},{label:'Net',data:net,borderColor:'#f59e0b'}]};
@@ -190,7 +206,7 @@ function renderPnlChart(canvasId, labels, upnl, rpnl, net){
 async function refreshPnlSpot(){
   try{
     const sym=currentSymbol?`&symbol=${currentSymbol}`:'';
-    const r=await fetch(`/pnl/timeseries?venue=binance_spot_testnet&bucket=1%20minute&hours=6${sym}`);
+    const r=await fetch(`/pnl/timeseries?venue=${currentVenueSpot}&bucket=1%20minute&hours=6${sym}`);
     const j=await r.json();
     const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
     const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
@@ -200,7 +216,7 @@ async function refreshPnlSpot(){
 async function refreshPnlFut(){
   try{
     const sym=currentSymbol?`&symbol=${currentSymbol}`:'';
-    const r=await fetch(`/pnl/timeseries?venue=binance_futures_um_testnet&bucket=1%20minute&hours=6${sym}`);
+    const r=await fetch(`/pnl/timeseries?venue=${currentVenueFut}&bucket=1%20minute&hours=6${sym}`);
     const j=await r.json();
     const pts=j.points||[]; const labels=pts.map(p=>p.ts.replace('T',' ').replace('Z',''));
     const upnl=pts.map(p=>p.upnl||0); const rpnl=pts.map(p=>p.rpnl||0); const net=pts.map(p=>p.net||0);
@@ -210,7 +226,7 @@ async function refreshPnlFut(){
 async function refreshPnlSummarySpot(){
   try{
     const sym=currentSymbol?`&symbol=${currentSymbol}`:'';
-    const r=await fetch(`/pnl/summary?venue=binance_spot_testnet${sym}`);
+    const r=await fetch(`/pnl/summary?venue=${currentVenueSpot}${sym}`);
     const j=await r.json();
     const body=document.querySelector('#tbl-pnl-spot tbody');
     body.innerHTML='';
@@ -224,7 +240,7 @@ async function refreshPnlSummarySpot(){
 async function refreshPnlSummaryFut(){
   try{
     const sym=currentSymbol?`&symbol=${currentSymbol}`:'';
-    const r=await fetch(`/pnl/summary?venue=binance_futures_um_testnet${sym}`);
+    const r=await fetch(`/pnl/summary?venue=${currentVenueFut}${sym}`);
     const j=await r.json();
     const body=document.querySelector('#tbl-pnl-fut tbody');
     body.innerHTML='';
@@ -238,7 +254,7 @@ async function refreshPnlSummaryFut(){
 async function refreshFillsSummary(){
   try{
     const sym=currentSymbol?`&symbol=${currentSymbol}`:'';
-    const venues=['binance_spot_testnet','binance_futures_um_testnet'];
+    const venues=[currentVenueSpot,currentVenueFut];
     const body=document.querySelector('#tbl-fills-summary tbody');
     body.innerHTML='';
     for(const v of venues){
@@ -293,6 +309,8 @@ async function refreshRiskStats(){
 }
 function applyFilters(){
   currentSymbol=document.getElementById('fl-symbol').value.trim();
+  currentVenueSpot=document.getElementById('fl-venue-spot').value;
+  currentVenueFut=document.getElementById('fl-venue-fut').value;
   refreshPnlSpot();
   refreshPnlFut();
   refreshPnlSummarySpot();


### PR DESCRIPTION
## Summary
- allow selecting spot and futures venues in stats UI
- build PnL API URLs using chosen venue values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c371330830832db18819957a2a6ccf