### PR TITLE
Adjust order logging and open order tracking

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -395,6 +395,26 @@ async def run_paper(
                             json.dumps({"event": "skip", "reason": "below_min_qty"}),
                         )
                         continue
+                    log.info(
+                        "METRICS %s",
+                        json.dumps(
+                            {
+                                "event": "order",
+                                "side": close_side,
+                                "price": price,
+                                "qty": qty_close,
+                                "fee": 0.0,
+                                "pnl": broker.state.realized_pnl,
+                            }
+                        ),
+                    )
+                    risk.account.update_open_order(symbol, close_side, qty_close)
+                    cur_qty = risk.account.current_exposure(symbol)[0]
+                    locked = risk.account.get_locked_usd(symbol)
+                    log.info(
+                        "METRICS %s",
+                        json.dumps({"exposure": cur_qty, "locked": locked}),
+                    )
                     resp = await exec_broker.place_limit(
                         symbol,
                         close_side,
@@ -405,36 +425,13 @@ async def run_paper(
                         on_order_expiry=on_oe,
                         slip_bps=slippage_bps,
                     )
-                    if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
-                        SKIPS.inc()
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"event": "skip", "reason": "insufficient_cash"}),
-                        )
-                        continue
+                    status = resp.get("status")
+                    reason = resp.get("reason")
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
                     exec_price = float(resp.get("price", price))
-                    if resp.get("status") != "rejected":
-                        log.info(
-                            "METRICS %s",
-                            json.dumps(
-                                {
-                                    "event": "order",
-                                    "side": close_side,
-                                    "price": price,
-                                    "qty": qty_close,
-                                    "fee": 0.0,
-                                    "pnl": broker.state.realized_pnl,
-                                }
-                            ),
-                        )
-                        prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                            close_side, 0.0
-                        )
-                        risk.account.update_open_order(
-                            symbol, close_side, pending_qty - prev_pending
-                        )
+                    if status == "rejected":
+                        risk.account.update_open_order(symbol, close_side, -qty_close)
                         cur_qty = risk.account.current_exposure(symbol)[0]
                         if step_size > 0 and abs(cur_qty) < step_size:
                             cur_qty = 0.0
@@ -444,6 +441,34 @@ async def run_paper(
                             "METRICS %s",
                             json.dumps({"exposure": cur_qty, "locked": locked}),
                         )
