### PR TITLE
Add requested quantity and inventory to risk check logs

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -468,7 +468,14 @@ async def run_paper(
                 log.warning("orden bloqueada: %s", reason)
                 log.info(
                     "METRICS %s",
-                    json.dumps({"event": "risk_check_reject", "reason": reason}),
+                    json.dumps(
+                        {
+                            "event": "risk_check_reject",
+                            "reason": reason,
+                            "requested_qty": abs(delta),
+                            "inventory": risk.account.current_exposure(symbol)[0],
+                        }
+                    ),
                 )
                 continue
             if abs(delta) <= 0:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Tuple
 import time
+import json
 
 import pandas as pd
 import uvicorn
@@ -295,9 +296,22 @@ async def _run_symbol(
             volatility=bar.get("atr") or bar.get("volatility"),
             target_volatility=bar.get("target_volatility"),
         )
-        if not allowed or abs(delta) <= 0:
+        if not allowed:
             if reason:
                 log.warning("[PG] Bloqueado %s: %s", cfg.symbol, reason)
+            log.info(
+                "METRICS %s",
+                json.dumps(
+                    {
+                        "event": "risk_check_reject",
+                        "reason": reason,
+                        "requested_qty": abs(delta),
+                        "inventory": risk.account.current_exposure(cfg.symbol)[0],
+                    }
+                ),
+            )
+            continue
+        if abs(delta) <= 0:
             continue
         side = "buy" if delta > 0 else "sell"
         qty = abs(delta)


### PR DESCRIPTION
## Summary
- log requested_qty and inventory in risk_check_reject metrics for paper, real, and testnet runners

## Testing
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c603766f8c832d9428ca2518fdf9a1