### PR TITLE
Handle paper adapter events in execution router

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -211,7 +211,9 @@ async def run_live_binance(
         ts: datetime = t["ts"] or datetime.now(timezone.utc)
         px: float = float(t["price"])
         qty: float = float(t["qty"] or 0.0)
-        broker.update_last_price(symbol, px)
+        events = broker.update_last_price(symbol, px)
+        for ev in events or []:
+            await router.handle_paper_event(ev)
         risk.mark_price(symbol, px)
         halted, reason = risk.daily_mark(broker, symbol, px, 0.0)
         if halted:

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -322,7 +322,9 @@ async def run_paper(
                     }
                 ),
             )
-            broker.update_last_price(symbol, px)
+            events = broker.update_last_price(symbol, px)
+            for ev in events or []:
+                await router.handle_paper_event(ev)
             risk.mark_price(symbol, px)
             if time.time() - last_purge >= purge_interval:
                 risk.purge([symbol])

--- a/tests/test_execution_router_paper_events.py
+++ b/tests/test_execution_router_paper_events.py
@@ -1,0 +1,61 @@
+import pytest
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.order_types import Order
+from tradingbot.strategies.base import Strategy
+
+
+class StubStrategy(Strategy):
+    name = "stub"
+
+    def on_bar(self, bar):
+        return None
+
+    def __init__(self):
+        self.partial_called = False
+        self.expiry_called = False
+
+    def on_partial_fill(self, order, res):
+        self.partial_called = True
+        return None
+
+    def on_order_expiry(self, order, res):
+        self.expiry_called = True
+        return None
+
+
+@pytest.mark.asyncio
+async def test_partial_fill_event_triggers_callback():
+    strat = StubStrategy()
+    adapter = PaperAdapter()
+    adapter.state.cash = 1000.0
+    adapter.update_last_price("BTC/USDT", 100.0)
+    router = ExecutionRouter(adapter, on_partial_fill=strat.on_partial_fill)
+
+    order = Order(symbol="BTC/USDT", side="buy", type_="limit", qty=1.0, price=90.0)
+    res = await router.execute(order)
+    assert res["status"] == "new"
+
+    events = adapter.update_last_price("BTC/USDT", 89.0, qty=0.4)
+    for ev in events:
+        await router.handle_paper_event(ev)
+    assert strat.partial_called is True
+
+
+@pytest.mark.asyncio
+async def test_expiry_event_triggers_callback():
+    strat = StubStrategy()
+    adapter = PaperAdapter()
+    adapter.state.cash = 1000.0
+    adapter.update_last_price("BTC/USDT", 100.0)
+    router = ExecutionRouter(adapter, on_order_expiry=strat.on_order_expiry)
+
+    order = Order(symbol="BTC/USDT", side="buy", type_="limit", qty=1.0, price=90.0)
+    order.timeout = 0.0
+    res = await router.execute(order)
+    assert res["status"] == "new"
+
+    events = adapter.update_last_price("BTC/USDT", 100.0)
+    for ev in events:
+        await router.handle_paper_event(ev)
+    assert strat.expiry_called is True


### PR DESCRIPTION
## Summary
- track open orders in `ExecutionRouter` and react to PaperAdapter events
- forward PaperAdapter fills/expirations to the router in live runners
- test that strategy callbacks fire on partial fill and expiry events

## Testing
- `pytest tests/test_execution_router_paper_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71f874948832db57fd5c6a1e7234e