### PR TITLE
Call manage_position on original trades

### DIFF
--- a/src/tradingbot/strategies/depth_imbalance.py
+++ b/src/tradingbot/strategies/depth_imbalance.py
@@ -59,11 +59,49 @@ class DepthImbalance(Strategy):
             return None
 
         if self.risk_service is not None and getattr(self, "trade", None):
-            self.risk_service.update_trailing(self.trade, price)
-            self.trade["_trail_done"] = True
-            decision = self.risk_service.manage_position(
-                {**self.trade, "current_price": price}, None
-            )
+            trade = self.trade
+            self.risk_service.update_trailing(trade, price)
+            is_dict = isinstance(trade, dict)
+            _missing = object()
+            if is_dict:
+                trail_prev = trade.get("_trail_done") if "_trail_done" in trade else _missing
+            else:
+                trail_prev = (
+                    getattr(trade, "_trail_done") if hasattr(trade, "_trail_done") else _missing
+                )
+            if is_dict:
+                trade["_trail_done"] = True
+                had_price = "current_price" in trade
+                prev_price = trade.get("current_price") if had_price else None
+                trade["current_price"] = price
+            else:
+                setattr(trade, "_trail_done", True)
+                had_price = hasattr(trade, "current_price")
+                prev_price = getattr(trade, "current_price") if had_price else None
+                setattr(trade, "current_price", price)
+            try:
+                decision = self.risk_service.manage_position(trade, None)
+            finally:
+                if is_dict:
+                    if had_price:
+                        trade["current_price"] = prev_price
+                    else:
+                        trade.pop("current_price", None)
+                    if trail_prev is _missing:
+                        trade.pop("_trail_done", None)
+                    else:
+                        trade["_trail_done"] = trail_prev
+                else:
+                    if had_price:
+                        setattr(trade, "current_price", prev_price)
+                    else:
+                        if hasattr(trade, "current_price"):
+                            delattr(trade, "current_price")
+                    if trail_prev is _missing:
+                        if hasattr(trade, "_trail_done"):
+                            delattr(trade, "_trail_done")
+                    else:
+                        setattr(trade, "_trail_done", trail_prev)
             if decision == "close":
                 side = "sell" if self.trade.get("side") == "buy" else "buy"
                 close_sig = Signal(side, 1.0)
@@ -93,6 +131,10 @@ class DepthImbalance(Strategy):
                 "stop": stop,
                 "atr": atr_val,
             }
-            self.risk_service.update_trailing(self.trade, price)
-            self.trade["_trail_done"] = True
+            trade = self.trade
+            self.risk_service.update_trailing(trade, price)
+            if isinstance(trade, dict):
+                trade["_trail_done"] = True
+            else:
+                setattr(trade, "_trail_done", True)
         return self.finalize_signal(bar, price, sig)


### PR DESCRIPTION
## Summary
- have Strategy.finalize_signal call RiskService.manage_position on the live trade object while temporarily wiring in helper fields
- restore temporary attributes in both Strategy.finalize_signal and DepthImbalance to avoid leaking state onto the trade
- add a regression test that ensures calc_position_size observes updated strengths across consecutive signals

## Testing
- pytest tests/test_subminimum_signal.py

------
https://chatgpt.com/codex/tasks/task_e_68d2de993d60832dbd326fa5e346099f