### PR TITLE
Remove manual cancel handling

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -24,7 +24,7 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from ..execution.paper import PaperAdapter
 from ..backtesting.engine import SlippageModel
 from ..execution.router import ExecutionRouter
-from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS, CANCELS
+from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS
 from ..utils.price import limit_price_from_close
 from ..broker.broker import Broker
 from ..config import settings
@@ -247,7 +247,6 @@ async def run_paper(
 
     def on_order_cancel(res: dict) -> None:
         """Handle broker order cancellation notifications."""
-        CANCELS.inc()
         symbol = res.get("symbol")
         side = res.get("side")
         prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
@@ -406,8 +405,6 @@ async def run_paper(
                         on_order_expiry=on_oe,
                         slip_bps=slippage_bps,
                     )
-                    if resp.get("status") == "canceled":
-                        on_order_cancel(resp)
                     if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
                         SKIPS.inc()
                         log.info(
@@ -531,8 +528,6 @@ async def run_paper(
                             on_order_expiry=on_oe,
                             slip_bps=slippage_bps,
                         )
-                        if resp.get("status") == "canceled":
-                            on_order_cancel(resp)
                         if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
                             SKIPS.inc()
                             log.info(
@@ -731,8 +726,6 @@ async def run_paper(
                 signal_ts=signal_ts,
                 slip_bps=slippage_bps,
             )
-            if resp.get("status") == "canceled":
-                on_order_cancel(resp)
             if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
                 SKIPS.inc()
                 log.info(

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -51,7 +51,6 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
-from ..utils.metrics import CANCELS
 from ..utils.price import limit_price_from_close
 
 try:
@@ -219,7 +218,6 @@ async def _run_symbol(
 
     def on_order_cancel(order, res: dict) -> None:
         """Track broker order cancellations."""
-        CANCELS.inc()
         symbol = res.get("symbol") or getattr(order, "symbol", None)
         side = res.get("side") or getattr(order, "side", None)
         pending_qty = res.get("pending_qty")
@@ -319,8 +317,6 @@ async def _run_symbol(
                     on_order_expiry=on_oe,
                     slip_bps=slippage_bps,
                 )
-                if resp.get("status") == "canceled":
-                    on_order_cancel(None, resp)
                 filled_qty = float(resp.get("filled_qty", 0.0))
                 pending_qty = float(resp.get("pending_qty", 0.0))
                 prev_pending = risk.account.open_orders.get(symbol, {}).get(
@@ -366,18 +362,16 @@ async def _run_symbol(
                         )
                         continue
                     prev_rpnl = broker.state.realized_pnl
-                    resp = await exec_broker.place_limit(
-                        symbol,
-                        side,
-                        price,
-                        qty_scale,
-                        tif=tif,
-                        on_partial_fill=on_pf,
-                        on_order_expiry=on_oe,
-                        slip_bps=slippage_bps,
-                    )
-                    if resp.get("status") == "canceled":
-                        on_order_cancel(None, resp)
+                        resp = await exec_broker.place_limit(
+                            symbol,
+                            side,
+                            price,
+                            qty_scale,
+                            tif=tif,
+                            on_partial_fill=on_pf,
+                            on_order_expiry=on_oe,
+                            slip_bps=slippage_bps,
+                        )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
                     prev_pending = risk.account.open_orders.get(symbol, {}).get(
@@ -476,8 +470,6 @@ async def _run_symbol(
             signal_ts=signal_ts,
             slip_bps=slippage_bps,
         )
-        if resp.get("status") == "canceled":
-            on_order_cancel(None, resp)
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -37,7 +37,6 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
-from ..utils.metrics import CANCELS
 from ..utils.price import limit_price_from_close
 
 try:
@@ -192,7 +191,6 @@ async def _run_symbol(
     strat.risk_service = risk
     def on_order_cancel(order, res: dict) -> None:
         """Track broker order cancellations."""
-        CANCELS.inc()
         symbol = res.get("symbol") or getattr(order, "symbol", None)
         side = res.get("side") or getattr(order, "side", None)
         pending_qty = res.get("pending_qty")
@@ -336,8 +334,6 @@ async def _run_symbol(
             signal_ts=signal_ts,
             slip_bps=slippage_bps,
         )
-        if resp.get("status") == "canceled":
-            on_order_cancel(None, resp)
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))


### PR DESCRIPTION
## Summary
- stop incrementing CANCELS metric on cancellation callbacks
- rely on broker callbacks for cancellations instead of response status checks
- keep open order cleanup in cancellation handlers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8289c0c60832da0ab1c610331d13a