### PR TITLE
Allow configuring min strength for HFT sizing

### DIFF
--- a/src/tradingbot/strategies/base.py
+++ b/src/tradingbot/strategies/base.py
@@ -72,7 +72,21 @@ class Strategy(ABC):
     name: str
     max_signal_strength: float = 3.0
     min_signal_strength: float = 0.3
-    min_strength_fraction: float = 0.1
+    min_strength_fraction: float = 0.0
+
+    def __init__(self, *, min_strength_fraction: float | None = None) -> None:
+        """Initialise common strategy parameters."""
+
+        if min_strength_fraction is None:
+            return
+
+        try:
+            value = float(min_strength_fraction)
+        except (TypeError, ValueError):
+            return
+        if not math.isfinite(value):
+            return
+        self.min_strength_fraction = float(min(max(0.0, value), 1.0))
 
     @abstractmethod
     def on_bar(self, bar: dict[str, Any]) -> Signal | None:

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -85,10 +85,12 @@ class ScalpPingPong(Strategy):
         **kwargs,
     ):
         params = {**load_params(config_path), **kwargs}
-        params.pop("risk_service", None)
-        tf = str(params.pop("timeframe", kwargs.get("timeframe", "1m")))
+        risk_service = params.pop("risk_service", None)
+        min_strength_param = params.pop("min_strength_fraction", None)
+        super().__init__(min_strength_fraction=min_strength_param)
+        tf = str(params.pop("timeframe", "1m"))
         self.cfg = cfg or ScalpPingPongConfig(**params)
-        self.risk_service = kwargs.get("risk_service")
+        self.risk_service = risk_service
         self.timeframe = tf
 
     def _calc_zscore(self, closes: pd.Series, lookback: int) -> float:
@@ -172,10 +174,15 @@ class ScalpPingPong(Strategy):
             strength = max(0.3, min(2.5, abs(z) / z_sell))
         else:
             return None
-        raw_size = max(0.3, min(3.0, strength * vol_size))
+        raw_size = max(0.0, min(3.0, strength * vol_size))
         if raw_size <= 0:
             return self.finalize_signal(bar, price, None)
-        normalized = min(1.0, max(self.min_strength_fraction, raw_size / self.max_signal_strength))
+        if self.max_signal_strength <= 0:
+            return self.finalize_signal(bar, price, None)
+        normalized = raw_size / self.max_signal_strength
+        if normalized < self.min_strength_fraction:
+            return self.finalize_signal(bar, price, None)
+        normalized = min(1.0, normalized)
         sig = Signal(side, normalized)
         base_price = price
         best_bid = bar.get("bid")

--- a/tests/backtesting/test_min_strength_fraction.py
+++ b/tests/backtesting/test_min_strength_fraction.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.strategies.base import Strategy, Signal
+from tradingbot.strategies import STRATEGIES
+
+
+def test_min_strength_fraction_filters_small_signals(monkeypatch):
+    class StrengthSequenceBase(Strategy):
+        name = "seq_base"
+        max_signal_strength = 1.0
+        strengths: list[float] = []
+        min_strength_fraction = 0.05
+
+        def __init__(self, *, risk_service=None, timeframe: str | None = None, **kwargs):
+            super().__init__(**kwargs)
+            self.risk_service = None
+            if timeframe is not None:
+                self.timeframe = timeframe
+            self._i = 0
+
+        def _next_raw(self) -> float | None:
+            if self._i >= len(self.strengths):
+                return None
+            raw = self.strengths[self._i]
+            self._i += 1
+            return raw
+
+        def _normalise(self, raw: float) -> float | None:
+            raise NotImplementedError
+
+        def on_bar(self, bar: dict) -> Signal | None:
+            raw = self._next_raw()
+            if raw is None or raw <= 0:
+                return None
+            price = float(bar["window"]["close"].iloc[-1])
+            strength = self._normalise(raw)
+            if strength is None:
+                return None
+            sig = Signal("buy", strength)
+            sig.limit_price = price
+            return sig
+
+    class SequentialHFT(StrengthSequenceBase):
+        name = "sequential_hft"
+
+        def _normalise(self, raw: float) -> float | None:
+            if self.max_signal_strength <= 0:
+                return None
+            strength = raw / self.max_signal_strength
+            if strength < self.min_strength_fraction:
+                return None
+            return min(1.0, strength)
+
+    class LegacySequentialHFT(StrengthSequenceBase):
+        name = "legacy_sequential_hft"
+
+        def _normalise(self, raw: float) -> float | None:
+            if self.max_signal_strength <= 0:
+                return None
+            strength = raw / self.max_signal_strength
+            strength = max(self.min_strength_fraction, strength)
+            return min(1.0, strength)
+
+    monkeypatch.setitem(STRATEGIES, SequentialHFT.name, SequentialHFT)
+    monkeypatch.setitem(STRATEGIES, LegacySequentialHFT.name, LegacySequentialHFT)
+
+    strengths = [0.02, 0.06, 0.5, 0.04, 0.2]
+    SequentialHFT.strengths = strengths.copy()
+    LegacySequentialHFT.strengths = strengths.copy()
+
+    length = len(strengths) + 2
+    closes = [100 + i * 0.1 for i in range(length)]
+    data = pd.DataFrame(
+        {
+            "timestamp": range(length),
+            "open": closes,
+            "high": [c + 0.2 for c in closes],
+            "low": [c - 0.2 for c in closes],
+            "close": closes,
+            "volume": [1_000] * length,
+        }
+    )
+
+    engine_new = EventDrivenBacktestEngine(
+        {"SYM": data},
+        [(SequentialHFT.name, "SYM")],
+        window=1,
+        latency=0,
+        verbose_fills=True,
+        risk_pct=0.01,
+    )
+    result_new = engine_new.run()
+
+    engine_legacy = EventDrivenBacktestEngine(
+        {"SYM": data},
+        [(LegacySequentialHFT.name, "SYM")],
+        window=1,
+        latency=0,
+        verbose_fills=True,
+        risk_pct=0.01,
+    )
+    result_legacy = engine_legacy.run()
+
+    fills_new = [fill for fill in result_new["fills"] if fill[1] == "order"]
+    fills_legacy = [fill for fill in result_legacy["fills"] if fill[1] == "order"]
+
+    below_threshold = sum(1 for raw in strengths if raw < SequentialHFT.min_strength_fraction)
+    assert len(fills_new) == len(strengths) - below_threshold
+    assert len(fills_new) < len(fills_legacy)


### PR DESCRIPTION
## Summary
- allow all strategies to accept a configurable `min_strength_fraction` with a default of 0.0
- update ScalpPingPong sizing to drop orders below the configurable threshold instead of forcing tiny fills
- add a backtest regression that compares legacy and new sizing to ensure sub-5% signals no longer generate fills

## Testing
- PYTHONPATH=src pytest tests/test_scalp_pingpong.py tests/backtesting/test_min_strength_fraction.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d9e3faabf0832db43c3e2be5024a17