### PR TITLE
Ajustes de cuantización y cancelación residual

### DIFF
--- a/src/tradingbot/execution/normalize.py
+++ b/src/tradingbot/execution/normalize.py
@@ -8,7 +8,7 @@ def _round_step(x: float, step: float) -> float:
         return x
     return round(round(x / step) * step, 12)
 
-def _floor_step(x: float, step: float) -> float:
+def floor_to_step(x: float, step: float) -> float:
     if step is None or step == 0:
         return x
     n = int(x / step)
@@ -41,33 +41,32 @@ def adjust_order(price: Optional[float], qty: float, mark_price: float, rules: S
         price = _round_step(price, rules.price_step)
 
     if rules.qty_step:
-        qty = _floor_step(qty, rules.qty_step)
-
-    if rules.min_qty and qty < rules.min_qty:
-        # aumenta al mínimo permitido (al piso del grid)
-        if rules.qty_step:
-            # subimos al múltiplo más cercano >= min_qty
-            mult = int((rules.min_qty + rules.qty_step - 1e-12) / rules.qty_step)
-            qty = round(mult * rules.qty_step, 12)
-        else:
-            qty = rules.min_qty
+        qty = floor_to_step(qty, rules.qty_step)
 
     # notional para validar (usa mark_price si market)
     px = price if price is not None else mark_price
-    notional = (px or 0.0) * qty
+    px = px or 0.0
+    notional = px * qty
+
+    if rules.min_qty and qty < rules.min_qty:
+        return AdjustResult(
+            price=price,
+            qty=qty,
+            notional=notional,
+            ok=False,
+            reason="min_qty",
+        )
 
     if rules.min_notional and notional < rules.min_notional:
-        # escalar qty al mínimo notional
-        target_qty = (rules.min_notional / (px or 1.0))
-        if rules.qty_step:
-            mult = int((target_qty + rules.qty_step - 1e-12) / rules.qty_step)
-            target_qty = round(mult * rules.qty_step, 12)
-        qty = max(qty, target_qty)
-        notional = (px or 0.0) * qty
+        return AdjustResult(
+            price=price,
+            qty=qty,
+            notional=notional,
+            ok=False,
+            reason="min_notional",
+        )
 
     # Validación final básica
     if qty <= 0:
         return AdjustResult(price=price, qty=qty, notional=notional, ok=False, reason="qty<=0 tras ajuste")
-    if rules.min_notional and notional < rules.min_notional:
-        return AdjustResult(price=price, qty=qty, notional=notional, ok=False, reason="minNotional no alcanzado")
     return AdjustResult(price=price, qty=qty, notional=notional, ok=True)


### PR DESCRIPTION
## Summary
- Cuantiza las órdenes al step_size antes de enviarlas y rechaza tamaños menores al mínimo requerido.
- Registra los filtros de símbolo en el ExecutionRouter para recalcular cantidades pendientes tras fills parciales y cancelar residuos que queden por debajo de los mínimos, liberando el capital bloqueado.
- Conserva la metainformación de reglas al re-cotar órdenes hijas para mantener una gestión consistente de restricciones.

## Testing
- pytest *(finalizado por el entorno tras un tiempo prolongado)*

------
https://chatgpt.com/codex/tasks/task_e_68cb00ef7dc8832d934f79d802312a6e