### PR TITLE
Handle remaining quantity after order cancellation

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -226,7 +226,9 @@ class Broker:
             if expiry is not None and status not in {"canceled", "rejected"}:
                 await asyncio.sleep(expiry)
                 try:
-                    await self.adapter.cancel_order(res.get("order_id"), symbol)
+                    res = await self.adapter.cancel_order(res.get("order_id"), symbol)
+                    remaining = float(res.get("pending_qty", remaining))
+                    last_res = res
                 except Exception:
                     pass
                 action = on_order_expiry(order, res) if on_order_expiry else "re_quote"


### PR DESCRIPTION
## Summary
- Update broker to capture cancel_order response and update remaining quantity

## Testing
- `pytest tests/broker -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8289d9a90832dbc19dc857da97b41