### PR TITLE
Inject timeframe into strategy setup

### DIFF
--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -145,6 +145,13 @@ async def _run_symbol(
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     raw_symbol = cfg.symbol
     symbol = normalize(cfg.symbol)
+    params = dict(params or {})
+    timeframe_value = params.get("timeframe", timeframe)
+    if timeframe_value is None:
+        timeframe_value = timeframe
+    timeframe_value = str(timeframe_value)
+    params["timeframe"] = timeframe_value
+    timeframe = timeframe_value
     timeframe_seconds = ccxt.Exchange.parse_timeframe(timeframe)
     expiry = timeframe_seconds
     log.info("Connecting to %s %s for %s", exchange, market, symbol)
@@ -182,8 +189,22 @@ async def _run_symbol(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    params = params or {}
-    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
+    strat_kwargs = dict(params)
+    if config_path is not None:
+        strat_kwargs["config_path"] = config_path
+    if strat_kwargs:
+        try:
+            strat = strat_cls(**strat_kwargs)
+        except TypeError:
+            fallback_kwargs = dict(strat_kwargs)
+            fallback_kwargs.pop("timeframe", None)
+            strat = strat_cls(**fallback_kwargs) if fallback_kwargs else strat_cls()
+            setattr(strat, "timeframe", timeframe_value)
+        else:
+            setattr(strat, "timeframe", timeframe_value)
+    else:
+        strat = strat_cls()
+        setattr(strat, "timeframe", timeframe_value)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -111,6 +111,13 @@ async def _run_symbol(
     ws_cls, exec_cls, venue = ADAPTERS[(exchange, market)]
     raw_symbol = cfg.symbol
     symbol = normalize(cfg.symbol)
+    params = dict(params or {})
+    timeframe_value = params.get("timeframe", timeframe)
+    if timeframe_value is None:
+        timeframe_value = timeframe
+    timeframe_value = str(timeframe_value)
+    params["timeframe"] = timeframe_value
+    timeframe = timeframe_value
     timeframe_seconds = ccxt.Exchange.parse_timeframe(timeframe)
     expiry = timeframe_seconds
     log.info(
@@ -160,8 +167,22 @@ async def _run_symbol(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    params = params or {}
-    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
+    strat_kwargs = dict(params)
+    if config_path is not None:
+        strat_kwargs["config_path"] = config_path
+    if strat_kwargs:
+        try:
+            strat = strat_cls(**strat_kwargs)
+        except TypeError:
+            fallback_kwargs = dict(strat_kwargs)
+            fallback_kwargs.pop("timeframe", None)
+            strat = strat_cls(**fallback_kwargs) if fallback_kwargs else strat_cls()
+            setattr(strat, "timeframe", timeframe_value)
+        else:
+            setattr(strat, "timeframe", timeframe_value)
+    else:
+        strat = strat_cls()
+        setattr(strat, "timeframe", timeframe_value)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,

--- a/tests/test_cli_backtest_param_config.py
+++ b/tests/test_cli_backtest_param_config.py
@@ -37,4 +37,44 @@ def test_backtest_param_config_path(monkeypatch, tmp_path):
     )
 
     assert captured["config_path"] == str(cfgfile)
+    assert captured["timeframe"] == "1m"
+
+
+def test_backtest_param_overrides_timeframe(monkeypatch, tmp_path):
+    monkeypatch.setenv("TRADINGBOT_SKIP_NTP_CHECK", "1")
+    from tradingbot.cli.commands import backtesting as cli_backtesting
+    from tradingbot.backtest import event_engine as ev_module
+    from tradingbot import strategies as strat_module
+
+    datafile = tmp_path / "data.csv"
+    datafile.write_text("ts,o,h,l,c,v\n0,1,1,1,1,1\n")
+
+    class DummyEngine:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+        def run(self, fills_csv=None):
+            return {}
+
+    monkeypatch.setattr(ev_module, "EventDrivenBacktestEngine", DummyEngine)
+    monkeypatch.setattr(cli_backtesting, "generate_report", lambda result: "")
+
+    captured = {}
+
+    class DummyStrategy:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+        def on_bar(self, bar):
+            pass
+
+    monkeypatch.setitem(strat_module.STRATEGIES, "dummy", DummyStrategy)
+
+    cli_backtesting.backtest(
+        data=str(datafile),
+        symbol="BTC/USDT",
+        strategy="dummy",
+        config=None,
+        param=["timeframe=5m"],
+    )
+
+    assert captured["timeframe"] == "5m"
 


### PR DESCRIPTION
## Summary
- ensure live runners inject the timeframe into strategy kwargs while respecting overrides
- pass timeframe through CLI backtest commands and into the event-driven engine
- extend EventDrivenBacktestEngine to forward per-strategy timeframe values
- add tests covering timeframe propagation in the engine and CLI helpers

## Testing
- `pytest tests/test_backtest_engine.py::test_event_engine_assigns_strategy_timeframe`
- `pytest tests/backtesting/test_slippage_microscopic_volume.py tests/backtesting/test_slippage_zero_volume.py tests/integration/test_stress_resilience.py` *(fails on baseline as well; slippage and latency expectations mismatch current engine behaviour)*

------
https://chatgpt.com/codex/tasks/task_e_68d307904924832dbacafb8f0c341b13