### PR TITLE
Restrict cancel metrics to execution router

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional
 
 from ..config import settings
 from ..execution.order_types import Order
-from ..utils.metrics import ORDERS, SKIPS, FILL_COUNT, CANCELS
+from ..utils.metrics import ORDERS, SKIPS, FILL_COUNT
 
 
 class Broker:
@@ -50,11 +50,7 @@ class Broker:
                             risk.on_fill(symbol, side, qty, price=price, venue=venue)
                         except Exception:
                             pass
-                if status in {"expired", "cancelled", "canceled"}:
-                    CANCELS.inc()
-                    cb = cb_exp
-                else:
-                    cb = cb_pf
+                cb = cb_exp if status in {"expired", "cancelled", "canceled"} else cb_pf
                 if cb is not None and side:
                     try:
                         order_qty = f.get("qty")

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -21,7 +21,6 @@ from ..risk.portfolio_guard import PortfolioGuard, GuardConfig
 from ..risk.service import RiskService
 from ..broker.broker import Broker
 from ..config import settings
-from ..utils.metrics import CANCELS
 from ..core.symbols import normalize
 from ..utils.price import limit_price_from_close
 
@@ -270,7 +269,6 @@ async def run_live_binance(
                 risk.account.update_open_order(symbol, close_side, pending_qty)
                 risk.on_fill(symbol, close_side, filled_qty, venue="binance")
                 if pending_qty > 0:
-                    CANCELS.inc()
                     risk.account.update_open_order(symbol, close_side, -pending_qty)
                 delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                 halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -302,7 +300,6 @@ async def run_live_binance(
                     risk.account.update_open_order(symbol, side, pending_qty)
                     risk.on_fill(symbol, side, filled_qty, venue="binance")
                     if pending_qty > 0:
-                        CANCELS.inc()
                         risk.account.update_open_order(symbol, side, -pending_qty)
                     delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -377,7 +374,6 @@ async def run_live_binance(
         risk.account.update_open_order(symbol, side, pending_qty)
         risk.on_fill(symbol, side, filled_qty, venue="binance")
         if pending_qty > 0:
-            CANCELS.inc()
             risk.account.update_open_order(symbol, side, -pending_qty)
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)

--- a/tests/broker/test_update_last_price.py
+++ b/tests/broker/test_update_last_price.py
@@ -66,7 +66,7 @@ def test_update_last_price_processes_fills():
         and s.labels.get("side") == "buy"
     ][0]
     assert fill_sample.value == 1.0
-    assert CANCELS._value.get() == 1.0
+    assert CANCELS._value.get() == 0.0
     assert adapter.pf_calls == 1
     assert adapter.exp_calls == 1
     assert adapter.risk_service.calls == [("BTCUSDT", "buy", 1.0, 100.0, "dummy")]


### PR DESCRIPTION
## Summary
- remove CANCELS metric increments from broker update_last_price and the live runner logic
- ensure the cancel counter is only updated by `ExecutionRouter.cancel_order`
- adjust the broker update_last_price test to reflect the new metric behaviour

## Testing
- pytest tests/broker/test_update_last_price.py tests/test_router_cancel_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68c96a281a14832dad5033c2df751b2a