### PR TITLE
Propagate timeframe context and fix liquidation slippage

### DIFF
--- a/src/tradingbot/cli/commands/backtesting.py
+++ b/src/tradingbot/cli/commands/backtesting.py
@@ -304,6 +304,7 @@ def backtest_db(
             slippage=slippage,
             fee_bps=fee_bps,
             slippage_bps=slippage_bps,
+            timeframes={symbol: timeframe},
         )
         params = _parse_params(param) if isinstance(param, list) else {}
         if not isinstance(config, str):
@@ -316,6 +317,7 @@ def backtest_db(
         kwargs = dict(params)
         if config is not None:
             kwargs["config_path"] = config
+        kwargs.setdefault("timeframe", timeframe)
         strat = strat_cls(**kwargs)
         eng.strategies[(strategy, symbol)] = strat
         result = eng.run(fills_csv=fills_csv)

--- a/src/tradingbot/core/risk_manager.py
+++ b/src/tradingbot/core/risk_manager.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, MutableMapping
+import math
 
 from .account import Account
 from ..execution.normalize import adjust_order, SymbolRules
@@ -173,6 +174,10 @@ class RiskManager:
             mult = float(atr_mult) if atr_mult is not None else float(self.atr_mult)
             delta = mult * float(atr)
         else:
+            if self.risk_pct <= 0:
+                return (
+                    float("-inf") if side.lower() in {"buy", "long"} else float("inf")
+                )
             delta = float(entry_price) * float(self.risk_pct)
         if side.lower() in {"buy", "long"}:
             return float(entry_price) - delta
@@ -193,6 +198,9 @@ class RiskManager:
         atr = float(_get(trade, "atr", 0.0))
         stage = int(_get(trade, "stage", 0))
         qty = float(_get(trade, "qty", 1.0))
+
+        if not math.isfinite(stop):
+            return
 
         # Distance from entry to stop defines the initial risk per unit
         risk = abs(entry - stop)

--- a/src/tradingbot/live/runner.py
+++ b/src/tradingbot/live/runner.py
@@ -135,8 +135,12 @@ async def run_live_binance(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    params = params or {}
-    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
+    params = dict(params or {})
+    params.setdefault("timeframe", timeframe)
+    if config_path is not None:
+        strat = strat_cls(config_path=config_path, **params)
+    else:
+        strat = strat_cls(**params)
     router = ExecutionRouter([
         broker
     ], prefer="maker")
@@ -330,7 +334,7 @@ async def run_live_binance(
         if len(df) < 140:  # warmup básico
             continue
 
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         signal = strat.on_bar(bar)
         if signal is None:
             continue

--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -525,11 +525,11 @@ async def run_paper(
     params = dict(params or {})
     leverage_value = params.pop("leverage", 1)
     log.info("METRICS %s", json.dumps({"leverage": leverage_value}))
-    strat = (
-        strat_cls(config_path=config_path, **params)
-        if (config_path or params)
-        else strat_cls()
-    )
+    params.setdefault("timeframe", timeframe)
+    if config_path is not None:
+        strat = strat_cls(config_path=config_path, **params)
+    else:
+        strat = strat_cls(**params)
     strat.risk_service = risk
 
     def _recalc_locked_total() -> float:
@@ -1670,7 +1670,7 @@ async def run_paper(
                     log.info("Warm-up progress %d/%d", progress, warmup_total)
                     last_progress, last_log = progress, now
                 continue
-            bar = {"window": df, "symbol": symbol}
+            bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
             signal = strat.on_bar(bar)
             if signal is None:
                 continue

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -183,7 +183,12 @@ async def _run_symbol(
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
     params = params or {}
-    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
+    params = dict(params or {})
+    params.setdefault("timeframe", timeframe)
+    if config_path is not None:
+        strat = strat_cls(config_path=config_path, **params)
+    else:
+        strat = strat_cls(**params)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,
@@ -1001,7 +1006,7 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         sig = strat.on_bar(bar)
         if sig is None:
             continue

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -160,8 +160,12 @@ async def _run_symbol(
     strat_cls = STRATEGIES.get(strategy_name)
     if strat_cls is None:
         raise ValueError(f"unknown strategy: {strategy_name}")
-    params = params or {}
-    strat = strat_cls(config_path=config_path, **params) if (config_path or params) else strat_cls()
+    params = dict(params or {})
+    params.setdefault("timeframe", timeframe)
+    if config_path is not None:
+        strat = strat_cls(config_path=config_path, **params)
+    else:
+        strat = strat_cls(**params)
     guard = PortfolioGuard(
         GuardConfig(
             total_cap_pct=total_cap_pct,
@@ -775,7 +779,7 @@ async def _run_symbol(
         df: pd.DataFrame = agg.last_n_bars_df(200)
         if len(df) < 140:
             continue
-        bar = {"window": df, "symbol": symbol}
+        bar = {"window": df, "symbol": symbol, "timeframe": timeframe}
         sig = strat.on_bar(bar)
         if sig is None:
             continue

--- a/tests/test_timeframe_adaptation.py
+++ b/tests/test_timeframe_adaptation.py
@@ -1,0 +1,139 @@
+import math
+
+import pandas as pd
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.strategies import STRATEGIES
+from tradingbot.strategies.base import Strategy
+from tradingbot.strategies.breakout_atr import BreakoutATR
+from tradingbot.strategies.breakout_vol import BreakoutVol
+from tradingbot.strategies.mean_reversion import MeanReversion
+from tradingbot.strategies.momentum import Momentum
+from tradingbot.strategies.scalp_pingpong import ScalpPingPong
+from tradingbot.strategies.trend_following import TrendFollowing
+
+
+def _make_ohlcv(rows: int) -> pd.DataFrame:
+    base = 100.0
+    data = {
+        "open": [base + i * 0.5 for i in range(rows)],
+        "high": [base + i * 0.5 + 0.4 for i in range(rows)],
+        "low": [base + i * 0.5 - 0.4 for i in range(rows)],
+        "close": [base + i * 0.5 + 0.2 for i in range(rows)],
+        "volume": [10.0] * rows,
+    }
+    return pd.DataFrame(data)
+
+
+def test_breakout_atr_cooldown_scales_with_timeframe():
+    fast = BreakoutATR(timeframe="1m")
+    mid = BreakoutATR(timeframe="3m")
+    slow = BreakoutATR(timeframe="1h")
+
+    assert fast.cooldown_bars == 3
+    assert mid.cooldown_bars == 1
+    assert slow.cooldown_bars == 1
+
+
+def test_breakout_vol_lookback_scales():
+    df = _make_ohlcv(60)
+    strat_fast = BreakoutVol(timeframe="1m")
+    strat_slow = BreakoutVol(timeframe="15m")
+
+    strat_fast.on_bar({"window": df, "timeframe": "1m", "symbol": "X"})
+    strat_slow.on_bar({"window": df, "timeframe": "15m", "symbol": "X"})
+
+    assert strat_fast.lookback == 10
+    assert strat_slow.lookback == 2
+
+
+def test_momentum_cooldown_scales():
+    df = pd.DataFrame({
+        "close": [1 + 0.1 * i for i in range(80)],
+        "volume": [5.0] * 80,
+    })
+    strat_fast = Momentum(timeframe="1m", min_volume=0, min_volatility=0)
+    strat_slow = Momentum(timeframe="15m", min_volume=0, min_volatility=0)
+
+    strat_fast.on_bar({"window": df, "timeframe": "1m"})
+    strat_slow.on_bar({"window": df, "timeframe": "15m"})
+
+    assert strat_fast.cooldown_bars == 3
+    assert strat_slow.cooldown_bars == 1
+
+
+def test_mean_reversion_time_stop_scales():
+    df = _make_ohlcv(80)
+    strat_fast = MeanReversion(timeframe="1m", time_stop=10, min_volatility=0)
+    strat_slow = MeanReversion(timeframe="1h", time_stop=10, min_volatility=0)
+
+    strat_fast.on_bar({"window": df, "timeframe": "1m", "symbol": "X"})
+    strat_slow.on_bar({"window": df, "timeframe": "1h", "symbol": "X"})
+
+    assert strat_fast.time_stop == 10
+    assert strat_slow.time_stop == 1
+
+
+def test_scalp_pingpong_lookback_scales():
+    df = pd.DataFrame({"close": [100 + 0.01 * i for i in range(100)]})
+    strat_fast = ScalpPingPong(timeframe="1m")
+    strat_slow = ScalpPingPong(timeframe="1h")
+
+    strat_fast.on_bar({"window": df, "timeframe": "1m"})
+    strat_slow.on_bar({"window": df, "timeframe": "1h"})
+
+    lookback_fast = max(1, int(math.ceil(strat_fast.cfg.lookback / 1)))
+    lookback_slow = max(1, int(math.ceil(strat_slow.cfg.lookback / 60)))
+
+    assert lookback_fast == 15
+    assert lookback_slow == 1
+
+
+def test_trend_following_uses_timeframe_minutes():
+    df = _make_ohlcv(40)
+    strat = TrendFollowing(timeframe="1h", vol_lookback=20)
+    # With 40 rows and 1-hour timeframe, there should be enough history for the
+    # strategy to run without triggering the warm-up guard.
+    result = strat.on_bar({"window": df, "timeframe": "1h"})
+    assert strat._tf_minutes("1h", strat.timeframe) == 60
+    # Strategy may or may not emit a signal depending on the random walk; we
+    # only verify that the call completed without raising and the timeframe is
+    # stored.
+    assert strat.timeframe == "1h"
+
+
+def test_engine_propagates_timeframe_into_strategy(monkeypatch):
+    class DummyStrategy(Strategy):
+        name = "dummy_tf"
+
+        def __init__(self, timeframe: str | None = None, **kwargs) -> None:
+            self.timeframe = timeframe
+            self.seen: list[str | None] = []
+
+        def on_bar(self, bar: dict) -> None:
+            self.seen.append(bar.get("timeframe"))
+            return None
+
+    data = pd.DataFrame({
+        "open": [1, 2, 3, 4, 5],
+        "high": [1.1, 2.1, 3.1, 4.1, 5.1],
+        "low": [0.9, 1.9, 2.9, 3.9, 4.9],
+        "close": [1, 2, 3, 4, 5],
+        "volume": [1] * 5,
+    })
+
+    STRATEGIES[DummyStrategy.name] = DummyStrategy
+    try:
+        engine = EventDrivenBacktestEngine(
+            {"SYM": data},
+            [(DummyStrategy.name, "SYM")],
+            window=2,
+            timeframes={"SYM": "15m"},
+        )
+        engine.run()
+        strat = engine.strategies[(DummyStrategy.name, "SYM")]
+        assert strat.timeframe == "15m"
+        assert strat.seen
+        assert all(tf == "15m" for tf in strat.seen)
+    finally:
+        STRATEGIES.pop(DummyStrategy.name, None)


### PR DESCRIPTION
## Summary
- propagate timeframe configuration through the backtesting engine and runners so strategies receive timeframe context and bar payloads include timeframe metadata
- refactor the shared strategy utilities plus individual strategies to scale lookbacks, cooldowns, and liquidity metrics with the actual bar timeframe
- gate liquidation slippage so it is opt-in for explicitly supplied base slippage models while keeping realized PnL accounting intact, and add timeframe adaptation regression tests

## Testing
- pytest tests/backtesting/test_slippage_realized_pnl.py
- pytest tests/backtesting/test_slippage_microscopic_volume.py tests/backtesting/test_slippage_zero_volume.py
- pytest tests/test_timeframe_adaptation.py
- pytest tests/integration/test_stress_resilience.py::test_engine_resilient_under_stress

------
https://chatgpt.com/codex/tasks/task_e_68d307750874832db7e79c2f51a782fa