### PR TITLE
Increment cancellation metric across live runners

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -24,7 +24,7 @@ from ..adapters.okx_futures import OKXFuturesAdapter
 from ..execution.paper import PaperAdapter
 from ..backtesting.engine import SlippageModel
 from ..execution.router import ExecutionRouter
-from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS
+from ..utils.metrics import MARKET_LATENCY, AGG_COMPLETED, SKIPS, CANCELS
 from ..utils.price import limit_price_from_close
 from ..broker.broker import Broker
 from ..config import settings
@@ -375,6 +375,7 @@ async def run_paper(
         if res.get("_cancel_handled"):
             return
         res["_cancel_handled"] = True
+        CANCELS.inc()
         symbol = res.get("symbol")
         side = res.get("side")
         side_norm = str(side).lower() if isinstance(side, str) else None

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -52,6 +52,7 @@ from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
 from ._symbol_rules import resolve_symbol_rules
+from ..utils.metrics import CANCELS
 from ..utils.price import limit_price_from_close
 from ._metrics import infer_maker_flag
 
@@ -350,6 +351,7 @@ async def _run_symbol(
         if res.get("_cancel_handled"):
             return
         res["_cancel_handled"] = True
+        CANCELS.inc()
         symbol = res.get("symbol") or getattr(order, "symbol", None)
         side = res.get("side") or getattr(order, "side", None)
         side_norm = str(side).lower() if isinstance(side, str) else None

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -38,6 +38,7 @@ from monitoring import panel
 from ..execution.order_sizer import adjust_qty
 from ..core.symbols import normalize
 from ._symbol_rules import resolve_symbol_rules
+from ..utils.metrics import CANCELS
 from ..utils.price import limit_price_from_close
 from ._metrics import infer_maker_flag
 
@@ -323,6 +324,7 @@ async def _run_symbol(
         if res.get("_cancel_handled"):
             return
         res["_cancel_handled"] = True
+        CANCELS.inc()
         symbol = res.get("symbol") or getattr(order, "symbol", None)
         side = res.get("side") or getattr(order, "side", None)
         side_norm = str(side).lower() if isinstance(side, str) else None


### PR DESCRIPTION
## Summary
- increment the CANCELS metric whenever paper/testnet/real runners handle cancel or expiry events
- ensure cancellation notifications bump the counter so GTD timeouts surface in the UI

## Testing
- pytest tests/test_router_cancel_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6b2a8f44832d9b06a59c0da85d3c