### PR TITLE
Add 4h timeframe option to bot creation UI

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -89,6 +89,7 @@
           <option value="5m">5m</option>
           <option value="15m">15m</option>
           <option value="30m">30m</option>
+          <option value="4h">4h</option>
         </select>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- allow selecting 4h timeframe when creating a bot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4c2226cf4832d915c531fb496ac48