### PR TITLE
Add bar participation limits to OHLCV slippage fills

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -184,6 +184,12 @@ class SlippageModel:
     base_spread: float, default ``0.0``
         Fallback spread (absolute price difference) used when bid/ask columns
         are absent, ``NaN`` or when ``source`` is ``"fixed_spread"``.
+    max_bar_participation: float, default ``1.0``
+        Maximum fraction of the bar volume that can be executed when the
+        dataset only has OHLCV information (no depth).
+    min_bar_liquidity: float, default ``0.0``
+        Minimum effective liquidity required to attempt a fill when only
+        OHLCV data is available.
     """
 
     def __init__(
@@ -194,6 +200,8 @@ class SlippageModel:
         source: str = "bba",
         base_spread: float = 0.0,
         pct: float = 0.0001,
+        max_bar_participation: float = 1.0,
+        min_bar_liquidity: float = 0.0,
     ) -> None:
         self.volume_impact = float(volume_impact)
         self.spread_mult = float(spread_mult)
@@ -204,6 +212,12 @@ class SlippageModel:
         self.source = source
         self.base_spread = float(base_spread)
         self.pct = float(pct)
+        self.max_bar_participation = float(max_bar_participation)
+        if self.max_bar_participation < 0:
+            raise ValueError("max_bar_participation must be non-negative")
+        self.min_bar_liquidity = float(min_bar_liquidity)
+        if self.min_bar_liquidity < 0:
+            raise ValueError("min_bar_liquidity must be non-negative")
     def _compute_spread(self, bar: Mapping[str, float] | pd.Series) -> float:
         if self.source == "bba":
             bid = bar.get("bid") or bar.get("bid_px") or bar.get("bid_price")
@@ -315,12 +329,19 @@ class SlippageModel:
             if not partial and exec_qty < qty:
                 return float(price), 0.0, queue_pos_val
         else:
-            if vol <= liquidity_floor:
+            cap = max(0.0, vol * self.max_bar_participation)
+            bar_liquidity = max(cap - queue_pos_val, 0.0)
+            if bar_liquidity < max(self.min_bar_liquidity, liquidity_floor):
                 return float(price), 0.0, queue_pos_val
-            exec_qty = qty
+            exec_qty = min(qty, bar_liquidity)
+            if not partial and exec_qty < qty:
+                return float(price), 0.0, queue_pos_val
         side_is_buy = side == "buy"
         passive = bool(has_depth)
         if not has_depth:
+            if exec_qty <= 0.0:
+                new_queue = max(queue_pos_val + exec_qty - cap, 0.0)
+                return float(price), 0.0, new_queue
             adj_price = _slippage_core(
                 side_is_buy,
                 exec_qty,
@@ -333,7 +354,8 @@ class SlippageModel:
                 self.pct,
                 apply_half_spread=True,
             )
-            return float(adj_price), float(exec_qty), queue_pos_val
+            new_queue = max(queue_pos_val + exec_qty - cap, 0.0)
+            return float(adj_price), float(exec_qty), float(new_queue)
         adj_price, fill_qty, new_queue = _fill_core(
             side_is_buy,
             exec_qty,

--- a/tests/backtesting/test_slippage_microscopic_volume.py
+++ b/tests/backtesting/test_slippage_microscopic_volume.py
@@ -108,3 +108,102 @@ def test_healthy_volume_fill_matches_original_behaviour(monkeypatch):
     )
     expected_slippage = (fill_price - order_summary["place_price"]) * fill_qty
     assert result["slippage"] == pytest.approx(expected_slippage)
+
+
+def test_fill_respects_max_bar_participation():
+    model = SlippageModel(
+        volume_impact=0.0,
+        pct=0.0,
+        max_bar_participation=0.25,
+        min_bar_liquidity=0.0,
+    )
+
+    bar = {"volume": 100.0}
+    qty = 80.0
+    queue_pos = 0.0
+    fills = []
+
+    for _ in range(10):
+        _, fill_qty, queue_pos = model.fill(
+            "buy", qty, 100.0, bar, queue_pos=queue_pos, partial=True
+        )
+        fills.append(fill_qty)
+        qty -= fill_qty
+        if qty <= 1e-9:
+            break
+        # avoid infinite loop in case of regression
+        assert fill_qty > 0
+
+    assert qty <= 1e-9
+    assert fills[:3] == pytest.approx([25.0, 25.0, 25.0])
+    assert fills[3] == pytest.approx(5.0)
+
+
+def test_fill_respects_min_bar_liquidity():
+    model = SlippageModel(
+        volume_impact=0.0,
+        pct=0.0,
+        max_bar_participation=0.1,
+        min_bar_liquidity=2.0,
+    )
+
+    bar = {"volume": 10.0}
+    price, fill_qty, queue_pos = model.fill(
+        "buy", 5.0, 100.0, bar, queue_pos=0.0, partial=True
+    )
+
+    assert fill_qty == pytest.approx(0.0)
+    assert price == pytest.approx(100.0)
+    assert queue_pos == pytest.approx(0.0)
+
+
+def test_engine_partial_fills_respect_participation(monkeypatch):
+    class LargeOrderStrategy:
+        def __init__(self, risk_service=None):
+            self._sent = False
+
+        def on_bar(self, _):
+            if self._sent:
+                return None
+            self._sent = True
+            return SimpleNamespace(side="buy", strength=1.0, limit_price=105.0)
+
+    monkeypatch.setitem(STRATEGIES, "large_participation", LargeOrderStrategy)
+    monkeypatch.setattr(
+        "tradingbot.backtesting.engine.RiskService.calc_position_size",
+        lambda self, strength, price, *args, **kwargs: 100.0,
+    )
+
+    data = pd.DataFrame(
+        {
+            "timestamp": list(range(8)),
+            "open": [100.0] * 8,
+            "high": [100.0] * 8,
+            "low": [100.0] * 8,
+            "close": [100.0] * 8,
+            "volume": [100.0] * 8,
+        }
+    )
+
+    slippage = SlippageModel(
+        volume_impact=0.0,
+        pct=0.0,
+        max_bar_participation=0.25,
+    )
+    engine = EventDrivenBacktestEngine(
+        {"SYM": data},
+        [("large_participation", "SYM")],
+        latency=1,
+        window=1,
+        slippage=slippage,
+        verbose_fills=True,
+    )
+    result = engine.run()
+
+    order_fills = [f for f in result["fills"] if f[1] == "order"]
+    fill_qtys = [f[4] for f in order_fills]
+
+    # Expect four fills of 25 units each for the 100 unit order
+    assert len(fill_qtys) >= 4
+    assert fill_qtys[:3] == pytest.approx([25.0, 25.0, 25.0])
+    assert fill_qtys[3] == pytest.approx(25.0)


### PR DESCRIPTION
## Summary
- add `max_bar_participation` and `min_bar_liquidity` settings to the slippage model for OHLCV datasets
- cap OHLCV order fills to the configured bar participation while persisting queue positions
- extend slippage tests to cover participation limits, minimum liquidity, and engine-level partial fills

## Testing
- pytest tests/backtesting/test_slippage_microscopic_volume.py

------
https://chatgpt.com/codex/tasks/task_e_68db25f56cd0832d8c4f43479556ced1