### PR TITLE
Clear near-zero positions after fills in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -357,6 +357,7 @@ async def run_paper(
                     if abs(cur_qty) < step_size:
                         cur_qty = 0.0
                         risk.account.positions[symbol] = 0.0
+                        risk.account.open_orders.pop(symbol, None)
                     locked = risk.account.get_locked_usd(symbol)
                     log.info(
                         "METRICS %s",
@@ -495,6 +496,7 @@ async def run_paper(
                         if abs(cur_qty) < step_size:
                             cur_qty = 0.0
                             risk.account.positions[symbol] = 0.0
+                            risk.account.open_orders.pop(symbol, None)
                         locked = risk.account.get_locked_usd(symbol)
                         log.info(
                             "METRICS %s",
@@ -667,6 +669,7 @@ async def run_paper(
             if abs(cur_qty) < step_size:
                 cur_qty = 0.0
                 risk.account.positions[symbol] = 0.0
+                risk.account.open_orders.pop(symbol, None)
             locked = risk.account.get_locked_usd(symbol)
             log.info(
                 "METRICS %s",


### PR DESCRIPTION
## Summary
- Reset position and clear open-order reserves when fills leave quantities below step size

## Testing
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5beb04560832d85751d1f620b7c4b