### PR TITLE
Remove cancel metrics from live runners

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -24,7 +24,7 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from ..execution.paper import PaperAdapter
 from ..backtesting.engine import SlippageModel
 from ..execution.router import ExecutionRouter
-from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS, CANCELS
+from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS
 from ..utils.price import limit_price_from_close
 from ..broker.broker import Broker
 from ..config import settings
@@ -319,10 +319,8 @@ async def run_paper(
             metric_pending = float(metric_pending)
         except (TypeError, ValueError):
             metric_pending = 0.0
-        if metric_pending > 0:
-            CANCELS.inc()
-        else:
-            return  # treat as filled; no cancel metric
+        if metric_pending <= 0:
+            return  # treat as filled; no cancel handling needed
         risk.complete_order()
 
     router = ExecutionRouter([

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -52,7 +52,6 @@ from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
 from ..utils.price import limit_price_from_close
-from ..utils.metrics import CANCELS
 
 try:
     from ..storage.timescale import get_engine
@@ -295,10 +294,8 @@ async def _run_symbol(
             metric_pending = float(metric_pending)
         except (TypeError, ValueError):
             metric_pending = 0.0
-        if metric_pending > 0:
-            CANCELS.inc()
-        else:
-            return  # treat as filled; no cancel metric
+        if metric_pending <= 0:
+            return  # treat as filled; no cancel handling needed
         already_completed = order is not None and getattr(
             order, "_risk_order_completed", False
         )

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -38,7 +38,6 @@ from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
 from ..utils.price import limit_price_from_close
-from ..utils.metrics import CANCELS
 
 try:
     from ..storage.timescale import get_engine
@@ -268,10 +267,8 @@ async def _run_symbol(
             metric_pending = float(metric_pending)
         except (TypeError, ValueError):
             metric_pending = 0.0
-        if metric_pending > 0:
-            CANCELS.inc()
-        else:
-            return  # treat as filled; no cancel metric
+        if metric_pending <= 0:
+            return  # treat as filled; no cancel handling needed
         already_completed = order is not None and getattr(
             order, "_risk_order_completed", False
         )


### PR DESCRIPTION
## Summary
- stop incrementing the CANCELS metric inside paper, real and testnet live runners
- let ExecutionRouter own cancellation metrics while keeping risk cleanup on genuine cancels

## Testing
- pytest tests/test_router_cancel_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c548ca70832da9f1775bb38e3871