### PR TITLE
Add timeframe metadata to live and backtest bars

### DIFF
--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -330,7 +330,7 @@ async def run_live_binance(
         if len(df) < 140:  # warmup básico
             continue
 
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         signal = strat.on_bar(bar)
         if signal is None:
             continue

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -1670,7 +1670,7 @@ async def run_paper(
                     log.info("Warm-up progress %d/%d", progress, warmup_total)
                     last_progress, last_log = progress, now
                 continue
-            bar = {"window": df, "symbol": symbol}
+            bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
             signal = strat.on_bar(bar)
             if signal is None:
                 continue

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -1001,7 +1001,7 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         sig = strat.on_bar(bar)
         if sig is None:
             continue

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -775,7 +775,7 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         sig = strat.on_bar(bar)
         if sig is None:
             continue

--- a/tests/backtesting/test_engine_timeframe.py
+++ b/tests/backtesting/test_engine_timeframe.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import pytest
+
+from tradingbot.backtesting import engine as engine_module
+
+
+def _sample_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": [0, 1, 2, 3, 4],
+            "open": [100.0, 101.0, 102.0, 103.0, 104.0],
+            "high": [101.0, 102.0, 103.0, 104.0, 105.0],
+            "low": [99.0, 100.0, 101.0, 102.0, 103.0],
+            "close": [100.5, 101.5, 102.5, 103.5, 104.5],
+            "volume": [10.0, 11.0, 12.0, 13.0, 14.0],
+        }
+    )
+
+
+def test_event_engine_includes_timeframe_in_df_window(monkeypatch):
+    timeframe = "15m"
+    captured: list[dict] = []
+
+    class RecordingStrategy:
+        def __init__(self, risk_service=None):  # noqa: ANN001
+            self.risk_service = risk_service
+
+        def on_bar(self, bar):  # noqa: ANN001
+            captured.append(bar)
+            raise RuntimeError("stop")
+
+    monkeypatch.setitem(engine_module.STRATEGIES, "recording_tf", RecordingStrategy)
+    data = {"SYM": _sample_frame()}
+    eng = engine_module.EventDrivenBacktestEngine(
+        data,
+        [("recording_tf", "SYM")],
+        window=1,
+        timeframes={"SYM": timeframe},
+    )
+
+    with pytest.raises(RuntimeError):
+        eng.run()
+
+    assert captured, "strategy should receive at least one bar"
+    assert captured[0]["timeframe"] == timeframe
+    assert captured[0]["symbol"] == "SYM"
+    assert "window" in captured[0]
+
+
+def test_event_engine_includes_timeframe_in_array_window(monkeypatch):
+    timeframe = "15m"
+    captured: list[dict] = []
+
+    class ArrayStrategy:
+        needs_window_df = False
+
+        def __init__(self, risk_service=None):  # noqa: ANN001
+            self.risk_service = risk_service
+
+        def on_bar(self, bar):  # noqa: ANN001
+            captured.append(bar)
+            raise RuntimeError("stop")
+
+    monkeypatch.setitem(engine_module.STRATEGIES, "array_tf", ArrayStrategy)
+    data = {"SYM": _sample_frame()}
+    eng = engine_module.EventDrivenBacktestEngine(
+        data,
+        [("array_tf", "SYM")],
+        window=1,
+        timeframes={"SYM": timeframe},
+    )
+
+    with pytest.raises(RuntimeError):
+        eng.run()
+
+    assert captured, "strategy should receive at least one bar"
+    bar = captured[0]
+    assert bar["timeframe"] == timeframe
+    assert bar["symbol"] == "SYM"
+    assert "symbol" in bar

