### PR TITLE
Verify order acceptance before emitting metrics

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -411,37 +411,38 @@ async def run_paper(
                             json.dumps({"event": "skip", "reason": "insufficient_cash"}),
                         )
                         continue
-                    log.info(
-                        "METRICS %s",
-                        json.dumps(
-                            {
-                                "event": "order",
-                                "side": close_side,
-                                "price": price,
-                                "qty": qty_close,
-                                "fee": 0.0,
-                                "pnl": broker.state.realized_pnl,
-                            }
-                        ),
-                    )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
                     exec_price = float(resp.get("price", price))
-                    prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                        close_side, 0.0
-                    )
-                    risk.account.update_open_order(
-                        symbol, close_side, pending_qty - prev_pending
-                    )
-                    cur_qty = risk.account.current_exposure(symbol)[0]
-                    if step_size > 0 and abs(cur_qty) < step_size:
-                        cur_qty = 0.0
-                        risk.account.positions[symbol] = 0.0
-                    locked = risk.account.get_locked_usd(symbol)
-                    log.info(
-                        "METRICS %s",
-                        json.dumps({"exposure": cur_qty, "locked": locked}),
-                    )
+                    if resp.get("status") == "open":
+                        log.info(
+                            "METRICS %s",
+                            json.dumps(
+                                {
+                                    "event": "order",
+                                    "side": close_side,
+                                    "price": price,
+                                    "qty": qty_close,
+                                    "fee": 0.0,
+                                    "pnl": broker.state.realized_pnl,
+                                }
+                            ),
+                        )
+                        prev_pending = risk.account.open_orders.get(symbol, {}).get(
+                            close_side, 0.0
+                        )
+                        risk.account.update_open_order(
+                            symbol, close_side, pending_qty - prev_pending
+                        )
+                        cur_qty = risk.account.current_exposure(symbol)[0]
+                        if step_size > 0 and abs(cur_qty) < step_size:
+                            cur_qty = 0.0
+                            risk.account.positions[symbol] = 0.0
+                        locked = risk.account.get_locked_usd(symbol)
+                        log.info(
+                            "METRICS %s",
+                            json.dumps({"exposure": cur_qty, "locked": locked}),
+                        )
                     delta_rpnl = (
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
@@ -535,37 +536,38 @@ async def run_paper(
                                 json.dumps({"event": "skip", "reason": "insufficient_cash"}),
                             )
                             continue
-                        log.info(
-                            "METRICS %s",
-                            json.dumps(
-                                {
-                                    "event": "order",
-                                    "side": side,
-                                    "price": price,
-                                    "qty": qty_scale,
-                                    "fee": 0.0,
-                                    "pnl": broker.state.realized_pnl,
-                                }
-                            ),
-                        )
                         filled_qty = float(resp.get("filled_qty", 0.0))
                         pending_qty = float(resp.get("pending_qty", 0.0))
                         exec_price = float(resp.get("price", price))
-                        prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                            side, 0.0
-                        )
-                        risk.account.update_open_order(
-                            symbol, side, pending_qty - prev_pending
-                        )
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        if step_size > 0 and abs(cur_qty) < step_size:
-                            cur_qty = 0.0
-                            risk.account.positions[symbol] = 0.0
-                        locked = risk.account.get_locked_usd(symbol)
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
+                        if resp.get("status") == "open":
+                            log.info(
+                                "METRICS %s",
+                                json.dumps(
+                                    {
+                                        "event": "order",
+                                        "side": side,
+                                        "price": price,
+                                        "qty": qty_scale,
+                                        "fee": 0.0,
+                                        "pnl": broker.state.realized_pnl,
+                                    }
+                                ),
+                            )
+                            prev_pending = risk.account.open_orders.get(symbol, {}).get(
+                                side, 0.0
+                            )
+                            risk.account.update_open_order(
+                                symbol, side, pending_qty - prev_pending
+                            )
+                            cur_qty = risk.account.current_exposure(symbol)[0]
+                            if step_size > 0 and abs(cur_qty) < step_size:
+                                cur_qty = 0.0
+                                risk.account.positions[symbol] = 0.0
+                            locked = risk.account.get_locked_usd(symbol)
+                            log.info(
+                                "METRICS %s",
+                                json.dumps({"exposure": cur_qty, "locked": locked}),
+                            )
                         delta_rpnl = (
                             resp.get("realized_pnl", broker.state.realized_pnl)
                             - prev_rpnl
@@ -734,33 +736,34 @@ async def run_paper(
                     json.dumps({"event": "skip", "reason": "insufficient_cash"}),
                 )
                 continue
-            log.info(
-                "METRICS %s",
-                json.dumps(
-                    {
-                        "event": "order",
-                        "side": side,
-                        "price": price,
-                        "qty": qty,
-                        "fee": 0.0,
-                        "pnl": broker.state.realized_pnl,
-                    }
-                ),
-            )
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
-            prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
-            risk.account.update_open_order(symbol, side, pending_qty - prev_pending)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            if step_size > 0 and abs(cur_qty) < step_size:
-                cur_qty = 0.0
-                risk.account.positions[symbol] = 0.0
-            locked = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
-            )
+            if resp.get("status") == "open":
+                log.info(
+                    "METRICS %s",
+                    json.dumps(
+                        {
+                            "event": "order",
+                            "side": side,
+                            "price": price,
+                            "qty": qty,
+                            "fee": 0.0,
+                            "pnl": broker.state.realized_pnl,
+                        }
+                    ),
+                )
+                prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
+                risk.account.update_open_order(symbol, side, pending_qty - prev_pending)
+                cur_qty = risk.account.current_exposure(symbol)[0]
+                if step_size > 0 and abs(cur_qty) < step_size:
+                    cur_qty = 0.0
+                    risk.account.positions[symbol] = 0.0
+                locked = risk.account.get_locked_usd(symbol)
+                log.info(
+                    "METRICS %s",
+                    json.dumps({"exposure": cur_qty, "locked": locked}),
+                )
             delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
             if filled_qty > 0:
                 slippage = ((exec_price - price) / price) * 10000 if price else 0.0


### PR DESCRIPTION
## Summary
- ensure paper runner only logs order metrics and updates open orders when response status is `open`

## Testing
- `pytest tests/test_paper_runner.py::test_run_paper -q` *(fails: KeyboardInterrupt after ~87s)*

------
https://chatgpt.com/codex/tasks/task_e_68c81fdee268832dac17ce90f26003e0