### PR TITLE
Align live runners with backtesting order handling

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -35,7 +35,6 @@ from ..adapters.bybit_futures import BybitFuturesAdapter
 from ..adapters.okx_futures import OKXFuturesAdapter
 from monitoring import panel
 from ..execution.order_sizer import adjust_qty
-from ..utils.metrics import CANCELS
 from ..core.symbols import normalize
 
 try:
@@ -271,25 +270,16 @@ async def _run_symbol(
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(symbol, side, pending_qty)
+        prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
+        delta_open = (
+            filled_qty + pending_qty - prev_pending
+            if not dry_run
+            else pending_qty - prev_pending
+        )
+        risk.account.update_open_order(symbol, side, delta_open)
         risk.on_fill(
             symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )
-        if pending_qty > 0:
-            CANCELS.inc()
-            log.info(
-                "METRICS %s",
-                json.dumps(
-                    {
-                        "event": "cancel",
-                        "side": side,
-                        "price": price,
-                        "qty": pending_qty,
-                        "reason": "expired",
-                    }
-                ),
-            )
-            risk.account.update_open_order(symbol, side, -pending_qty)
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
         if halted:

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -492,6 +492,7 @@ class RiskService:
         if delta < 0 and not self.allow_short:
             cur_qty, _ = self.account.current_exposure(symbol)
             if cur_qty <= 0:
+                log.warning("short_not_allowed: %s cur_qty=%.8f", symbol, cur_qty)
                 return False, "short_not_allowed", 0.0
             sellable = min(abs(delta), cur_qty)
             delta = -sellable


### PR DESCRIPTION
## Summary
- Log inventory when a short order is rejected
- Keep live and paper runners' orders resting and update open orders incrementally
- Use risk service delta directly and avoid clearing exposure for small balances

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c60aa028fc832d88e8d9487bf72c39