--- a/tests/live/test_runner_timeframe.py
+++ b/tests/live/test_runner_timeframe.py
@@ -1,0 +1,186 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from tradingbot.live import runner
+
+
+class DummyAccount:
+    def __init__(self) -> None:
+        self.market_type = ""
+        self.open_orders: dict[str, dict[str, float]] = {}
+
+    def current_exposure(self, symbol: str) -> tuple[float, float]:
+        return 0.0, 0.0
+
+    def update_open_order(self, symbol: str, side: str, qty: float) -> None:
+        orders = self.open_orders.setdefault(symbol, {})
+        orders[side] = qty
+
+
+class DummyPaperAdapter:
+    def __init__(self, fee_bps: float = 0.0) -> None:
+        self.account = DummyAccount()
+        self.state = SimpleNamespace(realized_pnl=0.0, last_px={}, order_book={})
+
+    def update_last_price(self, symbol: str, px: float) -> list[dict]:
+        self.state.last_px[symbol] = px
+        return []
+
+    def equity(self, *_args, **_kwargs) -> float:
+        return 1000.0
+
+
+class DummyExecutionRouter:
+    def __init__(self, adapters, prefer: str | None = None) -> None:  # noqa: ANN001
+        self.adapters = adapters
+        self.prefer = prefer
+        self.on_partial_fill = None
+        self.on_order_expiry = None
+
+    async def handle_paper_event(self, _event) -> None:  # noqa: ANN001
+        return None
+
+
+class DummyExecBroker:
+    def __init__(self, adapter) -> None:  # noqa: ANN001
+        self.adapter = adapter
+        self.state = SimpleNamespace(realized_pnl=0.0)
+
+    async def place_limit(self, *args, **kwargs):  # noqa: ANN001, D401
+        """Minimal async interface returning an empty execution response."""
+
+        return {"filled_qty": 0.0, "pending_qty": 0.0, "realized_pnl": 0.0}
+
+
+class DummyPortfolioGuard:
+    def __init__(self, cfg) -> None:  # noqa: ANN001
+        self.cfg = cfg
+
+    def refresh_usd_caps(self, _equity: float) -> None:
+        return None
+
+
+class DummyDailyGuard:
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN001
+        return None
+
+
+class DummyRiskService:
+    def __init__(
+        self,
+        *args,
+        account=None,
+        **_kwargs,
+    ) -> None:  # noqa: ANN001
+        self.account = account or DummyAccount()
+        self.min_order_qty = 0.0
+        self.allow_short = True
+
+    def mark_price(self, *args, **kwargs) -> None:  # noqa: ANN001
+        return None
+
+    def daily_mark(self, *args, **kwargs) -> tuple[bool, str]:  # noqa: ANN001
+        return False, ""
+
+    def get_trade(self, *args, **kwargs):  # noqa: ANN001
+        return None
+
+    def register_order(self, *args, **kwargs) -> bool:  # noqa: ANN001
+        return True
+
+    def update_trailing(self, *args, **kwargs) -> None:  # noqa: ANN001
+        return None
+
+    def manage_position(self, *args, **kwargs):  # noqa: ANN001
+        return None
+
+    def on_fill(self, *args, **kwargs) -> None:  # noqa: ANN001
+        return None
+
+    def update_position(self, *args, **kwargs) -> None:  # noqa: ANN001
+        return None
+
+
+class DummyAdapter:
+    meta = None
+
+    async def stream_trades(self, symbol):  # noqa: ANN001
+        yield {"ts": datetime.now(timezone.utc), "price": 100.0, "qty": 1.0}
+
+
+class DummyAgg:
+    def __init__(self, timeframe: str = "1m") -> None:
+        self.timeframe = timeframe
+        ts_now = datetime.now(timezone.utc)
+        base_bar = SimpleNamespace(ts_open=ts_now, o=100.0, h=100.0, l=100.0, c=100.0, v=1.0)
+        self.completed = [base_bar for _ in range(200)]
+        self._closed = False
+
+    def on_trade(self, ts, px, qty):  # noqa: ANN001
+        if self._closed:
+            return None
+        self._closed = True
+        return SimpleNamespace(ts_open=ts, o=px, h=px, l=px, c=px, v=qty)
+
+    def last_n_bars_df(self, n: int) -> pd.DataFrame:  # noqa: D401
+        """Return a constant window to satisfy warm-up checks."""
+
+        rows = list(range(200))
+        return pd.DataFrame(
+            {
+                "timestamp": rows,
+                "open": [100.0] * 200,
+                "high": [101.0] * 200,
+                "low": [99.0] * 200,
+                "close": [100.0] * 200,
+                "volume": [1.0] * 200,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_live_binance_passes_timeframe(monkeypatch):
+    timeframe = "15m"
+    captured: list[dict] = []
+
+    class CaptureStrategy:
+        pending_qty: dict = {}
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN001
+            self.pending_qty = {}
+            self.risk_service = None
+
+        def on_partial_fill(self, *args, **kwargs):  # noqa: ANN001
+            return None
+
+        def on_order_expiry(self, *args, **kwargs):  # noqa: ANN001
+            return None
+
+        def on_bar(self, bar):  # noqa: ANN001
+            captured.append(bar)
+            raise RuntimeError("stop")
+
+    monkeypatch.setitem(runner.STRATEGIES, "dummy", CaptureStrategy)
+    monkeypatch.setattr(runner, "BinanceWSAdapter", DummyAdapter)
+    monkeypatch.setattr(runner, "BarAggregator", DummyAgg)
+    monkeypatch.setattr(runner, "PaperAdapter", DummyPaperAdapter)
+    monkeypatch.setattr(runner, "ExecutionRouter", DummyExecutionRouter)
+    monkeypatch.setattr(runner, "Broker", DummyExecBroker)
+    monkeypatch.setattr(runner, "PortfolioGuard", DummyPortfolioGuard)
+    monkeypatch.setattr(runner, "DailyGuard", DummyDailyGuard)
+    monkeypatch.setattr(runner, "RiskService", DummyRiskService)
+    monkeypatch.setattr(runner, "load_positions", lambda *args, **kwargs: {})
+
+    with pytest.raises(RuntimeError):
+        await runner.run_live_binance(
+            symbol="BTC/USDT",
+            strategy_name="dummy",
+            timeframe=timeframe,
+        )
+
+    assert captured, "strategy should receive at least one bar"
+    assert captured[0]["timeframe"] == timeframe
+    assert captured[0]["symbol"] == "BTC/USDT"


### PR DESCRIPTION
## Summary
- include the configured timeframe in live runner bar payloads
- extend EventDrivenBacktestEngine to accept per-symbol timeframes and forward them to strategies
- add tests covering timeframe propagation in live runner and backtest engine

## Testing
- pytest tests/backtesting/test_engine_timeframe.py
- pytest tests/live/test_runner_timeframe.py

------
https://chatgpt.com/codex/tasks/task_e_68d3079555fc832d8a937c1c764c9a10