### PR TITLE
Handle paper remainder cancellation

### DIFF
--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -365,7 +365,36 @@ class ExecutionRouter:
         order._mark_price = float(mark_price or 0.0)
         order._step_size = float(rules.qty_step) if rules and rules.qty_step else None
         order._min_qty = float(rules.min_qty) if rules and rules.min_qty else None
-        order._min_notional = float(rules.min_notional) if rules and rules.min_notional else None
+        order._min_notional = (
+            float(rules.min_notional) if rules and rules.min_notional else None
+        )
+        if order._step_size is None:
+            step_attr = getattr(adapter, "step_size", None)
+            if step_attr is None:
+                step_attr = getattr(adapter, "qty_step", None)
+            if step_attr not in (None, ""):
+                try:
+                    order._step_size = float(step_attr)
+                except (TypeError, ValueError):
+                    order._step_size = None
+        if order._min_qty is None:
+            min_qty_attr = getattr(adapter, "min_qty", None)
+            if min_qty_attr in (None, ""):
+                min_qty_attr = getattr(adapter, "min_order_qty", None)
+            if min_qty_attr not in (None, ""):
+                try:
+                    order._min_qty = float(min_qty_attr)
+                except (TypeError, ValueError):
+                    order._min_qty = None
+        if order._min_notional is None:
+            min_notional_attr = getattr(adapter, "min_notional", None)
+            if min_notional_attr in (None, ""):
+                min_notional_attr = getattr(adapter, "min_trade_notional", None)
+            if min_notional_attr not in (None, ""):
+                try:
+                    order._min_notional = float(min_notional_attr)
+                except (TypeError, ValueError):
+                    order._min_notional = None
         if rules is not None:
             adj = adjust_order(order.price, order.qty, float(mark_price or 0.0), rules, order.side)
             if not adj.ok:

--- a/tests/test_paper_remainders.py
+++ b/tests/test_paper_remainders.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tradingbot.execution.order_types import Order
+from tradingbot.execution.paper import PaperAdapter
+from tradingbot.execution.router import ExecutionRouter
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
+from tradingbot.risk.service import RiskService
+
+
+@pytest.mark.asyncio
+async def test_paper_partial_fill_remainder_cancelled():
+    adapter = PaperAdapter(min_notional=50.0)
+    adapter.state.cash = 1000.0
+    symbol = "BTC/USDT"
+    adapter.update_last_price(symbol, 100.0)
+    guard = PortfolioGuard(GuardConfig(venue="paper"))
+    risk = RiskService(guard, account=adapter.account)
+    router = ExecutionRouter(adapter, risk_service=risk)
+
+    order = Order(symbol=symbol, side="buy", type_="limit", qty=1.0, price=90.0)
+    res = await router.execute(order)
+    assert res["status"] == "new"
+    assert risk.account.open_orders[symbol]["buy"] == pytest.approx(order.qty)
+
+    events = adapter.update_last_price(symbol, 89.0, qty=0.6)
+    assert events
+
+    handled_results = []
+    for ev in events:
+        res_event = await router.handle_paper_event(ev)
+        if res_event is not None:
+            handled_results.append(res_event)
+
+    assert handled_results, "Expected router to process paper events"
+    final = handled_results[-1]
+    assert final["pending_qty"] == pytest.approx(0.0)
+    assert final.get("remaining_cancelled") is True
+    assert risk.account.get_locked_usd(symbol) == pytest.approx(0.0)
+    assert symbol not in risk.account.open_orders


### PR DESCRIPTION
## Summary
- fall back to adapter-level quantity and notional limits when symbol metadata is missing
- add a paper adapter regression test that ensures small remainders are cancelled and reservations cleared

## Testing
- pytest tests/test_paper_remainders.py

------
https://chatgpt.com/codex/tasks/task_e_68ccafe4bdf4832d8d2cf18ac30594ca