### PR TITLE
Add post-only enforcement coverage and align integration expectations

### DIFF
--- a/tests/integration/test_recorded_flow.py
+++ b/tests/integration/test_recorded_flow.py
@@ -71,5 +71,5 @@ def test_recorded_full_flow_validates_fills_pnl_and_risk(monkeypatch):
     final_price = df["close"].iloc[-1]
     expected_equity = cash + base * final_price
     assert result["equity"] == pytest.approx(expected_equity)
-    assert result["equity"] == pytest.approx(104.07283406244801)
-    assert result["pnl"] == pytest.approx(3.5728340624480097)
+    assert result["equity"] == pytest.approx(104.27891815229592)
+    assert result["pnl"] == pytest.approx(3.7789181522959154)

--- a/tests/test_execution_router_extra.py
+++ b/tests/test_execution_router_extra.py
@@ -1,11 +1,12 @@
 import pytest
 
 from tradingbot.execution.order_types import Order
-from tradingbot.execution.router import ExecutionRouter
+from tradingbot.execution.router import ExecutionRouter, PRICE_TOLERANCE
 from tradingbot.storage import timescale
 from tradingbot.execution.paper import PaperAdapter
 from tradingbot.risk.portfolio_guard import PortfolioGuard, GuardConfig
 from tradingbot.risk.service import RiskService
+from tradingbot.execution.normalize import SymbolRules
 
 
 class DummyAdapter:
@@ -14,8 +15,12 @@ class DummyAdapter:
         self.state = type("S", (), {"order_book": {}, "last_px": {}})()
         self.maker_fee_bps = maker_fee_bps
         self.taker_fee_bps = taker_fee_bps
+        self.last_kwargs = None
+        self.called = False
 
     async def place_order(self, **kwargs):
+        self.last_kwargs = dict(kwargs)
+        self.called = True
         return {"status": "filled", **kwargs, "price": kwargs.get("price")}
 
 
@@ -93,6 +98,62 @@ async def test_execute_persists_reduce_only(monkeypatch):
     order = Order(symbol="X", side="buy", type_="market", qty=1.0, reduce_only=True)
     await router.execute(order)
     assert captured["notes"]["reduce_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_adjusts_post_only_limit_to_best_ask():
+    adapter = DummyAdapter()
+    symbol = "BTCUSDT"
+    adapter.state.order_book[symbol] = {
+        "bids": [(99.0, 1.0)],
+        "asks": [(101.0, 1.0)],
+    }
+    adapter.state.last_px[symbol] = 100.0
+    router = ExecutionRouter(adapter)
+    order = Order(
+        symbol=symbol,
+        side="buy",
+        type_="limit",
+        qty=1.0,
+        price=105.0,
+        post_only=True,
+    )
+    res = await router.execute(order)
+    expected = 101.0 - PRICE_TOLERANCE
+    assert adapter.called is True
+    assert adapter.last_kwargs is not None
+    assert adapter.last_kwargs["price"] == pytest.approx(expected)
+    assert res["price"] == pytest.approx(expected)
+    assert res["status"] == "filled"
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_post_only_when_adjustment_would_cross():
+    adapter = DummyAdapter()
+    symbol = "DOGEUSDT"
+    adapter.state.order_book[symbol] = {
+        "bids": [(0.004, 1.0)],
+        "asks": [(0.005, 1.0)],
+    }
+    adapter.state.last_px[symbol] = 0.005
+    adapter.meta = type(
+        "Meta",
+        (),
+        {"rules_for": lambda self, _: SymbolRules(price_step=0.01)},
+    )()
+    router = ExecutionRouter(adapter)
+    order = Order(
+        symbol=symbol,
+        side="buy",
+        type_="limit",
+        qty=1.0,
+        price=0.01,
+        post_only=True,
+    )
+    res = await router.execute(order)
+    assert res["status"] == "rejected"
+    assert res["reason"] == "post_only_would_cross"
+    assert adapter.called is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend router coverage with post-only limit adjustment and rejection tests, asserting prices stay maker-side when book data suggests a cross
- add paper adapter regression tests for maker-side adjustment and invalid reference handling, and update the queue simulation scenario to reflect the slippage queue model
- refresh the recorded flow integration expectation to match the corrected equity/pnls from the new post-only enforcement

## Testing
- pytest tests/test_execution_router_extra.py -q
- pytest tests/test_paper_limit_book.py -q
- pytest tests/integration/test_recorded_flow.py::test_recorded_full_flow_validates_fills_pnl_and_risk -q
- pytest (killed after several minutes by the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3716304b8832da5334c1a49ca2b42