### PR TITLE
Handle limit re-quotes on backtest order expiry

### DIFF
--- a/tests/test_backtest_limit_price.py
+++ b/tests/test_backtest_limit_price.py
@@ -99,3 +99,55 @@ def test_backtest_default_limit_price(monkeypatch):
     assert order["avg_price"] == pytest.approx(close_price)
     assert fill[3] == pytest.approx(close_price)
     assert limit_price_from_close("buy", close_price, 0.0) == pytest.approx(close_price)
+
+
+def test_backtest_limit_requote(monkeypatch):
+    """Strategies can request a re-quote after an untouched bar and update limits."""
+
+    initial_limit = 95.0
+    requoted_limit = 99.0
+
+    class RequoteStrategy:
+        def __init__(self, risk_service=None):
+            self.called = False
+            self.expiry_calls = 0
+
+        def on_bar(self, _):
+            if self.called:
+                return None
+            self.called = True
+            return SimpleNamespace(side="buy", strength=1.0, limit_price=initial_limit)
+
+        def on_order_expiry(self, order, res):
+            self.expiry_calls += 1
+            assert res["status"] == "expired"
+            # Request a higher limit price before re-queuing
+            order.price = requoted_limit
+            return "re_quote"
+
+    monkeypatch.setitem(STRATEGIES, "limit_requote", RequoteStrategy)
+
+    data = pd.DataFrame(
+        {
+            "timestamp": [0, 1, 2, 3, 4],
+            "open": [100.0, 100.0, 100.0, 100.0, 100.0],
+            "high": [100.0, 100.0, 101.0, 102.0, 102.0],
+            "low": [100.0, 100.0, 100.0, 98.0, 98.0],
+            "close": [100.0, 100.0, 100.0, 100.0, 100.0],
+            "volume": [1000, 1000, 1000, 1000, 1000],
+        }
+    )
+
+    engine = EventDrivenBacktestEngine(
+        {"SYM": data}, [("limit_requote", "SYM")], latency=1, window=1, verbose_fills=True
+    )
+    res = engine.run()
+
+    strat = engine.strategies[("limit_requote", "SYM")]
+    assert strat.expiry_calls == 1
+
+    order = res["orders"][0]
+    fill = res["fills"][0]
+
+    assert order["place_price"] == pytest.approx(requoted_limit)
+    assert fill[3] == pytest.approx(requoted_limit)


### PR DESCRIPTION
## Summary
- expose a mutable `price` field on backtest `Order` objects and propagate it when orders are created
- invoke the strategy `on_order_expiry` callback when a limit order is missed, letting the callback decide whether to re-queue and copying any updated limit back onto the order
- add a regression test that exercises a strategy-requested re-quote and verifies the new limit price is honoured

## Testing
- pytest tests/test_backtest_limit_price.py


------
https://chatgpt.com/codex/tasks/task_e_68d5cd719e78832daa550a7fe0f40524