### PR TITLE
Ensure initial bot metrics exposed to UI

### DIFF
--- a/src/tradingbot/apps/api/main.py
+++ b/src/tradingbot/apps/api/main.py
@@ -1278,8 +1278,12 @@ async def update_bot_stats(pid: int, stats: dict | None = None, **kwargs) -> Non
         orders = buf.get("orders", 0)
         fills = buf.get("fills", 0)
         cancels = buf.get("cancels", 0)
-        buf["hit_rate"] = fills / orders if orders else 0.0
-        buf["cancel_ratio"] = cancels / orders if orders else 0.0
+
+        hit_rate = fills / orders if orders else 0.0
+        cancel_ratio = cancels / orders if orders else 0.0
+
+        buf["hit_rate"] = hit_rate
+        buf["cancel_ratio"] = cancel_ratio
 
 
 async def _scrape_metrics(
@@ -1525,6 +1529,9 @@ async def start_bot(cfg: BotConfig, request: Request = None):
                 "monitor_task": monitor_task,
                 "log_buffer": log_buffer,
             }
+
+        # Initialize stats so the UI receives metrics from the start
+        await update_bot_stats(proc.pid)
         return {"pid": proc.pid, "status": "running"}
 
 

--- a/tests/test_metrics_initialization.py
+++ b/tests/test_metrics_initialization.py
@@ -1,0 +1,16 @@
+import pytest
+import tradingbot.apps.api.main as api_main
+
+
+@pytest.mark.asyncio
+async def test_initial_metrics_zero():
+    api_main._BOTS.clear()
+    try:
+        api_main._BOTS[1] = {"stats": {}}
+        await api_main.update_bot_stats(1)
+        stats = api_main._BOTS[1]["stats"]
+        assert stats["hit_rate"] == 0.0
+        assert stats["cancel_ratio"] == 0.0
+    finally:
+        api_main._BOTS.clear()
+


### PR DESCRIPTION
## Summary
- Compute `hit_rate` and `cancel_ratio` safely using order counts
- Initialize bot stats upon launch so UI immediately has metric values
- Add regression test for zero-order metrics initialization

## Testing
- `pytest tests/test_metrics_accumulation.py tests/test_metrics_initialization.py tests/test_api_bots.py::test_bot_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_68c764e7eee0832db2e0637935ce89b2