### PR TITLE
Adjust scalp pingpong signal sizing floor

### DIFF
--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -76,6 +76,7 @@ class ScalpPingPong(Strategy):
     """Mean-reversion scalping strategy using z-score of returns."""
 
     name = "scalp_pingpong"
+    max_signal_strength = 6.0
 
     def __init__(
         self,
@@ -168,10 +169,10 @@ class ScalpPingPong(Strategy):
 
         if z <= -z_buy:
             side = "buy"
-            strength = max(0.3, min(2.5, abs(z) / z_buy))
+            strength = max(0.05, min(2.5, abs(z) / z_buy))
         elif z >= z_sell:
             side = "sell"
-            strength = max(0.3, min(2.5, abs(z) / z_sell))
+            strength = max(0.05, min(2.5, abs(z) / z_sell))
         else:
             return None
         raw_size = max(0.0, min(3.0, strength * vol_size))
@@ -180,7 +181,8 @@ class ScalpPingPong(Strategy):
         if self.max_signal_strength <= 0:
             return self.finalize_signal(bar, price, None)
         normalized = raw_size / self.max_signal_strength
-        if normalized < self.min_strength_fraction:
+        effective_min = self.min_strength_fraction * 0.5
+        if normalized < effective_min:
             return self.finalize_signal(bar, price, None)
         normalized = min(1.0, normalized)
         sig = Signal(side, normalized)


### PR DESCRIPTION
## Summary
- raise the scalp_pingpong strategy cap to allow smaller normalised signals by setting `max_signal_strength` to 6.0 and reducing the per-side strength floor to 0.05
- relax the `min_strength_fraction` gate by checking against half the configured threshold so tiny convictions are ignored without forcing orders

## Testing
- PYTHONPATH=src python - <<'PY'
...custom backtest snippet producing 5m/15m metrics...
PY

------
https://chatgpt.com/codex/tasks/task_e_68daec418244832d9862640c067b7e0e