### PR TITLE
Handle missing pending quantities in cancel callbacks

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -252,19 +252,25 @@ async def run_paper(
         pending_raw = res.get("pending_qty")
         if pending_raw is None:
             pending_raw = res.get("qty")
-        try:
-            pending_qty = float(pending_raw) if pending_raw is not None else 0.0
-        except (TypeError, ValueError):
-            pending_qty = 0.0
-        if (not pending_qty) and symbol and side:
-            pending_qty = float(
-                risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
-            )
-        if symbol and side and pending_qty > 0:
+        pending_qty = None
+        if pending_raw is not None:
+            try:
+                pending_qty = float(pending_raw)
+            except (TypeError, ValueError):
+                pending_qty = None
+        prev_pending = 0.0
+        if symbol and side:
+            try:
+                prev_pending = float(
+                    risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
+                )
+            except (TypeError, ValueError):
+                prev_pending = 0.0
+        if (pending_qty is None or pending_qty == 0.0) and symbol and side:
+            pending_qty = prev_pending
+        if symbol and side and pending_qty and pending_qty > 0:
             risk.account.update_open_order(symbol, side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
-        if symbol and not risk.account.open_orders.get(symbol):
-            locked = 0.0
         log.info(
             "METRICS %s",
             json.dumps(

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -225,19 +225,25 @@ async def _run_symbol(
             pending_raw = getattr(order, "pending_qty", None)
         if pending_raw is None:
             pending_raw = res.get("qty")
-        try:
-            pending_qty = float(pending_raw) if pending_raw is not None else 0.0
-        except (TypeError, ValueError):
-            pending_qty = 0.0
-        if (not pending_qty) and symbol and side:
-            pending_qty = float(
-                risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
-            )
-        if symbol and side and pending_qty > 0:
+        pending_qty = None
+        if pending_raw is not None:
+            try:
+                pending_qty = float(pending_raw)
+            except (TypeError, ValueError):
+                pending_qty = None
+        prev_pending = 0.0
+        if symbol and side:
+            try:
+                prev_pending = float(
+                    risk.account.open_orders.get(symbol, {}).get(side, 0.0) or 0.0
+                )
+            except (TypeError, ValueError):
+                prev_pending = 0.0
+        if (pending_qty is None or pending_qty == 0.0) and symbol and side:
+            pending_qty = prev_pending
+        if symbol and side and pending_qty and pending_qty > 0:
             risk.account.update_open_order(symbol, side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
-        if symbol and not risk.account.open_orders.get(symbol):
-            locked = 0.0
         log.info(
             "METRICS %s",
             json.dumps(


### PR DESCRIPTION
## Summary
- fall back to the stored open order quantity when cancel notifications omit pending_qty
- log the updated locked capital after adjusting open orders so the dashboard reflects releases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c96a4da5bc832dbb273cfa8f5ade50