### PR TITLE
Refine backtest latency and volatility-aware sizing

### DIFF
--- a/src/tradingbot/live/runner_paper.py
+++ b/src/tradingbot/live/runner_paper.py
@@ -172,7 +172,7 @@ async def run_paper(
     params: dict | None = None,
     timeframe: str = "1m",
     initial_cash: float = 1000.0,
-    risk_per_trade: float = 1.0,
+    risk_per_trade: float | None = None,
     total_cap_pct: float | None = None,
     per_symbol_cap_pct: float | None = None,
     maker_fee_bps: float | None = None,
@@ -388,12 +388,16 @@ async def run_paper(
     )
     guard.refresh_usd_caps(initial_cash)
     corr = CorrelationService()
+    if risk_per_trade is None:
+        risk_per_trade_val = abs(risk_pct) if risk_pct > 0 else 1.0
+    else:
+        risk_per_trade_val = float(risk_per_trade)
     risk = RiskService(
         guard,
         corr_service=corr,
         account=broker.account,
         risk_pct=risk_pct,
-        risk_per_trade=risk_per_trade,
+        risk_per_trade=risk_per_trade_val,
         market_type=market,
     )
     min_qty_value = min_qty_val if min_qty_val > 0 else 0.0

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -134,7 +134,7 @@ async def _run_symbol(
     params: dict | None = None,
     config_path: str | None = None,
     timeframe: str = "1m",
-    risk_per_trade: float = 1.0,
+    risk_per_trade: float | None = None,
     maker_fee_bps: float | None = None,
     taker_fee_bps: float | None = None,
     slippage_bps: float = 0.0,
@@ -222,13 +222,17 @@ async def _run_symbol(
     broker.account.market_type = market
     exec_broker = Broker(exec_adapter if not dry_run else broker)
     tif = f"GTD:{expiry}|PO"
+    if risk_per_trade is None:
+        risk_per_trade_val = abs(cfg.risk_pct) if cfg.risk_pct > 0 else 1.0
+    else:
+        risk_per_trade_val = float(risk_per_trade)
     risk = RiskService(
         guard,
         dguard,
         corr_service=corr,
         account=broker.account,
         risk_pct=cfg.risk_pct,
-        risk_per_trade=risk_per_trade,
+        risk_per_trade=risk_per_trade_val,
         market_type=market,
     )
     min_qty_value = min_qty_val if min_qty_val > 0 else 0.0
@@ -1170,7 +1174,7 @@ async def run_live_real(
     config_path: str | None = None,
     params: dict | None = None,
     timeframe: str = "1m",
-    risk_per_trade: float = 1.0,
+    risk_per_trade: float | None = None,
     maker_fee_bps: float | None = None,
     taker_fee_bps: float | None = None,
     slippage_bps: float = 0.0,
@@ -1220,6 +1224,10 @@ async def run_live_real(
             log.warning("metrics port %s in use, trying %s", port, port + 1)
             port += 1
             continue
+    if risk_per_trade is None:
+        risk_per_trade_val = abs(risk_pct) if risk_pct > 0 else 1.0
+    else:
+        risk_per_trade_val = float(risk_per_trade)
     tasks = [
         _run_symbol(
             exchange,
@@ -1238,7 +1246,7 @@ async def run_live_real(
             params=params,
             config_path=config_path,
             timeframe=timeframe,
-            risk_per_trade=risk_per_trade,
+            risk_per_trade=risk_per_trade_val,
             maker_fee_bps=maker_fee_bps,
             taker_fee_bps=taker_fee_bps,
             slippage_bps=slippage_bps,

--- a/src/tradingbot/live/runner_testnet.py
+++ b/src/tradingbot/live/runner_testnet.py
@@ -100,7 +100,7 @@ async def _run_symbol(
     params: dict | None = None,
     config_path: str | None = None,
     timeframe: str = "1m",
-    risk_per_trade: float = 1.0,
+    risk_per_trade: float | None = None,
     maker_fee_bps: float | None = None,
     taker_fee_bps: float | None = None,
     slippage_bps: float = 0.0,
@@ -195,13 +195,17 @@ async def _run_symbol(
     )
     broker.account.market_type = market
     exec_broker = Broker(exec_adapter if not dry_run else broker)
+    if risk_per_trade is None:
+        risk_per_trade_val = abs(cfg.risk_pct) if cfg.risk_pct > 0 else 1.0
+    else:
+        risk_per_trade_val = float(risk_per_trade)
     risk = RiskService(
         guard,
         dguard,
         corr_service=corr,
         account=broker.account,
         risk_pct=cfg.risk_pct,
-        risk_per_trade=risk_per_trade,
+        risk_per_trade=risk_per_trade_val,
         market_type=market,
     )
     min_qty_value = min_qty_val if min_qty_val > 0 else 0.0
@@ -942,7 +946,7 @@ async def run_live_testnet(
     config_path: str | None = None,
     params: dict | None = None,
     timeframe: str = "1m",
-    risk_per_trade: float = 1.0,
+    risk_per_trade: float | None = None,
     maker_fee_bps: float | None = None,
     taker_fee_bps: float | None = None,
     slippage_bps: float = 0.0,
@@ -986,6 +990,10 @@ async def run_live_testnet(
             log.warning("metrics port %s in use, trying %s", port, port + 1)
             port += 1
             continue
+    if risk_per_trade is None:
+        risk_per_trade_val = abs(risk_pct) if risk_pct > 0 else 1.0
+    else:
+        risk_per_trade_val = float(risk_per_trade)
     tasks = [
         _run_symbol(
             exchange,
@@ -1004,7 +1012,7 @@ async def run_live_testnet(
             params=params,
             config_path=config_path,
             timeframe=timeframe,
-            risk_per_trade=risk_per_trade,
+            risk_per_trade=risk_per_trade_val,
             maker_fee_bps=maker_fee_bps,
             taker_fee_bps=taker_fee_bps,
             slippage_bps=slippage_bps,

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -133,6 +133,11 @@ class ScalpPingPong(Strategy):
             vol_bps = vol * 10000
         if vol_bps < self.cfg.min_volatility:
             return None
+        abs_price = max(abs(price), 1e-9)
+        price_vol = abs_price * (vol_bps / 10000.0)
+        bar["volatility"] = price_vol
+        target_bps = max(vol_bps, self.cfg.min_volatility)
+        bar["target_volatility"] = abs_price * (target_bps / 10000.0)
         # ``vol_bps`` ya está expresada en puntos básicos, por lo que el factor
         # de volatilidad actúa directamente como un multiplicador fraccional.
         # El tamaño final se acota en ``[0, 1]`` para evitar sobre-apalancamiento


### PR DESCRIPTION
## Summary
- allow the backtest engine to compute zero-bar delays when simulated latency is zero and only fall back to one bar otherwise
- align default risk-per-trade sizing with the configured risk percentage across backtests and live runners while keeping legacy behaviour when no percentage is supplied
- expose volatility and target-volatility context from adaptive strategies so the shared risk manager can scale orders, and soften breakout offsets for better fill rates

## Testing
- pytest tests/backtesting/test_limit_order_touch.py tests/backtesting/test_slippage_microscopic_volume.py tests/backtesting/test_slippage_realized_pnl.py tests/backtesting/test_slippage_zero_volume.py tests/integration/test_recorded_flow.py tests/integration/test_stress_resilience.py tests/test_account_cash_backtesting.py

------
https://chatgpt.com/codex/tasks/task_e_68d404811a0c832daa02e4744cd31ca5