### PR TITLE
Enforce short restrictions across trading modes

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1104,6 +1104,12 @@ class EventDrivenBacktestEngine:
                         continue
                     if sig is None or sig.side == "flat":
                         continue
+                    if (
+                        sig.side == "sell"
+                        and not svc.allow_short
+                        and svc.account.current_exposure(symbol)[0] <= 0
+                    ):
+                        continue
                     pending = svc.account.open_orders.get(symbol, {}).get(sig.side, 0.0)
                     atr_map = getattr(strat, "_last_atr", {})
                     tgt_map = getattr(strat, "_last_target_vol", {})

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -576,6 +576,18 @@ async def run_paper(
             signal = strat.on_bar(bar)
             if signal is None:
                 continue
+            if (
+                signal.side == "sell"
+                and not risk.allow_short
+                and risk.account.current_exposure(symbol)[0] <= 0
+            ):
+                log.info("Skipping signal: short_not_allowed")
+                SKIPS.inc()
+                log.info(
+                    "METRICS %s",
+                    json.dumps({"event": "skip", "reason": "short_not_allowed"}),
+                )
+                continue
             signal_ts = getattr(signal, "signal_ts", time.time())
             allowed, reason, delta = risk.check_order(
                 symbol,

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -364,6 +364,17 @@ async def _run_symbol(
         sig = strat.on_bar(bar)
         if sig is None:
             continue
+        if (
+            sig.side == "sell"
+            and not risk.allow_short
+            and risk.account.current_exposure(symbol)[0] <= 0
+        ):
+            log.warning("[PG] Bloqueado %s: short_not_allowed", symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"event": "skip", "reason": "short_not_allowed"}),
+            )
+            continue
         signal_ts = getattr(sig, "signal_ts", time.time())
         allowed, reason, delta = risk.check_order(
             symbol,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -221,6 +221,17 @@ async def _run_symbol(
         sig = strat.on_bar(bar)
         if sig is None:
             continue
+        if (
+            sig.side == "sell"
+            and not risk.allow_short
+            and risk.account.current_exposure(symbol)[0] <= 0
+        ):
+            log.warning("[PG] Bloqueado %s: short_not_allowed", symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"event": "skip", "reason": "short_not_allowed"}),
+            )
+            continue
         signal_ts = getattr(sig, "signal_ts", time.time())
         allowed, reason, delta = risk.check_order(
             symbol,

--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -51,6 +51,7 @@ class RiskService:
         risk_pct: float = 0.01,
         profit_lock_usd: float = 1.0,
         market_type: str | None = None,
+        allow_short: bool | None = None,
     ) -> None:
         self.guard = guard
         self.daily = daily
@@ -73,7 +74,9 @@ class RiskService:
         # Internal risk tracking previously handled by _RiskManager
         self.risk_pct = abs(risk_pct)
         self.market_type = mt
-        self._allow_short = mt != "spot"
+        self._allow_short = (
+            bool(allow_short) if allow_short is not None else mt != "spot"
+        )
         self._min_order_qty = 1e-9
         self.enabled = True
         self.last_kill_reason: str | None = None

--- a/tests/test_live_runner.py
+++ b/tests/test_live_runner.py
@@ -38,6 +38,7 @@ class DummyRisk:
         from types import SimpleNamespace
 
         self.rm = SimpleNamespace(allow_short=True)
+        self.allow_short = True
         self.account = Account(float("inf"))
 
     def get_trade(self, symbol):

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -45,6 +45,7 @@ class DummyRisk:
         self.last_strength: float | None = None
         self.min_order_qty = 0.0
         self.rm = types.SimpleNamespace(allow_short=True)
+        self.allow_short = True
         self.account = types.SimpleNamespace(
             current_exposure=lambda symbol: (0.0, 0.0),
             update_open_order=lambda symbol, side, qty: None,
@@ -198,6 +199,7 @@ class DummyRiskNoInventory(DummyRisk):
     def __init__(self, *a, **k):
         super().__init__(*a, **k)
         self.register_called = False
+        self.allow_short = False
 
     def register_order(self, symbol, notional):
         self.register_called = True


### PR DESCRIPTION
## Summary
- expose `allow_short` in `RiskService` with market-aware default
- reject short signals in paper, testnet and real runners when shorts disabled
- align backtesting engine and add coverage for short signal rejection

## Testing
- `pytest tests/test_backtest_engine.py::test_spot_long_only_enforced -q`
- `pytest tests/test_backtest_engine.py::test_spot_short_signal_rejected -q`
- `pytest tests/test_live_runner.py::test_bybit_futures_order -q` *(skipped)*
- `pytest tests/test_paper_runner.py::test_run_paper_skip_sell_no_inventory -q` *(hang: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0d0e9b4832d99e86167b044787b