### PR TITLE
Validate order size before runner

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -75,6 +75,7 @@ class RiskService:
         self.market_type = mt
         self._allow_short = mt != "spot"
         self._min_order_qty = 1e-9
+        self._min_notional = 0.0
         self.enabled = True
         self.last_kill_reason: str | None = None
         self._pos = Position()
@@ -89,6 +90,14 @@ class RiskService:
     @min_order_qty.setter
     def min_order_qty(self, value: float) -> None:
         self._min_order_qty = float(value)
+
+    @property
+    def min_notional(self) -> float:
+        return self._min_notional
+
+    @min_notional.setter
+    def min_notional(self, value: float) -> None:
+        self._min_notional = float(value)
 
     @property
     def allow_short(self) -> bool:

--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -9,6 +9,9 @@ import yaml
 from ..utils.metrics import REQUEST_LATENCY
 from ..storage import timescale
 from ..execution.order_types import Order
+from ..utils.logging import get_logger
+
+log = get_logger(__name__)
 
 
 @dataclass
@@ -139,6 +142,14 @@ class Strategy(ABC):
             if decision == "hold" and signal is not None:
                 return signal
             return None
+        if signal is not None:
+            qty = rs.calc_position_size(signal.strength, price)
+            notional = abs(qty) * price
+            if qty < rs.min_order_qty or (
+                getattr(rs, "min_notional", 0.0) and notional < rs.min_notional
+            ):
+                log.info("orden submínima qty=%.8f notional=%.8f", qty, notional)
+                return None
         return signal
 
 

--- a/tests/test_subminimum_signal.py
+++ b/tests/test_subminimum_signal.py
@@ -1,0 +1,28 @@
+import logging
+from tradingbot.strategies.base import Strategy, Signal
+
+class DummyRisk:
+    def __init__(self):
+        self.min_order_qty = 1.0
+        self.min_notional = 10.0
+    def get_trade(self, symbol):
+        return None
+    def calc_position_size(self, strength, price, **kwargs):
+        return strength
+
+class SmallStrat(Strategy):
+    name = "small"
+    def on_bar(self, bar):
+        sig = Signal("buy", strength=0.5)
+        return self.finalize_signal(bar, bar["price"], sig)
+
+
+def test_subminimum_signal_is_discarded(caplog):
+    risk = DummyRisk()
+    strat = SmallStrat()
+    strat.risk_service = risk
+    bar = {"price": 1.0, "symbol": "BTC"}
+    with caplog.at_level(logging.INFO):
+        sig = strat.on_bar(bar)
+    assert sig is None
+    assert "orden submínima" in caplog.text


### PR DESCRIPTION
## Summary
- ensure RiskService tracks `min_notional`
- drop sub-minimum signals inside `Strategy.finalize_signal`
- test that undersized signals are ignored

## Testing
- `pytest -q` *(fails: Killed)*
- `pytest tests/test_subminimum_signal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1098bd8832d9802fde8b11c5b4d