### PR TITLE
Align backtest slippage baseline with mark price

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -996,10 +996,11 @@ class EventDrivenBacktestEngine:
                         heapq.heappush(order_queue, order)
                     continue
 
+                expected_price = order.mark_price or order.place_price
                 slip = (
-                    order.place_price - price
+                    expected_price - price
                     if order.side == "buy"
-                    else price - order.place_price
+                    else price - expected_price
                 )
                 slip_cash = -slip * fill_qty
                 slippage_total += slip_cash
@@ -1283,7 +1284,7 @@ class EventDrivenBacktestEngine:
                     elif hasattr(sig, "__dict__"):
                         setattr(sig, "limit_price", limit_price)
                     mark_price = market_price
-                    price_for_order = limit_price if limit_price is not None else mark_price
+                    price_for_order = mark_price
                     svc.mark_price(symbol, mark_price)
                     if equity < 0:
                         continue
@@ -1313,7 +1314,7 @@ class EventDrivenBacktestEngine:
                         elif hasattr(sig, "__dict__"):
                             setattr(sig, "limit_price", limit_price)
                         mark_price = market_price
-                        price_for_order = limit_price if limit_price is not None else mark_price
+                        price_for_order = mark_price
                         svc.mark_price(symbol, mark_price)
                         if decision in {"close", "scale_in", "scale_out"}:
                             limit_price = mark_price
@@ -1344,7 +1345,7 @@ class EventDrivenBacktestEngine:
                             )
                         qty = adjust_qty(
                             qty_raw,
-                            price_for_order,
+                            limit_price if limit_price is not None else mark_price,
                             constraints.min_notional or None,
                             constraints.step_size or None,
                             constraints.min_qty or None,
@@ -1418,7 +1419,7 @@ class EventDrivenBacktestEngine:
                     side = "buy" if delta > 0 else "sell"
                     qty = adjust_qty(
                         abs(delta),
-                        price_for_order,
+                        limit_price if limit_price is not None else mark_price,
                         constraints.min_notional or None,
                         constraints.step_size or None,
                         constraints.min_qty or None,

--- a/tests/test_backtest_limit_price.py
+++ b/tests/test_backtest_limit_price.py
@@ -50,11 +50,13 @@ def test_backtest_limit_price(monkeypatch):
     fill = res["fills"][0]
     fill_price = fill[3]
 
-    assert order["place_price"] == pytest.approx(limit)
+    close_price = data["close"].iloc[1]
+    assert order["place_price"] == pytest.approx(close_price)
+    assert order["mark_price"] == pytest.approx(close_price)
     assert order["avg_price"] == pytest.approx(limit)
     assert fill_price == pytest.approx(limit)
-    # Place price, average fill price and actual fill should all match the limit
-    assert fill_price == order["avg_price"] == order["place_price"]
+    # Average fill price and actual fill should match the limit, while placement reflects the mark
+    assert fill_price == order["avg_price"]
     # Confirm the fill price differs from the bar close to ensure the limit was honoured
     assert fill_price != data["close"].iloc[-1]
 
@@ -96,6 +98,7 @@ def test_backtest_default_limit_price(monkeypatch):
     close_price = data["close"].iloc[1]
 
     assert order["place_price"] == pytest.approx(close_price)
+    assert order["mark_price"] == pytest.approx(close_price)
     assert order["avg_price"] == pytest.approx(close_price)
     assert fill[3] == pytest.approx(close_price)
     assert limit_price_from_close("buy", close_price, 0.0) == pytest.approx(close_price)


### PR DESCRIPTION
## Summary
- compute slippage against the stored mark price when filling backtest orders and keep limit prices as execution barriers
- adjust quantity sizing utilities to receive the correct limit reference while keeping order summaries aligned with the mark
- refresh the limit-price regression tests to assert the new placement semantics

## Testing
- pytest tests/test_backtest_limit_price.py
- pytest tests/backtesting/test_slippage_realized_pnl.py
- PYTHONPATH=src python - <<'PY' (custom aggressive-order smoke backtest)
PY


------
https://chatgpt.com/codex/tasks/task_e_68d3715da2f4832da1f4ba6bb9af955b