### PR TITLE
Relax mean reversion confirmation and add 15m backtest

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -10,16 +10,29 @@ from ..utils.rolling_quantile import RollingQuantileCache
 liquidity = LiquidityFilterManager()
 
 
-def _normalized_strength(raw: float, *, center: float = 0.8) -> float:
+def _normalized_strength(raw: float, *, center: float = 0.68) -> float:
+    """Map the raw strength into ``[0, 1]`` with a smooth non-linear scale."""
+
     if not math.isfinite(raw) or raw <= 0:
         return 0.0
-    scaled = math.log1p(raw)
-    adjusted = scaled - center
+
+    stretch = 1.25
+    slope = 1.65
+
+    scaled = math.log1p(raw * stretch)
+    adjusted = (scaled - center) * slope
+
     try:
-        val = 1.0 / (1.0 + math.exp(-adjusted))
+        logistic = 1.0 / (1.0 + math.exp(-adjusted))
     except OverflowError:
-        val = 1.0 if adjusted > 0 else 0.0
-    return max(0.0, min(1.0, val))
+        logistic = 1.0 if adjusted > 0 else 0.0
+
+    baseline = 1.0 / (1.0 + math.exp(center * slope))
+    if logistic <= baseline:
+        return 0.0
+
+    normalised = (logistic - baseline) / (1.0 - baseline)
+    return max(0.0, min(1.0, normalised))
 
 
 def _best_quote(bar: dict, side: str) -> float | None:
@@ -170,6 +183,71 @@ class MeanReversion(Strategy):
             return min(offset, self.trend_rsi_shift_max)
         return offset
 
+    def _confirm_reversal(
+        self,
+        price_series: pd.Series,
+        rsi_series: pd.Series,
+        side: str,
+    ) -> bool:
+        """Relaxed reversal confirmation for 5m/15m bars.
+
+        Historically the strategy required the immediately previous tick to
+        point in the opposite direction before acting on an RSI excursion.  On
+        medium intraday bars (5m/15m) that filter was too strict and often
+        missed fills even when short term momentum had already stalled.
+
+        We now confirm the reversal whenever a short moving average or a small
+        tolerance band indicates exhaustion, giving a slightly wider window for
+        execution while still blocking momentum trades.
+        """
+
+        if self.timeframe not in {"5m", "15m"}:
+            return True
+        if side not in {"buy", "sell"}:
+            return True
+        if len(price_series) < 2 or len(rsi_series) < 2:
+            return False
+
+        last_price = float(price_series.iloc[-1])
+        prev_price = float(price_series.iloc[-2])
+        last_rsi = float(rsi_series.iloc[-1])
+        prev_rsi = float(rsi_series.iloc[-2])
+
+        price_tol = 0.001 if self.timeframe == "5m" else 0.0015
+        rsi_tol = 0.7 if self.timeframe == "5m" else 0.9
+
+        ma_window = 3 if self.timeframe == "5m" else 4
+        price_ma = price_series.rolling(ma_window, min_periods=1).mean()
+        rsi_ma = rsi_series.rolling(ma_window, min_periods=1).mean()
+
+        price_ma_curr = float(price_ma.iloc[-1])
+        price_ma_prev = float(price_ma.iloc[-2]) if len(price_ma) >= 2 else prev_price
+        rsi_ma_curr = float(rsi_ma.iloc[-1])
+        rsi_ma_prev = float(rsi_ma.iloc[-2]) if len(rsi_ma) >= 2 else prev_rsi
+
+        price_change = 0.0
+        if prev_price:
+            price_change = (last_price - prev_price) / prev_price
+
+        price_ma_slope = price_ma_curr - price_ma_prev
+        rsi_ma_slope = rsi_ma_curr - rsi_ma_prev
+
+        if side == "sell":
+            return (
+                price_change <= price_tol
+                or price_ma_slope <= last_price * price_tol
+                or last_rsi <= prev_rsi + rsi_tol
+                or rsi_ma_slope <= rsi_tol
+            )
+
+        # side == "buy"
+        return (
+            price_change >= -price_tol
+            or price_ma_slope >= -last_price * price_tol
+            or last_rsi >= prev_rsi - rsi_tol
+            or rsi_ma_slope >= -rsi_tol
+        )
+
     @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
         df: pd.DataFrame = bar["window"]
@@ -284,22 +362,15 @@ class MeanReversion(Strategy):
         elif trend_dir == -1:
             lower -= trend_offset
 
-        prev_rsi = rsi_series.iloc[-2]
-        prev_price = float(price_series.iloc[-2])
-
         raw_strength = 0.0
         if last_rsi > upper:
-            if self.timeframe in {"5m", "15m"} and not (
-                prev_rsi > last_rsi and price < prev_price
-            ):
+            if not self._confirm_reversal(price_series, rsi_series, "sell"):
                 return self.finalize_signal(bar, price, None)
             deviation = (last_rsi - upper) / max(1.0, 100 - upper)
             raw_strength = max(0.0, deviation * 3.0)
             side = "sell"
         elif last_rsi < lower:
-            if self.timeframe in {"5m", "15m"} and not (
-                prev_rsi < last_rsi and price > prev_price
-            ):
+            if not self._confirm_reversal(price_series, rsi_series, "buy"):
                 return self.finalize_signal(bar, price, None)
             deviation = (lower - last_rsi) / max(1.0, lower)
             raw_strength = max(0.0, deviation * 3.0)
