### PR TITLE
Add rolling volatility floor to mean reversion strategy

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,9 +1,11 @@
-import pandas as pd
 import math
+
+import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics, timeframe_to_minutes
 from ..data.features import rsi
 from ..filters.liquidity import LiquidityFilterManager
+from ..utils.rolling_quantile import RollingQuantileCache
 
 liquidity = LiquidityFilterManager()
 
@@ -90,7 +92,14 @@ class MeanReversion(Strategy):
         if tf in {"30m", "1h"}:
             self.trend_threshold *= 1.5
 
-        self.min_volatility = kwargs.get("min_volatility", 0.0)
+        min_vol_param = kwargs.get("min_volatility")
+        if min_vol_param is None:
+            self.min_volatility: float | None = None
+        else:
+            try:
+                self.min_volatility = float(min_vol_param)
+            except (TypeError, ValueError):
+                self.min_volatility = None
         self.only_buy_dip = kwargs.get("only_buy_dip", tf in {"30m", "1h"})
         default_time_stop_bars = 0.0
         min_time_stop_bars = 1
@@ -113,6 +122,34 @@ class MeanReversion(Strategy):
         self._time_stop_minutes = self._time_stop_target_bars * tf_minutes if self._time_stop_target_bars else 0
         self.time_stop = 0
         self._open_bars: dict[str, int] = {}
+        vol_floor_window_param = kwargs.get("vol_floor_window")
+        if vol_floor_window_param is None:
+            vol_floor_window = max(self.rsi_n, 20)
+        else:
+            vol_floor_window = int(vol_floor_window_param)
+        self._vol_floor_window = vol_floor_window
+        quantile_param = kwargs.get("vol_floor_quantile", 0.2)
+        try:
+            quantile = float(quantile_param)
+        except (TypeError, ValueError):
+            quantile = 0.2
+        self._vol_floor_quantile = min(max(quantile, 0.0), 1.0)
+        min_periods_param = kwargs.get("vol_floor_min_periods")
+        if min_periods_param is None:
+            if self._vol_floor_window > 0:
+                default_min_periods = max(1, min(self._vol_floor_window, self.rsi_n))
+            else:
+                default_min_periods = 0
+        else:
+            default_min_periods = int(min_periods_param)
+        if self._vol_floor_window > 0:
+            self._vol_floor_min_periods = max(
+                1, min(default_min_periods, self._vol_floor_window)
+            )
+        else:
+            self._vol_floor_min_periods = 0
+        self._rq = RollingQuantileCache()
+        self._vol_floor_last: dict[tuple[str, str], float] = {}
         self.risk_service = kwargs.get("risk_service")
 
     def auto_threshold(self, rsi_series: pd.Series) -> tuple[float, float]:
@@ -166,8 +203,50 @@ class MeanReversion(Strategy):
             else pd.Series(dtype=float)
         )
         vol = float(vol_series.iloc[-1]) if len(vol_series) else 0.0
-        if vol * 10000 < self.min_volatility:
-            return None
+        vol_bps = vol * 10000.0
+        bar["volatility_bps"] = vol_bps if math.isfinite(vol_bps) else None
+        scaled_floor: float | None = None
+        floor_candidates: list[float] = []
+        if self.min_volatility is not None and self.min_volatility > 0:
+            floor_candidates.append(float(self.min_volatility))
+        symbol = str(bar.get("symbol") or "")
+        tf_label = str(bar_timeframe)
+        if self._vol_floor_window > 0 and symbol:
+            rq = self._rq.get(
+                symbol,
+                f"volatility_floor:{tf_label}",
+                window=max(1, self._vol_floor_window),
+                q=self._vol_floor_quantile,
+                min_periods=self._vol_floor_min_periods or None,
+            )
+            dynamic_candidate: float | None = None
+            if math.isfinite(vol_bps):
+                dynamic_value = float(rq.update(vol_bps))
+                if math.isfinite(dynamic_value) and dynamic_value > 0:
+                    dynamic_candidate = dynamic_value
+            if dynamic_candidate is not None:
+                floor_candidates.append(dynamic_candidate)
+                self._vol_floor_last[(symbol, tf_label)] = dynamic_candidate
+            else:
+                prev = self._vol_floor_last.get((symbol, tf_label))
+                if prev is not None and prev > 0:
+                    floor_candidates.append(prev)
+        floor_bps = max(floor_candidates) if floor_candidates else None
+        if floor_bps is not None and floor_bps > 0:
+            scale_factor = 1.0
+            base_minutes = self._base_timeframe_minutes
+            if base_minutes > 0 and tf_minutes > 0:
+                scale_factor = math.sqrt(tf_minutes / base_minutes)
+            scaled_floor = floor_bps * scale_factor
+            bar["volatility_floor_bps"] = scaled_floor
+        else:
+            bar["volatility_floor_bps"] = None
+        if (
+            scaled_floor is not None
+            and math.isfinite(vol_bps)
+            and vol_bps < scaled_floor
+        ):
+            return self.finalize_signal(bar, price, None)
         abs_price = max(abs(price), 1e-9)
         price_vol = abs_price * vol if math.isfinite(vol) and vol > 0 else 0.0
         bar["volatility"] = price_vol

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -179,3 +179,112 @@ def test_mean_reversion_multi_timeframe_time_stop(monkeypatch):
     assert exit_sig.side == "sell"
     assert strat.time_stop == expected_bars
     assert strat._open_bars[symbol] == expected_bars
