### PR TITLE
Fix taker limit fill price in backtest engine

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1008,7 +1008,10 @@ class EventDrivenBacktestEngine:
                             limit_touched = low_val <= limit_price + tol
                         else:
                             limit_touched = market_price <= limit_price + tol
-                        price = min(market_price, limit_price)
+                        if not order.post_only and not self.use_l2:
+                            price = limit_price
+                        else:
+                            price = min(market_price, limit_price)
                     else:
                         high_arr = arrs.get("high")
                         high_val = None
@@ -1021,7 +1024,10 @@ class EventDrivenBacktestEngine:
                             limit_touched = high_val >= limit_price - tol
                         else:
                             limit_touched = market_price >= limit_price - tol
-                        price = max(market_price, limit_price)
+                        if not order.post_only and not self.use_l2:
+                            price = limit_price
+                        else:
+                            price = max(market_price, limit_price)
                     if not limit_touched:
                         if not self.cancel_unfilled:
                             order.execute_index = i + 1


### PR DESCRIPTION
## Summary
- ensure non-post-only limit orders executed on bar data fill at their submitted limit price instead of the bar close
- prevent artificial slippage values when running backtests without L2 depth

## Testing
- pytest tests/test_backtest_limit_price.py


------
https://chatgpt.com/codex/tasks/task_e_68d599f14e70832db0f9c7a02ccf0567