### PR TITLE
Improve symbol rules fallback

### DIFF
--- a/src/tradingbot/live/_symbol_rules.py
+++ b/src/tradingbot/live/_symbol_rules.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from ..core.symbols import normalize
+
+_DEFAULT_QUOTES = [
+    "USDT",
+    "FDUSD",
+    "TUSD",
+    "USDC",
+    "BUSD",
+    "BTC",
+    "ETH",
+    "BNB",
+]
+
+
+def _iter_sources(meta: Any) -> Iterable[Any]:
+    if meta is not None:
+        yield meta
+        client = getattr(meta, "client", None)
+        if client is not None:
+            yield client
+
+
+def _collect_quotes(meta: Any) -> list[str]:
+    quotes: set[str] = set()
+    for source in _iter_sources(meta):
+        markets = getattr(source, "markets", None)
+        if isinstance(markets, dict):
+            for details in markets.values():
+                quote = details.get("quote") if isinstance(details, dict) else None
+                if isinstance(quote, str) and quote:
+                    quotes.add(quote.upper())
+        extra_quotes = getattr(source, "quotes", None)
+        if isinstance(extra_quotes, Iterable) and not isinstance(extra_quotes, (str, bytes)):
+            for quote in extra_quotes:
+                if isinstance(quote, str) and quote:
+                    quotes.add(quote.upper())
+    quotes.update(_DEFAULT_QUOTES)
+    return sorted(quotes, key=len, reverse=True)
+
+
+def denormalize_for_rules(
+    raw_symbol: str | None,
+    normalized_symbol: str,
+    meta: Any | None = None,
+) -> str | None:
+    """Rebuild the venue formatted symbol used by ``rules_for``."""
+    if raw_symbol:
+        raw = raw_symbol.upper()
+        if "/" in raw:
+            return raw
+    normalized = normalize(raw_symbol or normalized_symbol)
+    base_part, _, suffix = normalized.partition("-")
+    quotes = _collect_quotes(meta)
+    for quote in quotes:
+        if base_part.endswith(quote):
+            base = base_part[: -len(quote)]
+            if not base:
+                continue
+            symbol = f"{base}/{quote}"
+            if suffix:
+                symbol = f"{symbol}-{suffix}"
+            return symbol
+    match = re.match(r"([A-Z0-9]+?)([A-Z]{2,6})$", base_part)
+    if match:
+        base, quote = match.groups()
+        symbol = f"{base}/{quote}"
+        if suffix:
+            symbol = f"{symbol}-{suffix}"
+        return symbol
+    if raw_symbol:
+        candidate = raw_symbol.replace("-", "/").upper()
+        if "/" in candidate:
+            return candidate
+    return None
+
+
+def resolve_symbol_rules(
+    meta: Any,
+    raw_symbol: str | None,
+    normalized_symbol: str,
+):
+    """Return venue ``rules`` and the resolved symbol identifier."""
+    if meta is None:
+        raise LookupError("symbol metadata unavailable")
+    fetch_symbol: str | None = None
+    client = getattr(meta, "client", None)
+    symbols = getattr(client, "symbols", None)
+    if isinstance(symbols, Iterable) and not isinstance(symbols, (str, bytes)):
+        for symbol in symbols:
+            if not isinstance(symbol, str):
+                continue
+            try:
+                if normalize(symbol) == normalized_symbol:
+                    fetch_symbol = symbol
+                    break
+            except Exception:
+                continue
+    if fetch_symbol is None:
+        fetch_symbol = denormalize_for_rules(raw_symbol, normalized_symbol, meta)
+    if not fetch_symbol:
+        raise LookupError(f"unable to determine venue symbol for {normalized_symbol}")
+    rules = meta.rules_for(fetch_symbol)
+    return rules, fetch_symbol

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -35,6 +35,7 @@ from ..risk.correlation_service import CorrelationService
 from ..strategies import STRATEGIES
 from monitoring import panel
 from ..core.symbols import normalize
+from ._symbol_rules import resolve_symbol_rules
 from ..execution.order_sizer import adjust_qty
 
 try:
