### PR TITLE
Adjust mean reversion time stop scaling

### DIFF
--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -1,5 +1,8 @@
+import math
+
 import pandas as pd
 from tradingbot.strategies import mean_reversion as mr
+from tradingbot.strategies.base import timeframe_to_minutes
 from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
 
 def test_mean_reversion_on_bar_signals():
@@ -41,3 +44,59 @@ def test_trend_detection_5m(monkeypatch):
     strat = MeanReversion(timeframe="5m")
     sig = strat.on_bar({"window": df})
     assert sig is None
+
+
+class DummyRiskService:
+    def __init__(self, side: str = "buy") -> None:
+        self._trade = {"side": side}
+        self.min_order_qty = 0.0
+        self.min_notional = 0.0
+
+    def get_trade(self, symbol: str) -> dict | None:
+        return self._trade
+
+    def update_trailing(self, trade, price):
+        return None
+
+    def manage_position(self, trade, sig):
+        return "hold"
+
+
+def test_mean_reversion_multi_timeframe_time_stop(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "open": [100 + 0.2 * i for i in range(60)],
+            "high": [100 + 0.2 * i + 0.1 for i in range(60)],
+            "low": [100 + 0.2 * i - 0.1 for i in range(60)],
+            "close": [100 + 0.2 * i for i in range(60)],
+            "volume": [50.0] * 60,
+        }
+    )
+    monkeypatch.setattr(mr, "rsi", _const_rsi(50))
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60, 40))
+
+    risk = DummyRiskService("buy")
+    strat = MeanReversion(timeframe="1h", time_stop=6, min_volatility=0, risk_service=risk)
+    bar_minutes = timeframe_to_minutes("4h")
+    expected_bars = max(
+        strat._min_time_stop_bars or 1,
+        math.ceil(
+            strat._time_stop_target_bars
+            * strat._base_timeframe_minutes
+            / bar_minutes
+        ),
+    )
+    assert expected_bars >= 3
+
+    symbol = "X"
+    for idx in range(1, expected_bars):
+        sig = strat.on_bar({"window": df, "timeframe": "4h", "symbol": symbol, "volume": 50.0})
+        assert sig is None
+        assert strat.time_stop == expected_bars
+        assert strat._open_bars[symbol] == idx
+
+    exit_sig = strat.on_bar({"window": df, "timeframe": "4h", "symbol": symbol, "volume": 50.0})
+    assert exit_sig is not None
+    assert exit_sig.side == "sell"
+    assert strat.time_stop == expected_bars
+    assert strat._open_bars[symbol] == expected_bars

--- a/tests/test_timeframe_adaptation.py
+++ b/tests/test_timeframe_adaptation.py
@@ -66,12 +66,21 @@ def test_mean_reversion_time_stop_scales():
     df = _make_ohlcv(80)
     strat_fast = MeanReversion(timeframe="1m", time_stop=10, min_volatility=0)
     strat_slow = MeanReversion(timeframe="1h", time_stop=10, min_volatility=0)
+    strat_default_30m = MeanReversion(timeframe="30m", min_volatility=0)
+    strat_default_1h = MeanReversion(timeframe="1h", min_volatility=0)
 
     strat_fast.on_bar({"window": df, "timeframe": "1m", "symbol": "X"})
     strat_slow.on_bar({"window": df, "timeframe": "1h", "symbol": "X"})
+    strat_default_30m.on_bar({"window": df, "timeframe": "30m", "symbol": "X"})
+    strat_default_1h.on_bar({"window": df, "timeframe": "1h", "symbol": "X"})
 
     assert strat_fast.time_stop == 10
-    assert strat_slow.time_stop == 1
+    assert strat_slow.time_stop == 10
+    assert strat_default_30m.time_stop == 5
+    assert strat_default_1h.time_stop == 3
+
+    strat_slow.on_bar({"window": df, "timeframe": "4h", "symbol": "X"})
+    assert strat_slow.time_stop == 3
 
 
 def test_scalp_pingpong_lookback_scales():


### PR DESCRIPTION
## Summary
- interpret the mean reversion `time_stop` parameter as bars and enforce higher minimums on 30m+ timeframes so exits do not collapse to a single bar
- rescale the time-stop countdown in `on_bar` using the base timeframe minutes to keep multi-timeframe bars aligned
- extend timeframe adaptation coverage and add a multi-timeframe regression test to ensure positions stay open long enough to mean-revert

## Testing
- pytest tests/test_timeframe_adaptation.py::test_mean_reversion_time_stop_scales
- pytest tests/test_mean_reversion.py::test_mean_reversion_multi_timeframe_time_stop

------
https://chatgpt.com/codex/tasks/task_e_68d33ccdd240832db4141c9f84b5c744