@@ -310,7 +381,7 @@ class MeanReversion(Strategy):
         if side == "sell" and trend_dir == 1 and self.only_buy_dip:
             return self.finalize_signal(bar, price, None)
 
-        strength = _normalized_strength(raw_strength, center=0.8)
+        strength = _normalized_strength(raw_strength)
         if strength <= 0.0:
             return self.finalize_signal(bar, price, None)
 

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -3,8 +3,12 @@ import math
 import pandas as pd
 from tradingbot.execution.order_types import Order
 from tradingbot.strategies import mean_reversion as mr
-from tradingbot.strategies.base import timeframe_to_minutes
-from tradingbot.strategies.mean_reversion import MeanReversion, generate_signals
+from tradingbot.strategies.base import Signal, timeframe_to_minutes
+from tradingbot.strategies.mean_reversion import (
+    MeanReversion,
+    _normalized_strength,
+    generate_signals,
+)
 
 def test_mean_reversion_on_bar_signals():
     df_down = pd.DataFrame({"close": list(range(20, 0, -1))})
@@ -310,3 +314,86 @@ def test_mean_reversion_backtest_vol_floor_reduces_fees(monkeypatch):
     assert baseline_low_signals > 0
     assert filtered_low_signals == 0
     assert filtered_fee < baseline_fee
+
+
+def test_mean_reversion_relaxed_confirmation_backtest(monkeypatch):
+    prices: list[float] = []
+    rsi_values: list[float] = []
+    base = 100.0
+    for _ in range(4):
+        p0 = base + 0.6
+        p1 = base + 1.1
+        p2 = base + 1.6
+        p3 = p2 * (1 + 0.0012)
+        p4 = p3 - 0.9
+        p5 = p4 - 0.5
+        p6 = p5 - 0.3
+        prices.extend([p0, p1, p2, p3, p4, p5, p6])
+        rsi_values.extend([55.0, 62.0, 68.5, 73.0, 69.5, 61.0, 45.0])
+        base = p6 + 1.0
+
+    df = pd.DataFrame({"close": prices})
+
+    def fake_rsi(data: pd.DataFrame, n: int):  # noqa: ANN001
+        return pd.Series(rsi_values[: len(data)], index=data.index)
+
+    monkeypatch.setattr(mr, "rsi", fake_rsi)
+    monkeypatch.setattr(MeanReversion, "auto_threshold", lambda self, series: (60.0, 40.0))
+
+    strat = MeanReversion(timeframe="15m", rsi_n=5, min_volatility=0.0)
+    closes = df["close"].to_numpy()
+
+    fee_per_trade = 0.0004
+    signals: list[tuple[int, Signal]] = []
+    pnl_total = 0.0
+    fee_total = 0.0
+
+    for idx in range(len(df)):
+        window = df.iloc[: idx + 1]
+        sig = strat.on_bar({"window": window, "timeframe": "15m"})
+        if sig is None:
+            continue
+        signals.append((idx, sig))
+        strength = float(sig.strength)
+        fee_total += abs(strength) * fee_per_trade
+        exit_idx = min(idx + 2, len(df) - 1)
+        entry_price = closes[idx]
+        exit_price = closes[exit_idx]
+        direction = 1.0 if sig.side == "buy" else -1.0
+        pnl_total += direction * (exit_price - entry_price) / entry_price * strength
+
+    assert signals, "Expected at least one fill under relaxed confirmation"
+
+    upper = 60.0
+    strict_indices: list[int] = []
+    strict_fee = 0.0
+    strict_pnl = 0.0
+    for idx in range(1, len(df)):
+        if idx < strat.rsi_n:
+            continue
+        last_rsi = rsi_values[idx]
+        prev_rsi = rsi_values[idx - 1]
+        if last_rsi <= upper:
+            continue
+        if prev_rsi > last_rsi and closes[idx] < closes[idx - 1]:
+            strict_indices.append(idx)
+            deviation = (last_rsi - upper) / max(1.0, 100.0 - upper)
+            raw = max(0.0, deviation * 3.0)
+            strength = _normalized_strength(raw)
+            strict_fee += strength * fee_per_trade
+            exit_idx = min(idx + 2, len(df) - 1)
+            entry_price = closes[idx]
+            exit_price = closes[exit_idx]
+            strict_pnl += (-1.0) * (exit_price - entry_price) / entry_price * strength
+
+    signalled_indices = {idx for idx, _ in signals}
+    assert set(strict_indices) <= signalled_indices
+
+    additional_indices = [idx for idx in signalled_indices if idx not in strict_indices]
+    assert additional_indices, "Relaxed confirmation should add extra fills"
+
+    assert pnl_total >= strict_pnl - 1e-6
+    assert pnl_total > 0
+    assert strict_indices, "Baseline strict confirmation should exist"
+    assert strict_fee > 0
+    assert fee_total <= strict_fee * 2.5


### PR DESCRIPTION
## Summary
- relax the 5m/15m reversal confirmation in mean reversion by using short moving averages and tolerances
- retune raw strength normalisation to keep signal strength consistent after the wider confirmation window
- add a 15m synthetic backtest test covering fills, pnl and fee impact under the relaxed confirmation

## Testing
- pytest tests/test_mean_reversion.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dae8fbe4f0832d981d3615646563db