### PR TITLE
Update paper runner ack open order tracking

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -505,6 +505,26 @@ async def run_paper(
             account = getattr(risk, "account", None)
             if account is None:
                 return
+            pending_qty = qty_float
+            if pending_qty < 0.0 and abs(pending_qty) <= 1e-9:
+                pending_qty = 0.0
+            try:
+                side_norm = str(side).lower()
+            except Exception:
+                side_norm = side
+            prev_pending = _prev_pending_qty(symbol, side_norm)
+            delta_pending = pending_qty - prev_pending
+            if delta_pending < 0.0 and abs(delta_pending) <= 1e-9:
+                delta_pending = 0.0
+            update_open = getattr(account, "update_open_order", None)
+            if (
+                callable(update_open)
+                and symbol
+                and isinstance(symbol, str)
+                and side_norm
+            ):
+                with contextlib.suppress(Exception):
+                    update_open(symbol, side_norm, delta_pending)
             try:
                 cur_qty = float(account.current_exposure(symbol)[0])
             except Exception:


### PR DESCRIPTION
## Summary
- normalize order side on acknowledgement and refresh the open order reservation with the delta quantity
- guard against tiny negative pending quantities so locked capital matches the latest acknowledgement before fills

## Testing
- pytest tests/test_paper_runner.py::test_run_paper_clears_existing_pending_after_fill

------
https://chatgpt.com/codex/tasks/task_e_68cd7441fa88832d8a40d281c8cf20a9