### PR TITLE
Refine momentum limit anchoring and add breakout regression

### DIFF
--- a/src/tradingbot/strategies/momentum.py
+++ b/src/tradingbot/strategies/momentum.py
@@ -72,6 +72,105 @@ def _pivot_price(df: pd.DataFrame, side: str, lookback: int = 5) -> float | None
         return None
     return result if math.isfinite(result) else None
 
+
+def _configure_limit(
+    side: str,
+    price: float,
+    anchor_price: float,
+    atr_val: float,
+    bar: dict,
+) -> tuple[float, dict[str, float]]:
+    """Return limit metadata anchored around the best quote.
+
+    Parameters
+    ----------
+    side:
+        Order side, ``"buy"`` or ``"sell"``.
+    price:
+        Latest traded price.
+    anchor_price:
+        Reference price derived from the best bid/ask or an internal pivot.
+    atr_val:
+        Latest Average True Range value.
+    bar:
+        Bar payload passed to :meth:`Momentum.on_bar` containing optional
+        ``tick_size`` information.
+    """
+
+    try:
+        tick_size = float(bar.get("tick_size", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        tick_size = 0.0
+    if not math.isfinite(tick_size) or tick_size <= 0:
+        tick_size = 0.0
+
+    atr_abs = abs(float(atr_val)) if math.isfinite(atr_val) else 0.0
+    abs_price = max(abs(float(price)), 1e-9)
+    anchor_gap = abs(float(anchor_price) - price)
+
+    base_unit = max(abs_price * 0.00025, tick_size * 2 if tick_size else 0.0)
+    atr_unit = atr_abs * 0.5 if atr_abs > 0 else 0.0
+    limit_span = max(base_unit, atr_unit)
+    if anchor_gap > 0:
+        limit_span = max(limit_span, anchor_gap * 0.5)
+    if atr_abs > 0:
+        limit_span = min(limit_span, atr_abs)
+    if not math.isfinite(limit_span) or limit_span <= 0:
+        limit_span = base_unit if base_unit > 0 else max(abs_price * 0.00025, 1e-6)
+    if tick_size:
+        limit_span = max(limit_span, tick_size)
+
+    if side == "buy":
+        base_price = max(0.0, anchor_price - limit_span)
+    else:
+        base_price = anchor_price + limit_span
+
+    initial_offset = max(
+        limit_span * 0.65,
+        atr_abs * 0.35 if atr_abs > 0 else 0.0,
+        tick_size * 1.5 if tick_size else 0.0,
+        abs_price * 0.0002,
+    )
+    initial_offset = min(initial_offset, limit_span)
+
+    step_offset = max(
+        limit_span * 0.25,
+        atr_abs * 0.2 if atr_abs > 0 else 0.0,
+        tick_size if tick_size else 0.0,
+        abs_price * 0.0001,
+    )
+    step_offset = min(step_offset, limit_span)
+
+    maker_initial = max(
+        initial_offset,
+        min(limit_span, max(limit_span * 0.75, atr_abs * 0.4 if atr_abs > 0 else 0.0)),
+    )
+
+    direction = 1.0 if side == "buy" else -1.0
+    limit_price = base_price + direction * initial_offset
+    if side == "buy":
+        limit_price = min(limit_price, anchor_price)
+    else:
+        limit_price = max(limit_price, anchor_price)
+
+    meta: dict[str, float | bool] = {
+        "base_price": base_price,
+        "limit_offset": limit_span,
+        "initial_offset": initial_offset,
+        "offset_step": step_offset,
+        "max_offset": limit_span,
+        "maker_initial_offset": maker_initial,
+        "maker_patience": 2,
+        "step_mult": 0.5,
+        "chase": True,
+        "post_only": True,
+        "anchor_price": anchor_price,
+    }
+    if tick_size:
+        meta["tick_size"] = tick_size
+
+    return limit_price, meta
+
 PARAM_INFO = {
     "rsi_n": "Ventana para el cálculo del RSI",
     "min_volume": "Volumen mínimo requerido",
@@ -285,44 +384,9 @@ class Momentum(Strategy):
         if anchor_price is None or anchor_price <= 0:
             anchor_price = price
 
-        limit_span = max(price * 0.001, atr_val * 0.5)
-        limit_span = max(limit_span, abs(price - anchor_price))
-        limit_span = max(limit_span, price * 0.0005)
-        if not math.isfinite(limit_span) or limit_span <= 0:
-            limit_span = max(abs(price) * 0.0005, 1e-6)
-
-        if side == "buy":
-            base_price = max(0.0, anchor_price - limit_span)
-        else:
-            base_price = anchor_price + limit_span
-
-        initial_offset = max(limit_span * 0.4, price * 0.0003, atr_val * 0.25)
-        initial_offset = min(initial_offset, limit_span)
-        step_offset = max(limit_span * 0.25, price * 0.0002)
-        step_offset = min(step_offset, limit_span)
-        maker_initial = max(price * 0.0002, min(initial_offset * 0.5, limit_span))
-
-        direction = 1.0 if side == "buy" else -1.0
-        limit_price = base_price + direction * initial_offset
-        if side == "buy":
-            limit_price = min(limit_price, anchor_price)
-        else:
-            limit_price = max(limit_price, anchor_price)
+        limit_price, meta = _configure_limit(side, price, anchor_price, atr_val, bar)
         sig.limit_price = max(0.0, limit_price)
-        sig.metadata.update(
-            {
-                "base_price": base_price,
-                "limit_offset": abs(limit_span),
-                "initial_offset": abs(initial_offset),
-                "offset_step": abs(step_offset),
-                "max_offset": abs(limit_span),
-                "maker_initial_offset": abs(maker_initial),
-                "maker_patience": 1,
-                "step_mult": 0.5,
-                "chase": True,
-                "post_only": True,
-            }
-        )
+        sig.metadata.update(meta)
         sig.post_only = True
 
         if self.risk_service is not None:

--- a/tests/test_momentum_limit_price.py
+++ b/tests/test_momentum_limit_price.py
@@ -1,9 +1,12 @@
 import math
 
+import math
+
 import pandas as pd
 
 import tradingbot.strategies.momentum as momentum_module
 from tradingbot.execution.order_types import Order
+from tradingbot.strategies import STRATEGIES
 from tradingbot.strategies.momentum import Momentum
 
 
@@ -89,9 +92,10 @@ def test_momentum_sets_maker_limit_and_clamps_size(monkeypatch):
     assert risk.calls and risk.calls[0].get("clamp") is True
 
     meta = sig.metadata
-    anchor = meta["base_price"] + meta["limit_offset"]
+    anchor = meta["anchor_price"]
     assert math.isclose(anchor, best_bid, rel_tol=1e-9, abs_tol=1e-9)
     assert sig.limit_price <= anchor + 1e-9
+    assert anchor - sig.limit_price <= bar["atr"] + 1e-9
 
     order = Order("X", sig.side, "limit", 1.0, price=sig.limit_price, post_only=sig.post_only)
     res = {"price": best_bid, "pending_qty": order.qty}
@@ -101,3 +105,165 @@ def test_momentum_sets_maker_limit_and_clamps_size(monkeypatch):
         assert order.price <= anchor + 1e-9
 
     assert math.isclose(strat.trade["qty"], sig.strength, rel_tol=1e-9, abs_tol=1e-9)
+
+
+def _breakout_window() -> pd.DataFrame:
+    base = 200.0
+    closes = [base - 0.2 * i for i in range(17)]
+    closes.append(closes[-1] + 15.0)
+    closes.append(closes[-1] + 3.0)
+    highs = [c + 0.8 for c in closes]
+    lows = [c - 0.9 for c in closes]
+    lows[-1] = closes[-1] - 4.2
+    highs[-1] = closes[-1] + 1.2
+    bids = [c - 0.05 for c in closes]
+    asks = [c + 0.05 for c in closes]
+    volumes = [25.0] * 17 + [120.0, 80.0]
+    return pd.DataFrame(
+        {
+            "timestamp": list(range(len(closes))),
+            "open": closes,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": volumes,
+            "bid": bids,
+            "ask": asks,
+        }
+    )
+
+
+def _legacy_limit(side, price, anchor, atr_val, bar):  # noqa: ANN001
+    limit_span = max(price * 0.001, atr_val * 0.5)
+    limit_span = max(limit_span, abs(price - anchor))
+    limit_span = max(limit_span, price * 0.0005)
+    if not math.isfinite(limit_span) or limit_span <= 0:
+        limit_span = max(abs(price) * 0.0005, 1e-6)
+
+    if side == "buy":
+        base_price = max(0.0, anchor - limit_span)
+    else:
+        base_price = anchor + limit_span
+
+    initial_offset = max(limit_span * 0.4, price * 0.0003, atr_val * 0.25)
+    initial_offset = min(initial_offset, limit_span)
+    step_offset = max(limit_span * 0.25, price * 0.0002)
+    step_offset = min(step_offset, limit_span)
+    maker_initial = max(price * 0.0002, min(initial_offset * 0.5, limit_span))
+
+    direction = 1.0 if side == "buy" else -1.0
+    limit_price = base_price + direction * initial_offset
+    if side == "buy":
+        limit_price = min(limit_price, anchor)
+    else:
+        limit_price = max(limit_price, anchor)
+
+    meta = {
+        "base_price": base_price,
+        "limit_offset": abs(limit_span),
+        "initial_offset": abs(initial_offset),
+        "offset_step": abs(step_offset),
+        "max_offset": abs(limit_span),
+        "maker_initial_offset": abs(maker_initial),
+        "maker_patience": 1,
+        "step_mult": 0.5,
+        "chase": True,
+        "post_only": True,
+        "anchor_price": anchor,
+    }
+    return limit_price, meta
+
+
+def test_momentum_breakout_backtest_improves_fills(monkeypatch):
+    monkeypatch.setattr(momentum_module, "MIN_BARS", 3)
+
+    df = _breakout_window()
+    bar = {
+        "window": df.iloc[:-1],
+        "timeframe": "1m",
+        "symbol": "X",
+        "volatility": 0.0,
+        "bid": float(df["bid"].iloc[-2]),
+        "ask": float(df["ask"].iloc[-2]),
+        "tick_size": 0.01,
+    }
+
+    strat = Momentum(
+        fast_ema=2,
+        slow_ema=4,
+        rsi_n=3,
+        atr_n=3,
+        roc_n=1,
+        vol_window=4,
+        min_volume=0,
+        min_volatility=0,
+        use_rsi=False,
+    )
+    sig = strat.on_bar(bar)
+    assert sig is not None and sig.side == "buy"
+    anchor = sig.metadata["anchor_price"]
+    assert anchor - sig.limit_price <= bar["atr"] + 1e-9
+
+    orig_cls = momentum_module.Momentum
+
+    class BacktestMomentum(orig_cls):
+        name = "momentum"
+
+        def __init__(self, **kwargs):
+            kwargs.setdefault("fast_ema", 2)
+            kwargs.setdefault("slow_ema", 4)
+            kwargs.setdefault("rsi_n", 3)
+            kwargs.setdefault("atr_n", 3)
+            kwargs.setdefault("roc_n", 1)
+            kwargs.setdefault("vol_window", 4)
+            kwargs.setdefault("min_volume", 0)
+            kwargs.setdefault("min_volatility", 0)
+            kwargs.setdefault("use_rsi", False)
+            super().__init__(**kwargs)
+
+        def on_bar(self, bar):  # noqa: D401
+            window = bar.get("window")
+            if isinstance(window, pd.DataFrame) and not window.empty:
+                if "bid" in window.columns:
+                    bar.setdefault("bid", float(window["bid"].iloc[-1]))
+                if "ask" in window.columns:
+                    bar.setdefault("ask", float(window["ask"].iloc[-1]))
+            bar.setdefault("tick_size", 0.01)
+            return super().on_bar(bar)
+
+    monkeypatch.setitem(STRATEGIES, "momentum", BacktestMomentum)
+
+    from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+
+    new_engine = EventDrivenBacktestEngine(
+        {"X": df},
+        [("momentum", "X")],
+        latency=0,
+        window=17,
+        verbose_fills=True,
+        exchange_configs={"default": {"tick_size": 0.01}},
+        risk_pct=0.01,
+    )
+    new_res = new_engine.run()
+    new_orders = new_res["orders"]
+    assert new_orders
+    breakout_low = float(df["low"].iloc[-1])
+    new_fills = sum(1 for order in new_orders if breakout_low <= order["place_price"] + 1e-9)
+
+    legacy_helper = _legacy_limit
+    monkeypatch.setattr(momentum_module, "_configure_limit", legacy_helper)
+
+    legacy_engine = EventDrivenBacktestEngine(
+        {"X": df},
+        [("momentum", "X")],
+        latency=0,
+        window=17,
+        verbose_fills=True,
+        exchange_configs={"default": {"tick_size": 0.01}},
+        risk_pct=0.01,
+    )
+    legacy_res = legacy_engine.run()
+    legacy_orders = legacy_res["orders"]
+    legacy_fills = sum(1 for order in legacy_orders if breakout_low <= order["place_price"] + 1e-9)
+
+    assert new_fills > legacy_fills


### PR DESCRIPTION
## Summary
- center momentum maker limits around the best quote using ATR- and tick-size-aware offsets
- update momentum metadata to keep the requoter effective with tighter spreads
- add a breakout regression that compares new and legacy offsets to ensure fills stay within one ATR of the quote

## Testing
- pytest tests/test_momentum_limit_price.py

------
https://chatgpt.com/codex/tasks/task_e_68da7ceb7304832daf86bd6aa18d2f07