### PR TITLE
Ensure risk order completion after full cancellation

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -320,6 +320,7 @@ async def run_paper(
         except (TypeError, ValueError):
             metric_pending = 0.0
         if metric_pending <= 0:
+            risk.complete_order()
             return  # treat as filled; no cancel handling needed
         risk.complete_order()
 

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -295,6 +295,9 @@ async def _run_symbol(
         except (TypeError, ValueError):
             metric_pending = 0.0
         if metric_pending <= 0:
+            risk.complete_order()
+            if order is not None:
+                setattr(order, "_risk_order_completed", True)
             return  # treat as filled; no cancel handling needed
         already_completed = order is not None and getattr(
             order, "_risk_order_completed", False

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -268,6 +268,9 @@ async def _run_symbol(
         except (TypeError, ValueError):
             metric_pending = 0.0
         if metric_pending <= 0:
+            risk.complete_order()
+            if order is not None:
+                setattr(order, "_risk_order_completed", True)
             return  # treat as filled; no cancel handling needed
         already_completed = order is not None and getattr(
             order, "_risk_order_completed", False


### PR DESCRIPTION
## Summary
- invoke `risk.complete_order()` before returning from paper runner order cancellations that report no pending quantity
- mirror the early completion in the real and testnet runners and mark the order as completed when pending goes to zero

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca071850c0832d9a29e6c26e63b942