### PR TITLE
Avoid duplicate cancel handling in live runners

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -275,7 +275,10 @@ async def run_paper(
 
     def _wrap_cb(orig_cb, *, call_cancel=False):
         def _cb(order, res):
-            if call_cancel:
+            status = ""
+            if isinstance(res, dict):
+                status = str(res.get("status", "")).lower()
+            if call_cancel and status not in {"canceled", "cancelled"}:
                 on_order_cancel(res)
             action = orig_cb(order, res) if orig_cb else None
             if not call_cancel:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -249,7 +249,10 @@ async def _run_symbol(
 
     def _wrap_cb(orig_cb, *, call_cancel=False):
         def _cb(order, res):
-            if call_cancel:
+            status = ""
+            if isinstance(res, dict):
+                status = str(res.get("status", "")).lower()
+            if call_cancel and status not in {"canceled", "cancelled"}:
                 on_order_cancel(order, res)
             action = orig_cb(order, res) if orig_cb else None
             if not call_cancel:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -222,7 +222,10 @@ async def _run_symbol(
 
     def _wrap_cb(orig_cb, *, call_cancel=False):
         def _cb(order, res):
-            if call_cancel:
+            status = ""
+            if isinstance(res, dict):
+                status = str(res.get("status", "")).lower()
+            if call_cancel and status not in {"canceled", "cancelled"}:
                 on_order_cancel(order, res)
             action = orig_cb(order, res) if orig_cb else None
             if not call_cancel:


### PR DESCRIPTION
## Summary
- guard the on_order_cancel wrappers in the paper, real, and testnet runners so they skip when the router already marks a response as canceled

## Testing
- pytest tests/test_router_cancel_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a51a8d64832da05a86802af44491