### PR TITLE
Add market type tracking and order reservation cleanup

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -418,16 +418,17 @@ class EventDrivenBacktestEngine:
             if strat_cls is None:
                 raise ValueError(f"unknown strategy: {strat_name}")
             key = (strat_name, symbol)
-            allow_short = self.exchange_mode.get(exchange, "perp") != "spot"
+            market_mode = self.exchange_mode.get(exchange, "perp")
+            mt = "spot" if market_mode == "spot" else "futures"
             guard = PortfolioGuard(GuardConfig(venue=exchange))
-            account = CoreAccount(float("inf"), cash=self.initial_equity)
+            account = CoreAccount(float("inf"), cash=self.initial_equity, market_type=mt)
             svc = RiskService(
                 guard,
                 account=account,
                 risk_per_trade=self.risk_per_trade,
                 risk_pct=self._risk_pct,
+                market_type=mt,
             )
-            svc.allow_short = allow_short
             svc.min_order_qty = self.min_order_qty
             self.risk[key] = svc
             self.strategy_exchange[key] = exchange

--- a/src/tradingbot/core/account.py
+++ b/src/tradingbot/core/account.py
@@ -22,10 +22,14 @@ class Account:
         enforcement is left to higher level components.
     cash:
         Optional starting cash balance.
+    market_type:
+        Market type for this account, "spot" or "futures". Determines
+        whether short positions are permitted.
     """
 
     max_symbol_exposure: float
     cash: float = 0.0
+    market_type: str = "futures"
     positions: Dict[str, float] = field(default_factory=dict)
     prices: Dict[str, float] = field(default_factory=dict)
     open_orders: Dict[str, Dict[str, float]] = field(default_factory=dict)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -142,6 +142,7 @@ async def run_paper(
     broker.state.cash = initial_cash
     if hasattr(broker.account, "update_cash"):
         broker.account.update_cash(initial_cash)
+    broker.account.market_type = market
 
     guard = PortfolioGuard(
         GuardConfig(
@@ -158,9 +159,8 @@ async def run_paper(
         account=broker.account,
         risk_pct=risk_pct,
         risk_per_trade=risk_per_trade,
+        market_type=market,
     )
-    from ..utils.venues import is_spot
-    risk.allow_short = not is_spot(venue)
     engine = None
     if _CAN_PG:
         while True:


### PR DESCRIPTION
## Summary
- Track market type (spot or futures) across runners and account
- Configure risk service short permissions via market type
- Release reserved balances when orders cancel, expire, or are discarded

## Testing
- `pytest -q` *(killed: container out of memory?)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e654c1a0832dbf84ea5e9647645b