### PR TITLE
Fix paper order reservation clipping

### DIFF
--- a/src/tradingbot/execution/router.py
+++ b/src/tradingbot/execution/router.py
@@ -465,6 +465,15 @@ class ExecutionRouter:
                 pending_for_lock = (
                     order.pending_qty if order.pending_qty is not None else order.qty
                 )
+            pending_for_lock = max(float(pending_for_lock or 0.0), 0.0)
+            order.pending_qty = pending_for_lock
+            try:
+                existing_qty = float(order.qty)
+            except (TypeError, ValueError):
+                existing_qty = None
+            if existing_qty is None or pending_for_lock < existing_qty - 1e-12:
+                order.qty = pending_for_lock
+            res["pending_qty"] = pending_for_lock
             self._update_open_order_reservation(order, pending_for_lock)
         if status == "new":
             oid = res.get("order_id")

--- a/tests/test_execution_router_paper_events.py
+++ b/tests/test_execution_router_paper_events.py
@@ -73,6 +73,66 @@ async def test_open_order_locked_notional_tracks_fill_lifecycle():
 
 
 @pytest.mark.asyncio
+async def test_paper_order_clip_updates_pending_and_unlocks_cash():
+    adapter = PaperAdapter(maker_fee_bps=250.0)
+    adapter.state.cash = 100.0
+    adapter.account.cash = 100.0
+    symbol = "BTC/USDT"
+    adapter.update_last_price(symbol, 100.0)
+
+    guard = PortfolioGuard(GuardConfig(venue="paper"))
+    risk = RiskService(guard, account=adapter.account)
+    router = ExecutionRouter(adapter, risk_service=risk)
+
+    requested_qty = 5.0
+    order = Order(symbol=symbol, side="buy", type_="limit", qty=requested_qty, price=95.0)
+    res = await router.execute(order)
+
+    assert res["status"] == "new"
+    clipped_qty = float(res["pending_qty"])
+    expected_affordable = adapter.state.cash / (order.price * (1 + adapter.maker_fee_bps / 10000.0))
+    assert clipped_qty == pytest.approx(expected_affordable)
+    assert clipped_qty < requested_qty
+    assert order.pending_qty == pytest.approx(clipped_qty)
+    assert order.qty == pytest.approx(clipped_qty)
+
+    locked_after_submit = risk.account.get_locked_usd(symbol)
+    assert locked_after_submit == pytest.approx(clipped_qty * adapter.state.last_px[symbol])
+    assert symbol in risk.account.open_orders
+    assert risk.account.open_orders[symbol]["buy"] == pytest.approx(clipped_qty)
+
+    events = adapter.update_last_price(symbol, 94.0, qty=clipped_qty)
+    for ev in events:
+        await router.handle_paper_event(ev)
+
+    assert order.pending_qty == pytest.approx(0.0)
+    assert symbol not in risk.account.open_orders
+    assert risk.account.get_locked_usd(symbol) == pytest.approx(0.0)
+
+    def _recalc_locked_total(account) -> float:
+        total_locked = 0.0
+        for sym, orders in getattr(account, "open_orders", {}).items():
+            qty_total = 0.0
+            if isinstance(orders, dict):
+                for qty_val in orders.values():
+                    try:
+                        qty_total += abs(float(qty_val))
+                    except (TypeError, ValueError):
+                        continue
+            else:
+                try:
+                    qty_total = abs(float(orders))
+                except (TypeError, ValueError):
+                    qty_total = 0.0
+            price = float(account.prices.get(sym, 0.0))
+            total_locked += qty_total * price
+        return 0.0 if total_locked <= 1e-9 else total_locked
+
+    locked_total = _recalc_locked_total(risk.account)
+    assert locked_total == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
 async def test_expiry_event_triggers_callback():
     strat = StubStrategy()
     adapter = PaperAdapter()


### PR DESCRIPTION
## Summary
- clamp adapter pending quantity to a non-negative float and mirror it on the order before locking risk exposure
- ensure the router shrinks tracked order quantity when the paper venue only accepts a partial amount
- add a regression test covering paper order clipping and verifying reservations release after a full fill

## Testing
- pytest tests/test_execution_router_paper_events.py

------
https://chatgpt.com/codex/tasks/task_e_68cda87c84ec832da9f56992b928d0a8