### PR TITLE
Ensure paper runner logs newly accepted orders

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -1060,7 +1060,7 @@ async def run_paper(
                         continue
                     log_order = False
                     order_qty = qty_close
-                    if status in {"open", "filled"}:
+                    if status in {"open", "filled", "new"}:
                         log_order = True
                     elif status == "canceled" and filled_qty > 0:
                         log_order = True
@@ -1223,7 +1223,7 @@ async def run_paper(
                             continue
                         log_order = False
                         order_qty = qty_scale
-                        if status in {"open", "filled"}:
+                        if status in {"open", "filled", "new"}:
                             log_order = True
                         elif status == "canceled" and filled_qty > 0:
                             log_order = True
@@ -1469,7 +1469,7 @@ async def run_paper(
                 continue
             log_order = False
             order_qty = qty
-            if status in {"open", "filled"}:
+            if status in {"open", "filled", "new"}:
                 log_order = True
             elif status == "canceled" and filled_qty > 0:
                 log_order = True


### PR DESCRIPTION
## Summary
- treat the paper broker's "new" status as a placed order across the close, scale, and entry flows so metrics are emitted immediately

## Testing
- pytest tests/test_metrics_accumulation.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8ccde184832d8bfd54d14e56f23d