### PR TITLE
Limit spot allocations when volatility scaling overshoots

### DIFF
--- a/src/tradingbot/core/account.py
+++ b/src/tradingbot/core/account.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -37,7 +41,20 @@ class Account:
     # ------------------------------------------------------------------
     def update_cash(self, delta: float) -> None:
         """Adjust available cash by ``delta``."""
-        self.cash += float(delta)
+
+        amount = float(delta)
+        new_cash = float(self.cash) + amount
+        if (
+            isinstance(self.market_type, str)
+            and self.market_type.lower() == "spot"
+            and amount < 0.0
+            and new_cash < -1e-9
+        ):
+            log.warning(
+                "Spot account debit rejected: delta=%s would leave cash %.2f", amount, new_cash
+            )
+            raise ValueError("spot cash debit would result in negative balance")
+        self.cash = new_cash
 
     def update_position(self, symbol: str, delta_qty: float, price: float | None = None) -> None:
         """Update net position for ``symbol`` and optionally its last price."""

--- a/src/tradingbot/core/risk_manager.py
+++ b/src/tradingbot/core/risk_manager.py
@@ -140,6 +140,12 @@ class RiskManager:
         if volatility is not None and target_volatility is not None and volatility > 0:
             scale = self.effective_risk_pct(volatility, target_volatility) / self.risk_pct
             alloc *= scale
+        market_type = getattr(self.account, "market_type", None)
+        scaled_alloc = alloc
+        if not isinstance(market_type, str) or market_type.lower() != "futures":
+            alloc = min(alloc, balance)
+        else:
+            alloc = scaled_alloc
         if price <= 0:
             return 0.0
         size = alloc / float(price)

--- a/tests/test_core_position_size.py
+++ b/tests/test_core_position_size.py
@@ -125,6 +125,32 @@ def test_calc_position_size_adjusts_with_atr():
     assert low_atr > base
 
 
+def test_spot_position_size_never_exceeds_balance_with_target_volatility():
+    account = Account(float("inf"), cash=1000.0, market_type="spot")
+    rm = CoreRiskManager(account, risk_per_trade=1.5, risk_pct=0.02)
+    price = 100.0
+    size = rm.calc_position_size(
+        1.0,
+        price,
+        volatility=0.5,
+        target_volatility=1.5,
+    )
+    assert size * price <= account.get_available_balance() + 1e-6
+
+
+def test_futures_position_size_still_allows_leverage_with_target_volatility():
+    account = Account(float("inf"), cash=1000.0, market_type="futures")
+    rm = CoreRiskManager(account, risk_per_trade=1.5, risk_pct=0.02)
+    price = 100.0
+    size = rm.calc_position_size(
+        1.0,
+        price,
+        volatility=0.5,
+        target_volatility=1.5,
+    )
+    assert size * price > account.get_available_balance()
+
+
 def test_effective_risk_pct_varies_with_std():
     """Effective risk pct should shrink/grow with volatility changes."""
     account = Account(float("inf"), cash=1000.0)

--- a/tests/test_spot_balance_assertions.py
+++ b/tests/test_spot_balance_assertions.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 
 from tradingbot.backtesting.engine import EventDrivenBacktestEngine, FeeModel
 from tradingbot.risk.service import RiskService
+from tradingbot.risk.portfolio_guard import GuardConfig, PortfolioGuard
 from tradingbot.strategies import STRATEGIES
+from tradingbot.core import Account
 
 
 class BuyOnceStrategy:
@@ -54,10 +56,10 @@ class SneakyFeeModel(FeeModel):
 class CheatingRiskService(RiskService):
     """Risk service that deducts double the sold quantity."""
 
-    def on_fill(self, symbol, side, qty, price=None, venue=None):  # type: ignore[override]
+    def on_fill(self, symbol, side, qty, price=None, venue=None, **kwargs):  # type: ignore[override]
         if side == "sell":
             qty *= 2
-        super().on_fill(symbol, side, qty, price, venue)
+        super().on_fill(symbol, side, qty, price=price, venue=venue, **kwargs)
 
 
 def _make_data():
@@ -89,7 +91,7 @@ def test_buy_order_exceeding_cash_triggers_assert(monkeypatch):
         risk_pct=100.0,
     )
     engine.exchange_fees["default"] = SneakyFeeModel()
-    with pytest.raises(AssertionError, match="cash became negative"):
+    with pytest.raises(ValueError, match="negative balance"):
         engine.run()
 
 
@@ -122,4 +124,33 @@ def test_sell_order_exceeding_position_triggers_assert(monkeypatch):
     engine.risk[("sell_once", "SYM")] = cheat
     with pytest.raises(AssertionError, match="position went negative"):
         engine.run()
+
+
+def test_spot_account_rejects_manual_cash_debit():
+    account = Account(float("inf"), cash=100.0, market_type="spot")
+    with pytest.raises(ValueError, match="negative balance"):
+        account.update_cash(-101.0)
+
+
+def test_spot_risk_service_clamps_target_volatility_size():
+    guard = PortfolioGuard(GuardConfig(venue="test"))
+    account = Account(float("inf"), cash=100.0, market_type="spot")
+    svc = RiskService(
+        guard,
+        account=account,
+        risk_per_trade=1.5,
+        atr_mult=2.0,
+        risk_pct=0.02,
+    )
+    price = 10.0
+    allowed, reason, delta = svc.check_order(
+        "SYM",
+        "buy",
+        price,
+        strength=1.0,
+        volatility=0.5,
+        target_volatility=1.5,
+    )
+    assert allowed is True
+    assert delta * price <= account.get_available_balance() + 1e-6
 


### PR DESCRIPTION
## Summary
- clamp spot allocations in the risk manager after volatility scaling while keeping futures leverage intact
- prevent spot accounts from applying debits that would create negative cash balances and log the rejection
- extend spot-focused tests to cover high target volatility scenarios and validate new safeguards

## Testing
- pytest tests/test_core_position_size.py tests/test_spot_balance_assertions.py

------
https://chatgpt.com/codex/tasks/task_e_68db202272a4832da4a53663ce613b98