### PR TITLE
Track cancellation metrics for expired orders

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1337,6 +1337,10 @@ class EventDrivenBacktestEngine:
             for o in orders
         ]
 
+        order_count = len(orders)
+        cancel_count = sum(1 for o in orders if o.remaining_qty > 1e-9)
+        cancel_ratio = cancel_count / order_count if order_count else 0.0
+
         result = {
             "equity": equity_curve[-1],
             "pnl": pnl,
@@ -1347,6 +1351,9 @@ class EventDrivenBacktestEngine:
             "max_drawdown": max_drawdown,
             "equity_curve": equity_curve,
             "fill_count": fill_count,
+            "order_count": order_count,
+            "cancel_count": cancel_count,
+            "cancel_ratio": cancel_ratio,
             "fills": fills if collect_fills else [],
         }
         log.info(

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -353,32 +353,45 @@ async def run_paper(
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
                     if filled_qty > 0:
-                        slippage = (
-                            ((exec_price - price) / price) * 10000 if price else 0.0
-                        )
-                        maker = exec_price == price
-                        fee_bps = (
-                            exec_broker.maker_fee_bps if maker else broker.taker_fee_bps
-                        )
-                        fee = filled_qty * exec_price * (fee_bps / 10000.0)
+                          slippage = (
+                              ((exec_price - price) / price) * 10000 if price else 0.0
+                          )
+                          maker = exec_price == price
+                          fee_bps = (
+                              exec_broker.maker_fee_bps if maker else broker.taker_fee_bps
+                          )
+                          fee = filled_qty * exec_price * (fee_bps / 10000.0)
+                          log.info(
+                              "METRICS %s",
+                              json.dumps(
+                                  {
+                                      "event": "fill",
+                                      "side": close_side,
+                                      "price": exec_price,
+                                      "qty": filled_qty,
+                                      "fee": fee,
+                                      "pnl": delta_rpnl,
+                                      "slippage_bps": slippage,
+                                      "maker": maker,
+                                  }
+                              ),
+                    )
+                    if pending_qty > 0:
                         log.info(
                             "METRICS %s",
                             json.dumps(
                                 {
-                                    "event": "fill",
+                                    "event": "cancel",
                                     "side": close_side,
-                                    "price": exec_price,
-                                    "qty": filled_qty,
-                                    "fee": fee,
-                                    "pnl": delta_rpnl,
-                                    "slippage_bps": slippage,
-                                    "maker": maker,
+                                    "price": price,
+                                    "qty": pending_qty,
+                                    "reason": "expired",
                                 }
                             ),
                         )
-                    delta_rpnl = (
-                        resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
-                    )
+                      delta_rpnl = (
+                          resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
+                      )
                     opened_at = trade.get("opened_at")
                     duration = time.time() - opened_at if opened_at else 0.0
                     log.info(
@@ -465,37 +478,50 @@ async def run_paper(
                             resp.get("realized_pnl", broker.state.realized_pnl)
                             - prev_rpnl
                         )
-                        if filled_qty > 0:
-                            slippage = (
-                                ((exec_price - price) / price) * 10000 if price else 0.0
-                            )
-                            maker = exec_price == price
-                            fee_bps = (
-                                exec_broker.maker_fee_bps
-                                if maker
-                                else broker.taker_fee_bps
-                            )
-                            fee = filled_qty * exec_price * (fee_bps / 10000.0)
-                            log.info(
-                                "METRICS %s",
-                                json.dumps(
-                                    {
-                                        "event": "fill",
-                                        "side": side,
-                                        "price": exec_price,
-                                        "qty": filled_qty,
-                                        "fee": fee,
-                                        "pnl": delta_rpnl,
-                                        "slippage_bps": slippage,
-                                        "maker": maker,
-                                    }
-                                ),
-                            )
+                          if filled_qty > 0:
+                              slippage = (
+                                  ((exec_price - price) / price) * 10000 if price else 0.0
+                              )
+                              maker = exec_price == price
+                              fee_bps = (
+                                  exec_broker.maker_fee_bps
+                                  if maker
+                                  else broker.taker_fee_bps
+                              )
+                              fee = filled_qty * exec_price * (fee_bps / 10000.0)
+                              log.info(
+                                  "METRICS %s",
+                                  json.dumps(
+                                      {
+                                          "event": "fill",
+                                          "side": side,
+                                          "price": exec_price,
+                                          "qty": filled_qty,
+                                          "fee": fee,
+                                          "pnl": delta_rpnl,
+                                          "slippage_bps": slippage,
+                                          "maker": maker,
+                                      }
+                                  ),
+                              )
+                          if pending_qty > 0:
+                              log.info(
+                                  "METRICS %s",
+                                  json.dumps(
+                                      {
+                                          "event": "cancel",
+                                          "side": side,
+                                          "price": price,
+                                          "qty": pending_qty,
+                                          "reason": "expired",
+                                      }
+                                  ),
+                              )
 
-                        halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
-                        if halted:
-                            log.error("[HALT] motivo=%s", reason)
-                            break
+                          halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
+                          if halted:
+                              log.error("[HALT] motivo=%s", reason)
+                              break
                     continue
             closed = agg.on_trade(ts, px, qty)
             latency = (datetime.now(timezone.utc) - ts).total_seconds()
@@ -595,41 +621,54 @@ async def run_paper(
             )
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
-            exec_price = float(resp.get("price", price))
-            risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
-            if not (
-                filled_qty == 0 and resp.get("reason") == "insufficient_position"
-            ):
-                risk.on_fill(
-                    symbol, side, filled_qty, price=exec_price, venue="paper"
-                )
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            log.info("METRICS %s", json.dumps({"inventory": cur_qty}))
-            delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
-            if filled_qty > 0:
-                slippage = ((exec_price - price) / price) * 10000 if price else 0.0
-                maker = exec_price == price
-                fee_bps = exec_broker.maker_fee_bps if maker else broker.taker_fee_bps
-                fee = filled_qty * exec_price * (fee_bps / 10000.0)
-                log.info(
-                    "METRICS %s",
-                    json.dumps(
-                        {
-                            "event": "fill",
-                            "side": side,
-                            "price": exec_price,
-                            "qty": filled_qty,
-                            "fee": fee,
-                            "pnl": delta_rpnl,
-                            "slippage_bps": slippage,
-                            "maker": maker,
-                        }
-                    ),
-                )
-            halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
-            if halted:
-                log.error("[HALT] motivo=%s", reason)
-                break
+              exec_price = float(resp.get("price", price))
+              risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
+              if not (
+                  filled_qty == 0 and resp.get("reason") == "insufficient_position"
+              ):
+                  risk.on_fill(
+                      symbol, side, filled_qty, price=exec_price, venue="paper"
+                  )
+              cur_qty = risk.account.current_exposure(symbol)[0]
+              log.info("METRICS %s", json.dumps({"inventory": cur_qty}))
+              delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
+              if filled_qty > 0:
+                  slippage = ((exec_price - price) / price) * 10000 if price else 0.0
+                  maker = exec_price == price
+                  fee_bps = exec_broker.maker_fee_bps if maker else broker.taker_fee_bps
+                  fee = filled_qty * exec_price * (fee_bps / 10000.0)
+                  log.info(
+                      "METRICS %s",
+                      json.dumps(
+                          {
+                              "event": "fill",
+                              "side": side,
+                              "price": exec_price,
+                              "qty": filled_qty,
+                              "fee": fee,
+                              "pnl": delta_rpnl,
+                              "slippage_bps": slippage,
+                              "maker": maker,
+                          }
+                      ),
+                  )
+              if pending_qty > 0:
+                  log.info(
+                      "METRICS %s",
+                      json.dumps(
+                          {
+                              "event": "cancel",
+                              "side": side,
+                              "price": price,
+                              "qty": pending_qty,
+                              "reason": "expired",
+                          }
+                      ),
+                  )
+              halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
+              if halted:
+                  log.error("[HALT] motivo=%s", reason)
+                  break
     finally:
         server.should_exit = True
         if metrics_task is not None:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -268,6 +268,19 @@ async def _run_symbol(
                     filled_qty,
                     venue=venue if not dry_run else "paper",
                 )
+                if pending_qty > 0:
+                    log.info(
+                        "METRICS %s",
+                        json.dumps(
+                            {
+                                "event": "cancel",
+                                "side": close_side,
+                                "price": price,
+                                "qty": pending_qty,
+                                "reason": "expired",
+                            }
+                        ),
+                    )
                 delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                 halted, reason = risk.daily_mark(broker, cfg.symbol, px, delta_rpnl)
                 if halted:
@@ -316,6 +329,19 @@ async def _run_symbol(
                         filled_qty,
                         venue=venue if not dry_run else "paper",
                     )
+                    if pending_qty > 0:
+                        log.info(
+                            "METRICS %s",
+                            json.dumps(
+                                {
+                                    "event": "cancel",
+                                    "side": side,
+                                    "price": price,
+                                    "qty": pending_qty,
+                                    "reason": "expired",
+                                }
+                            ),
+                        )
                     delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     halted, reason = risk.daily_mark(broker, cfg.symbol, px, delta_rpnl)
                     if halted:
@@ -393,6 +419,19 @@ async def _run_symbol(
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )
+        if pending_qty > 0:
+            log.info(
+                "METRICS %s",
+                json.dumps(
+                    {
+                        "event": "cancel",
+                        "side": side,
+                        "price": price,
+                        "qty": pending_qty,
+                        "reason": "expired",
+                    }
+                ),
+            )
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, delta_rpnl)
         if halted:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -272,6 +272,19 @@ async def _run_symbol(
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )
+        if pending_qty > 0:
+            log.info(
+                "METRICS %s",
+                json.dumps(
+                    {
+                        "event": "cancel",
+                        "side": side,
+                        "price": price,
+                        "qty": pending_qty,
+                        "reason": "expired",
+                    }
+                ),
+            )
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, cfg.symbol, px, delta_rpnl)
         if halted:

--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -33,6 +33,9 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
     engine.verbose_fills = True
     result = engine.run()
     assert result["fill_count"] == 2
+    assert result["order_count"] == len(result["orders"])
+    assert result["cancel_count"] == 1
+    assert result["cancel_ratio"] == pytest.approx(1 / result["order_count"])
     fills = pd.DataFrame(
         result["fills"],
         columns=[

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -21,6 +21,7 @@ async def test_update_bot_stats_events():
     )
     await api_main.update_bot_stats(1, {"event": "trade", "pnl": 5})
     await api_main.update_bot_stats(1, {"event": "trade", "pnl": 7})
+    await api_main.update_bot_stats(1, {"event": "cancel"})
     stats = api_main._BOTS[1]["stats"]
     assert stats["orders_sent"] == 1
     assert stats["fills"] == 1
@@ -28,4 +29,6 @@ async def test_update_bot_stats_events():
     assert stats["hit_rate"] == 1.0
     assert stats["slippage_bps"] == 5
     assert stats["pnl"] == 9
+    assert stats["cancels"] == 1
+    assert stats["cancel_ratio"] == 1.0
     assert "trades_processed" not in stats


### PR DESCRIPTION
## Summary
- emit `METRICS cancel` events when orders expire in paper/real/testnet runners
- track cancelled orders in backtesting results and expose `cancel_ratio`
- extend metrics accumulation test to cover cancel counting

## Testing
- `pytest tests/test_metrics.py tests/test_metrics_accumulation.py tests/integration/test_recorded_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4c13ebbf8832d995b21eb8c428a70