### PR TITLE
Adjust order metrics logging after broker responses

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -412,6 +412,28 @@ async def run_paper(
                             json.dumps({"event": "skip", "reason": "below_min_qty"}),
                         )
                         continue
+                    resp = await exec_broker.place_limit(
+                        symbol,
+                        close_side,
+                        price,
+                        qty_close,
+                        tif=tif,
+                        on_partial_fill=on_pf,
+                        on_order_expiry=on_oe,
+                        slip_bps=slippage_bps,
+                    )
+                    status = str(resp.get("status", ""))
+                    if status == "rejected":
+                        if resp.get("reason") == "insufficient_cash":
+                            SKIPS.inc()
+                            log.info(
+                                "METRICS %s",
+                                json.dumps({"event": "skip", "reason": "insufficient_cash"}),
+                            )
+                        continue
+                    filled_qty = float(resp.get("filled_qty", 0.0))
+                    pending_qty = float(resp.get("pending_qty", 0.0))
+                    exec_price = float(resp.get("price", price))
                     log.info(
                         "METRICS %s",
                         json.dumps(
@@ -425,62 +447,16 @@ async def run_paper(
                             }
                         ),
                     )
-                    risk.account.update_open_order(symbol, close_side, qty_close)
-                    cur_qty_pre = risk.account.current_exposure(symbol)[0]
-                    locked_pre = risk.account.get_locked_usd(symbol)
+                    risk.account.update_open_order(symbol, close_side, pending_qty)
+                    cur_qty = risk.account.current_exposure(symbol)[0]
+                    if step_size > 0 and abs(cur_qty) < step_size:
+                        cur_qty = 0.0
+                        risk.account.positions[symbol] = 0.0
+                    locked = risk.account.get_locked_usd(symbol)
                     log.info(
                         "METRICS %s",
-                        json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
+                        json.dumps({"exposure": cur_qty, "locked": locked}),
                     )
-                    resp = await exec_broker.place_limit(
-                        symbol,
-                        close_side,
-                        price,
-                        qty_close,
-                        tif=tif,
-                        on_partial_fill=on_pf,
-                        on_order_expiry=on_oe,
-                        slip_bps=slippage_bps,
-                    )
-                    status = str(resp.get("status", ""))
-                    if status == "rejected":
-                        risk.account.update_open_order(symbol, close_side, -qty_close)
-                        if resp.get("reason") == "insufficient_cash":
-                            SKIPS.inc()
-                            log.info(
-                                "METRICS %s",
-                                json.dumps({"event": "skip", "reason": "insufficient_cash"}),
-                            )
-                        continue
-                    filled_qty = float(resp.get("filled_qty", 0.0))
-                    pending_qty = float(resp.get("pending_qty", 0.0))
-                    exec_price = float(resp.get("price", price))
-                    if status == "canceled" and filled_qty == 0.0:
-                        risk.account.update_open_order(symbol, close_side, -qty_close)
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        if step_size > 0 and abs(cur_qty) < step_size:
-                            cur_qty = 0.0
-                            risk.account.positions[symbol] = 0.0
-                        locked = risk.account.get_locked_usd(symbol)
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
-                    else:
-                        delta_pending = pending_qty - qty_close
-                        if delta_pending:
-                            risk.account.update_open_order(
-                                symbol, close_side, delta_pending
-                            )
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        if step_size > 0 and abs(cur_qty) < step_size:
-                            cur_qty = 0.0
-                            risk.account.positions[symbol] = 0.0
-                        locked = risk.account.get_locked_usd(symbol)
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
                     delta_rpnl = (
                         resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     )
@@ -555,6 +531,28 @@ async def run_paper(
                                 json.dumps({"event": "skip", "reason": "below_min_qty"}),
                             )
                             continue
