### PR TITLE
Ensure volatility lookback covers requested minutes

### DIFF
--- a/src/tradingbot/strategies/trend_following.py
+++ b/src/tradingbot/strategies/trend_following.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas as pd
 from .base import Strategy, Signal, record_signal_metrics
 from ..data.features import rsi, calc_ofi
@@ -72,7 +74,7 @@ class TrendFollowing(Strategy):
         df: pd.DataFrame = bar["window"]
         tf = bar.get("timeframe")
         tf_minutes = self._tf_minutes(tf)
-        lookback_bars = max(1, int(self.vol_lookback / tf_minutes))
+        lookback_bars = max(1, math.ceil(self.vol_lookback / tf_minutes))
         if len(df) < max(self.rsi_n, lookback_bars) + 1:
             return None
         price_col = "close" if "close" in df.columns else "price"


### PR DESCRIPTION
## Summary
- ensure the trend-following strategy rounds volatility lookback bars up so the requested minute window is fully covered
- update trend-following tests to use the rounded lookback and add a regression test that checks the rolling quantile cache is queried with the expected window

## Testing
- pytest tests/test_trend_following.py

------
https://chatgpt.com/codex/tasks/task_e_68cd80a0af58832d9071d1de63938708