### PR TITLE
Ensure hit and cancel ratios default to zero

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1279,9 +1279,8 @@ async def update_bot_stats(pid: int, stats: dict | None = None, **kwargs) -> Non
         orders = buf.get("orders", 0)
         fills = buf.get("fills", 0)
         cancels = buf.get("cancels", 0)
-        if orders:
-            buf["hit_rate"] = fills / orders
-            buf["cancel_ratio"] = cancels / orders
+        buf["hit_rate"] = fills / orders if orders else 0.0
+        buf["cancel_ratio"] = cancels / orders if orders else 0.0
 
 
 async def _scrape_metrics(


### PR DESCRIPTION
## Summary
- avoid undefined hit rate and cancel ratio by defaulting to 0 when no orders are present

## Testing
- `pytest tests/test_metrics_accumulation.py -q`
- `pytest tests/integration/test_recorded_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ef0fd8a8832d9e4bde840879b00e