### PR TITLE
Enhance breakout ATR timeframe scaling and regime filter

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -13,6 +13,68 @@ from hypothesis import given, strategies as st, settings
 from tradingbot.data.features import keltner_channels, atr
 
 
+def _make_ohlcv(rows: int, *, slope: float = 0.2, noise: float = 0.0) -> pd.DataFrame:
+    base = 100.0
+    closes = [base + slope * i + noise * ((-1) ** i) for i in range(rows)]
+    highs = [c + 0.3 for c in closes]
+    lows = [c - 0.3 for c in closes]
+    opens = [base + slope * i for i in range(rows)]
+    volume = [50.0] * rows
+    return pd.DataFrame({
+        "open": opens,
+        "high": highs,
+        "low": lows,
+        "close": closes,
+        "volume": volume,
+    })
+
+
+def test_breakout_atr_timeframe_parameters_scale():
+    strat = BreakoutATR(timeframe="3m")
+    fast_tf = strat._ema_period(1)
+    slow_tf = strat._ema_period(60)
+    assert fast_tf < slow_tf
+
+    fast_atr = strat._atr_period(1)
+    slow_atr = strat._atr_period(60)
+    assert fast_atr < slow_atr
+
+    fast_stop = strat._stop_multiplier(1)
+    slow_stop = strat._stop_multiplier(60)
+    assert fast_stop < slow_stop
+
+    fast_hold = strat._max_hold_bars(1)
+    slow_hold = strat._max_hold_bars(60)
+    assert fast_hold < slow_hold
+
+
+def test_breakout_atr_regime_filters_sideways():
+    strat = BreakoutATR(timeframe="5m")
+    df = _make_ohlcv(120, slope=0.0, noise=0.002)
+    bar = {"window": df, "timeframe": "5m", "symbol": "X", "volatility": 0.0}
+    sig = strat.on_bar(bar)
+    assert sig is None
+    assert abs(strat.last_regime) < 0.3
+
+
+def test_breakout_atr_regime_scales_strength_and_cooldown():
+    strat = BreakoutATR(timeframe="3m")
+    df = _make_ohlcv(200, slope=0.6)
+    df.loc[df.index[-1], "close"] += 8.0
+    df.loc[df.index[-1], "high"] = df["close"].iloc[-1] + 0.3
+    df.loc[df.index[-1], "volume"] = 200.0
+    tf_mult = strat._tf_multiplier("3m")
+    base_cooldown = strat._cooldown_for(tf_mult)
+    bar = {"window": df, "timeframe": "3m", "symbol": "TREND", "volatility": 0.0}
+    sig = strat.on_bar(bar)
+    assert sig is not None
+    assert sig.metadata["regime"] == pytest.approx(strat.last_regime)
+    assert abs(sig.metadata["regime"]) >= 0.55
+    assert sig.strength > 0.6
+    if base_cooldown > 0:
+        assert strat.cooldown_bars <= base_cooldown
+
+
 @pytest.mark.parametrize("timeframe", ["1m"])
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell, timeframe):
     strat = BreakoutATR(ema_n=2, atr_n=2)
@@ -26,44 +88,52 @@ def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell, timeframe):
     sig_buy = strat.on_bar(bar_common)
     tf_mult = strat._tf_multiplier(timeframe)
     offset_frac = strat._offset_fraction(tf_mult)
-    if tf_mult <= 3:
-        ema_used = 15
-        atr_used = 10
-    elif tf_mult >= 30:
-        ema_used = max(strat.ema_n, 30)
-        atr_used = max(strat.atr_n, 20)
-    else:
-        ema_used = strat.ema_n
-        atr_used = strat.atr_n
+    ema_used = strat._ema_period(tf_mult)
+    atr_used = strat._atr_period(tf_mult)
     atr_buy = atr(breakout_df_buy, atr_used).dropna().iloc[-1]
     upper, lower = keltner_channels(breakout_df_buy, ema_used, atr_used, strat.mult)
     last_close_buy = breakout_df_buy["close"].iloc[-1]
     assert sig_buy.side == "buy"
+    abs_price_buy = abs(last_close_buy)
+    offset_buy = float(atr_buy) * offset_frac
+    max_offset_buy = abs_price_buy * 0.006
+    min_offset_buy = abs_price_buy * 0.0005
+    offset_buy = max(min_offset_buy, min(offset_buy, max_offset_buy))
     expected_buy = max(
         last_close_buy,
-        float(upper.iloc[-1]) + float(atr_buy) * offset_frac,
+        float(upper.iloc[-1]),
     )
+    expected_buy += offset_buy
     assert sig_buy.limit_price == pytest.approx(expected_buy)
     assert sig_buy.limit_price >= last_close_buy
 
+    sell_df = breakout_df_sell.copy()
     sig_sell = strat.on_bar(
         {
-            "window": breakout_df_sell,
+            "window": sell_df,
             "volatility": 0.0,
             "timeframe": timeframe,
             "symbol": "BTC/USDT",
         }
     )
