### PR TITLE
Use per-symbol tick sizes from exchange rules

### DIFF
--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -139,6 +139,7 @@ async def _run_symbol(
     step_size: float = 0.0,
 ) -> None:
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
+    raw_symbol = cfg.symbol
     symbol = normalize(cfg.symbol)
     log.info("Connecting to %s %s for %s", exchange, market, symbol)
     api_key, api_secret = _get_keys(exchange)
@@ -148,7 +149,20 @@ async def _run_symbol(
     ws = ws_cls()
     exec_adapter = exec_cls(**exec_kwargs)
     cfg_app = load_config()
-    tick_size = float(cfg_app.exchange_configs.get(venue, {}).get("tick_size", 0.0))
+    tick_size = 0.0
+    meta = getattr(exec_adapter, "meta", None)
+    if meta is not None:
+        try:
+            fetch_symbol = None
+            symbols = getattr(meta.client, "symbols", [])
+            if symbols:
+                fetch_symbol = next((s for s in symbols if normalize(s) == symbol), None)
+            if fetch_symbol is None:
+                fetch_symbol = raw_symbol.replace("-", "/")
+            rules = meta.rules_for(fetch_symbol)
+            tick_size = float(getattr(rules, "price_step", 0.0) or 0.0)
+        except Exception:
+            tick_size = 0.0
     agg = BarAggregator(timeframe=timeframe)
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:

--- a/tests/test_execution_router_tick_size.py
+++ b/tests/test_execution_router_tick_size.py
@@ -1,0 +1,44 @@
+import pytest
+
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.order_types import Order
+from tradingbot.execution.normalize import SymbolRules
+
+
+class DummyMeta:
+    def __init__(self, rules):
+        self.rules = rules
+        self.client = type("C", (), {"symbols": list(rules.keys())})()
+
+    def rules_for(self, symbol):
+        return self.rules[symbol]
+
+
+class DummyAdapter:
+    def __init__(self, rules):
+        self.meta = DummyMeta(rules)
+        self.state = type("S", (), {"order_book": {}, "last_px": {}})()
+        self.name = "d"
+        self.maker_fee_bps = 0.0
+        self.taker_fee_bps = 0.0
+
+    async def place_order(self, **kwargs):
+        return {"status": "filled", **kwargs}
+
+
+@pytest.mark.asyncio
+async def test_router_uses_tick_size_per_symbol():
+    rules = {
+        "AAA/USDT": SymbolRules(price_step=0.5),
+        "BBB/USDT": SymbolRules(price_step=0.1),
+    }
+    adapter = DummyAdapter(rules)
+    router = ExecutionRouter(adapter)
+
+    order_a = Order(symbol="AAA/USDT", side="buy", type_="limit", qty=1.0, price=1.23)
+    res_a = await router.execute(order_a)
+    assert res_a["price"] == pytest.approx(1.0)
+
+    order_b = Order(symbol="BBB/USDT", side="buy", type_="limit", qty=1.0, price=1.23)
+    res_b = await router.execute(order_b)
+    assert res_b["price"] == pytest.approx(1.2)

--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -17,6 +17,13 @@ sys.modules.pop("tradingbot.adapters.binance", None)
 
 
 class DummyWS:
+    def __init__(self):
+        meta = types.SimpleNamespace(
+            client=types.SimpleNamespace(symbols=[]),
+            rules_for=lambda s: SimpleNamespace(qty_step=1e-9, price_step=0.1),
+        )
+        self.rest = types.SimpleNamespace(meta=meta)
+
     async def stream_trades(self, symbol):
         yield {"ts": datetime.now(timezone.utc), "price": 100.0, "qty": 1.0}
 


### PR DESCRIPTION
## Summary
- query exchange metadata for tick size at startup in live runners
- remove global tick size references and apply per-symbol ticks
- cover per-symbol tick rounding when placing orders

## Testing
- `pytest tests/test_execution_router_tick_size.py -q`
- ⚠️ `pytest tests/test_paper_runner.py::test_run_paper -vv` (hung)


------
https://chatgpt.com/codex/tasks/task_e_68c6e6fb1c2c832d8edbfa7ff1c6e513