### PR TITLE
Restore limit guards and silence zero-bps slippage

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1161,6 +1161,9 @@ class EventDrivenBacktestEngine:
                 if order.post_only and fill_respects_limit:
                     slip_cash = 0.0
                     slippage_pnl = 0.0
+                elif not self._slippage_supplied and self.slippage_bps == 0.0:
+                    slip_cash = 0.0
+                    slippage_pnl = 0.0
                 else:
                     slip = (
                         float(order.place_price) - price


### PR DESCRIPTION
## Summary
- restore the limit-touch checks used to gate fills so queued orders only execute once the bar extremes cross the submitted price
- short-circuit slippage accounting when no explicit model is supplied and the requested slippage bps is zero, preventing artificial slippage noise
- extend limit price unit tests to ensure fills report zero slippage when slippage is disabled and that aggressive limits continue to match the prevailing price

## Testing
- pytest tests/test_backtest_limit_price.py

------
https://chatgpt.com/codex/tasks/task_e_68d599f14e70832db0f9c7a02ccf0567