### PR TITLE
Track fees and slippage for trailing stops

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -1010,10 +1010,7 @@ class EventDrivenBacktestEngine:
                             limit_touched = low_val <= limit_price + tol
                         else:
                             limit_touched = market_price <= limit_price + tol
-                        if not order.post_only and not self.use_l2:
-                            price = limit_price
-                        else:
-                            price = min(market_price, limit_price)
+                        price = min(market_price, limit_price)
                     else:
                         high_arr = arrs.get("high")
                         high_val = None
@@ -1026,10 +1023,7 @@ class EventDrivenBacktestEngine:
                             limit_touched = high_val >= limit_price - tol
                         else:
                             limit_touched = market_price >= limit_price - tol
-                        if not order.post_only and not self.use_l2:
-                            price = limit_price
-                        else:
-                            price = max(market_price, limit_price)
+                        price = max(market_price, limit_price)
                     if not limit_touched:
                         expiry_price = float(price)
                         expiry_res = {
@@ -1215,7 +1209,14 @@ class EventDrivenBacktestEngine:
                 cash += delta_cash
                 svc.account.update_cash(delta_cash)
                 prev_qty = svc.account.current_exposure(order.symbol)[0]
-                svc.on_fill(order.symbol, order.side, fill_qty, price)
+                svc.on_fill(
+                    order.symbol,
+                    order.side,
+                    fill_qty,
+                    price,
+                    fee=fee_cost,
+                    slippage=slippage_pnl,
+                )
                 sync_cash()
                 new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 realized_pnl = new_rpnl - prev_rpnl - fee_cost - slippage_pnl
@@ -1390,7 +1391,14 @@ class EventDrivenBacktestEngine:
                     cash += delta_cash
                     svc.account.update_cash(delta_cash)
                     prev_qty = svc.account.current_exposure(symbol)[0]
-                    svc.on_fill(symbol, side, exit_qty, exit_price)
+                    svc.on_fill(
+                        symbol,
+                        side,
+                        exit_qty,
+                        exit_price,
+                        fee=fee_cost,
+                        slippage=slippage_pnl,
+                    )
                     sync_cash()
                     new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                     realized_pnl = new_rpnl - prev_rpnl - fee_cost - slippage_pnl
@@ -1874,7 +1882,14 @@ class EventDrivenBacktestEngine:
                     delta_cash = -(trade_value + fee_cost)
                 cash += delta_cash
                 svc.account.update_cash(delta_cash)
-                svc.on_fill(symbol, side, qty, last_price)
+                svc.on_fill(
+                    symbol,
+                    side,
+                    qty,
+                    last_price,
+                    fee=fee_cost,
+                    slippage=slippage_pnl,
+                )
                 new_rpnl = getattr(svc.pos, "realized_pnl", 0.0)
                 realized_pnl = new_rpnl - prev_rpnl - fee_cost - slippage_pnl
                 realized_pnl_total += realized_pnl

--- a/src/tradingbot/broker/broker.py
+++ b/src/tradingbot/broker/broker.py
@@ -194,8 +194,22 @@ class Broker:
                 if side and qty > 0:
                     FILL_COUNT.labels(symbol=symbol, side=side).inc()
                     if risk is not None:
+                        fee_val = event.get("fee")
+                        if fee_val is None:
+                            fee_val = event.get("fee_cost")
+                        slip_val = event.get("slippage")
+                        if slip_val is None:
+                            slip_val = event.get("slippage_cost")
                         try:
-                            risk.on_fill(symbol, side, qty, price=price, venue=venue)
+                            risk.on_fill(
+                                symbol,
+                                side,
+                                qty,
+                                price=price,
+                                fee=fee_val,
+                                slippage=slip_val,
+                                venue=venue,
+                            )
                         except Exception:
                             pass
                 cb = cb_exp if status in _FINAL_STATUSES else cb_pf

--- a/src/tradingbot/live/runner_real.py
+++ b/src/tradingbot/live/runner_real.py
@@ -882,10 +882,35 @@ async def _run_symbol(
                         "METRICS %s",
                         json.dumps({"exposure": cur_qty, "locked": locked}),
                     )
+                exec_price = resp.get("price") or resp.get("avg_price")
+                if exec_price is None:
+                    exec_price = price
+                try:
+                    exec_price_f = float(exec_price) if exec_price is not None else None
+                except (TypeError, ValueError):
+                    exec_price_f = None
+                fee_val = resp.get("fee")
+                if fee_val is None:
+                    fee_val = resp.get("fee_cost")
+                slippage_cash = resp.get("slippage")
+                if slippage_cash is None:
+                    slippage_cash = resp.get("slippage_cost")
+                if slippage_cash is None and exec_price_f is not None and price is not None:
+                    try:
+                        base_price_f = float(price)
+                        if close_side.lower() == "buy":
+                            slippage_cash = (exec_price_f - base_price_f) * filled_qty
+                        else:
+                            slippage_cash = (base_price_f - exec_price_f) * filled_qty
+                    except (TypeError, ValueError):
+                        slippage_cash = None
                 risk.on_fill(
                     symbol,
                     close_side,
                     filled_qty,
+                    price=exec_price_f,
+                    fee=fee_val,
+                    slippage=slippage_cash,
                     venue=venue if not dry_run else "paper",
                 )
                 realized_raw = resp.get("realized_pnl", getattr(broker.state, "realized_pnl", prev_rpnl))
@@ -981,10 +1006,41 @@ async def _run_symbol(
                         "METRICS %s",
                         json.dumps({"exposure": cur_qty, "locked": locked}),
                     )
+                    exec_price = resp.get("price") or resp.get("avg_price")
+                    if exec_price is None:
+                        exec_price = price
+                    try:
+                        exec_price_f = (
+                            float(exec_price) if exec_price is not None else None
+                        )
+                    except (TypeError, ValueError):
+                        exec_price_f = None
+                    fee_val = resp.get("fee")
+                    if fee_val is None:
+                        fee_val = resp.get("fee_cost")
+                    slippage_cash = resp.get("slippage")
+                    if slippage_cash is None:
+                        slippage_cash = resp.get("slippage_cost")
+                    if (
+                        slippage_cash is None
+                        and exec_price_f is not None
+                        and price is not None
+                    ):
+                        try:
+                            base_price_f = float(price)
+                            if side.lower() == "buy":
+                                slippage_cash = (exec_price_f - base_price_f) * filled_qty
+                            else:
+                                slippage_cash = (base_price_f - exec_price_f) * filled_qty
+                        except (TypeError, ValueError):
+                            slippage_cash = None
                     risk.on_fill(
                         symbol,
                         side,
                         filled_qty,
+                        price=exec_price_f,
+                        fee=fee_val,
+                        slippage=slippage_cash,
                         venue=venue if not dry_run else "paper",
                     )
                     realized_raw = resp.get("realized_pnl", getattr(broker.state, "realized_pnl", prev_rpnl))
@@ -1132,8 +1188,36 @@ async def _run_symbol(
             "METRICS %s",
             json.dumps({"exposure": cur_qty, "locked": locked}),
         )
+        exec_price = resp.get("price") or resp.get("avg_price")
+        if exec_price is None:
+            exec_price = price
+        try:
+            exec_price_f = float(exec_price) if exec_price is not None else None
+        except (TypeError, ValueError):
+            exec_price_f = None
+        fee_val = resp.get("fee")
+        if fee_val is None:
+            fee_val = resp.get("fee_cost")
+        slippage_cash = resp.get("slippage")
+        if slippage_cash is None:
+            slippage_cash = resp.get("slippage_cost")
+        if slippage_cash is None and exec_price_f is not None and price is not None:
+            try:
+                base_price_f = float(price)
+                if side.lower() == "buy":
+                    slippage_cash = (exec_price_f - base_price_f) * filled_qty
+                else:
+                    slippage_cash = (base_price_f - exec_price_f) * filled_qty
+            except (TypeError, ValueError):
+                slippage_cash = None
         risk.on_fill(
-            symbol, side, filled_qty, venue=venue if not dry_run else "paper"
+            symbol,
+            side,
+            filled_qty,
+            price=exec_price_f,
+            fee=fee_val,
+            slippage=slippage_cash,
+            venue=venue if not dry_run else "paper",
         )
         realized_raw = resp.get("realized_pnl", getattr(broker.state, "realized_pnl", prev_rpnl))
         try:

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -33,6 +33,9 @@ class DummyStrategy:
         side = "buy" if self.i % 2 == 0 else "sell"
         return SimpleNamespace(side=side, strength=1.0)
 
+    def on_order_expiry(self, order, event):
+        return None
+
 
 def _make_csv(tmp_path):
     rng = pd.date_range("2021-01-01", periods=50, freq="T")


### PR DESCRIPTION
## Summary
- extend the risk service to accumulate per-trade fees/slippage and feed the totals into trailing stop logic
- forward real fill fees from the broker, live runners, and backtesting engine, ensuring limit orders execute at the best observed price
- add coverage so trailing stops only advance after net profit clears fees and stub out the dummy strategy order expiry hook

## Testing
- pytest tests/test_risk.py tests/test_backtest_engine.py


------
https://chatgpt.com/codex/tasks/task_e_68d6d19bedb8832d9c12c41757426001