-    atr_sell = atr(breakout_df_sell, atr_used).dropna().iloc[-1]
-    upper, lower = keltner_channels(breakout_df_sell, ema_used, atr_used, strat.mult)
-    last_close_sell = breakout_df_sell["close"].iloc[-1]
+    atr_sell = atr(sell_df, atr_used).dropna().iloc[-1]
+    upper, lower = keltner_channels(sell_df, ema_used, atr_used, strat.mult)
+    last_close_sell = sell_df["close"].iloc[-1]
     assert sig_sell.side == "sell"
+    abs_price_sell = abs(last_close_sell)
+    offset_sell = float(atr_sell) * offset_frac
+    max_offset_sell = abs_price_sell * 0.006
+    min_offset_sell = abs_price_sell * 0.0005
+    offset_sell = max(min_offset_sell, min(offset_sell, max_offset_sell))
     expected_sell = min(
         last_close_sell,
-        float(lower.iloc[-1]) - float(atr_sell) * offset_frac,
+        float(lower.iloc[-1]),
     )
+    expected_sell -= offset_sell
     assert sig_sell.limit_price == pytest.approx(expected_sell)
     assert sig_sell.limit_price <= last_close_sell
+    assert "regime" in sig_buy.metadata
+    assert isinstance(sig_buy.metadata["regime"], float)
 
 
 @pytest.mark.parametrize("timeframe", ["1m"])
@@ -90,12 +160,7 @@ def test_breakout_atr_risk_service_handles_stop_and_size(breakout_df_buy, timefr
     expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])
     assert trade["qty"] == pytest.approx(expected_qty)
     tf_mult = strat._tf_multiplier(timeframe)
-    if tf_mult <= 3:
-        stop_mult = 1.5
-    elif tf_mult >= 30:
-        stop_mult = 2.0
-    else:
-        stop_mult = 1.5
+    stop_mult = strat._stop_multiplier(tf_mult)
     expected_stop = svc.initial_stop(trade["entry_price"], "buy", trade["atr"], atr_mult=stop_mult)
     assert trade["stop"] == pytest.approx(expected_stop)
 
@@ -123,21 +188,18 @@ async def test_breakout_atr_limit_crosses_market_gets_fill(
     assert sig and sig.side == "buy"
 
     tf_mult = strat._tf_multiplier("1m")
-    if tf_mult <= 3:
-        ema_used = 15
-        atr_used = 10
-    elif tf_mult >= 30:
-        ema_used = max(strat.ema_n, 30)
-        atr_used = max(strat.atr_n, 20)
-    else:
-        ema_used = strat.ema_n
-        atr_used = strat.atr_n
+    ema_used = strat._ema_period(tf_mult)
+    atr_used = strat._atr_period(tf_mult)
     atr_buy = atr(breakout_df_buy, atr_used).dropna().iloc[-1]
     upper, _ = keltner_channels(breakout_df_buy, ema_used, atr_used, strat.mult)
-    naive_limit = float(upper.iloc[-1]) + float(atr_buy) * strat._offset_fraction(tf_mult)
     last_close = float(breakout_df_buy["close"].iloc[-1])
-    assert naive_limit < last_close
-    assert sig.limit_price == pytest.approx(last_close)
+    offset = float(atr_buy) * strat._offset_fraction(tf_mult)
+    max_offset = last_close * 0.006
+    min_offset = last_close * 0.0005
+    offset = max(min_offset, min(offset, max_offset))
+    expected_limit = max(last_close, float(upper.iloc[-1])) + offset
+    assert sig.limit_price == pytest.approx(expected_limit)
+    assert sig.limit_price >= last_close
 
     paper_adapter.update_last_price(symbol, last_close)
     res = await paper_adapter.place_order(


### PR DESCRIPTION
## Summary
- replace the static timeframe conditionals in breakout_atr with helper methods that scale EMA/ATR periods, stop multipliers, and hold time by the bar duration while clamping to practical bounds
- add a volatility-normalized EMA slope regime filter that blocks choppy-market signals, annotates signal metadata, and adjusts cooldown and strength according to market state
- expand the breakout_atr test coverage with regime-aware fixtures to verify parameter scaling, signal gating, and limit-price computation across multiple timeframe scenarios

## Testing
- pytest tests/test_strategies.py::test_breakout_atr_signals tests/test_strategies.py::test_breakout_atr_risk_service_handles_stop_and_size tests/test_strategies.py::test_breakout_atr_timeframe_parameters_scale tests/test_strategies.py::test_breakout_atr_regime_filters_sideways tests/test_strategies.py::test_breakout_atr_regime_scales_strength_and_cooldown tests/test_strategies.py::test_breakout_atr_limit_crosses_market_gets_fill
- pytest tests/test_timeframe_adaptation.py::test_breakout_atr_cooldown_scales_with_timeframe

------
https://chatgpt.com/codex/tasks/task_e_68d605742c74832db74247bd7573a068