### PR TITLE
Pass pending quantity to risk check

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -640,6 +640,9 @@ async def run_paper(
                 )
                 continue
             signal_ts = getattr(signal, "signal_ts", time.time())
+            pending = risk.account.open_orders.get(symbol, {}).get(
+                signal.side, 0.0
+            )
             allowed, reason, delta = risk.check_order(
                 symbol,
                 signal.side,
@@ -647,6 +650,7 @@ async def run_paper(
                 strength=signal.strength,
                 volatility=bar.get("atr") or bar.get("volatility"),
                 target_volatility=bar.get("target_volatility"),
+                pending_qty=pending,
             )
             if not allowed:
                 if reason == "below_min_qty":

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -417,6 +417,7 @@ async def _run_symbol(
             )
             continue
         signal_ts = getattr(sig, "signal_ts", time.time())
+        pending = risk.account.open_orders.get(symbol, {}).get(sig.side, 0.0)
         allowed, reason, delta = risk.check_order(
             symbol,
             sig.side,
@@ -424,6 +425,7 @@ async def _run_symbol(
             strength=sig.strength,
             volatility=bar.get("atr") or bar.get("volatility"),
             target_volatility=bar.get("target_volatility"),
+            pending_qty=pending,
         )
         if not allowed:
             if reason == "below_min_qty":

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -280,6 +280,7 @@ async def _run_symbol(
             )
             continue
         signal_ts = getattr(sig, "signal_ts", time.time())
+        pending = risk.account.open_orders.get(symbol, {}).get(sig.side, 0.0)
         allowed, reason, delta = risk.check_order(
             symbol,
             sig.side,
@@ -288,6 +289,7 @@ async def _run_symbol(
             corr_threshold=corr_threshold,
             volatility=bar.get("atr") or bar.get("volatility"),
             target_volatility=bar.get("target_volatility"),
+            pending_qty=pending,
         )
         if not allowed:
             if reason == "below_min_qty":


### PR DESCRIPTION
## Summary
- ensure paper, real, and testnet live runners read pending open order quantities before invoking risk checks
- forward the pending quantity to `RiskService.check_order` so position sizing considers outstanding orders

## Testing
- pytest *(killed by the environment after extended runtime)*
- pytest tests/test_open_orders.py

------
https://chatgpt.com/codex/tasks/task_e_68c86b9fa5d0832d9a1a7fb824c93329