+
+
+def test_mean_reversion_volatility_floor_blocks_low_vol(monkeypatch):
+    high_prices = [100, 112, 94, 118, 90, 122, 88, 126]
+    low_prices = [100.0, 100.1, 99.95, 100.08, 100.02, 100.05, 100.01, 100.03]
+    high_df = pd.DataFrame({"close": high_prices})
+    low_df = pd.DataFrame({"close": low_prices})
+
+    def fake_rsi(df: pd.DataFrame, n: int) -> pd.Series:  # noqa: ANN001
+        pattern = [70.0 if i % 2 == 0 else 30.0 for i in range(len(df))]
+        return pd.Series(pattern, index=df.index)
+
+    monkeypatch.setattr(mr, "rsi", fake_rsi)
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60, 40))
+
+    symbol = "TEST"
+    strat = MeanReversion(
+        timeframe="3m",
+        rsi_n=5,
+        vol_floor_window=4,
+        vol_floor_min_periods=1,
+        vol_floor_quantile=0.4,
+    )
+    baseline = MeanReversion(timeframe="3m", rsi_n=5, vol_floor_window=0)
+
+    warm_bar = {"window": high_df, "symbol": symbol, "timeframe": "3m"}
+    strat.on_bar(warm_bar.copy())
+    strat.on_bar(warm_bar.copy())
+    baseline.on_bar(warm_bar.copy())
+
+    baseline_bar = {"window": low_df, "symbol": symbol, "timeframe": "3m"}
+    base_sig = baseline.on_bar(baseline_bar)
+    assert base_sig is not None
+
+    filtered_bar = {"window": low_df, "symbol": symbol, "timeframe": "3m"}
+    filtered_sig = strat.on_bar(filtered_bar)
+    assert filtered_sig is None
+    assert filtered_bar["volatility_floor_bps"] is not None
+    assert filtered_bar["volatility_bps"] < filtered_bar["volatility_floor_bps"]
+
+
+def test_mean_reversion_dynamic_floor_reduces_backtest_fees(monkeypatch):
+    high_prices = [100, 114, 92, 120, 88, 126, 84, 130, 82, 134]
+    low_prices = [100.0, 100.2, 99.95, 100.15, 100.05, 100.12, 100.02, 100.08, 100.01, 100.06]
+    closes = high_prices + low_prices
+    df = pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 0.6 for c in closes],
+            "low": [c - 0.6 for c in closes],
+            "close": closes,
+            "volume": [500.0] * len(closes),
+        }
+    )
+    split_index = len(high_prices)
+
+    def fake_rsi(df: pd.DataFrame, n: int) -> pd.Series:  # noqa: ANN001
+        pattern = [70.0 if i % 2 == 0 else 30.0 for i in range(len(df))]
+        return pd.Series(pattern, index=df.index)
+
+    monkeypatch.setattr(mr, "rsi", fake_rsi)
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60, 40))
+
+    fee_rate = 0.001
+    symbol = "TEST"
+
+    def run_strategy(vol_window: int) -> tuple[float, int, list[bool]]:
+        risk = ClampRiskService()
+        strat = MeanReversion(
+            timeframe="3m",
+            rsi_n=5,
+            vol_floor_window=vol_window,
+            vol_floor_min_periods=1,
+            vol_floor_quantile=0.4,
+            risk_service=risk,
+        )
+        total_fee = 0.0
+        low_vol_signals = 0
+        low_vol_flags: list[bool] = []
+        for end in range(strat.rsi_n + 1, len(df) + 1):
+            window = df.iloc[:end]
+            bar = {"window": window, "symbol": symbol, "timeframe": "3m"}
+            sig = strat.on_bar(bar)
+            if end - 1 >= split_index and sig is not None:
+                low_vol_signals += 1
+                low_vol_flags.append(True)
+            elif end - 1 >= split_index:
+                low_vol_flags.append(False)
+            if sig is None:
+                continue
+            price = float(window["close"].iloc[-1])
+            qty = (
+                strat.trade.get("qty")
+                if getattr(strat, "trade", None)
+                else float(sig.strength)
+            )
+            total_fee += abs(price * qty) * fee_rate
+        return total_fee, low_vol_signals, low_vol_flags
+
+    baseline_fee, baseline_low, baseline_flags = run_strategy(0)
+    filtered_fee, filtered_low, filtered_flags = run_strategy(4)
+
+    assert baseline_low > 0
+    assert filtered_low < baseline_low
+    assert filtered_fee < baseline_fee
+    assert len(filtered_flags) == len(baseline_flags) == len(low_prices)
+    assert sum(filtered_flags) == filtered_low
+    assert sum(baseline_flags) == baseline_low
+    assert all(flag is False for flag in filtered_flags[1:])


### PR DESCRIPTION
## Summary
- add a per-symbol rolling quantile volatility floor that scales across timeframes in the mean reversion strategy
- surface the computed floor in bar metadata while preserving manual fallbacks
- add regression tests covering low-volatility filtering and reduced 3m backtest fees

## Testing
- pytest tests/test_mean_reversion.py -q
- pytest tests/test_basic_strategies.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da7cf2aa80832d98df2e36d6d8bd47