### PR TITLE
Use adapter pending quantity in limit order

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -204,7 +204,7 @@ class Broker:
                 res.get("qty") or res.get("filled") or res.get("filled_qty") or 0.0
             )
             filled += qty_filled
-            remaining = max(remaining - qty_filled, 0.0)
+            remaining = float(res.get("pending_qty", remaining - qty_filled))
             order.pending_qty = remaining
             res.setdefault("filled_qty", qty_filled)
             res.setdefault("pending_qty", remaining)


### PR DESCRIPTION
## Summary
- Rely on adapter-reported pending quantity when tracking remaining size for limit orders

## Testing
- `pytest tests/broker/test_place_limit.py -q`
- `pytest tests/test_order_metrics.py::test_skips_counter_incremented -q` *(fails: assert 2 == 1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c82476667c832db004c447e138a947