### PR TITLE
Normalize strategy strength and enforce maker execution

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -7,6 +7,50 @@ from ..filters.liquidity import LiquidityFilterManager
 
 liquidity = LiquidityFilterManager()
 
+
+def _normalized_strength(raw: float, *, center: float = 0.8) -> float:
+    if not math.isfinite(raw) or raw <= 0:
+        return 0.0
+    scaled = math.log1p(raw)
+    adjusted = scaled - center
+    try:
+        val = 1.0 / (1.0 + math.exp(-adjusted))
+    except OverflowError:
+        val = 1.0 if adjusted > 0 else 0.0
+    return max(0.0, min(1.0, val))
+
+
+def _best_quote(bar: dict, side: str) -> float | None:
+    keys = (
+        ("bid", "best_bid", "bid_px", "bid_price")
+        if side == "buy"
+        else ("ask", "best_ask", "ask_px", "ask_price")
+    )
+    for key in keys:
+        if key not in bar:
+            continue
+        try:
+            value = float(bar[key])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            return value
+    return None
+
+
+def _pivot_price(df: pd.DataFrame, side: str, lookback: int = 5) -> float | None:
+    if side == "buy":
+        series = df["low"] if "low" in df else df["close"]
+        value = series.iloc[-lookback:].min()
+    else:
+        series = df["high"] if "high" in df else df["close"]
+        value = series.iloc[-lookback:].max()
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
 PARAM_INFO = {
     "rsi_n": "Ventana para el cálculo del RSI",
     "trend_ma": "Ventana para la media móvil de tendencia",
@@ -171,19 +215,22 @@ class MeanReversion(Strategy):
         prev_rsi = rsi_series.iloc[-2]
         prev_price = float(price_series.iloc[-2])
 
+        raw_strength = 0.0
         if last_rsi > upper:
             if self.timeframe in {"5m", "15m"} and not (
                 prev_rsi > last_rsi and price < prev_price
             ):
                 return self.finalize_signal(bar, price, None)
-            strength = max(0.3, min(2.5, (last_rsi - upper) / max(1.0, 100 - upper) * 3.0))
+            deviation = (last_rsi - upper) / max(1.0, 100 - upper)
+            raw_strength = max(0.0, deviation * 3.0)
             side = "sell"
         elif last_rsi < lower:
             if self.timeframe in {"5m", "15m"} and not (
                 prev_rsi < last_rsi and price > prev_price
             ):
                 return self.finalize_signal(bar, price, None)
-            strength = max(0.3, min(2.5, (lower - last_rsi) / max(1.0, lower) * 3.0))
+            deviation = (lower - last_rsi) / max(1.0, lower)
+            raw_strength = max(0.0, deviation * 3.0)
             side = "buy"
         else:
             return self.finalize_signal(bar, price, None)
@@ -191,29 +238,64 @@ class MeanReversion(Strategy):
         if side == "sell" and trend_dir == 1 and self.only_buy_dip:
             return self.finalize_signal(bar, price, None)
 
+        strength = _normalized_strength(raw_strength, center=0.8)
+        if strength <= 0.0:
+            return self.finalize_signal(bar, price, None)
+
         sig = Signal(side, strength)
-        offset = max(atr_val * 0.5, price * 0.001)
-        direction = -1 if side == "sell" else 1
-        base_price = price
-        sig.limit_price = base_price + direction * offset
+
+        anchor_price = _best_quote(bar, side)
+        if anchor_price is None:
+            anchor_price = _pivot_price(df, side, lookback=6)
+        if anchor_price is None or anchor_price <= 0:
+            anchor_price = price
+
+        limit_span = max(price * 0.001, atr_val * 0.6)
+        limit_span = max(limit_span, abs(price - anchor_price))
+        limit_span = max(limit_span, price * 0.0005)
+        if not math.isfinite(limit_span) or limit_span <= 0:
+            limit_span = max(abs(price) * 0.0005, 1e-6)
+
+        if side == "buy":
+            base_price = max(0.0, anchor_price - limit_span)
+        else:
+            base_price = anchor_price + limit_span
+
+        initial_offset = max(limit_span * 0.45, atr_val * 0.4, price * 0.0003)
+        initial_offset = min(initial_offset, limit_span)
+        step_offset = max(limit_span * 0.3, price * 0.0002)
+        step_offset = min(step_offset, limit_span)
+        maker_initial = max(price * 0.0002, min(initial_offset * 0.5, limit_span))
+
+        direction = -1.0 if side == "sell" else 1.0
+        limit_price = base_price + direction * initial_offset
+        if side == "buy":
+            limit_price = min(limit_price, anchor_price)
+        else:
+            limit_price = max(limit_price, anchor_price)
+        sig.limit_price = max(0.0, limit_price)
         sig.metadata.update(
             {
                 "base_price": base_price,
-                "limit_offset": abs(offset),
-                "max_offset": abs(price * 0.005),
-                "step_mult": 0.4,
-                "chase": False,
-                "decay": 0.7,
-                "min_offset": price * 0.0005,
+                "limit_offset": abs(limit_span),
+                "initial_offset": abs(initial_offset),
+                "offset_step": abs(step_offset),
+                "max_offset": abs(limit_span),
+                "step_mult": 0.45,
+                "chase": True,
+                "maker_initial_offset": abs(maker_initial),
+                "maker_patience": 1,
+                "post_only": True,
             }
         )
+        sig.post_only = True
         if self.risk_service is not None:
             qty = self.risk_service.calc_position_size(
                 strength,
                 price,
                 volatility=bar.get("volatility"),
                 target_volatility=bar.get("target_volatility"),
-                clamp=False,
+                clamp=True,
             )
             stop = self.risk_service.initial_stop(price, side, atr_val)
             if (

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -1,6 +1,7 @@
 import math
 
 import pandas as pd
+from tradingbot.execution.order_types import Order
 from tradingbot.strategies import mean_reversion as mr
 from tradingbot.strategies.base import timeframe_to_minutes
 from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
@@ -13,6 +14,84 @@ def test_mean_reversion_on_bar_signals():
     sig_sell = strat.on_bar({"window": df_up, "volatility": 0.0})
     assert sig_buy.side == "buy"
     assert sig_sell.side == "sell"
+
+
+class ClampRiskService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.min_order_qty = 0.0
+        self.min_notional = 0.0
+        self.pos = type("Pos", (), {"realized_pnl": 0.0, "qty": 0.0})()
+
+    def calc_position_size(self, strength, price, **kwargs):  # noqa: ANN001
+        self.calls.append(kwargs)
+        return float(strength)
+
+    @staticmethod
+    def initial_stop(price, side, atr):  # noqa: ANN001
+        atr = float(atr or 0.0)
+        if str(side).lower() == "buy":
+            return float(price) - atr
+        return float(price) + atr
+
+    @staticmethod
+    def get_trade(symbol):  # noqa: ANN001
+        return None
+
+    @staticmethod
+    def update_trailing(trade, price):  # noqa: ANN001
+        return None
+
+    @staticmethod
+    def manage_position(trade, sig):  # noqa: ANN001
+        return "hold"
+
+    @staticmethod
+    def update_signal_strength(symbol, strength):  # noqa: ANN001
+        return None
+
+
+def test_mean_reversion_uses_maker_limits_and_clamp():
+    prices = [12.0, 11.5, 11.0, 10.5, 10.0, 9.5, 9.0]
+    df = pd.DataFrame(
+        {
+            "open": prices,
+            "high": [p + 0.2 for p in prices],
+            "low": [p - 0.2 for p in prices],
+            "close": prices,
+            "volume": [100.0] * len(prices),
+        }
+    )
+    best_bid = prices[-1] - 0.1
+    best_ask = prices[-1] + 0.1
+    risk = ClampRiskService()
+    strat = MeanReversion(rsi_n=5, risk_service=risk)
+    bar = {
+        "window": df,
+        "volatility": 0.0,
+        "symbol": "X",
+        "bid": best_bid,
+        "ask": best_ask,
+    }
+    sig = strat.on_bar(bar)
+    assert sig is not None and sig.side == "buy"
+    assert sig.post_only is True
+    assert 0.0 < sig.strength <= 1.0
+    assert risk.calls and risk.calls[0].get("clamp") is True
+
+    meta = sig.metadata
+    anchor = meta["base_price"] + meta["limit_offset"]
+    assert math.isclose(anchor, best_bid, rel_tol=1e-9, abs_tol=1e-9)
+    assert sig.limit_price <= anchor + 1e-9
+
+    order = Order("X", sig.side, "limit", 1.0, price=sig.limit_price, post_only=sig.post_only)
+    res = {"price": best_bid, "pending_qty": order.qty}
+    for _ in range(3):
+        action = strat.on_order_expiry(order, res)
+        assert action == "re_quote"
+        assert order.price <= anchor + 1e-9
+
+    assert math.isclose(strat.trade["qty"], sig.strength, rel_tol=1e-9, abs_tol=1e-9)
 
 def test_mean_reversion_generate_signals():
     df = pd.DataFrame({"price": [1, 2, 3, 4, 3, 2, 1, 2, 3]})

--- a/tests/test_momentum_limit_price.py
+++ b/tests/test_momentum_limit_price.py
@@ -1,9 +1,103 @@
+import math
+
 import pandas as pd
+
+import tradingbot.strategies.momentum as momentum_module
+from tradingbot.execution.order_types import Order
 from tradingbot.strategies.momentum import Momentum
 
-def test_momentum_sets_limit_price():
-    df = pd.DataFrame({"close": [1, 2, 1, 2]})
-    strat = Momentum(rsi_n=2)
-    sig = strat.on_bar({"window": df, "close": df["close"].iloc[-1], "volatility": 0.0})
+
+class DummyRiskService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.min_order_qty = 0.0
+        self.min_notional = 0.0
+        self.pos = type("Pos", (), {"realized_pnl": 0.0, "qty": 0.0})()
+
+    def calc_position_size(self, strength, price, **kwargs):  # noqa: ANN001
+        self.calls.append(kwargs)
+        return float(strength)
+
+    @staticmethod
+    def initial_stop(price, side, atr, atr_mult=None):  # noqa: ANN001
+        atr_val = float(atr or 0.0)
+        mult = 1.0
+        if atr_mult is not None:
+            try:
+                mult = float(atr_mult)
+            except (TypeError, ValueError):
+                mult = 1.0
+        offset = atr_val * mult
+        if str(side).lower() == "buy":
+            return float(price) - offset
+        return float(price) + offset
+
+    @staticmethod
+    def get_trade(symbol):  # noqa: ANN001
+        return None
+
+    @staticmethod
+    def update_trailing(trade, price):  # noqa: ANN001
+        return None
+
+    @staticmethod
+    def manage_position(trade, sig):  # noqa: ANN001
+        return "hold"
+
+    @staticmethod
+    def update_signal_strength(symbol, strength):  # noqa: ANN001
+        return None
+
+
+def test_momentum_sets_maker_limit_and_clamps_size(monkeypatch):
+    monkeypatch.setattr(momentum_module, "MIN_BARS", 2)
+    df = pd.DataFrame(
+        {
+            "open": [1, 1, 1, 2, 1, 2],
+            "high": [1.02, 1.02, 1.01, 2.02, 1.01, 2.02],
+            "low": [0.98, 0.98, 0.99, 1.98, 0.99, 1.98],
+            "close": [1, 1, 1, 2, 1, 2],
+            "volume": [10.0] * 6,
+        }
+    )
+    best_bid = 1.99
+    best_ask = 2.01
+    risk = DummyRiskService()
+    strat = Momentum(
+        fast_ema=2,
+        slow_ema=4,
+        rsi_n=3,
+        atr_n=3,
+        roc_n=1,
+        vol_window=4,
+        min_volume=0,
+        min_volatility=0,
+        risk_service=risk,
+    )
+    bar = {
+        "window": df,
+        "timeframe": "1m",
+        "symbol": "X",
+        "volatility": 0.0,
+        "bid": best_bid,
+        "ask": best_ask,
+    }
+    sig = strat.on_bar(bar)
     assert sig is not None and sig.side == "buy"
-    assert sig.limit_price == df["close"].iloc[-1]
+    assert sig.post_only is True
+    assert 0.0 < sig.strength <= 1.0
+    assert risk.calls and risk.calls[0].get("clamp") is True
+
+    meta = sig.metadata
+    anchor = meta["base_price"] + meta["limit_offset"]
+    assert math.isclose(anchor, best_bid, rel_tol=1e-9, abs_tol=1e-9)
+    assert sig.limit_price <= anchor + 1e-9
+
+    order = Order("X", sig.side, "limit", 1.0, price=sig.limit_price, post_only=sig.post_only)
+    res = {"price": best_bid, "pending_qty": order.qty}
+    for _ in range(3):
+        action = strat.on_order_expiry(order, res)
+        assert action == "re_quote"
+        assert order.price <= anchor + 1e-9
+
+    assert math.isclose(strat.trade["qty"], sig.strength, rel_tol=1e-9, abs_tol=1e-9)


### PR DESCRIPTION
## Summary
- map the momentum, trend following, and mean reversion signal strengths into the [0,1] range and clamp position sizing
- anchor limit prices to the prevailing best bid/ask (or recent pivots), set post-only flags, and configure maker offset steps
- add regression tests ensuring signals stay maker-side across expiries and that exposure remains capped at 100%

## Testing
- pytest tests/test_momentum_limit_price.py tests/test_trend_following.py tests/test_mean_reversion.py

------
https://chatgpt.com/codex/tasks/task_e_68d816244170832d8f93fe272a66e115