+                        resp = await exec_broker.place_limit(
+                            symbol,
+                            side,
+                            price,
+                            qty_scale,
+                            tif=tif,
+                            on_partial_fill=on_pf,
+                            on_order_expiry=on_oe,
+                            slip_bps=slippage_bps,
+                        )
+                        status = str(resp.get("status", ""))
+                        if status == "rejected":
+                            if resp.get("reason") == "insufficient_cash":
+                                SKIPS.inc()
+                                log.info(
+                                    "METRICS %s",
+                                    json.dumps({"event": "skip", "reason": "insufficient_cash"}),
+                                )
+                            continue
+                        filled_qty = float(resp.get("filled_qty", 0.0))
+                        pending_qty = float(resp.get("pending_qty", 0.0))
+                        exec_price = float(resp.get("price", price))
                         log.info(
                             "METRICS %s",
                             json.dumps(
@@ -568,60 +566,16 @@ async def run_paper(
                                 }
                             ),
                         )
-                        risk.account.update_open_order(symbol, side, qty_scale)
-                        cur_qty_pre = risk.account.current_exposure(symbol)[0]
-                        locked_pre = risk.account.get_locked_usd(symbol)
+                        risk.account.update_open_order(symbol, side, pending_qty)
+                        cur_qty = risk.account.current_exposure(symbol)[0]
+                        if step_size > 0 and abs(cur_qty) < step_size:
+                            cur_qty = 0.0
+                            risk.account.positions[symbol] = 0.0
+                        locked = risk.account.get_locked_usd(symbol)
                         log.info(
                             "METRICS %s",
-                            json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
+                            json.dumps({"exposure": cur_qty, "locked": locked}),
                         )
