### PR TITLE
feat: add slippage model to paper runner

### DIFF
--- a/tests/test_paper_runner.py
+++ b/tests/test_paper_runner.py
@@ -163,7 +163,12 @@ class DummyExecBrokerRecord(DummyExecBroker):
 
 
 class DummyBroker:
-    def __init__(self):
+    def __init__(
+        self,
+        slip_bps_per_qty: float = 0.0,
+        slippage_model=None,
+        **_,
+    ):
         self.account = SimpleNamespace(update_cash=lambda amount: None)
         self.state = SimpleNamespace(realized_pnl=0.0, last_px={}, order_book={})
 
@@ -187,8 +192,13 @@ class DummyBrokerSlip(DummyBroker):
 
     last_slip: float | None = None
 
-    def __init__(self, slip_bps_per_qty: float = 0.0, **_):
-        super().__init__()
+    def __init__(
+        self,
+        slip_bps_per_qty: float = 0.0,
+        slippage_model=None,
+        **_,
+    ):
+        super().__init__(slip_bps_per_qty=slip_bps_per_qty, slippage_model=slippage_model)
         DummyBrokerSlip.last_slip = slip_bps_per_qty
 
 

--- a/tests/test_slippage_mean_paper_vs_backtest.py
+++ b/tests/test_slippage_mean_paper_vs_backtest.py
@@ -1,0 +1,39 @@
+import pytest
+from tradingbot.backtesting.engine import SlippageModel
+from tradingbot.execution.paper import PaperAdapter
+
+
+@pytest.mark.asyncio
+async def test_average_slippage_matches_backtest():
+    model = SlippageModel(
+        volume_impact=0.1,
+        spread_mult=1.0,
+        ofi_impact=0.0,
+        source="bba",
+        base_spread=0.0,
+        pct=0.0001,
+    )
+    adapter = PaperAdapter(slippage_model=model, slip_bps_per_qty=0.0)
+    adapter.state.cash = 1_000_000.0
+    adapter.update_last_price("BTC/USDT", 100.0)
+
+    bars = [
+        {"bid": 99.5, "ask": 100.5, "bid_size": 10.0, "ask_size": 10.0, "volume": 1000.0},
+        {"bid": 99.0, "ask": 101.0, "bid_size": 20.0, "ask_size": 20.0, "volume": 1000.0},
+    ]
+    orders = [
+        ("buy", 2.0, 100.0),
+        ("buy", 4.0, 100.0),
+    ]
+
+    slips_bt = []
+    slips_pp = []
+    for (side, qty, price), bar in zip(orders, bars):
+        res = await adapter.place_order("BTC/USDT", side, "market", qty, book=bar)
+        slips_pp.append(res["slippage_bps"])
+        adj_price, _, _ = model.fill(side, qty, price, bar)
+        slips_bt.append((adj_price - price) / price * 10000)
+
+    avg_bt = sum(slips_bt) / len(slips_bt)
+    avg_pp = sum(slips_pp) / len(slips_pp)
+    assert avg_pp == pytest.approx(avg_bt)


### PR DESCRIPTION
## Summary
- wire default backtesting SlippageModel into paper runner
- document and default slip_bps_per_qty to minimal cost
- add regression test matching average slippage between backtest and paper

## Testing
- `pytest tests/test_slippage_mean_paper_vs_backtest.py -q`
- `pytest tests/test_paper_runner.py::test_run_paper -q` *(fails: KeyboardInterrupt after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c5737e4832d83c8b74a6dca37b4