### PR TITLE
Log cancel metrics as JSON payload

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -307,8 +307,10 @@ async def run_paper(
             risk.account.update_open_order(symbol, lookup_side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
         log.info(
-            "METRICS",
-            {"event": "cancel", "reason": res.get("reason"), "locked": locked},
+            "METRICS %s",
+            json.dumps(
+                {"event": "cancel", "reason": res.get("reason"), "locked": locked}
+            ),
         )
         metric_pending = res.get("pending_qty", pending_qty)
         if metric_pending_override is not None:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -283,8 +283,10 @@ async def _run_symbol(
             risk.account.update_open_order(symbol, lookup_side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
         log.info(
-            "METRICS",
-            {"event": "cancel", "reason": res.get("reason"), "locked": locked},
+            "METRICS %s",
+            json.dumps(
+                {"event": "cancel", "reason": res.get("reason"), "locked": locked}
+            ),
         )
         metric_pending = res.get("pending_qty", pending_qty)
         if metric_pending_override is not None:

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -256,8 +256,10 @@ async def _run_symbol(
             risk.account.update_open_order(symbol, lookup_side, -pending_qty)
         locked = risk.account.get_locked_usd(symbol) if symbol else 0.0
         log.info(
-            "METRICS",
-            {"event": "cancel", "reason": res.get("reason"), "locked": locked},
+            "METRICS %s",
+            json.dumps(
+                {"event": "cancel", "reason": res.get("reason"), "locked": locked}
+            ),
         )
         metric_pending = res.get("pending_qty", pending_qty)
         if metric_pending_override is not None:


### PR DESCRIPTION
## Summary
- log cancellation metrics using JSON payloads in the paper, testnet, and real live runners to match other metric events

## Testing
- PYTHONPATH=src pytest tests/test_router_cancel_metrics.py


------
https://chatgpt.com/codex/tasks/task_e_68c9ac769614832db1a8c94ec4528b04