### PR TITLE
Add rolling volatility floor to mean reversion strategy

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -1,9 +1,11 @@
-import pandas as pd
 import math
+
+import pandas as pd
 
 from .base import Strategy, Signal, record_signal_metrics, timeframe_to_minutes
 from ..data.features import rsi
 from ..filters.liquidity import LiquidityFilterManager
+from ..utils.rolling_quantile import RollingQuantileCache
 
 liquidity = LiquidityFilterManager()
 
@@ -96,7 +98,19 @@ class MeanReversion(Strategy):
         shift_cap = float(kwargs.get("trend_rsi_shift_max", 18.0))
         self.trend_rsi_shift_max = max(base_shift, shift_cap) if shift_cap > 0 else base_shift
 
-        self.min_volatility = kwargs.get("min_volatility", 0.0)
+        self.min_volatility = max(0.0, float(kwargs.get("min_volatility", 0.0)))
+        self.vol_floor_quantile = float(kwargs.get("vol_floor_quantile", 0.25))
+        if self.vol_floor_quantile < 0:
+            self.vol_floor_quantile = 0.0
+        default_floor_window = max(40, self.rsi_n * 2)
+        self._vol_floor_window = max(
+            5,
+            int(kwargs.get("vol_floor_window", default_floor_window)),
+        )
+        self._vol_floor_min_periods = max(
+            3,
+            int(kwargs.get("vol_floor_min_periods", max(5, self.rsi_n))),
+        )
         self.only_buy_dip = kwargs.get("only_buy_dip", tf in {"30m", "1h"})
         default_time_stop_bars = 0.0
         min_time_stop_bars = 1
@@ -120,6 +134,22 @@ class MeanReversion(Strategy):
         self.time_stop = 0
         self._open_bars: dict[str, int] = {}
         self.risk_service = kwargs.get("risk_service")
+        self._rq = RollingQuantileCache()
+
+    def _vol_floor_windows(self, tf_minutes: float) -> tuple[int, int]:
+        base_minutes = self._base_timeframe_minutes or tf_minutes
+        if tf_minutes <= 0 or base_minutes <= 0:
+            window = max(5, self._vol_floor_window)
+            min_periods = max(1, min(window, self._vol_floor_min_periods))
+            return window, min_periods
+
+        ratio = tf_minutes / base_minutes
+        ratio = max(ratio, 1e-9)
+        scaled_window = int(math.ceil(self._vol_floor_window / ratio))
+        window = max(5, scaled_window)
+        scaled_min = int(math.ceil(self._vol_floor_min_periods / ratio))
+        min_periods = max(1, min(window, max(1, scaled_min)))
+        return window, min_periods
 
     def auto_threshold(self, rsi_series: pd.Series) -> tuple[float, float]:
         """Derive upper and lower RSI bounds from recent variability."""
@@ -183,7 +213,31 @@ class MeanReversion(Strategy):
         )
         vol = float(vol_series.iloc[-1]) if len(vol_series) else 0.0
         vol_bps = vol * 10000 if math.isfinite(vol) and vol > 0 else 0.0
-        if vol_bps < self.min_volatility:
+
+        vol_floor_bps = self.min_volatility
+        symbol = str(bar.get("symbol", "") or "")
+        if (
+            symbol
+            and self.vol_floor_quantile > 0
+            and math.isfinite(vol_bps)
+        ):
+            window, min_periods = self._vol_floor_windows(tf_minutes)
+            rq = self._rq.get(
+                symbol,
+                "volatility_floor",
+                window=window,
+                q=self.vol_floor_quantile,
+                min_periods=min_periods,
+            )
+            floor_candidate = float(rq.update(float(vol_bps)))
+            if math.isfinite(floor_candidate) and floor_candidate > 0:
+                vol_floor_bps = max(vol_floor_bps, floor_candidate)
+
+        scaled_floor = vol_floor_bps
+        base_minutes = self._base_timeframe_minutes or tf_minutes
+        if vol_floor_bps > 0 and tf_minutes > 0 and base_minutes > 0:
+            scaled_floor = vol_floor_bps * math.sqrt(tf_minutes / base_minutes)
+        if scaled_floor > 0 and vol_bps < scaled_floor:
             return None
         abs_price = max(abs(price), 1e-9)
         price_vol = abs_price * vol if math.isfinite(vol) and vol > 0 else 0.0

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -222,3 +222,91 @@ def test_mean_reversion_multi_timeframe_time_stop(monkeypatch):
     assert exit_sig.side == "sell"
     assert strat.time_stop == expected_bars
     assert strat._open_bars[symbol] == expected_bars
