### PR TITLE
Adjust breakout ATR limit offsets

### DIFF
--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -262,9 +262,11 @@ class BreakoutATR(Strategy):
         level = float(upper.iloc[-1]) if side == "buy" else float(lower.iloc[-1])
         offset = atr_val * self._offset_fraction(tf_mult)
         if side == "buy":
-            sig.limit_price = max(last_close, level + offset)
+            ref_price = max(last_close, level)
+            sig.limit_price = ref_price + offset
         else:
-            sig.limit_price = min(last_close, level - offset)
+            ref_price = min(last_close, level)
+            sig.limit_price = ref_price - offset
 
         symbol = bar.get("symbol")
         if symbol:


### PR DESCRIPTION
## Summary
- ensure BreakoutATR limit prices always cross the latest traded price by offsetting from the most aggressive of close and channel
- keep ATR exposure unchanged so the risk manager can continue updating trailing stops

## Testing
- PYTHONPATH=src python - <<'PY'
import math
import pandas as pd
from tradingbot.backtest.event_engine import EventDrivenBacktestEngine
from tradingbot.strategies.breakout_atr import BreakoutATR

rows = []
price = 100.0
for i in range(80):
    rows.append({
        'timestamp': i,
        'open': price,
        'high': price + 1.5,
        'low': price - 1.0,
        'close': price + 0.6,
        'volume': 100 + i,
    })
    price += 0.6

df = pd.DataFrame(rows)
symbol = 'TEST/USDT'
engine = EventDrivenBacktestEngine(
    {symbol: df},
    [('breakout_atr', symbol)],
    window=20,
    fee_bps=0.0,
    slippage_bps=0.0,
    verbose_fills=True,
    initial_equity=10000,
    risk_pct=0.02,
    timeframes={symbol: '1m'},
)
svc = engine.risk[('breakout_atr', symbol)]
strat = BreakoutATR(
    ema_n=5,
    atr_n=3,
    vol_quantile=0.0,
    volume_factor=0.0,
    offset_frac=0.02,
    timeframe='1m',
    risk_service=svc,
)
engine.strategies[('breakout_atr', symbol)] = strat
orig_check = svc.check_order

def check(symbol, side, price, *, volatility=None, target_volatility=None, **kwargs):
    tv = target_volatility
    if tv is None or (isinstance(tv, float) and math.isnan(tv)):
        tv = volatility
    return orig_check(symbol, side, price, volatility=volatility, target_volatility=tv, **kwargs)

svc.check_order = check
result = engine.run()
print('orders', len(result['orders']))
print('fills', len(result['fills']))
print('first_fill', result['fills'][0] if result['fills'] else None)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d33cb22bc0832d8bba5c562fb21c41