### PR TITLE
Respect manual min volatility override in trend strategy

### DIFF
--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -30,7 +30,11 @@ class TrendFollowing(Strategy):
         # ``vol_lookback`` se especifica en minutos y se escalará al timeframe
         # real en ``on_bar``.
         self.vol_lookback = kwargs.get("vol_lookback", self.rsi_n)
-        self.min_volatility = 0.0
+        self._min_volatility_override = kwargs.get("min_volatility")
+        if self._min_volatility_override is not None:
+            self.min_volatility = float(self._min_volatility_override)
+        else:
+            self.min_volatility = 0.0
         self.risk_service = kwargs.get("risk_service")
         self._rq = RollingQuantileCache()
 
@@ -88,8 +92,9 @@ class TrendFollowing(Strategy):
                 min_periods=lookback_bars,
             )
             val = rq_vol.update(vol_bps)
-            self.min_volatility = 0.0 if pd.isna(val) else float(val)
-        else:
+            if self._min_volatility_override is None:
+                self.min_volatility = 0.0 if pd.isna(val) else float(val)
+        elif self._min_volatility_override is None:
             self.min_volatility = 0.0
         if pd.isna(vol_bps) or vol_bps < self.min_volatility:
             return None

--- a/tests/test_trend_following.py
+++ b/tests/test_trend_following.py
@@ -60,3 +60,18 @@ def test_trend_following_generates_signal_across_timeframes(timeframe):
     sig = strat.on_bar(bar)
     assert sig and sig.side == "buy"
 
+
+def test_trend_following_respects_explicit_min_volatility():
+    prices = [100 + i * 0.01 for i in range(30)]
+    df = pd.DataFrame({"close": prices})
+    bar = {"window": df, "timeframe": "1m"}
+
+    strat_override = TrendFollowing(min_volatility=5.0)
+    sig_override = strat_override.on_bar(bar)
+    assert sig_override is None
+    assert strat_override.min_volatility == pytest.approx(5.0)
+
+    strat_auto = TrendFollowing()
+    sig_auto = strat_auto.on_bar(bar)
+    assert sig_auto and sig_auto.side == "buy"
+


### PR DESCRIPTION
## Summary
- allow configuring a manual minimum volatility threshold when instantiating the TrendFollowing strategy
- ensure the auto-computed threshold only applies when no manual override is provided
- add coverage to confirm signals are skipped when volatility falls below the explicit threshold

## Testing
- pytest tests/test_trend_following.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7ecf2400832dbe3153ac00d43e87