### PR TITLE
Remove redundant risk.on_fill in paper runner

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -349,13 +349,6 @@ async def run_paper(
                     risk.account.update_open_order(
                         symbol, close_side, pending_qty
                     )
-                    if not (
-                        filled_qty == 0
-                        and resp.get("reason") == "insufficient_position"
-                    ):
-                        risk.on_fill(
-                            symbol, close_side, filled_qty, price=exec_price, venue="paper"
-                        )
                     cur_qty = risk.account.current_exposure(symbol)[0]
                     if abs(cur_qty) < step_size:
                         cur_qty = 0.0
@@ -491,13 +484,6 @@ async def run_paper(
                         risk.account.update_open_order(
                             symbol, side, pending_qty
                         )
-                        if not (
-                            filled_qty == 0
-                            and resp.get("reason") == "insufficient_position"
-                        ):
-                            risk.on_fill(
-                                symbol, side, filled_qty, price=exec_price, venue="paper"
-                            )
                         cur_qty = risk.account.current_exposure(symbol)[0]
                         if abs(cur_qty) < step_size:
                             cur_qty = 0.0
@@ -700,12 +686,6 @@ async def run_paper(
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
             risk.account.update_open_order(symbol, side, pending_qty)
-            if not (
-                filled_qty == 0 and resp.get("reason") == "insufficient_position"
-            ):
-                risk.on_fill(
-                    symbol, side, filled_qty, price=exec_price, venue="paper"
-                )
             cur_qty = risk.account.current_exposure(symbol)[0]
             if abs(cur_qty) < step_size:
                 cur_qty = 0.0

--- a/tests/test_guard_account_sync.py
+++ b/tests/test_guard_account_sync.py
@@ -1,0 +1,40 @@
+import pytest
+
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.core import Account
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
+
+
+class FilledAdapter:
+    """Adapter that immediately fills orders at a fixed price."""
+
+    name = "paper"
+
+    def __init__(self, price: float = 100.0):
+        self.price = price
+        self.state = type("S", (), {"order_book": {}, "last_px": {}})()
+
+    async def place_order(self, **kwargs):
+        return {
+            "status": "filled",
+            "filled_qty": kwargs["qty"],
+            "price": kwargs.get("price", self.price),
+            "pending_qty": 0.0,
+        }
+
+
+@pytest.mark.asyncio
+async def test_guard_and_account_sync_after_fill():
+    guard = PortfolioGuard(GuardConfig(venue="paper"))
+    account = Account(float("inf"))
+    risk = RiskService(guard, account=account)
+    router = ExecutionRouter(FilledAdapter(), risk_service=risk)
+
+    await router.place_order("SYM", "buy", "market", 1.0)
+    assert account.positions["SYM"] == pytest.approx(1.0)
+    assert guard.st.venue_positions["paper"]["SYM"] == pytest.approx(1.0)
+
+    await router.place_order("SYM", "sell", "market", 0.4)
+    assert account.positions["SYM"] == pytest.approx(0.6)
+    assert guard.st.venue_positions["paper"]["SYM"] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
- stop calling `risk.on_fill` after paper limit orders and rely on `ExecutionRouter.update_position`
- add regression test ensuring PortfolioGuard and Account stay in sync after fills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c60dcb5a5c832dad1bbcd4f10dd8ae