### PR TITLE
Refine breakout volatility limit offsets

### DIFF
--- a/docs/breakout_vol_offset.md
+++ b/docs/breakout_vol_offset.md
@@ -1,0 +1,30 @@
+# BreakoutVol - Ajuste de offsets por volatilidad
+
+## Resumen del cambio
+
+La estrategia `BreakoutVol` ahora calcula el precio límite desplazándolo en
+puntos básicos respecto al último cierre.  El desplazamiento se obtiene a partir
+de la volatilidad en bps (`vol_bps`) y del ATR normalizado sobre el precio.  Un
+nuevo parámetro `max_offset_pct` (por defecto 1.5 %) evita que el offset crezca
+de forma descontrolada durante picos de volatilidad.  El valor final queda
+expuesto en `bar["limit_offset"]` y en `bar["context"]` para que el gestor de
+riesgo pueda reajustar el tamaño o aplicar límites adicionales.
+
+## Señales para el gestor de riesgo
+
+Las siguientes claves se incluyen en cada barra procesada:
+
+- `limit_offset`: desplazamiento absoluto aplicado al límite.
+- `limit_offset_bps`: desplazamiento en puntos básicos.
+- `limit_offset_pct`: desplazamiento expresado como porcentaje decimal.
+
+## Parámetros relevantes
+
+| Parámetro          | Descripción                                                        |
+|--------------------|--------------------------------------------------------------------|
+| `max_offset_pct`   | Tope máximo (fracción del precio) para el offset del límite.       |
+| `volatility_factor`| Escala de tamaño en función de la volatilidad medida en bps.       |
+
+Ajustar `max_offset_pct` permite suavizar el impacto de velas extremas sin
+renunciar a la sensibilidad que aporta `vol_bps`.
+


### PR DESCRIPTION
## Summary
- compute breakout limit offsets in basis points using normalized volatility references and cap them with a configurable percentage
- publish the resulting offsets on the bar context for risk controls and update strategy documentation

## Testing
- pytest tests/test_basic_strategies.py
- PYTHONPATH=src python - <<'PY'
from tradingbot.cli.commands.backtesting import backtest

result = backtest(
    data='/tmp/btcusdt_3m_high_vol.csv',
    symbol='BTC/USDT',
    strategy='breakout_vol',
    param=['timeframe=3m', 'lookback=3', 'volume_ma_n=3', 'cooldown_bars=1', 'max_offset_pct=0.02'],
    fee_bps=5.0,
    slippage_bps=1.0,
    capital=1000.0,
    verbose_fills=False,
    risk_pct=0.0,
    fills_csv=None,
)
print(result)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d3716f1ec4832dabf7f12243a9f068