### PR TITLE
Normalize breakout ATR strength and ensure full allocation test

### DIFF
--- a/src/tradingbot/strategies/breakout_atr.py
+++ b/src/tradingbot/strategies/breakout_atr.py
@@ -35,6 +35,7 @@ PARAM_INFO = {
     "offset_frac": "Fracción base del ATR usada para cruzar el mercado (1m)",
     "volume_factor": "Multiplicador de volumen mínimo requerido",
     "cooldown_bars": "Barras a esperar tras una pérdida",
+    "strength_target": "Intensidad necesaria para usar el 100% del capital",
 }
 
 
@@ -135,6 +136,9 @@ class BreakoutATR(Strategy):
         self.mult = 1.0
         self._rq = RollingQuantileCache()
         self.last_regime = float("nan")
+        self.strength_target = max(
+            0.1, float(params.get("strength_target", 1.5))
+        )
 
     @staticmethod
     def _tf_multiplier(tf: str | None) -> float:
@@ -203,6 +207,13 @@ class BreakoutATR(Strategy):
             elif "perp" in mt or "future" in mt:
                 quantile *= 0.92
         return self._clamp(quantile, 0.03, 0.9)
+
+    def _normalize_strength(self, raw_strength: float) -> float:
+        if not math.isfinite(raw_strength):
+            return 0.0
+        pivot = max(self.strength_target, 1e-6)
+        scaled = max(0.0, raw_strength / pivot)
+        return self._clamp(scaled, 0.0, 1.0)
 
     @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
@@ -347,12 +358,14 @@ class BreakoutATR(Strategy):
             avg_vol = vol_series.iloc[-20:].mean()
             if vol_series.iloc[-1] <= self.volume_factor * avg_vol:
                 return None
-        strength = 0.6
+        raw_strength = 0.6
         if math.isfinite(atr_bps_quant) and atr_bps_quant > 0:
             ratio = atr_bps / max(atr_bps_quant, 1e-9)
-            strength = max(0.3, min(3.0, ratio))
-        strength *= max(0.6, min(2.0, 0.7 + 0.5 * regime_abs))
+            raw_strength = max(0.3, min(3.0, ratio))
+        raw_strength *= max(0.6, min(2.0, 0.7 + 0.5 * regime_abs))
+        strength = self._normalize_strength(raw_strength)
         sig = Signal(side, strength)
+        sig.metadata["raw_strength"] = raw_strength
         level = float(upper.iloc[-1]) if side == "buy" else float(lower.iloc[-1])
         target_offset = atr_val * self._offset_fraction(tf_mult)
         abs_price = max(abs(last_close), 1e-9)
@@ -397,7 +410,7 @@ class BreakoutATR(Strategy):
                 last_close,
                 volatility=atr_val,
                 target_volatility=target_vol,
-                clamp=False,
+                clamp=True,
             )
             stop = self.risk_service.initial_stop(
                 last_close, side, atr_val, atr_mult=stop_mult

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -28,6 +28,20 @@ def test_size_scales_with_equity_and_strength():
     assert rs_big.calc_position_size(0.5, price) == pytest.approx(expected_big)
 
 
+def test_full_strength_uses_available_capital():
+    price = 200.0
+    equity = 5_000.0
+    rs = _make_rs(equity)
+
+    balance = rs.account.get_available_balance()
+    qty_full = rs.calc_position_size(1.0, price, clamp=True)
+
+    assert qty_full * price == pytest.approx(balance)
+
+    qty_over = rs.calc_position_size(2.0, price, clamp=True)
+    assert qty_over * price == pytest.approx(balance)
+
+
 def test_stop_loss_risk_pct():
     equity = 10_000.0
     risk_pct = 0.02
@@ -161,7 +175,7 @@ async def test_daily_guard_halts_on_loss():
     broker = PaperAdapter()
     symbol = "BTC/USDT"
     guard = DailyGuard(GuardLimits(daily_max_loss_pct=0.05), venue="paper")
-    broker.state.cash = 100.0
+    broker.state.cash = 200.0
 
     broker.update_last_price(symbol, 100.0)
     guard.on_mark(


### PR DESCRIPTION
## Summary
- normalize BreakoutATR signal strength using a configurable target so sizing stays within [0, 1]
- store the raw, pre-normalized strength in signal metadata and clamp sizing requests at the risk service
- add a risk service test to assert full-strength orders use available capital and adjust the daily guard test cash balance to cover fees

## Testing
- pytest tests/test_risk.py


------
https://chatgpt.com/codex/tasks/task_e_68d61d57f130832d8e91b4ec8e196920