-                        resp = await exec_broker.place_limit(
-                            symbol,
-                            side,
-                            price,
-                            qty_scale,
-                            tif=tif,
-                            on_partial_fill=on_pf,
-                            on_order_expiry=on_oe,
-                            slip_bps=slippage_bps,
-                        )
-                        status = str(resp.get("status", ""))
-                        if status == "rejected":
-                            risk.account.update_open_order(symbol, side, -qty_scale)
-                            if resp.get("reason") == "insufficient_cash":
-                                SKIPS.inc()
-                                log.info(
-                                    "METRICS %s",
-                                    json.dumps({"event": "skip", "reason": "insufficient_cash"}),
-                                )
-                            continue
-                        filled_qty = float(resp.get("filled_qty", 0.0))
-                        pending_qty = float(resp.get("pending_qty", 0.0))
-                        exec_price = float(resp.get("price", price))
-                        if status == "canceled" and filled_qty == 0.0:
-                            risk.account.update_open_order(symbol, side, -qty_scale)
-                            cur_qty = risk.account.current_exposure(symbol)[0]
-                            if step_size > 0 and abs(cur_qty) < step_size:
-                                cur_qty = 0.0
-                                risk.account.positions[symbol] = 0.0
-                            locked = risk.account.get_locked_usd(symbol)
-                            log.info(
-                                "METRICS %s",
-                                json.dumps({"exposure": cur_qty, "locked": locked}),
-                            )
-                        else:
-                            delta_pending = pending_qty - qty_scale
-                            if delta_pending:
-                                risk.account.update_open_order(symbol, side, delta_pending)
-                            cur_qty = risk.account.current_exposure(symbol)[0]
-                            if step_size > 0 and abs(cur_qty) < step_size:
-                                cur_qty = 0.0
-                                risk.account.positions[symbol] = 0.0
-                            locked = risk.account.get_locked_usd(symbol)
-                            log.info(
-                                "METRICS %s",
-                                json.dumps({"exposure": cur_qty, "locked": locked}),
-                            )
                         delta_rpnl = (
                             resp.get("realized_pnl", broker.state.realized_pnl)
                             - prev_rpnl
@@ -774,26 +728,6 @@ async def run_paper(
                 )
                 continue
             prev_rpnl = broker.state.realized_pnl
-            log.info(
-                "METRICS %s",
-                json.dumps(
-                    {
-                        "event": "order",
-                        "side": side,
-                        "price": price,
-                        "qty": qty,
-                        "fee": 0.0,
-                        "pnl": broker.state.realized_pnl,
-                    }
-                ),
-            )
-            risk.account.update_open_order(symbol, side, qty)
-            cur_qty_pre = risk.account.current_exposure(symbol)[0]
-            locked_pre = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
-            )
             resp = await exec_broker.place_limit(
                 symbol,
                 side,
@@ -807,7 +741,6 @@ async def run_paper(
             )
             status = str(resp.get("status", ""))
             if status == "rejected":
-                risk.account.update_open_order(symbol, side, -qty)
                 if resp.get("reason") == "insufficient_cash":
                     SKIPS.inc()
                     log.info(
@@ -818,30 +751,29 @@ async def run_paper(
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
-            if status == "canceled" and filled_qty == 0.0:
-                risk.account.update_open_order(symbol, side, -qty)
-                cur_qty = risk.account.current_exposure(symbol)[0]
-                if step_size > 0 and abs(cur_qty) < step_size:
-                    cur_qty = 0.0
-                    risk.account.positions[symbol] = 0.0
-                locked = risk.account.get_locked_usd(symbol)
-                log.info(
-                    "METRICS %s",
-                    json.dumps({"exposure": cur_qty, "locked": locked}),
-                )
-            else:
-                delta_pending = pending_qty - qty
-                if delta_pending:
-                    risk.account.update_open_order(symbol, side, delta_pending)
-                cur_qty = risk.account.current_exposure(symbol)[0]
-                if step_size > 0 and abs(cur_qty) < step_size:
-                    cur_qty = 0.0
-                    risk.account.positions[symbol] = 0.0
-                locked = risk.account.get_locked_usd(symbol)
-                log.info(
-                    "METRICS %s",
-                    json.dumps({"exposure": cur_qty, "locked": locked}),
-                )
+            log.info(
+                "METRICS %s",
+                json.dumps(
+                    {
+                        "event": "order",
+                        "side": side,
+                        "price": price,
+                        "qty": qty,
+                        "fee": 0.0,
+                        "pnl": broker.state.realized_pnl,
+                    }
+                ),
+            )
+            risk.account.update_open_order(symbol, side, pending_qty)
+            cur_qty = risk.account.current_exposure(symbol)[0]
+            if step_size > 0 and abs(cur_qty) < step_size:
+                cur_qty = 0.0
+                risk.account.positions[symbol] = 0.0
+            locked = risk.account.get_locked_usd(symbol)
+            log.info(
+                "METRICS %s",
+                json.dumps({"exposure": cur_qty, "locked": locked}),
+            )
             delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
             if filled_qty > 0:
                 slippage = ((exec_price - price) / price) * 10000 if price else 0.0

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -330,9 +330,21 @@ async def _run_symbol(
                         json.dumps({"event": "skip", "reason": "below_min_qty"}),
                     )
                     continue
-                prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                    close_side, 0.0
+                resp = await exec_broker.place_limit(
+                    symbol,
+                    close_side,
+                    price,
+                    qty_close,
+                    tif=tif,
+                    on_partial_fill=on_pf,
+                    on_order_expiry=on_oe,
+                    slip_bps=slippage_bps,
                 )
+                status = str(resp.get("status", ""))
+                if status == "rejected":
+                    continue
+                filled_qty = float(resp.get("filled_qty", 0.0))
+                pending_qty = float(resp.get("pending_qty", 0.0))
                 log.info(
                     "METRICS %s",
                     json.dumps(
@@ -346,51 +358,13 @@ async def _run_symbol(
                         }
                     ),
                 )
-                risk.account.update_open_order(symbol, close_side, qty_close)
-                cur_qty_pre = risk.account.current_exposure(symbol)[0]
-                locked_pre = risk.account.get_locked_usd(symbol)
+                risk.account.update_open_order(symbol, close_side, pending_qty)
+                cur_qty = risk.account.current_exposure(symbol)[0]
+                locked = risk.account.get_locked_usd(symbol)
                 log.info(
                     "METRICS %s",
-                    json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
+                    json.dumps({"exposure": cur_qty, "locked": locked}),
                 )
-                resp = await exec_broker.place_limit(
-                    symbol,
-                    close_side,
-                    price,
-                    qty_close,
-                    tif=tif,
-                    on_partial_fill=on_pf,
-                    on_order_expiry=on_oe,
-                    slip_bps=slippage_bps,
-                )
-                status = str(resp.get("status", ""))
-                if status == "rejected":
-                    risk.account.update_open_order(symbol, close_side, -qty_close)
-                    continue
-                filled_qty = float(resp.get("filled_qty", 0.0))
-                pending_qty = float(resp.get("pending_qty", 0.0))
-                if status == "canceled" and filled_qty == 0.0:
-                    risk.account.update_open_order(symbol, close_side, -qty_close)
-                    cur_qty = risk.account.current_exposure(symbol)[0]
-                    locked = risk.account.get_locked_usd(symbol)
-                    log.info(
-                        "METRICS %s",
-                        json.dumps({"exposure": cur_qty, "locked": locked}),
-                    )
-                else:
-                    delta_open = (
-                        filled_qty + pending_qty - prev_pending - qty_close
-                        if not dry_run
-                        else pending_qty - prev_pending - qty_close
-                    )
-                    if delta_open:
-                        risk.account.update_open_order(symbol, close_side, delta_open)
-                    cur_qty = risk.account.current_exposure(symbol)[0]
-                    locked = risk.account.get_locked_usd(symbol)
-                    log.info(
-                        "METRICS %s",
-                        json.dumps({"exposure": cur_qty, "locked": locked}),
-                    )
                 risk.on_fill(
                     symbol,
                     close_side,
@@ -425,9 +399,21 @@ async def _run_symbol(
                         )
                         continue
                     prev_rpnl = broker.state.realized_pnl
-                    prev_pending = risk.account.open_orders.get(symbol, {}).get(
-                        side, 0.0
+                    resp = await exec_broker.place_limit(
+                        symbol,
+                        side,
+                        price,
+                        qty_scale,
+                        tif=tif,
+                        on_partial_fill=on_pf,
+                        on_order_expiry=on_oe,
+                        slip_bps=slippage_bps,
                     )
+                    status = str(resp.get("status", ""))
+                    if status == "rejected":
+                        continue
+                    filled_qty = float(resp.get("filled_qty", 0.0))
+                    pending_qty = float(resp.get("pending_qty", 0.0))
                     log.info(
                         "METRICS %s",
                         json.dumps(
@@ -441,51 +427,13 @@ async def _run_symbol(
                             }
                         ),
                     )
-                    risk.account.update_open_order(symbol, side, qty_scale)
-                    cur_qty_pre = risk.account.current_exposure(symbol)[0]
-                    locked_pre = risk.account.get_locked_usd(symbol)
+                    risk.account.update_open_order(symbol, side, pending_qty)
+                    cur_qty = risk.account.current_exposure(symbol)[0]
+                    locked = risk.account.get_locked_usd(symbol)
                     log.info(
                         "METRICS %s",
-                        json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
+                        json.dumps({"exposure": cur_qty, "locked": locked}),
                     )
-                    resp = await exec_broker.place_limit(
-                        symbol,
-                        side,
-                        price,
-                        qty_scale,
-                        tif=tif,
-                        on_partial_fill=on_pf,
-                        on_order_expiry=on_oe,
-                        slip_bps=slippage_bps,
-                    )
-                    status = str(resp.get("status", ""))
-                    if status == "rejected":
-                        risk.account.update_open_order(symbol, side, -qty_scale)
-                        continue
-                    filled_qty = float(resp.get("filled_qty", 0.0))
-                    pending_qty = float(resp.get("pending_qty", 0.0))
-                    if status == "canceled" and filled_qty == 0.0:
-                        risk.account.update_open_order(symbol, side, -qty_scale)
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        locked = risk.account.get_locked_usd(symbol)
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
-                    else:
-                        delta_open = (
-                            filled_qty + pending_qty - prev_pending - qty_scale
-                            if not dry_run
-                            else pending_qty - prev_pending - qty_scale
-                        )
-                        if delta_open:
-                            risk.account.update_open_order(symbol, side, delta_open)
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        locked = risk.account.get_locked_usd(symbol)
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
                     risk.on_fill(
                         symbol,
                         side,
@@ -564,27 +512,6 @@ async def _run_symbol(
         if not risk.register_order(symbol, notional):
             continue
         prev_rpnl = broker.state.realized_pnl
-        prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
-        log.info(
-            "METRICS %s",
-            json.dumps(
-                {
-                    "event": "order",
-                    "side": side,
-                    "price": price,
-                    "qty": qty,
-                    "fee": 0.0,
-                    "pnl": broker.state.realized_pnl,
-                }
-            ),
-        )
-        risk.account.update_open_order(symbol, side, qty)
-        cur_qty_pre = risk.account.current_exposure(symbol)[0]
-        locked_pre = risk.account.get_locked_usd(symbol)
-        log.info(
-            "METRICS %s",
-            json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
-        )
         resp = await exec_broker.place_limit(
             symbol,
             side,
@@ -598,34 +525,31 @@ async def _run_symbol(
         )
         status = str(resp.get("status", ""))
         if status == "rejected":
-            risk.account.update_open_order(symbol, side, -qty)
             log.info("LIVE FILL %s", resp)
             continue
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        if status == "canceled" and filled_qty == 0.0:
-            risk.account.update_open_order(symbol, side, -qty)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            locked = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
-            )
-        else:
-            delta_open = (
-                filled_qty + pending_qty - prev_pending - qty
-                if not dry_run
-                else pending_qty - prev_pending - qty
-            )
-            if delta_open:
-                risk.account.update_open_order(symbol, side, delta_open)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            locked = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
-            )
+        log.info(
+            "METRICS %s",
+            json.dumps(
+                {
+                    "event": "order",
+                    "side": side,
+                    "price": price,
+                    "qty": qty,
+                    "fee": 0.0,
+                    "pnl": broker.state.realized_pnl,
+                }
+            ),
+        )
+        risk.account.update_open_order(symbol, side, pending_qty)
+        cur_qty = risk.account.current_exposure(symbol)[0]
+        locked = risk.account.get_locked_usd(symbol)
+        log.info(
+            "METRICS %s",
+            json.dumps({"exposure": cur_qty, "locked": locked}),
+        )
         risk.on_fill(
             symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -348,27 +348,6 @@ async def _run_symbol(
         if not risk.register_order(symbol, notional):
             continue
         prev_rpnl = broker.state.realized_pnl
-        prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
-        log.info(
-            "METRICS %s",
-            json.dumps(
-                {
-                    "event": "order",
-                    "side": side,
-                    "price": price,
-                    "qty": qty,
-                    "fee": 0.0,
-                    "pnl": broker.state.realized_pnl,
-                }
-            ),
-        )
-        risk.account.update_open_order(symbol, side, qty)
-        cur_qty_pre = risk.account.current_exposure(symbol)[0]
-        locked_pre = risk.account.get_locked_usd(symbol)
-        log.info(
-            "METRICS %s",
-            json.dumps({"exposure": cur_qty_pre, "locked": locked_pre}),
-        )
         resp = await exec_broker.place_limit(
             symbol,
             side,
@@ -382,34 +361,31 @@ async def _run_symbol(
         )
         status = str(resp.get("status", ""))
         if status == "rejected":
-            risk.account.update_open_order(symbol, side, -qty)
             log.info("LIVE FILL %s", resp)
             continue
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        if status == "canceled" and filled_qty == 0.0:
-            risk.account.update_open_order(symbol, side, -qty)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            locked = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
-            )
-        else:
-            delta_open = (
-                filled_qty + pending_qty - prev_pending - qty
-                if not dry_run
-                else pending_qty - prev_pending - qty
-            )
-            if delta_open:
-                risk.account.update_open_order(symbol, side, delta_open)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            locked = risk.account.get_locked_usd(symbol)
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
-            )
+        log.info(
+            "METRICS %s",
+            json.dumps(
+                {
+                    "event": "order",
+                    "side": side,
+                    "price": price,
+                    "qty": qty,
+                    "fee": 0.0,
+                    "pnl": broker.state.realized_pnl,
+                }
+            ),
+        )
+        risk.account.update_open_order(symbol, side, pending_qty)
+        cur_qty = risk.account.current_exposure(symbol)[0]
+        locked = risk.account.get_locked_usd(symbol)
+        log.info(
+            "METRICS %s",
+            json.dumps({"exposure": cur_qty, "locked": locked}),
+        )
         risk.on_fill(
             symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )


### PR DESCRIPTION
## Summary
- move order metrics logging and risk open-order updates to after broker responses in the paper runner so exposure metrics reflect final pending quantities
- apply the same pending-quantity handling to the real and testnet runners

## Testing
- pytest *(fails: killed)*
- pytest tests/broker/test_place_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a518c54c832d8f030f6e569a4d63