### PR TITLE
Remove redundant paper risk fill updates

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -352,13 +352,6 @@ async def run_paper(
                     risk.account.update_open_order(
                         symbol, close_side, pending_qty - prev_pending
                     )
-                    if not (
-                        filled_qty == 0
-                        and resp.get("reason") == "insufficient_position"
-                    ):
-                        risk.on_fill(
-                            symbol, close_side, filled_qty, price=exec_price, venue="paper"
-                        )
                     cur_qty = risk.account.current_exposure(symbol)[0]
                     if abs(cur_qty) < step_size:
                         cur_qty = 0.0
@@ -497,13 +490,6 @@ async def run_paper(
                         risk.account.update_open_order(
                             symbol, side, pending_qty - prev_pending
                         )
-                        if not (
-                            filled_qty == 0
-                            and resp.get("reason") == "insufficient_position"
-                        ):
-                            risk.on_fill(
-                                symbol, side, filled_qty, price=exec_price, venue="paper"
-                            )
                         cur_qty = risk.account.current_exposure(symbol)[0]
                         if abs(cur_qty) < step_size:
                             cur_qty = 0.0
@@ -707,12 +693,6 @@ async def run_paper(
             exec_price = float(resp.get("price", price))
             prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
             risk.account.update_open_order(symbol, side, pending_qty - prev_pending)
-            if not (
-                filled_qty == 0 and resp.get("reason") == "insufficient_position"
-            ):
-                risk.on_fill(
-                    symbol, side, filled_qty, price=exec_price, venue="paper"
-                )
             cur_qty = risk.account.current_exposure(symbol)[0]
             if abs(cur_qty) < step_size:
                 cur_qty = 0.0

--- a/tests/test_execution_router_extra.py
+++ b/tests/test_execution_router_extra.py
@@ -3,6 +3,9 @@ import pytest
 from tradingbot.execution.order_types import Order
 from tradingbot.execution.router import ExecutionRouter
 from tradingbot.storage import timescale
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
+from tradingbot.risk.service import RiskService
 
 
 class DummyAdapter:
@@ -90,3 +93,24 @@ async def test_execute_persists_reduce_only(monkeypatch):
     order = Order(symbol="X", side="buy", type_="market", qty=1.0, reduce_only=True)
     await router.execute(order)
     assert captured["notes"]["reduce_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_router_syncs_guard_account_on_fill():
+    adapter = PaperAdapter()
+    adapter.state.cash = 1000.0
+    symbol = "BTCUSDT"
+    adapter.update_last_price(symbol, 100.0)
+    guard = PortfolioGuard(GuardConfig(venue="paper"))
+    risk = RiskService(guard, account=adapter.account)
+    router = ExecutionRouter(adapter, risk_service=risk)
+    order_buy = Order(symbol=symbol, side="buy", type_="limit", qty=1.0, price=100.0)
+    res_buy = await router.execute(order_buy)
+    assert res_buy["status"] == "filled"
+    assert risk.account.positions[symbol] == pytest.approx(1.0)
+    assert guard.st.venue_positions["paper"][symbol] == pytest.approx(1.0)
+    order_sell = Order(symbol=symbol, side="sell", type_="limit", qty=1.0, price=100.0)
+    res_sell = await router.execute(order_sell)
+    assert res_sell["status"] == "filled"
+    assert risk.account.positions.get(symbol, 0.0) == pytest.approx(0.0)
+    assert guard.st.venue_positions["paper"].get(symbol, 0.0) == pytest.approx(0.0)

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -156,7 +156,7 @@ class DummyExecBrokerRecord(DummyExecBroker):
 
 class DummyBroker:
     def __init__(self):
-        self.account = object()
+        self.account = SimpleNamespace(update_cash=lambda amount: None)
         self.state = SimpleNamespace(realized_pnl=0.0, last_px={}, order_book={})
 
     def update_last_price(self, symbol, px):
@@ -209,6 +209,7 @@ async def test_run_paper(monkeypatch):
     monkeypatch.setattr(rp, "BinanceWSAdapter", lambda: DummyWS())
     monkeypatch.setattr(rp, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rp, "STRATEGIES", {"dummy": DummyStrat})
+    monkeypatch.setattr(rp, "REST_ADAPTERS", {})
     # Use real RiskManager and PortfolioGuard to satisfy run_paper setup
     dummy_risk = DummyRisk()
     monkeypatch.setattr(rp, "RiskService", lambda *a, **k: dummy_risk)
@@ -238,6 +239,7 @@ async def test_run_paper_skips_on_fill(monkeypatch):
     monkeypatch.setattr(rp, "BinanceWSAdapter", lambda: DummyWS())
     monkeypatch.setattr(rp, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rp, "STRATEGIES", {"dummy": DummyStrat})
+    monkeypatch.setattr(rp, "REST_ADAPTERS", {})
     dummy_risk = DummyRiskRecord()
     monkeypatch.setattr(rp, "RiskService", lambda *a, **k: dummy_risk)
     monkeypatch.setattr(rp, "ExecutionRouter", DummyRouter)
@@ -259,6 +261,7 @@ async def test_run_paper_skip_sell_no_inventory(monkeypatch):
     monkeypatch.setattr(rp, "BinanceWSAdapter", lambda: DummyWS())
     monkeypatch.setattr(rp, "BarAggregator", DummyAgg)
     monkeypatch.setattr(rp, "STRATEGIES", {"dummy": SellStrat})
+    monkeypatch.setattr(rp, "REST_ADAPTERS", {})
     dummy_risk = DummyRiskNoInventory()
     monkeypatch.setattr(rp, "RiskService", lambda *a, **k: dummy_risk)
     monkeypatch.setattr(rp, "ExecutionRouter", DummyRouter)


### PR DESCRIPTION
## Summary
- rely on ExecutionRouter to sync positions in paper runner
- ensure guard and account stay aligned on fills
- adjust paper runner tests to avoid external dependencies

## Testing
- `pytest tests/test_execution_router_extra.py::test_router_syncs_guard_account_on_fill -q`
- `pytest tests/test_paper_runner.py::test_run_paper -q` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68c610befa00832db17295192da1add5