+
+
+def test_low_volatility_windows_block_signals(monkeypatch):
+    monkeypatch.setattr(mr, "rsi", _const_rsi(20))
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60, 40))
+
+    prices = []
+    price = 100.0
+    for idx in range(60):
+        price += 2.0 if idx % 2 == 0 else -2.0
+        prices.append(price)
+    for _ in range(20):
+        price += 0.02
+        prices.append(price)
+
+    windows = [pd.DataFrame({"close": prices[: idx + 1]}) for idx in range(len(prices))]
+
+    strat_filtered = MeanReversion(timeframe="1m", min_volatility=0.0)
+    strat_baseline = MeanReversion(
+        timeframe="1m",
+        min_volatility=0.0,
+        vol_floor_quantile=0.0,
+    )
+
+    filtered = [
+        strat_filtered.on_bar({"window": window, "symbol": "LOW"})
+        for window in windows
+    ]
+    baseline = [
+        strat_baseline.on_bar({"window": window, "symbol": "LOW"})
+        for window in windows
+    ]
+
+    assert any(sig is not None for sig in filtered[:-15])
+    assert all(sig is None for sig in filtered[-5:])
+    assert any(sig is not None for sig in baseline[-5:])
+
+
+def test_mean_reversion_backtest_vol_floor_reduces_fees(monkeypatch):
+    monkeypatch.setattr(mr, "rsi", _const_rsi(20))
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60, 40))
+
+    prices = []
+    segments = []
+    price = 100.0
+    for idx in range(160):
+        price += 1.6 if idx % 2 == 0 else -1.4
+        prices.append(price)
+        segments.append("high")
+    flat_price = price
+    for _ in range(20):
+        price = flat_price
+        prices.append(price)
+        segments.append("low")
+
+    strat_baseline = MeanReversion(
+        timeframe="3m",
+        min_volatility=0.0,
+        vol_floor_quantile=0.0,
+    )
+    strat_filtered = MeanReversion(
+        timeframe="3m",
+        min_volatility=0.0,
+    )
+
+    baseline_fee = 0.0
+    filtered_fee = 0.0
+    baseline_low_signals = 0
+    filtered_low_signals = 0
+    fee_per_trade = 0.0005
+
+    for idx in range(len(prices)):
+        window = pd.DataFrame({"close": prices[: idx + 1]})
+        bar = {"window": window, "symbol": "SIM", "timeframe": "3m"}
+        sig_base = strat_baseline.on_bar(bar)
+        sig_filt = strat_filtered.on_bar(bar)
+        if sig_base is not None:
+            baseline_fee += abs(sig_base.strength) * fee_per_trade
+            if segments[idx] == "low":
+                baseline_low_signals += 1
+        if sig_filt is not None:
+            filtered_fee += abs(sig_filt.strength) * fee_per_trade
+            if segments[idx] == "low":
+                filtered_low_signals += 1
+
+    assert baseline_low_signals > 0
+    assert filtered_low_signals == 0
+    assert filtered_fee < baseline_fee


### PR DESCRIPTION
## Summary
- track recent volatility per symbol with a RollingQuantileCache to derive a dynamic floor in basis points
- scale the volatility floor by timeframe duration before gating new signals
- add regression tests covering low-volatility windows and a 3m simulated backtest to confirm reduced fees

## Testing
- PYTHONPATH=src pytest tests/test_mean_reversion.py -q

------
https://chatgpt.com/codex/tasks/task_e_68daa5f7228c832dadd20e094ced1313