### PR TITLE
Handle OKX websocket ping messages

### DIFF
--- a/src/tradingbot/adapters/base.py
+++ b/src/tradingbot/adapters/base.py
@@ -234,6 +234,14 @@ class ExchangeAdapter(ABC):
                                     )
                                 )
                                 continue
+                            if data.get("event") == "ping" or data.get("op") == "ping":
+                                response: dict[str, object] = {"op": "pong"}
+                                if "event" in data:
+                                    response["event"] = "pong"
+                                if "args" in data:
+                                    response["args"] = data["args"]
+                                await ws.send(json.dumps(response))
+                                continue
                             yield msg
                     finally:
                         ping_task.cancel()


### PR DESCRIPTION
## Summary
- reply to OKX websocket ping events directly inside the shared message loop
- keep Deribit heartbeat handling intact while short-circuiting ping frames from reaching strategies
- add a regression test exercising ping/pong responses and heartbeat replies without triggering reconnect metrics

## Testing
- pytest tests/test_adapters.py::test_ws_messages_handle_ping_and_heartbeat -q

------
https://chatgpt.com/codex/tasks/task_e_68cdbb0410f0832daa59f41a5f9023eb