### PR TITLE
Ensure cancel callbacks release locked capital

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -249,13 +249,19 @@ async def run_paper(
         """Handle broker order cancellation notifications."""
         symbol = res.get("symbol")
         side = res.get("side")
-        prev_pending = risk.account.open_orders.get(symbol, {}).get(side, 0.0)
-        pending_qty = float(res.get("pending_qty") or 0.0)
-        if symbol and side:
-            if pending_qty > 0:
-                risk.account.update_open_order(symbol, side, -pending_qty)
-            else:
-                risk.account.update_open_order(symbol, side, -prev_pending)
+        pending_raw = res.get("pending_qty")
+        if pending_raw is None:
+            pending_raw = res.get("qty")
+        try:
+            pending_qty = float(pending_raw) if pending_raw is not None else 0.0
+        except (TypeError, ValueError):
+            pending_qty = 0.0
+        if (not pending_qty) and symbol and side:
+            pending_qty = float(
+                risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
+            )
+        if symbol and side and pending_qty > 0:
+            risk.account.update_open_order(symbol, side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
         if symbol and not risk.account.open_orders.get(symbol):
             locked = 0.0
@@ -279,6 +285,15 @@ async def run_paper(
             if isinstance(res, dict):
                 status = str(res.get("status", "")).lower()
             if call_cancel and status not in {"canceled", "cancelled"}:
+                res_dict = res if isinstance(res, dict) else {}
+                if order is not None:
+                    res_dict = {
+                        **res_dict,
+                        "symbol": getattr(order, "symbol", None),
+                        "side": getattr(order, "side", None),
+                        "pending_qty": getattr(order, "pending_qty", None),
+                    }
+                res = res_dict
                 on_order_cancel(res)
             action = orig_cb(order, res) if orig_cb else None
             if not call_cancel:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -220,16 +220,23 @@ async def _run_symbol(
         """Track broker order cancellations."""
         symbol = res.get("symbol") or getattr(order, "symbol", None)
         side = res.get("side") or getattr(order, "side", None)
-        pending_qty = res.get("pending_qty")
-        if pending_qty is None and order is not None:
-            pending_qty = getattr(order, "pending_qty", None)
-        if pending_qty is None:
-            pending_qty = res.get("qty", 0.0)
-        pending_qty = float(pending_qty or 0.0)
+        pending_raw = res.get("pending_qty")
+        if pending_raw is None and order is not None:
+            pending_raw = getattr(order, "pending_qty", None)
+        if pending_raw is None:
+            pending_raw = res.get("qty")
+        try:
+            pending_qty = float(pending_raw) if pending_raw is not None else 0.0
+        except (TypeError, ValueError):
+            pending_qty = 0.0
+        if (not pending_qty) and symbol and side:
+            pending_qty = float(
+                risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
+            )
         if symbol and side and pending_qty > 0:
             risk.account.update_open_order(symbol, side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
-        if not risk.account.open_orders.get(symbol):
+        if symbol and not risk.account.open_orders.get(symbol):
             locked = 0.0
         log.info(
             "METRICS %s",
@@ -253,6 +260,15 @@ async def _run_symbol(
             if isinstance(res, dict):
                 status = str(res.get("status", "")).lower()
             if call_cancel and status not in {"canceled", "cancelled"}:
+                res_dict = res if isinstance(res, dict) else {}
+                if order is not None:
+                    res_dict = {
+                        **res_dict,
+                        "symbol": getattr(order, "symbol", None),
+                        "side": getattr(order, "side", None),
+                        "pending_qty": getattr(order, "pending_qty", None),
+                    }
+                res = res_dict
                 on_order_cancel(order, res)
             action = orig_cb(order, res) if orig_cb else None
             if not call_cancel:


### PR DESCRIPTION
## Summary
- include order context when invoking cancel callbacks so risk tracking receives symbol, side, and pending quantity
- fall back to tracked open order quantity when cancel events omit the pending amount and recalculate locked funds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8af6386e4832d87beb75358bae399