### PR TITLE
Adjust slippage metrics to use absolute values

### DIFF
--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -107,7 +107,7 @@ def _avg_slippage() -> float:
         for sample in metric.samples
     ]
     slippage_sum = sum(
-        s.value for s in slippage_samples if s.name.endswith("_sum")
+        abs(s.value) for s in slippage_samples if s.name.endswith("_sum")
     )
     slippage_count = sum(
         s.value for s in slippage_samples if s.name.endswith("_count")
@@ -350,7 +350,7 @@ def _avg_slippage_by_symbol() -> dict[str, float]:
         for sample in metric_obj.samples:
             sym = sample.labels.get("symbol")
             if sample.name.endswith("_sum"):
-                sums[sym] = sums.get(sym, 0.0) + sample.value
+                sums[sym] = sums.get(sym, 0.0) + abs(sample.value)
             elif sample.name.endswith("_count"):
                 counts[sym] = counts.get(sym, 0.0) + sample.value
     return {sym: (sums.get(sym, 0.0) / counts.get(sym, 1.0)) for sym in sums}


### PR DESCRIPTION
## Summary
- update average slippage aggregations to rely on absolute sum values
- ensure per-symbol slippage averages reflect unsigned magnitudes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c858a6b884832db5089c0890f7ee17