### PR TITLE
Handle new paper order status in metrics logging

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -1469,7 +1469,7 @@ async def run_paper(
                 continue
             log_order = False
             order_qty = qty
-            if status in {"open", "filled"}:
+            if status in {"open", "filled", "new"}:
                 log_order = True
             elif status == "canceled" and filled_qty > 0:
                 log_order = True


### PR DESCRIPTION
## Summary
- treat paper orders with a `new` status the same as `open`/`filled`
- ensure baseline capture and locked metric updates run immediately for new orders

## Testing
- PYTHONPATH=src python -m tradingbot.live.runner_paper --symbol ETH/USDT

------
https://chatgpt.com/codex/tasks/task_e_68ccc23f472c832d85eac8f835447d79