### PR TITLE
Fix locked and hit rate metrics

### DIFF
--- a/src/tradingbot/apps/api/static/bots.html
+++ b/src/tradingbot/apps/api/static/bots.html
@@ -357,7 +357,7 @@ async function refreshBots(){
         (stats.maker_taker_ratio||0).toFixed(2),
         (stats.fees_usd||0).toFixed(2),
         (stats.slippage_bps||0).toFixed(2),
-        `${((stats.hit_rate||0)*100).toFixed(1)}%`,
+        `${(stats.hit_rate||0).toFixed(1)}%`,
         (stats.locked||0).toFixed(2),
         (stats.exposure||0).toFixed(4),
         (stats.leverage||0).toFixed(2),

--- a/src/tradingbot/apps/api/static/stats.html
+++ b/src/tradingbot/apps/api/static/stats.html
@@ -159,7 +159,7 @@ async function refreshMetrics(){
     document.getElementById('m-calmar').textContent = (j.calmar||0).toFixed(2);
     document.getElementById('m-maxdd').textContent = (j.max_drawdown||0).toFixed(2);
     document.getElementById('m-tuw').textContent = (j.time_under_water||0).toFixed(2);
-    document.getElementById('m-hit').textContent = ((j.hit_rate||0)*100).toFixed(1)+'%';
+    document.getElementById('m-hit').textContent = (j.hit_rate||0).toFixed(1)+'%';
     document.getElementById('m-expectancy').textContent = (j.expectancy||0).toFixed(2);
     document.getElementById('m-payoff').textContent = (j.payoff_ratio||0).toFixed(2);
     document.getElementById('m-trades-day').textContent = (j.trades_per_day||0).toFixed(2);

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -251,24 +251,36 @@ async def run_paper(
         account = getattr(risk, "account", None)
         if account is None:
             return 0.0
+
         open_orders = getattr(account, "open_orders", None)
         if not isinstance(open_orders, dict) or not open_orders:
             setattr(account, "locked_total", 0.0)
             setattr(risk, "locked_total", 0.0)
             return 0.0
-        prices = getattr(account, "prices", {})
 
-        def _symbol_locked(sym: str) -> float:
-            orders = open_orders.get(sym) or {}
-            total_qty = 0.0
-            for key in ("buy", "sell"):
-                qty_raw = orders.get(key)
-                if qty_raw is None:
-                    continue
+        prices = getattr(account, "prices", {})
+        get_locked = getattr(account, "get_locked_usd", None)
+
+        def _symbol_locked(sym: str, orders: object) -> float:
+            if callable(get_locked):
                 try:
-                    total_qty += float(qty_raw)
+                    return float(get_locked(sym))
+                except Exception:  # pragma: no cover - fallback below
+                    pass
+
+            total_qty = 0.0
+            if isinstance(orders, dict):
+                for key, qty_raw in orders.items():
+                    try:
+                        total_qty += abs(float(qty_raw))
+                    except (TypeError, ValueError):
+                        continue
+            else:
+                try:
+                    total_qty = abs(float(orders))
                 except (TypeError, ValueError):
-                    continue
+                    total_qty = 0.0
+
             try:
                 price = float(prices.get(sym, 0.0) or 0.0)
             except (TypeError, ValueError):
@@ -276,16 +288,8 @@ async def run_paper(
             return total_qty * price
 
         total_locked = 0.0
-        pending_exposure = getattr(account, "pending_exposure", None)
-        if callable(pending_exposure):
-            for sym in list(open_orders.keys()):
-                try:
-                    total_locked += float(pending_exposure(sym))
-                except Exception:
-                    total_locked += _symbol_locked(sym)
-        else:
-            for sym in list(open_orders.keys()):
-                total_locked += _symbol_locked(sym)
+        for sym, orders in list(open_orders.items()):
+            total_locked += _symbol_locked(sym, orders)
 
         if total_locked <= 1e-9:
             total_locked = 0.0

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -222,24 +222,36 @@ async def _run_symbol(
         account = getattr(risk, "account", None)
         if account is None:
             return 0.0
+
         open_orders = getattr(account, "open_orders", None)
         if not isinstance(open_orders, dict) or not open_orders:
             setattr(account, "locked_total", 0.0)
             setattr(risk, "locked_total", 0.0)
             return 0.0
-        prices = getattr(account, "prices", {})
 
-        def _symbol_locked(sym: str) -> float:
-            orders = open_orders.get(sym) or {}
-            total_qty = 0.0
-            for key in ("buy", "sell"):
-                qty_raw = orders.get(key)
-                if qty_raw is None:
-                    continue
+        prices = getattr(account, "prices", {})
+        get_locked = getattr(account, "get_locked_usd", None)
+
+        def _symbol_locked(sym: str, orders: object) -> float:
+            if callable(get_locked):
                 try:
-                    total_qty += float(qty_raw)
+                    return float(get_locked(sym))
+                except Exception:  # pragma: no cover - fallback below
+                    pass
+
+            total_qty = 0.0
+            if isinstance(orders, dict):
+                for _, qty_raw in orders.items():
+                    try:
+                        total_qty += abs(float(qty_raw))
+                    except (TypeError, ValueError):
+                        continue
+            else:
+                try:
+                    total_qty = abs(float(orders))
                 except (TypeError, ValueError):
-                    continue
+                    total_qty = 0.0
+
             try:
                 price = float(prices.get(sym, 0.0) or 0.0)
             except (TypeError, ValueError):
@@ -247,16 +259,8 @@ async def _run_symbol(
             return total_qty * price
 
         total_locked = 0.0
-        pending_exposure = getattr(account, "pending_exposure", None)
-        if callable(pending_exposure):
-            for sym in list(open_orders.keys()):
-                try:
-                    total_locked += float(pending_exposure(sym))
-                except Exception:
-                    total_locked += _symbol_locked(sym)
-        else:
-            for sym in list(open_orders.keys()):
-                total_locked += _symbol_locked(sym)
+        for sym, orders in list(open_orders.items()):
+            total_locked += _symbol_locked(sym, orders)
 
         if total_locked <= 1e-9:
             total_locked = 0.0

--- a/tests/test_metrics_accumulation.py
+++ b/tests/test_metrics_accumulation.py
@@ -26,9 +26,11 @@ async def test_update_bot_stats_events():
     assert stats["orders"] == 1
     assert stats["fills"] == 1
     assert stats["fees_usd"] == 0.2
-    assert stats["hit_rate"] == 1.0
+    assert stats["hit_rate"] == 100.0
     assert stats["slippage_bps"] == 5
     assert stats["pnl"] == 9
     assert stats["cancels"] == 1
     assert stats["cancel_ratio"] == 1.0
+    assert stats["trades_closed"] == 2
+    assert stats["trades_won"] == 2
     assert "trades_processed" not in stats


### PR DESCRIPTION
## Summary
- ensure account locked totals are recomputed from the notional of all open orders in the live runners
- derive the hit rate from closed trades, track trade win counts, and expose the percentage to consumers
- update the web dashboards and regression test expectations to reflect the new hit rate semantics

## Testing
- pytest tests/test_metrics_accumulation.py::test_update_bot_stats_events -q

------
https://chatgpt.com/codex/tasks/task_e_68caf73f82b8832d801a48a35b1c954f