### PR TITLE
Ensure cancel order responses default values

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -248,7 +248,9 @@ class Broker:
                         setattr(self.adapter, "on_order_expiry", _proxy)
                 try:
                     res = await self.adapter.cancel_order(res.get("order_id"), symbol)
-                    remaining = float(res.get("pending_qty", remaining))
+                    remaining = float(res.get("pending_qty", 0.0))
+                    res.setdefault("pending_qty", remaining)
+                    res.setdefault("status", res.get("status", "canceled"))
                     last_res = res
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- ensure cancel_order responses default pending quantity to zero when missing
- default cancel order status to `canceled` when adapter omits the field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97402ef40832da1f21d13d9ece7a0