### PR TITLE
Fix indentation in paper runner aggregator initialization

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -1242,9 +1242,9 @@ async def run_paper(
 
     warmup_total = getattr(strat, "warmup_bars", 140)
     try:
-    agg = BarAggregator(timeframe=timeframe)
-    if callable(getattr(adapter, "stream_bba", None)):
-        book_task = asyncio.create_task(_book_stream())
+        agg = BarAggregator(timeframe=timeframe)
+        if callable(getattr(adapter, "stream_bba", None)):
+            book_task = asyncio.create_task(_book_stream())
     except TypeError:
         agg = BarAggregator()
     if not hasattr(agg, "completed"):


### PR DESCRIPTION
## Summary
- fix the indentation of the BarAggregator initialization in the paper runner so the try/except block executes correctly
- ensure the order book stream task is only spawned when the adapter supports it during paper trading setup

## Testing
- pytest *(fails: terminated by system OOM while running full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d069632768832d879ef92aff5bd0e4