### PR TITLE
Align backtest engine with live/paper behaviour

### DIFF
--- a/src/tradingbot/execution/paper.py
+++ b/src/tradingbot/execution/paper.py
@@ -495,7 +495,16 @@ class PaperAdapter(ExchangeAdapter):
             and has_liquidity_proxy
             and self._book_capacity(book, "ask_size" if side == "buy" else "bid_size") > 0
         ):
-            adj = self.slippage_model.adjust(side, qty, px, book)
+            adj, fill_qty, _ = self.slippage_model.fill(
+                side,
+                qty,
+                px,
+                book,
+                queue_pos=0.0,
+                partial=True,
+            )
+            if fill_qty <= 0:
+                adj = float(px)
             if side == "buy":
                 slip_bps = (adj - px) / px * 10000.0
             else:

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -974,13 +974,13 @@ async def _run_symbol(
                         prev_rpnl,
                         prev_pos_qty,
                     )
-                        risk.account.update_open_order(symbol, side, pending_qty)
-                        cur_qty = risk.account.current_exposure(symbol)[0]
-                        locked = _recalc_locked_total()
-                        log.info(
-                            "METRICS %s",
-                            json.dumps({"exposure": cur_qty, "locked": locked}),
-                        )
+                    risk.account.update_open_order(symbol, side, pending_qty)
+                    cur_qty = risk.account.current_exposure(symbol)[0]
+                    locked = _recalc_locked_total()
+                    log.info(
+                        "METRICS %s",
+                        json.dumps({"exposure": cur_qty, "locked": locked}),
+                    )
                     risk.on_fill(
                         symbol,
                         side,
@@ -1125,12 +1125,12 @@ async def _run_symbol(
             prev_rpnl,
             prev_pos_qty,
         )
-            risk.account.update_open_order(symbol, side, pending_qty)
-            cur_qty = risk.account.current_exposure(symbol)[0]
-            locked = _recalc_locked_total()
-            log.info(
-                "METRICS %s",
-                json.dumps({"exposure": cur_qty, "locked": locked}),
+        risk.account.update_open_order(symbol, side, pending_qty)
+        cur_qty = risk.account.current_exposure(symbol)[0]
+        locked = _recalc_locked_total()
+        log.info(
+            "METRICS %s",
+            json.dumps({"exposure": cur_qty, "locked": locked}),
         )
         risk.on_fill(
             symbol, side, filled_qty, venue=venue if not dry_run else "paper"


### PR DESCRIPTION
## Summary
- Align default fee handling and market order execution in the backtest engine so strategies without explicit limits behave like the live/paper runners.
- Tighten limit-order tolerance handling, avoid duplicate liquidation orders, and keep order summaries free from redundant zero-fill entries while still exporting cancellations.
- Drive paper adapter slippage through the shared SlippageModel.fill path and fix live runner logging indentation for paper order tracking.

## Testing
- `pytest tests/test_backtest_engine.py tests/test_backtesting_integration.py tests/test_slippage_mean_paper_vs_backtest.py -q`
- `pytest tests/test_paper_runner.py -q`
- `pytest tests/test_live_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d549a2d7cc832d8b4996a65f03cac2