### PR TITLE
Use ccxt timeframe parsing for hourly bars

### DIFF
--- a/tests/test_bar_aggregator.py
+++ b/tests/test_bar_aggregator.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from tradingbot.live.runner import BarAggregator
+
+
+def test_bar_aggregator_4h_alignment():
+    agg = BarAggregator("4h")
+    first_ts = datetime(2023, 1, 1, 5, 30, tzinfo=timezone.utc)
+    agg.on_trade(first_ts, 100.0, 1.0)
+    assert agg.current_period == datetime(2023, 1, 1, 4, 0, tzinfo=timezone.utc)
+
+    second_ts = datetime(2023, 1, 1, 9, 0, tzinfo=timezone.utc)
+    closed = agg.on_trade(second_ts, 110.0, 1.0)
+
+    assert closed.ts_open == datetime(2023, 1, 1, 4, 0, tzinfo=timezone.utc)
+    assert agg.current_period == datetime(2023, 1, 1, 8, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- parse timeframe with `ccxt.Exchange.parse_timeframe` to support minute and hour units
- improve timestamp flooring using timedelta for multi-hour bars
- test 4h `BarAggregator` alignment

## Testing
- `pytest tests/test_bar_aggregator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d20ba660832d94a3e4db8822f6ce