### PR TITLE
Adjust breakout volatility limit offsets for immediate fills

### DIFF
--- a/src/tradingbot/strategies/breakout_vol.py
+++ b/src/tradingbot/strategies/breakout_vol.py
@@ -168,6 +168,15 @@ class BreakoutVol(Strategy):
         if side is None:
             return self.finalize_signal(bar, last, None)
         sig = Signal(side, size)
+        volatility_ref = atr_val if atr_val > 0 else std
+        if volatility_ref <= 0:
+            volatility_ref = max(abs(last) * 0.001, 1e-6)
+        buffer_factor = 0.5
+        offset = volatility_ref * buffer_factor
+        if sig.side == "buy":
+            sig.limit_price = last + offset
+        else:
+            sig.limit_price = last - offset
         if self.risk_service is not None:
             qty = self.risk_service.calc_position_size(size, last)
             stop = self.risk_service.initial_stop(last, side, vol)


### PR DESCRIPTION
## Summary
- add an explicit volatility-based buffer when assigning the limit price for BreakoutVol signals so breakout orders cross the market when momentum persists
- keep existing position sizing and volatility annotations unchanged while still handing the signal to the risk service

## Testing
- pytest tests/test_backtest_limit_price.py
- python - <<'PY' ... (custom breakout backtest)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d33cbad780832daa0ff0332d051569