### PR TITLE
Refine breakout vol signal placement and sizing

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -31,6 +31,7 @@ class Signal:
     strength: float = 1.0  # fraction of the base equity allocation
     reduce_only: bool = False
     limit_price: float | None = None
+    post_only: bool | None = None
     signal_ts: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -604,10 +604,16 @@ def test_breakout_vol_risk_service_handles_stop_and_size():
         strat.on_bar({"window": df_buy.iloc[: end], "volatility": 0.0})
     sig = strat.on_bar({"window": df_buy, "volatility": 0.0})
     assert sig and sig.side == "buy"
-    assert sig.limit_price >= df_buy["close"].iloc[-1]
+    assert sig.limit_price <= df_buy["close"].iloc[-1]
+    assert sig.post_only is True
+    assert 0.0 <= sig.strength <= 1.0
     trade = strat.trade
     assert trade is not None
-    expected_qty = svc.calc_position_size(sig.strength, trade["entry_price"])
+    expected_qty = svc.calc_position_size(
+        sig.strength,
+        trade["entry_price"],
+        clamp=True,
+    )
     assert trade["qty"] == pytest.approx(expected_qty)
     expected_stop = svc.initial_stop(trade["entry_price"], "buy", trade.get("atr"))
     assert trade["stop"] == pytest.approx(expected_stop)

--- a/tests/test_timeframe_adaptation.py
+++ b/tests/test_timeframe_adaptation.py
@@ -1,6 +1,7 @@
 import math
 
 import pandas as pd
+import pytest
 
 from tradingbot.backtesting.engine import EventDrivenBacktestEngine
 from tradingbot.strategies import STRATEGIES
@@ -45,6 +46,19 @@ def test_breakout_vol_lookback_scales():
 
     assert strat_fast.lookback == 10
     assert strat_slow.lookback == 2
+
+
+def test_breakout_vol_quantiles_adapt_with_market_type():
+    strat_3m_spot = BreakoutVol(timeframe="3m", market_type="spot")
+    strat_15m_perp = BreakoutVol(timeframe="15m", market_type="perp")
+    strat_1h_unknown = BreakoutVol(timeframe="1h", market_type="exotic")
+
+    assert strat_3m_spot._vol_quantile == pytest.approx(0.25)
+    assert strat_3m_spot._mult_quantile == pytest.approx(0.75)
+    assert strat_15m_perp._vol_quantile == pytest.approx(0.20)
+    assert strat_15m_perp._mult_quantile == pytest.approx(0.80)
+    assert strat_1h_unknown._vol_quantile == pytest.approx(0.19)
+    assert strat_1h_unknown._mult_quantile == pytest.approx(0.83)
 
 
 def test_momentum_cooldown_scales():


### PR DESCRIPTION
## Summary
- anchor breakout volatility limit orders to channel edges or best quotes while enforcing maker-only behaviour and spread-aware offsets
- normalise breakout volatility sizing, clamp risk calculations, and expose maker intent via the Signal data model
- derive volatility and multiplier quantiles from timeframe and market type with regression tests across 3m, 15m, and 1h configurations

## Testing
- pytest tests/test_strategies.py::test_breakout_vol_risk_service_handles_stop_and_size
- pytest tests/test_timeframe_adaptation.py::test_breakout_vol_quantiles_adapt_with_market_type

------
https://chatgpt.com/codex/tasks/task_e_68d81624fe50832d914c879796075856