### PR TITLE
Handle min order size in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -615,6 +615,16 @@ async def run_paper(
                 )
                 continue
             notional = qty * price
+            if qty < step_size or notional < min_notional:
+                reason = "below_min_qty" if qty < step_size else "below_min_notional"
+                log.info(
+                    "Skipping order: qty %.8f notional %.8f below min threshold", qty, notional
+                )
+                log.info(
+                    "METRICS %s",
+                    json.dumps({"event": "skip", "reason": reason}),
+                )
+                continue
             if not risk.register_order(symbol, notional):
                 reason = getattr(risk, "last_kill_reason", "register_reject")
                 log.warning("registro de orden bloqueado: %s", reason)


### PR DESCRIPTION
## Summary
- Skip orders when quantity is below step size or notional is below exchange minimum
- Prevents risk/limit order processing for tiny orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5beadeb4c832da5a9f708bc6106be