### PR TITLE
Log paper limit orders when not rejected

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -415,7 +415,7 @@ async def run_paper(
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
                     exec_price = float(resp.get("price", price))
-                    if resp.get("status") == "open":
+                    if resp.get("status") != "rejected":
                         log.info(
                             "METRICS %s",
                             json.dumps(
@@ -538,7 +538,7 @@ async def run_paper(
                         filled_qty = float(resp.get("filled_qty", 0.0))
                         pending_qty = float(resp.get("pending_qty", 0.0))
                         exec_price = float(resp.get("price", price))
-                        if resp.get("status") == "open":
+                        if resp.get("status") != "rejected":
                             log.info(
                                 "METRICS %s",
                                 json.dumps(
@@ -736,7 +736,7 @@ async def run_paper(
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
-            if resp.get("status") == "open":
+            if resp.get("status") != "rejected":
                 log.info(
                     "METRICS %s",
                     json.dumps(


### PR DESCRIPTION
## Summary
- treat non-rejected limit order responses in the paper runner as order events so filled orders update exposure and locked balances

## Testing
- pytest tests/broker/test_place_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68c854faf1b8832db4d9bc9dcd46719d