### PR TITLE
Fix paper runner metrics sequence and clean paper pending qty

### DIFF
--- a/src/tradingbot/adapters/binance_spot.py
+++ b/src/tradingbot/adapters/binance_spot.py
@@ -84,6 +84,37 @@ class BinanceSpotAdapter(ExchangeAdapter):
 
         self._start_fee_updater()
 
+    def on_paper_fill(self, symbol: str, side: str, pending_qty: float | None) -> None:
+        """Synchronise simulated open orders while paper trading."""
+
+        side_norm = str(side).lower() if side else None
+        if not side_norm or not symbol:
+            return
+
+        try:
+            pending = float(pending_qty or 0.0)
+        except (TypeError, ValueError):
+            pending = 0.0
+        if abs(pending) <= 1e-9:
+            pending = 0.0
+
+        orders = getattr(self.account, "open_orders", {})
+        current = 0.0
+        if isinstance(orders, dict):
+            try:
+                current = float(orders.get(symbol, {}).get(side_norm, 0.0) or 0.0)
+            except (TypeError, ValueError):
+                current = 0.0
+
+        target = pending if pending > 0 else 0.0
+        if target == 0.0 and current != 0.0:
+            self.account.update_open_order(symbol, side_norm, -current)
+            return
+
+        delta = target - current
+        if abs(delta) > 1e-12:
+            self.account.update_open_order(symbol, side_norm, delta)
+
     async def update_fees(self, symbol: str | None = None) -> None:
         client = getattr(self, "client", self.rest)
         if client.options.get("testnet"):

--- a/src/tradingbot/adapters/bybit_spot.py
+++ b/src/tradingbot/adapters/bybit_spot.py
@@ -71,6 +71,37 @@ class BybitSpotAdapter(ExchangeAdapter):
 
         self._start_fee_updater()
 
+    def on_paper_fill(self, symbol: str, side: str, pending_qty: float | None) -> None:
+        """Update simulated open orders when running in paper mode."""
+
+        side_norm = str(side).lower() if side else None
+        if not side_norm or not symbol:
+            return
+
+        try:
+            pending = float(pending_qty or 0.0)
+        except (TypeError, ValueError):
+            pending = 0.0
+        if abs(pending) <= 1e-9:
+            pending = 0.0
+
+        orders = getattr(self.account, "open_orders", {})
+        current = 0.0
+        if isinstance(orders, dict):
+            try:
+                current = float(orders.get(symbol, {}).get(side_norm, 0.0) or 0.0)
+            except (TypeError, ValueError):
+                current = 0.0
+
+        target = pending if pending > 0 else 0.0
+        if target == 0.0 and current != 0.0:
+            self.account.update_open_order(symbol, side_norm, -current)
+            return
+
+        delta = target - current
+        if abs(delta) > 1e-12:
+            self.account.update_open_order(symbol, side_norm, delta)
+
     async def update_fees(self, symbol: str | None = None) -> None:
         params = {"category": "spot"}
         if symbol:


### PR DESCRIPTION
## Summary
- ensure paper runner records order metrics before fill callbacks, normalises pending quantity to zero when appropriate and resets locked exposure when no open orders remain
- introduce on_paper_fill helpers for Binance, Bybit and OKX spot adapters to keep simulated open orders in sync during paper fills

## Testing
- pytest *(killed by OOM after long run)*

------
https://chatgpt.com/codex/tasks/task_e_68cb59f01258832d81420c18710dbe0a