### PR TITLE
Adjust breakout ATR hold dynamics for strong signals

### DIFF
--- a/tests/strategies/test_breakout_atr.py
+++ b/tests/strategies/test_breakout_atr.py
@@ -37,3 +37,31 @@ def test_breakout_atr_rejects_bull_breakout_in_bearish_regime():
     assert strat.last_regime < 0
     assert strat.last_regime_threshold > 0
     assert abs(strat.last_regime) >= strat.last_regime_threshold
+
+
+def test_breakout_atr_max_hold_scales_with_strength_and_regime():
+    strat = BreakoutATR()
+
+    base_hold = strat._max_hold_bars(3.0, strength=0.55, regime_abs=1.0)
+    strong_hold = strat._max_hold_bars(3.0, strength=0.9, regime_abs=1.8)
+    slow_hold = strat._max_hold_bars(20.0, strength=0.6, regime_abs=1.2)
+    slow_strong = strat._max_hold_bars(20.0, strength=0.95, regime_abs=1.9)
+
+    assert strong_hold > base_hold >= 10
+    assert strong_hold <= 160
+    assert slow_strong >= slow_hold
+
+
+def test_breakout_atr_partial_take_profit_adapts_to_timeframe_and_strength():
+    strat = BreakoutATR()
+
+    fast_high = strat._partial_take_profit_config(3.0, 0.9, 1.6)
+    fast_low = strat._partial_take_profit_config(3.0, 0.25, 0.8)
+    slow_high = strat._partial_take_profit_config(30.0, 0.85, 1.4)
+
+    assert fast_high["atr_multiple"] >= 2.0
+    assert fast_high["qty_pct"] < 0.2
+    assert fast_low["qty_pct"] <= 0.1
+    assert fast_low["qty_pct"] >= 0.0
+    assert slow_high["atr_multiple"] > fast_low["atr_multiple"]
+    assert slow_high["qty_pct"] >= fast_low["qty_pct"]


### PR DESCRIPTION
## Summary
- scale the breakout ATR max hold horizon with signal strength and regime intensity, exposing the computed cap in signal metadata
- retune the partial take profit configuration to favour deeper targets on fast strong setups while allowing lighter scaling when strength is weak
- add unit tests that exercise the new max-hold and partial take profit helpers across timeframe and strength combinations

## Testing
- pytest tests/strategies/test_breakout_atr.py

------
https://chatgpt.com/codex/tasks/task_e_68d7274afef4832d942c4ed423c2eba3