+                        if reason == "insufficient_cash":
+                            SKIPS.inc()
+                            log.info(
+                                "METRICS %s",
+                                json.dumps({"event": "skip", "reason": "insufficient_cash"}),
+                            )
+                            continue
+                    else:
+                        if status == "canceled" and filled_qty == 0.0:
+                            risk.account.update_open_order(
+                                symbol, close_side, -qty_close
+                            )
+                        else:
+                            risk.account.update_open_order(
+                                symbol, close_side, pending_qty - qty_close
+                            )
+                        cur_qty = risk.account.current_exposure(symbol)[0]
+                        if step_size > 0 and abs(cur_qty) < step_size:
+                            cur_qty = 0.0
+                            risk.account.positions[symbol] = 0.0
+                        locked = risk.account.get_locked_usd(symbol)
+                        log.info(
+                            "METRICS %s",
+                            json.dumps({"exposure": cur_qty, "locked": locked}),
+                        )
+                        if status == "canceled" and filled_qty == 0.0:
+                            # No further processing for canceled orders without fills
+                            continue
                     delta_rpnl = (
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
@@ -518,6 +543,26 @@ async def run_paper(
                                 json.dumps({"event": "skip", "reason": "below_min_qty"}),
                             )
                             continue
+                        log.info(
+                            "METRICS %s",
+                            json.dumps(
+                                {
+                                    "event": "order",
+                                    "side": side,
+                                    "price": price,
+                                    "qty": qty_scale,
+                                    "fee": 0.0,
+                                    "pnl": broker.state.realized_pnl,
+                                }
+                            ),
+                        )
+                        risk.account.update_open_order(symbol, side, qty_scale)
+                        cur_qty = risk.account.current_exposure(symbol)[0]
+                        locked = risk.account.get_locked_usd(symbol)
+                        log.info(
+                            "METRICS %s",
+                            json.dumps({"exposure": cur_qty, "locked": locked}),
+                        )
                         resp = await exec_broker.place_limit(
                             symbol,
                             side,
@@ -528,36 +573,13 @@ async def run_paper(
                             on_order_expiry=on_oe,
                             slip_bps=slippage_bps,
                         )
-                        if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
-                            SKIPS.inc()
-                            log.info(
-                                "METRICS %s",
-                                json.dumps({"event": "skip", "reason": "insufficient_cash"}),
-                            )
-                            continue
+                        status = resp.get("status")
+                        reason = resp.get("reason")
                         filled_qty = float(resp.get("filled_qty", 0.0))
                         pending_qty = float(resp.get("pending_qty", 0.0))
                         exec_price = float(resp.get("price", price))
-                        if resp.get("status") != "rejected":
-                            log.info(
-                                "METRICS %s",
-                                json.dumps(
-                                    {
-                                        "event": "order",
-                                        "side": side,
-                                        "price": price,
-                                        "qty": qty_scale,
-                                        "fee": 0.0,
-                                        "pnl": broker.state.realized_pnl,
-                                    }
-                                ),
-                            )
-                            prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                                side, 0.0
-                            )
-                            risk.account.update_open_order(
-                                symbol, side, pending_qty - prev_pending
-                            )
+                        if status == "rejected":
+                            risk.account.update_open_order(symbol, side, -qty_scale)
                             cur_qty = risk.account.current_exposure(symbol)[0]
                             if step_size > 0 and abs(cur_qty) < step_size:
                                 cur_qty = 0.0
@@ -567,6 +589,31 @@ async def run_paper(
                                 "METRICS %s",
                                 json.dumps({"exposure": cur_qty, "locked": locked}),
                             )
+                            if reason == "insufficient_cash":
+                                SKIPS.inc()
+                                log.info(
+                                    "METRICS %s",
+                                    json.dumps({"event": "skip", "reason": "insufficient_cash"}),
+                                )
+                                continue
+                        else:
+                            if status == "canceled" and filled_qty == 0.0:
+                                risk.account.update_open_order(symbol, side, -qty_scale)
+                            else:
+                                risk.account.update_open_order(
+                                    symbol, side, pending_qty - qty_scale
+                                )
+                            cur_qty = risk.account.current_exposure(symbol)[0]
+                            if step_size > 0 and abs(cur_qty) < step_size:
+                                cur_qty = 0.0
+                                risk.account.positions[symbol] = 0.0
+                            locked = risk.account.get_locked_usd(symbol)
+                            log.info(
+                                "METRICS %s",
+                                json.dumps({"exposure": cur_qty, "locked": locked}),
+                            )
+                            if status == "canceled" and filled_qty == 0.0:
+                                continue
                         delta_rpnl = (
                             resp.get("realized_pnl", broker.state.realized_pnl)
                             - prev_rpnl
@@ -715,6 +762,26 @@ async def run_paper(
                 )
                 continue
             prev_rpnl = broker.state.realized_pnl
+            log.info(
+                "METRICS %s",
+                json.dumps(
+                    {
+                        "event": "order",
+                        "side": side,
+                        "price": price,
+                        "qty": qty,
+                        "fee": 0.0,
+                        "pnl": broker.state.realized_pnl,
+                    }
+                ),
+            )
+            risk.account.update_open_order(symbol, side, qty)
+            cur_qty = risk.account.current_exposure(symbol)[0]
+            locked = risk.account.get_locked_usd(symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"exposure": cur_qty, "locked": locked}),
+            )
             resp = await exec_broker.place_limit(
                 symbol,
                 side,
@@ -726,32 +793,13 @@ async def run_paper(
                 signal_ts=signal_ts,
                 slip_bps=slippage_bps,
             )
-            if resp.get("status") == "rejected" and resp.get("reason") == "insufficient_cash":
-                SKIPS.inc()
-                log.info(
-                    "METRICS %s",
-                    json.dumps({"event": "skip", "reason": "insufficient_cash"}),
-                )
-                continue
+            status = resp.get("status")
+            reason = resp.get("reason")
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
-            if resp.get("status") != "rejected":
-                log.info(
-                    "METRICS %s",
-                    json.dumps(
-                        {
-                            "event": "order",
-                            "side": side,
-                            "price": price,
-                            "qty": qty,
-                            "fee": 0.0,
-                            "pnl": broker.state.realized_pnl,
-                        }
-                    ),
-                )
-                prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
-                risk.account.update_open_order(symbol, side, pending_qty - prev_pending)
+            if status == "rejected":
+                risk.account.update_open_order(symbol, side, -qty)
                 cur_qty = risk.account.current_exposure(symbol)[0]
                 if step_size > 0 and abs(cur_qty) < step_size:
                     cur_qty = 0.0
@@ -761,6 +809,29 @@ async def run_paper(
                     "METRICS %s",
                     json.dumps({"exposure": cur_qty, "locked": locked}),
                 )
+                if reason == "insufficient_cash":
+                    SKIPS.inc()
+                    log.info(
+                        "METRICS %s",
+                        json.dumps({"event": "skip", "reason": "insufficient_cash"}),
+                    )
+                    continue
+            else:
+                if status == "canceled" and filled_qty == 0.0:
+                    risk.account.update_open_order(symbol, side, -qty)
+                else:
+                    risk.account.update_open_order(symbol, side, pending_qty - qty)
+                cur_qty = risk.account.current_exposure(symbol)[0]
+                if step_size > 0 and abs(cur_qty) < step_size:
+                    cur_qty = 0.0
+                    risk.account.positions[symbol] = 0.0
+                locked = risk.account.get_locked_usd(symbol)
+                log.info(
+                    "METRICS %s",
+                    json.dumps({"exposure": cur_qty, "locked": locked}),
+                )
+                if status == "canceled" and filled_qty == 0.0:
+                    continue
             delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
             if filled_qty > 0:
                 slippage = ((exec_price - price) / price) * 10000 if price else 0.0

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -323,6 +323,26 @@ async def _run_symbol(
         if not risk.register_order(symbol, notional):
             continue
         prev_rpnl = broker.state.realized_pnl
+        log.info(
+            "METRICS %s",
+            json.dumps(
+                {
+                    "event": "order",
+                    "side": side,
+                    "price": price,
+                    "qty": qty,
+                    "fee": 0.0,
+                    "pnl": broker.state.realized_pnl,
+                }
+            ),
+        )
+        risk.account.update_open_order(symbol, side, qty)
+        cur_qty = risk.account.current_exposure(symbol)[0]
+        locked = risk.account.get_locked_usd(symbol)
+        log.info(
+            "METRICS %s",
+            json.dumps({"exposure": cur_qty, "locked": locked}),
+        )
         resp = await exec_broker.place_limit(
             symbol,
             side,
@@ -334,16 +354,40 @@ async def _run_symbol(
             signal_ts=signal_ts,
             slip_bps=slippage_bps,
         )
+        status = resp.get("status")
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
+        if status == "rejected":
+            risk.account.update_open_order(symbol, side, -qty)
+            cur_qty = risk.account.current_exposure(symbol)[0]
+            locked = risk.account.get_locked_usd(symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"exposure": cur_qty, "locked": locked}),
+            )
+            continue
+        if status == "canceled" and filled_qty == 0.0:
+            risk.account.update_open_order(symbol, side, -qty)
+            cur_qty = risk.account.current_exposure(symbol)[0]
+            locked = risk.account.get_locked_usd(symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"exposure": cur_qty, "locked": locked}),
+            )
+            continue
         delta_open = (
-            filled_qty + pending_qty - prev_pending
+            filled_qty + pending_qty - qty
             if not dry_run
-            else pending_qty - prev_pending
+            else pending_qty - qty
         )
         risk.account.update_open_order(symbol, side, delta_open)
+        cur_qty = risk.account.current_exposure(symbol)[0]
+        locked = risk.account.get_locked_usd(symbol)
+        log.info(
+            "METRICS %s",
+            json.dumps({"exposure": cur_qty, "locked": locked}),
+        )
         risk.on_fill(
             symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )


### PR DESCRIPTION
## Summary
- log order metrics and reserve account exposure before submitting paper runner limit orders, then revert on rejected or cancelled responses
- extend the same pre-submission logging and cancellation handling to real and testnet runners to keep metrics and open-order state in sync

## Testing
- pytest *(fails: killed by environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c871735c18832db9dfe73fa899a08e