### PR TITLE
Improve breakout ATR volatility scaling

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -202,6 +202,22 @@ def test_breakout_atr_vol_quantile_configures_threshold():
     assert rq_high.q == pytest.approx(expected_high)
 
 
+@pytest.mark.parametrize(
+    "timeframe, expected_range",
+    [
+        ("1m", (0.19, 0.21)),
+        ("15m", (0.25, 0.4)),
+        ("4h", (0.4, 0.7)),
+    ],
+)
+def test_breakout_atr_vol_quantile_scaling(timeframe, expected_range):
+    strat = BreakoutATR(vol_quantile=0.2)
+    tf_mult = strat._tf_multiplier(timeframe)
+    quantile = strat._vol_quantile_for(tf_mult)
+    lower, upper = expected_range
+    assert lower <= quantile <= upper
+
+
 @pytest.mark.parametrize("timeframe", ["1m"])
 def test_breakout_atr_signals(breakout_df_buy, breakout_df_sell, timeframe):
     strat = BreakoutATR(ema_n=2, atr_n=2, min_regime=0.1, max_regime=0.4, volume_factor=0.0)


### PR DESCRIPTION
## Summary
- adjust BreakoutATR volatility quantile scaling to grow with timeframe length and keep support for market type tweaks
- expose optional slow and fast timeframe volatility tuning parameters for venue- or symbol-specific overrides
- extend strategy tests to check volatility quantile behaviour on 1m, 15m, and 4h timeframes

## Testing
- pytest tests/test_strategies.py::test_breakout_atr_vol_quantile_scaling

------
https://chatgpt.com/codex/tasks/task_e_68d6b64ca59c832daf70f4a5748d3e91