### PR TITLE
Fix slippage sign handling and extend backtest coverage

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -941,11 +941,15 @@ class EventDrivenBacktestEngine:
                     continue
 
                 slip = (
-                    price - order.place_price
+                    order.place_price - price
                     if order.side == "buy"
-                    else order.place_price - price
+                    else price - order.place_price
                 )
-                slip_cash = slip * fill_qty
+                # ``slip`` is defined as expected minus executed price for buys and
+                # executed minus expected for sells so that a worse fill yields a
+                # negative ``slip``.  Negate it to express ``slippage_pnl`` as a
+                # positive cost when execution is worse than anticipated.
+                slip_cash = -slip * fill_qty
                 slippage_total += slip_cash
                 slippage_pnl = slip_cash
                 fill_count += 1


### PR DESCRIPTION
## Summary
- adjust slip calculation for buy orders to use the expected minus executed price and negate the slippage cash term so adverse fills remain a positive cost
- add a fixed favourable slippage model and regression test that exercises both beneficial and adverse fills to ensure realised PnL reacts with the correct sign

## Testing
- `pytest tests/backtesting -q`


------
https://chatgpt.com/codex/tasks/task_e_68d1e659cd98832d94655a765a06bad8