### PR TITLE
Handle limit expiry re-quotes

### DIFF
--- a/tests/test_backtest_limit_price.py
+++ b/tests/test_backtest_limit_price.py
@@ -99,3 +99,68 @@ def test_backtest_default_limit_price(monkeypatch):
     assert order["avg_price"] == pytest.approx(close_price)
     assert fill[3] == pytest.approx(close_price)
     assert limit_price_from_close("buy", close_price, 0.0) == pytest.approx(close_price)
+
+
+def test_expired_limit_order_requote(monkeypatch):
+    """Expired limit orders should reuse the updated limit price when re-queued."""
+
+    initial_limit = 90.0
+    requote_limit = 95.0
+
+    class RequoteStrategy:
+        instances = []
+
+        def __init__(self, risk_service=None):
+            self.submitted = False
+            self.expiry_calls = 0
+            self.last_order = None
+            RequoteStrategy.instances.append(self)
+
+        def on_bar(self, _):
+            if self.submitted:
+                return None
+            self.submitted = True
+            return SimpleNamespace(side="buy", strength=1.0, limit_price=initial_limit)
+
+        def on_order_expiry(self, order, res):
+            self.expiry_calls += 1
+            self.last_order = order
+            assert res["pending_qty"] == pytest.approx(order.remaining_qty)
+            # Strategy adjusts the price to a new limit before re-quoting
+            order.price = requote_limit
+            return "re_quote"
+
+    monkeypatch.setitem(STRATEGIES, "re_quote", RequoteStrategy)
+
+    data = pd.DataFrame(
+        {
+            "timestamp": [0, 1, 2],
+            "open": [100.0, 101.0, 102.0],
+            "high": [105.0, 106.0, 107.0],
+            "low": [101.0, 94.0, 95.0],
+            "close": [102.0, 105.0, 103.0],
+            "volume": [1000, 1000, 1000],
+        }
+    )
+
+    engine = EventDrivenBacktestEngine(
+        {"SYM": data}, [("re_quote", "SYM")], latency=1, window=1, verbose_fills=True
+    )
+    res = engine.run()
+
+    assert len(res["orders"]) == 1
+    order = res["orders"][0]
+
+    # No fills are expected because the re-quoted price remains above the simulated lows
+    assert res["fills"] == []
+    # The original limit should have been updated to the new price returned by the strategy
+    assert order["place_price"] == pytest.approx(requote_limit)
+    # Ensure the order was actually re-quoted at least once
+    assert RequoteStrategy.instances[0].expiry_calls >= 1
+    assert RequoteStrategy.instances[0].last_order is not None
+    assert RequoteStrategy.instances[0].last_order.limit_price == pytest.approx(
+        requote_limit
+    )
+    assert RequoteStrategy.instances[0].last_order.place_price == pytest.approx(
+        requote_limit
+    )


### PR DESCRIPTION
## Summary
- expose a mutable `price` on backtest `Order` objects so strategies can adjust quotes
- invoke `on_order_expiry` when a limit order is untouched and requeue only when a strategy requests a re-quote
- add a regression test ensuring expired limit orders reuse the updated limit price on the next attempt

## Testing
- NUMBA_DISABLE_JIT=1 pytest tests/test_backtest_limit_price.py


------
https://chatgpt.com/codex/tasks/task_e_68d5c98ad5f4832d96f05abc06d04a45