### PR TITLE
Ensure BreakoutATR limit orders cross current price and extend tests

### DIFF
--- a/src/tradingbot/config/config.yaml
+++ b/src/tradingbot/config/config.yaml
@@ -7,7 +7,8 @@ exchanges:
 strategies:
   default: breakout_atr
   params:
-    breakout_atr: {}
+    breakout_atr:
+      offset_frac: 0.02  # Fracción base del ATR usada para cruzar el último precio con órdenes límite
     mean_rev_ofi:
       ofi_window: 20
       zscore_threshold: 1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,26 +81,28 @@ def paper_adapter():
 @pytest.fixture
 def breakout_df_buy():
     import pandas as pd
-    data = {
-        "open": [1, 2, 3, 4],
-        "high": [2, 3, 4, 5],
-        "low": [0.5, 1.5, 2.5, 3.5],
-        "close": [1.5, 2.5, 3.5, 8.0],
-        "volume": [1, 1, 1, 1],
-    }
+    opens = [float(i) for i in range(1, 21)]
+    highs = [o + 1.0 for o in opens]
+    lows = [o - 0.5 for o in opens]
+    closes = [o + 0.5 for o in opens]
+    closes[-1] = closes[-2] + 4.0
+    highs[-1] = closes[-1] + 0.5
+    volume = [1.0] * (len(opens) - 1) + [3.0]
+    data = {"open": opens, "high": highs, "low": lows, "close": closes, "volume": volume}
     return pd.DataFrame(data)
 
 
 @pytest.fixture
 def breakout_df_sell():
     import pandas as pd
-    data = {
-        "open": [1, 2, 3, 4],
-        "high": [2, 3, 4, 5],
-        "low": [0.5, 1.5, 2.5, 3.5],
-        "close": [1.5, 2.5, 3.5, -2.0],
-        "volume": [1, 1, 1, 1],
-    }
+    opens = [float(i) for i in range(1, 21)]
+    highs = [o + 1.0 for o in opens]
+    lows = [o - 0.5 for o in opens]
+    closes = [o - 0.5 for o in opens]
+    closes[-1] = closes[-2] - 12.0
+    lows[-1] = closes[-1] - 0.5
+    volume = [1.0] * (len(opens) - 1) + [3.0]
+    data = {"open": opens, "high": highs, "low": lows, "close": closes, "volume": volume}
     return pd.DataFrame(data)
 
 


### PR DESCRIPTION
## Summary
- make BreakoutATR limit prices cross the last close via a reusable offset-fraction helper and guard the rolling quantile multiplier against NaNs
- expand breakout fixtures and strategy tests to check limit placement, risk-service integration, and immediate fills with a paper adapter
- document the default offset fraction in the strategy config

## Testing
- PYTHONPATH=src pytest tests/test_strategies.py -k breakout_atr -q

------
https://chatgpt.com/codex/tasks/task_e_68d2d86d9160832db00af6dca0d2ce3b