### PR TITLE
Clear stale open orders when completing risk orders

### DIFF
--- a/src/tradingbot/risk/service.py
+++ b/src/tradingbot/risk/service.py
@@ -175,7 +175,9 @@ class RiskService:
         return True
 
     def complete_order(self) -> None:
-        return None
+        """Clear pending order tracking once an order is finalised."""
+        with self._lock:
+            self.account.open_orders.clear()
 
     def set_position(self, qty: float) -> None:
         self._pos.qty = float(qty)


### PR DESCRIPTION
## Summary
- clear pending order tracking in the risk service when an order finishes so new orders are not blocked

## Testing
- pytest tests/test_risk_register_order.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a52203e4832d9488f36e7514b399