### PR TITLE
Pass pending order quantity into risk checks

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -456,11 +456,15 @@ async def run_paper(
             if signal is None:
                 continue
             signal_ts = getattr(signal, "signal_ts", time.time())
+            pending = risk.account.open_orders.get(symbol, {}).get(
+                signal.side, 0.0
+            )
             allowed, reason, delta = risk.check_order(
                 symbol,
                 signal.side,
                 closed.c,
                 strength=signal.strength,
+                pending_qty=pending,
                 volatility=bar.get("atr") or bar.get("volatility"),
                 target_volatility=bar.get("target_volatility"),
             )

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -287,11 +287,13 @@ async def _run_symbol(
         if sig is None:
             continue
         signal_ts = getattr(sig, "signal_ts", time.time())
+        pending = risk.account.open_orders.get(cfg.symbol, {}).get(sig.side, 0.0)
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
             closed.c,
             strength=sig.strength,
+            pending_qty=pending,
             volatility=bar.get("atr") or bar.get("volatility"),
             target_volatility=bar.get("target_volatility"),
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -189,12 +189,14 @@ async def _run_symbol(
         if sig is None:
             continue
         signal_ts = getattr(sig, "signal_ts", time.time())
+        pending = risk.account.open_orders.get(cfg.symbol, {}).get(sig.side, 0.0)
         allowed, reason, delta = risk.check_order(
             cfg.symbol,
             sig.side,
             closed.c,
             strength=sig.strength,
             corr_threshold=corr_threshold,
+            pending_qty=pending,
             volatility=bar.get("atr") or bar.get("volatility"),
             target_volatility=bar.get("target_volatility"),
         )


### PR DESCRIPTION
## Summary
- include outstanding order quantity when checking risk limits in paper and live runners

## Testing
- `pytest` *(partially executed: 19 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c603851250832db7c39df28c630bb4