@@ -150,15 +151,7 @@ async def run_paper(
     min_qty_val = 0.0
     try:
         if rest is not None and hasattr(rest, "meta"):
-            fetch_symbol = None
-            symbols = getattr(rest.meta.client, "symbols", [])
-            if symbols:
-                fetch_symbol = next(
-                    (s for s in symbols if normalize(s) == symbol), None
-                )
-            if fetch_symbol is None:
-                fetch_symbol = raw_symbol.replace("-", "/")
-            rules = rest.meta.rules_for(fetch_symbol)
+            rules, _ = resolve_symbol_rules(rest.meta, raw_symbol, symbol)
             qty_step = float(getattr(rules, "qty_step", 0.0) or 0.0)
             if step_size <= 0 and qty_step > 0:
                 step_size = qty_step

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -51,6 +51,7 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
+from ._symbol_rules import resolve_symbol_rules
 from ..utils.price import limit_price_from_close
 
 try:
@@ -157,13 +158,7 @@ async def _run_symbol(
     meta = getattr(exec_adapter, "meta", None)
     if meta is not None:
         try:
-            fetch_symbol = None
-            symbols = getattr(meta.client, "symbols", [])
-            if symbols:
-                fetch_symbol = next((s for s in symbols if normalize(s) == symbol), None)
-            if fetch_symbol is None:
-                fetch_symbol = raw_symbol.replace("-", "/")
-            rules = meta.rules_for(fetch_symbol)
+            rules, _ = resolve_symbol_rules(meta, raw_symbol, symbol)
             step_candidate = float(getattr(rules, "qty_step", 0.0) or 0.0)
             if step_size <= 0 and step_candidate > 0:
                 step_size = step_candidate

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -37,6 +37,7 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
+from ._symbol_rules import resolve_symbol_rules
 from ..utils.price import limit_price_from_close
 
 try:
@@ -135,13 +136,7 @@ async def _run_symbol(
     meta = getattr(exec_adapter, "meta", None)
     if meta is not None:
         try:
-            fetch_symbol = None
-            symbols = getattr(meta.client, "symbols", [])
-            if symbols:
-                fetch_symbol = next((s for s in symbols if normalize(s) == symbol), None)
-            if fetch_symbol is None:
-                fetch_symbol = raw_symbol.replace("-", "/")
-            rules = meta.rules_for(fetch_symbol)
+            rules, _ = resolve_symbol_rules(meta, raw_symbol, symbol)
             step_candidate = float(getattr(rules, "qty_step", 0.0) or 0.0)
             if step_size <= 0 and step_candidate > 0:
                 step_size = step_candidate

--- a/tests/live/test_symbol_rules_fallback.py
+++ b/tests/live/test_symbol_rules_fallback.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import pytest
+
+from tradingbot.live._symbol_rules import denormalize_for_rules, resolve_symbol_rules
+
+
+class _DummyMeta:
+    def __init__(self):
+        self.client = SimpleNamespace(symbols=[], markets={})
+
+    def rules_for(self, symbol: str) -> SimpleNamespace:
+        assert symbol == "ETH/USDT"
+        return SimpleNamespace(
+            qty_step=0.0001,
+            price_step=0.01,
+            min_notional=10,
+            min_qty=0.0001,
+        )
+
+
+def test_symbol_rules_fallback_reconstructs_and_keeps_qty_step():
+    meta = _DummyMeta()
+
+    fetch_symbol = denormalize_for_rules("ETHUSDT", "ETHUSDT", meta)
+    assert fetch_symbol == "ETH/USDT"
+
+    rules, resolved = resolve_symbol_rules(meta, "ETHUSDT", "ETHUSDT")
+    assert resolved == "ETH/USDT"
+    assert rules.qty_step == pytest.approx(0.0001)


### PR DESCRIPTION
## Summary
- add a shared helper that rebuilds venue symbols for rules lookups when exchange metadata is sparse
- use the helper in the paper, testnet, and real runners so Binance symbols retain their true sizing rules
- add a regression test covering the ETHUSDT fallback scenario when `load_markets` data is missing

## Testing
- pytest tests/live/test_symbol_rules_fallback.py


------
https://chatgpt.com/codex/tasks/task_e_68cc6149e158832da2792fa75a568ab8