### PR TITLE
Fix order quantization and residual cancellation

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -249,7 +249,7 @@ class Broker:
                 try:
                     res = await self.adapter.cancel_order(res.get("order_id"), symbol)
                     filled = float(res.get("filled_qty", 0.0))
-                    remaining = float(res.get("pending_qty", 0.0))
+                    remaining = float(res.get("pending_qty", remaining))
                     if remaining <= 0 and filled > 0:
                         res["status"] = "filled"
                     res.setdefault("pending_qty", remaining)


### PR DESCRIPTION
## Summary
- add a public `floor_to_step` helper and stop auto-scaling quantities in `adjust_order`
- quantize live orders before submission, reject sub-minimum notional/size requests, and auto-cancel residuals that fall below venue limits
- ensure broker GTD cancellations preserve the pending quantity when venues omit it so re-quote logic still fires

## Testing
- pytest tests/broker/test_place_limit.py
- pytest *(fails: killed by OOM/time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68caf7316c98832dac0d433e34d92ef8