### PR TITLE
Fix pending quantity accounting for limit orders

### DIFF
--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -145,10 +145,18 @@ class Broker:
                 res.get("qty") or res.get("filled") or res.get("filled_qty") or 0.0
             )
             filled += qty_filled
-            remaining = max(remaining - qty_filled, 0.0)
+            pending_reported = res.get("pending_qty")
+            if pending_reported is not None:
+                try:
+                    remaining = max(float(pending_reported), 0.0)
+                    res["pending_qty"] = remaining
+                except (TypeError, ValueError):
+                    remaining = max(remaining - qty_filled, 0.0)
+            else:
+                remaining = max(remaining - qty_filled, 0.0)
+                res.setdefault("pending_qty", remaining)
             order.pending_qty = remaining
             res.setdefault("filled_qty", qty_filled)
-            res.setdefault("pending_qty", remaining)
             last_res = res
 
             # Fully filled or adapter rejected/canceled the order

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -221,7 +221,12 @@ async def run_live_binance(
                 )
                 filled_qty = float(resp.get("filled_qty", 0.0))
                 pending_qty = float(resp.get("pending_qty", 0.0))
-                risk.account.update_open_order(symbol, close_side, filled_qty + pending_qty)
+                prev_pending = float(
+                    risk.account.open_orders.get(symbol, {}).get(close_side.lower(), 0.0)
+                )
+                delta_open = pending_qty - prev_pending + filled_qty
+                if abs(delta_open) > 1e-9:
+                    risk.account.update_open_order(symbol, close_side, delta_open)
                 risk.on_fill(symbol, close_side, filled_qty, venue="binance")
                 delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                 halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -250,7 +255,12 @@ async def run_live_binance(
                     )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
-                    risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
+                    prev_pending = float(
+                        risk.account.open_orders.get(symbol, {}).get(side.lower(), 0.0)
+                    )
+                    delta_open = pending_qty - prev_pending + filled_qty
+                    if abs(delta_open) > 1e-9:
+                        risk.account.update_open_order(symbol, side, delta_open)
                     risk.on_fill(symbol, side, filled_qty, venue="binance")
                     delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
                     halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)
