### PR TITLE
Align min order thresholds with venue steps in live runners

### DIFF
--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -203,9 +203,9 @@ async def _run_symbol(
         risk_per_trade=risk_per_trade,
         market_type=market,
     )
-    min_order_qty = min_qty_val if min_qty_val > 0 else 0.0
-    if min_order_qty <= 0 and step_size > 0:
-        min_order_qty = step_size
+    min_qty_value = min_qty_val if min_qty_val > 0 else 0.0
+    step_value = step_size if step_size > 0 else 0.0
+    min_order_qty = max(min_qty_value, step_value)
     risk.min_order_qty = min_order_qty if min_order_qty > 0 else 1e-9
     risk.min_notional = float(min_notional if min_notional > 0 else 0.0)
     strat.risk_service = risk
@@ -221,10 +221,12 @@ async def _run_symbol(
 
     def _flat_threshold() -> float:
         base = risk.min_order_qty
+        if base > 0:
+            return base
         step = step_size if step_size > 0 else 0.0
-        if step > base:
-            base = step
-        return base if base > 0 else 1e-9
+        if step > 0:
+            return step
+        return 1e-9
 
     def _position_closed(before: float, after: float) -> bool:
         threshold = _flat_threshold()
@@ -667,7 +669,15 @@ async def _run_symbol(
             elif reason:
                 log.warning("[PG] Bloqueado %s: %s", symbol, reason)
             continue
-        if abs(delta) <= 0:
+        threshold = _flat_threshold()
+        if abs(delta) < threshold:
+            log.info(
+                "Skipping order: qty %.8f below min threshold", abs(delta)
+            )
+            log.info(
+                "METRICS %s",
+                json.dumps({"event": "skip", "reason": "below_min_qty"}),
+            )
             continue
         side = "buy" if delta > 0 else "sell"
         price = (
@@ -676,7 +686,7 @@ async def _run_symbol(
             else limit_price_from_close(side, closed.c, tick_size)
         )
         qty = adjust_qty(abs(delta), price, min_notional, step_size, risk.min_order_qty)
-        if qty <= 0:
+        if qty < threshold:
             log.info(
                 "Skipping order: qty %.8f below min threshold", abs(delta)
             )


### PR DESCRIPTION
## Summary
- ensure the live paper, testnet, and real runners derive `risk.min_order_qty` from the max of the venue min quantity and step size
- centralize minimum quantity comparisons through `_flat_threshold()` before sending orders to `adjust_qty`
- gate close/scale/new orders below the threshold so that quantity skips are logged before routing

## Testing
- `pytest tests/test_paper_runner.py` *(hangs, interrupted after several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c0b8388832dbb8407b5b1674437