### PR TITLE
Align live execution sizing with backtester defaults

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -54,6 +54,8 @@ class Broker:
         on_partial_fill: Optional[Callable[[Order, dict], str | None]] = None,
         on_order_expiry: Optional[Callable[[Order, dict], str | None]] = None,
         signal_ts: float | None = None,
+        *,
+        slip_bps: float | None = None,
     ) -> dict:
         """Place a limit order respecting ``tif`` semantics.
 
@@ -131,6 +133,8 @@ class Broker:
                 post_only=post_only,
                 time_in_force=time_in_force,
             )
+            if slip_bps is not None:
+                kwargs["slip_bps"] = slip_bps
             if signal_ts is not None:
                 sig = inspect.signature(self.adapter.place_order)
                 params = sig.parameters
@@ -193,6 +197,8 @@ class Broker:
         side: str,
         qty: float,
         signal_ts: float | None = None,
+        *,
+        slip_bps: float | None = None,
     ) -> dict:
         """Place a market order and track submission metrics."""
 
@@ -202,6 +208,8 @@ class Broker:
             "type_": "market",
             "qty": qty,
         }
+        if slip_bps is not None:
+            kwargs["slip_bps"] = slip_bps
         if signal_ts is not None:
             kwargs["signal_ts"] = signal_ts
         ORDER_SENT.inc()

--- a/src/tradingbot/execution/order_sizer.py
+++ b/src/tradingbot/execution/order_sizer.py
@@ -1,0 +1,36 @@
+"""Common order sizing helpers for live and paper runners.
+
+These utilities mimic the sizing behaviour of the backtester without altering
+its code.  They allow the execution side to skip tiny orders that would be
+rounded up by venue rules and align live behaviour with historical simulations.
+"""
+from __future__ import annotations
+import math
+
+
+def _round_step(qty: float, step: float) -> float:
+    if not step:
+        return qty
+    return math.floor(qty / step) * step
+
+
+def adjust_qty(
+    qty: float,
+    price: float,
+    min_notional: float | None = None,
+    step_size: float | None = None,
+) -> float:
+    """Return ``qty`` rounded to ``step_size`` and validated against ``min_notional``.
+
+    If the resulting notional falls below ``min_notional`` the function returns
+    ``0`` signalling that the order should be skipped.
+    """
+    if price <= 0:
+        return 0.0
+    notional = qty * price
+    if min_notional and notional < min_notional:
+        return 0.0
+    qty = _round_step(qty, step_size or 0.0)
+    if min_notional and qty * price < min_notional:
+        return 0.0
+    return qty

--- a/src/tradingbot/utils/venues.py
+++ b/src/tradingbot/utils/venues.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+def is_spot(venue: str) -> bool:
+    """Return True if ``venue`` denotes a spot market.
+
+    A venue is considered spot when its identifier ends with ``"_spot"`` or
+    contains ``"_spot_"`` (e.g. ``"binance_spot_testnet"``).  This small helper
+    mirrors the backtester logic without modifying it so both live runners and
+    the backtest remain aligned.
+    """
+    v = venue.lower()
+    return v.endswith("_spot") or "_spot_" in v


### PR DESCRIPTION
## Summary
- default live/testnet runners to risk_per_trade=1.0 and remove portfolio caps
- share venue detection via `is_spot` and skip tiny orders with new `adjust_qty`
- allow PaperAdapter/Broker to honour min notional, step size and optional slippage

## Testing
- `pytest tests/test_paper_runner.py tests/test_live_runner.py -q` *(hangs, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c456a7c634832daf04fe8f3c5c674c