@@ -322,7 +332,12 @@ async def run_live_binance(
         log.info("FILL live %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
+        prev_pending = float(
+            risk.account.open_orders.get(symbol, {}).get(side.lower(), 0.0)
+        )
+        delta_open = pending_qty - prev_pending + filled_qty
+        if abs(delta_open) > 1e-9:
+            risk.account.update_open_order(symbol, side, delta_open)
         risk.on_fill(symbol, side, filled_qty, venue="binance")
         delta_rpnl = resp.get("realized_pnl", broker.state.realized_pnl) - prev_rpnl
         halted, reason = risk.daily_mark(broker, symbol, px, delta_rpnl)

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -294,9 +294,12 @@ async def run_paper(
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
                     exec_price = float(resp.get("price", price))
-                    risk.account.update_open_order(
-                        symbol, close_side, filled_qty + pending_qty
+                    prev_pending = float(
+                        risk.account.open_orders.get(symbol, {}).get(close_side.lower(), 0.0)
                     )
+                    delta_open = pending_qty - prev_pending + filled_qty
+                    if abs(delta_open) > 1e-9:
+                        risk.account.update_open_order(symbol, close_side, delta_open)
                     risk.on_fill(
                         symbol, close_side, filled_qty, price=exec_price, venue="paper"
                     )
@@ -386,9 +389,12 @@ async def run_paper(
                         filled_qty = float(resp.get("filled_qty", 0.0))
                         pending_qty = float(resp.get("pending_qty", 0.0))
                         exec_price = float(resp.get("price", price))
-                        risk.account.update_open_order(
-                            symbol, side, filled_qty + pending_qty
+                        prev_pending = float(
+                            risk.account.open_orders.get(symbol, {}).get(side.lower(), 0.0)
                         )
+                        delta_open = pending_qty - prev_pending + filled_qty
+                        if abs(delta_open) > 1e-9:
+                            risk.account.update_open_order(symbol, side, delta_open)
                         risk.on_fill(
                             symbol, side, filled_qty, price=exec_price, venue="paper"
                         )
@@ -523,7 +529,12 @@ async def run_paper(
             filled_qty = float(resp.get("filled_qty", 0.0))
             pending_qty = float(resp.get("pending_qty", 0.0))
             exec_price = float(resp.get("price", price))
-            risk.account.update_open_order(symbol, side, filled_qty + pending_qty)
+            prev_pending = float(
+                risk.account.open_orders.get(symbol, {}).get(side.lower(), 0.0)
+            )
+            delta_open = pending_qty - prev_pending + filled_qty
+            if abs(delta_open) > 1e-9:
+                risk.account.update_open_order(symbol, side, delta_open)
             risk.on_fill(
                 symbol, side, filled_qty, price=exec_price, venue="paper"
             )

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -229,7 +229,12 @@ async def _run_symbol(
                 )
                 filled_qty = float(resp.get("filled_qty", 0.0))
                 pending_qty = float(resp.get("pending_qty", 0.0))
-                risk.account.update_open_order(cfg.symbol, close_side, filled_qty + pending_qty)
+                prev_pending = float(
+                    risk.account.open_orders.get(cfg.symbol, {}).get(close_side.lower(), 0.0)
+                )
+                delta_open = pending_qty - prev_pending + filled_qty
+                if abs(delta_open) > 1e-9:
+                    risk.account.update_open_order(cfg.symbol, close_side, delta_open)
                 risk.on_fill(
                     cfg.symbol,
                     close_side,
@@ -264,7 +269,12 @@ async def _run_symbol(
                     )
                     filled_qty = float(resp.get("filled_qty", 0.0))
                     pending_qty = float(resp.get("pending_qty", 0.0))
-                    risk.account.update_open_order(cfg.symbol, side, filled_qty + pending_qty)
+                    prev_pending = float(
+                        risk.account.open_orders.get(cfg.symbol, {}).get(side.lower(), 0.0)
+                    )
+                    delta_open = pending_qty - prev_pending + filled_qty
+                    if abs(delta_open) > 1e-9:
+                        risk.account.update_open_order(cfg.symbol, side, delta_open)
                     risk.on_fill(
                         cfg.symbol,
                         side,
@@ -339,7 +349,12 @@ async def _run_symbol(
         log.info("LIVE FILL %s", resp)
         filled_qty = float(resp.get("filled_qty", 0.0))
         pending_qty = float(resp.get("pending_qty", 0.0))
-        risk.account.update_open_order(cfg.symbol, side, filled_qty + pending_qty)
+        prev_pending = float(
+            risk.account.open_orders.get(cfg.symbol, {}).get(side.lower(), 0.0)
+        )
+        delta_open = pending_qty - prev_pending + filled_qty
+        if abs(delta_open) > 1e-9:
+            risk.account.update_open_order(cfg.symbol, side, delta_open)
         risk.on_fill(
             cfg.symbol, side, filled_qty, venue=venue if not dry_run else "paper"
         )

--- a/tests/test_paper_limit_book.py
+++ b/tests/test_paper_limit_book.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from tradingbot.broker.broker import Broker
 from tradingbot.execution.paper import PaperAdapter
 
 
@@ -53,3 +54,42 @@ async def test_cancel_pending_order_reports_metrics():
     assert cancel["status"] == "canceled"
     assert cancel["time_in_book"] >= 0.02
     assert cancel["latency"] >= 0.01
+
+
+@pytest.mark.asyncio
+async def test_limit_fill_with_exact_cash_clears_reserve():
+    symbol = "BTC/USDT"
+    adapter = PaperAdapter()
+    adapter.update_last_price(symbol, 100.0)
+    maker_fee = adapter.maker_fee_bps / 10000.0
+    requested_qty = 2.0
+    accepted_qty = 1.0
+    price = 90.0
+    initial_cash = price * accepted_qty * (1 + maker_fee)
+    adapter.state.cash = initial_cash
+    adapter.account.cash = initial_cash
+
+    broker = Broker(adapter)
+
+    resp = await broker.place_limit(symbol, "buy", price, requested_qty)
+    assert resp["status"] == "new"
+    filled_qty = float(resp.get("filled_qty", 0.0))
+    pending_qty = float(resp.get("pending_qty", 0.0))
+    assert filled_qty == pytest.approx(0.0)
+    assert pending_qty == pytest.approx(accepted_qty)
+
+    account = adapter.account
+    prev_pending = float(account.open_orders.get(symbol, {}).get("buy", 0.0))
+    delta_open = pending_qty - prev_pending + filled_qty
+    if abs(delta_open) > 1e-9:
+        account.update_open_order(symbol, "buy", delta_open)
+
+    # Order matches fully once price trades through the limit
+    fills = adapter.update_last_price(symbol, price, qty=accepted_qty)
+    assert fills and fills[0]["status"] == "filled"
+    fill_qty = float(fills[0]["qty"])
+    account.update_open_order(symbol, "buy", -fill_qty)
+
+    assert account.open_orders == {}
+    assert account.get_available_balance() == pytest.approx(account.cash)
+    assert account.cash == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- consume the adapter reported `pending_qty` when tracking remaining limit size in the broker
- update the live runners to reserve only the outstanding portion of open orders
- add a paper adapter test covering full fills with tight cash to ensure reserves are released

## Testing
- pytest tests/test_paper_limit_book.py

------
https://chatgpt.com/codex/tasks/task_e_68cccf00e780832db0a705f8531bcbdb