### PR TITLE
Fix paper trading PnL and exposure handling

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -667,9 +667,10 @@ class RiskService:
         with self._lock:
             self.add_fill(side, qty, price=price)
             self.guard.update_position_on_order(symbol, side, qty, venue=venue)
-            self.account.update_open_order(symbol, side, -abs(qty))
-            delta = qty if side == "buy" else -qty
-            self.account.update_position(symbol, delta, price=price)
+            if venue != "paper":
+                self.account.update_open_order(symbol, side, -abs(qty))
+                delta = qty if side == "buy" else -qty
+                self.account.update_position(symbol, delta, price=price)
             if venue is not None:
                 book = self.guard.st.venue_positions.get(venue, {})
                 venue_book = self.positions_multi.setdefault(venue, {})

--- a/tests/test_risk_service_paper.py
+++ b/tests/test_risk_service_paper.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tradingbot.core import Account
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+
+
+def test_on_fill_skips_account_updates_for_paper():
+    account = Account(float("inf"), cash=0.0)
+    account.update_position("BTC", 1.0, price=100.0)
+
+    calls = {"pos": 0, "open": 0}
+
+    account.update_position_orig = account.update_position
+    account.update_open_order_orig = account.update_open_order
+
+    def mock_update_position(symbol, delta, price=None):
+        calls["pos"] += 1
+        account.update_position_orig(symbol, delta, price)
+
+    def mock_update_open_order(symbol, side, delta_qty):
+        calls["open"] += 1
+        account.update_open_order_orig(symbol, side, delta_qty)
+
+    account.update_position = mock_update_position
+    account.update_open_order = mock_update_open_order
+
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    rs = RiskService(guard, account=account)
+
+    rs.on_fill("BTC", "buy", 1.0, price=100.0, venue="paper")
+
+    assert calls["pos"] == 0
+    assert calls["open"] == 0
+    assert account.positions["BTC"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- ensure PaperAdapter records realized PnL when closing long or short positions
- skip account double updates on paper fills and clamp runner quantities to available inventory
- add regression tests for paper PnL, risk service, and runner behaviour

## Testing
- `pytest tests/test_paper_limit_book.py tests/test_risk_service_paper.py tests/test_paper_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47853b138832d9f63c11e1e940f06