### PR TITLE
feat(metrics): track locked usd and exposure

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1251,21 +1251,11 @@ async def update_bot_stats(pid: int, stats: dict | None = None, **kwargs) -> Non
             trades_buf.append(trade_data)
         elif event == "cancel":
             buf["cancels"] = buf.get("cancels", 0) + 1
+        elif event == "skip":
+            buf["skips"] = buf.get("skips", 0) + 1
         elif event == "trade":
             trades_buf = info.setdefault("trades", deque(maxlen=100))
             trade_payload = dict(data)
-            duration = data.get("duration")
-            if duration is not None:
-                try:
-                    dur = float(duration)
-                except (TypeError, ValueError):
-                    dur = None
-                if dur is not None:
-                    tot = buf.get("_dur_tot", 0.0) + dur
-                    cnt = buf.get("_dur_cnt", 0) + 1
-                    buf["_dur_tot"] = tot
-                    buf["_dur_cnt"] = cnt
-                    buf["avg_trade_duration"] = tot / cnt
             if pnl_val is not None:
                 trade_payload["pnl"] = pnl_val
             trades_buf.append(trade_payload)

--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -120,7 +120,7 @@
     <div class="muted">Auto-refresh 5s</div>
     <div style="overflow:auto; max-height:60vh; margin-top:10px">
       <table id="tbl-bots">
-        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders</th><th>Fills</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Duración</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
+        <thead><tr><th>PID</th><th>Bot</th><th>Pares</th><th>Estado</th><th>Orders</th><th>Fills</th><th>PnL</th><th>Cancel %</th><th>M/T</th><th>Fees</th><th>Slippage</th><th>Hit %</th><th>Locked (USD)</th><th>Exposure</th><th>Leverage</th><th>Risk</th><th>Acciones</th></tr></thead>
         <tbody></tbody>
       </table>
     </div>
@@ -358,8 +358,8 @@ async function refreshBots(){
         (stats.fees_usd||0).toFixed(2),
         (stats.slippage_bps||0).toFixed(2),
         `${((stats.hit_rate||0)*100).toFixed(1)}%`,
-        (stats.avg_trade_duration||0).toFixed(1),
-        (stats.inventory||0).toFixed(4),
+        (stats.locked||0).toFixed(2),
+        (stats.exposure||0).toFixed(4),
         (stats.leverage||0).toFixed(2),
         `${((b.risk_pct ?? 0)*100).toFixed(2)}%`
       ];

--- a/src/tradingbot/core/account.py
+++ b/src/tradingbot/core/account.py
@@ -84,3 +84,13 @@ class Account:
         qty = float(self.positions.get(symbol, 0.0))
         price = float(self.prices.get(symbol, 0.0))
         return qty, abs(qty) * price
+
+    # ------------------------------------------------------------------
+    def get_locked_usd(self, symbol: str) -> float:
+        """Return USD locked in open orders for ``symbol``.
+
+        This helper mirrors :meth:`pending_exposure` to clarify intent when
+        reporting metrics.  It sums the notional of all outstanding orders for
+        ``symbol`` using the last marked price.
+        """
+        return self.pending_exposure(symbol)

--- a/tests/test_bot_env.py
+++ b/tests/test_bot_env.py
@@ -78,7 +78,7 @@ async def test_update_bot_stats(monkeypatch):
 
     cfg = api_main.BotConfig(strategy="dummy")
     await api_main.start_bot(cfg)
-    await api_main.update_bot_stats(999, orders_sent=5, fills=2, inventory=1.5)
+    await api_main.update_bot_stats(999, orders_sent=5, fills=2, exposure=1.5)
 
     class DummyReq:
         headers = {}
@@ -87,7 +87,7 @@ async def test_update_bot_stats(monkeypatch):
     stats = data["bots"][0]["stats"]
     assert stats["orders_sent"] == 5
     assert stats["fills"] == 2
-    assert stats["inventory"] == 1.5
+    assert stats["exposure"] == 1.5
 
     # cleanup
     captured["proc"]._done.set()  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add Account.get_locked_usd helper and expose locked amount in metrics
- emit exposure and locked metrics in paper runner and handle skips
- remove trade duration metric and update API/UI for locked USD

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c58ce11730832db862e09eb7037121