### PR TITLE
Infer slippage defaults from configs and expose CLI controls

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -184,6 +184,9 @@ class SlippageModel:
     base_spread: float, default ``0.0``
         Fallback spread (absolute price difference) used when bid/ask columns
         are absent, ``NaN`` or when ``source`` is ``"fixed_spread"``.
+    max_bar_participation: float, optional
+        Maximum fraction of the bar volume allowed to execute in a single fill.
+        ``None`` disables the cap.
     """
 
     def __init__(
@@ -194,6 +197,7 @@ class SlippageModel:
         source: str = "bba",
         base_spread: float = 0.0,
         pct: float = 0.0001,
+        max_bar_participation: float | None = None,
     ) -> None:
         self.volume_impact = float(volume_impact)
         self.spread_mult = float(spread_mult)
@@ -204,6 +208,14 @@ class SlippageModel:
         self.source = source
         self.base_spread = float(base_spread)
         self.pct = float(pct)
+        if max_bar_participation is None:
+            self.max_bar_participation: float | None = None
+        else:
+            max_bar_participation = float(max_bar_participation)
+            if max_bar_participation < 0.0:
+                self.max_bar_participation = None
+            else:
+                self.max_bar_participation = min(max_bar_participation, 1.0)
     def _compute_spread(self, bar: Mapping[str, float] | pd.Series) -> float:
         if self.source == "bba":
             bid = bar.get("bid") or bar.get("bid_px") or bar.get("bid_price")
@@ -318,6 +330,17 @@ class SlippageModel:
             if vol <= liquidity_floor:
                 return float(price), 0.0, queue_pos_val
             exec_qty = qty
+        max_participation = self.max_bar_participation
+        if max_participation is not None and vol > 0.0:
+            max_exec = max(0.0, vol * max_participation)
+            if max_exec <= liquidity_floor:
+                return float(price), 0.0, queue_pos_val
+            if exec_qty > max_exec:
+                if not partial:
+                    return float(price), 0.0, queue_pos_val
+                exec_qty = max_exec
+        if exec_qty <= 0.0:
+            return float(price), 0.0, queue_pos_val
         side_is_buy = side == "buy"
         passive = bool(has_depth)
         if not has_depth:
@@ -411,6 +434,7 @@ class EventDrivenBacktestEngine:
         min_notional: float = 0.0,
     ) -> None:
         strategies = list(strategies)
+        exchange_configs = exchange_configs or {}
 
         self.data = data
         if isinstance(timeframes, str):
@@ -423,15 +447,147 @@ class EventDrivenBacktestEngine:
                 self.timeframes.setdefault(sym, "1m")
         self.latency = int(latency)
         self.window = int(window)
+        
+        def _strategy_exchange(info: Tuple[str, str] | Tuple[str, str, str]) -> str:
+            return "default" if len(info) == 2 else str(info[2])
+
+        def _infer_market_type(exchange: str) -> str:
+            cfg = exchange_configs.get(exchange, {}) or {}
+            market_type = cfg.get("market_type") if isinstance(cfg, Mapping) else None
+            if isinstance(market_type, str):
+                mt = market_type.lower()
+                if mt in {"spot", "perp", "futures"}:
+                    return "spot" if mt == "spot" else "perp"
+            if exchange.endswith("_spot"):
+                return "spot"
+            if exchange.endswith("_futures") or exchange.endswith("_perp"):
+                return "perp"
+            return "spot"
+
+        def _first_price_value(symbol: str | None = None) -> float:
+            frames: list[pd.DataFrame] = []
+            if symbol and symbol in self.data:
+                frames.append(self.data[symbol])
+            for sym, df_sym in self.data.items():
+                if sym == symbol:
+                    continue
+                frames.append(df_sym)
+            for df_sym in frames:
+                if not isinstance(df_sym, pd.DataFrame):
+                    continue
+                for col in (
+                    "mid",
+                    "close",
+                    "Close",
+                    "price",
+                    "last",
+                    "open",
+                    "Open",
+                    "high",
+                    "low",
+                ):
+                    if col in df_sym:
+                        series = pd.to_numeric(df_sym[col], errors="coerce")
+                        try:
+                            first_valid = series.dropna()
+                        except AttributeError:
+                            continue
+                        if not first_valid.empty:
+                            val = float(first_valid.iloc[0])
+                            if math.isfinite(val) and val > 0.0:
+                                return val
+            return 1.0
+
+        def _derive_slippage_defaults(
+            exchange: str, symbol: str | None
+        ) -> tuple[float, float, float]:
+            cfg = exchange_configs.get(exchange, {}) or {}
+            market_type = _infer_market_type(exchange)
+            price_scale = _first_price_value(symbol)
+            if not math.isfinite(price_scale) or price_scale <= 0.0:
+                price_scale = 1.0
+            base_spread = cfg.get("slippage_base_spread") if isinstance(cfg, Mapping) else None
+            if base_spread is not None:
+                try:
+                    base_spread = float(base_spread)
+                except (TypeError, ValueError):
+                    base_spread = None
+            base_spread_bps = None
+            if isinstance(cfg, Mapping):
+                base_spread_bps = cfg.get("slippage_base_spread_bps")
+                if base_spread_bps is None:
+                    base_spread_bps = cfg.get("base_spread_bps")
+            if base_spread_bps is not None:
+                try:
+                    base_spread_bps = float(base_spread_bps)
+                except (TypeError, ValueError):
+                    base_spread_bps = None
+            if base_spread is None:
+                if base_spread_bps is None:
+                    base_spread_bps = 1.5 if market_type == "spot" else 2.5
+                base_spread = price_scale * (base_spread_bps / 10000.0)
+            base_spread = float(base_spread)
+            if base_spread <= 0.0:
+                base_spread = max(price_scale * 1e-6, 1e-9)
+            volume_impact_cfg = None
+            if isinstance(cfg, Mapping):
+                volume_impact_cfg = cfg.get("slippage_volume_impact", cfg.get("volume_impact"))
+            if volume_impact_cfg is None:
+                volume_impact = 0.1 if market_type == "spot" else 0.2
+            else:
+                try:
+                    volume_impact = float(volume_impact_cfg)
+                except (TypeError, ValueError):
+                    volume_impact = 0.0
+            volume_impact = max(0.0, volume_impact)
+            max_part_cfg = None
+            if isinstance(cfg, Mapping):
+                max_part_cfg = cfg.get(
+                    "slippage_max_bar_participation",
+                    cfg.get("max_bar_participation"),
+                )
+            if max_part_cfg is None:
+                max_bar_part = 0.1 if market_type == "spot" else 0.2
+            else:
+                try:
+                    max_bar_part = float(max_part_cfg)
+                except (TypeError, ValueError):
+                    max_bar_part = 0.0
+            if max_bar_part > 1.0:
+                max_bar_part = 1.0
+            max_bar_part = max(0.0, max_bar_part)
+            return float(base_spread), float(volume_impact), float(max_bar_part)
+
+        default_exchange: str | None = None
+        default_symbol: str | None = None
+        if strategies:
+            first_info = strategies[0]
+            default_symbol = str(first_info[1])
+            default_exchange = _strategy_exchange(first_info)
+        if not default_exchange:
+            default_exchange = next(iter(exchange_configs), "default")
+        if default_symbol is None:
+            if strategies:
+                default_symbol = str(strategies[0][1])
+            elif self.data:
+                default_symbol = next(iter(self.data))
         self._slippage_supplied = slippage is not None
         self.slippage = slippage
         self.slippage_bps = float(slippage_bps)
         if self.slippage is None:
+            base_spread, volume_impact, max_bar_part = _derive_slippage_defaults(
+                default_exchange, default_symbol
+            )
             self.slippage = SlippageModel(
-                volume_impact=0.0, pct=self.slippage_bps / 10000.0
+                volume_impact=volume_impact,
+                base_spread=base_spread,
+                pct=self.slippage_bps / 10000.0,
+                max_bar_participation=max_bar_part,
             )
         else:
             self.slippage.pct = self.slippage_bps / 10000.0
+            if not hasattr(self.slippage, "max_bar_participation"):
+                setattr(self.slippage, "max_bar_participation", None)
         self.use_l2 = bool(use_l2)
         self.partial_fills = bool(partial_fills)
         self.cancel_unfilled = bool(cancel_unfilled)
@@ -480,10 +636,6 @@ class EventDrivenBacktestEngine:
         self.exchange_min_qty: Dict[str, float] = {}
         self.exchange_step_size: Dict[str, float] = {}
         self.exchange_min_notional: Dict[str, float] = {}
-        exchange_configs = exchange_configs or {}
-
-        def _strategy_exchange(info: Tuple[str, str] | Tuple[str, str, str]) -> str:
-            return "default" if len(info) == 2 else str(info[2])
 
         def _fallback_fee(exchange: str) -> tuple[float, float]:
             cfg = exchange_configs.get(exchange)

--- a/src/tradingbot/cli/commands/backtesting.py
+++ b/src/tradingbot/cli/commands/backtesting.py
@@ -14,6 +14,28 @@ from tradingbot.analysis.backtest_report import generate_report
 app = typer.Typer(help="Backtesting utilities")
 
 
+def _inject_slippage_defaults(
+    exchange_cfg: dict,
+    exchange: str,
+    base_spread_bps: float | None,
+    volume_impact: float | None,
+    max_bar_participation: float | None,
+) -> None:
+    if (
+        base_spread_bps is None
+        and volume_impact is None
+        and max_bar_participation is None
+    ):
+        return
+    cfg = exchange_cfg.setdefault(exchange, {})
+    if base_spread_bps is not None:
+        cfg["slippage_base_spread_bps"] = float(base_spread_bps)
+    if volume_impact is not None:
+        cfg["slippage_volume_impact"] = float(volume_impact)
+    if max_bar_participation is not None:
+        cfg["slippage_max_bar_participation"] = float(max_bar_participation)
+
+
 @app.command("cfg-validate")
 def cfg_validate(path: str) -> None:
     """Validate a YAML configuration file."""
@@ -59,6 +81,24 @@ def backtest(
     ),
     fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
     slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
+    slippage_base_spread_bps: float | None = typer.Option(
+        None,
+        "--slippage-base-spread-bps",
+        min=0.0,
+        help="Spread base por defecto en bps cuando solo hay OHLCV",
+    ),
+    slippage_volume_impact: float | None = typer.Option(
+        None,
+        "--slippage-volume-impact",
+        help="Impacto de volumen por defecto para el modelo de slippage",
+    ),
+    slippage_max_bar_participation: float | None = typer.Option(
+        None,
+        "--slippage-max-bar-participation",
+        min=0.0,
+        max=1.0,
+        help="Participación máxima por barra cuando se infiere el slippage",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -76,6 +116,15 @@ def backtest(
     data_path = Path(data)
     df = pd.read_csv(data_path)
     exchange_cfg = {}
+    _inject_slippage_defaults(
+        exchange_cfg,
+        "default",
+        slippage_base_spread_bps,
+        slippage_volume_impact,
+        slippage_max_bar_participation,
+    )
+    if "default" in exchange_cfg:
+        exchange_cfg["default"].setdefault("market_type", "spot")
     bt_cfg = {}
     min_fill_qty = float(getattr(bt_cfg, "min_fill_qty", MIN_FILL_QTY))
     slippage = None
@@ -119,6 +168,24 @@ def backtest_cfg(
     ),
     fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
     slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
+    slippage_base_spread_bps: float | None = typer.Option(
+        None,
+        "--slippage-base-spread-bps",
+        min=0.0,
+        help="Spread base por defecto en bps cuando solo hay OHLCV",
+    ),
+    slippage_volume_impact: float | None = typer.Option(
+        None,
+        "--slippage-volume-impact",
+        help="Impacto de volumen por defecto para el modelo de slippage",
+    ),
+    slippage_max_bar_participation: float | None = typer.Option(
+        None,
+        "--slippage-max-bar-participation",
+        min=0.0,
+        max=1.0,
+        help="Participación máxima por barra cuando se infiere el slippage",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -159,6 +226,15 @@ def backtest_cfg(
         exchange_cfg = OmegaConf.to_container(
             getattr(cfg, "exchange_configs", {}), resolve=True
         )
+        _inject_slippage_defaults(
+            exchange_cfg,
+            "default",
+            slippage_base_spread_bps,
+            slippage_volume_impact,
+            slippage_max_bar_participation,
+        )
+        if "default" in exchange_cfg:
+            exchange_cfg["default"].setdefault("market_type", "spot")
         bt_cfg = cfg.backtest
         min_fill_qty = float(getattr(bt_cfg, "min_fill_qty", MIN_FILL_QTY))
         slip_cfg = getattr(bt_cfg, "slippage", None)
@@ -229,6 +305,24 @@ def backtest_db(
     ),
     fee_bps: float = typer.Option(5.0, "--fee-bps", help="Comisión en bps"),
     slippage_bps: float = typer.Option(1.0, "--slippage-bps", help="Slippage en bps"),
+    slippage_base_spread_bps: float | None = typer.Option(
+        None,
+        "--slippage-base-spread-bps",
+        min=0.0,
+        help="Spread base por defecto en bps cuando solo hay OHLCV",
+    ),
+    slippage_volume_impact: float | None = typer.Option(
+        None,
+        "--slippage-volume-impact",
+        help="Impacto de volumen por defecto para el modelo de slippage",
+    ),
+    slippage_max_bar_participation: float | None = typer.Option(
+        None,
+        "--slippage-max-bar-participation",
+        min=0.0,
+        max=1.0,
+        help="Participación máxima por barra cuando se infiere el slippage",
+    ),
     verbose_fills: bool = typer.Option(
         False, "--verbose-fills", help="Log each fill during backtests"
     ),
@@ -292,7 +386,15 @@ def backtest_db(
         if not venue_cfg:
             typer.echo(f"missing config for {venue}")
             raise typer.Exit()
+        venue_cfg = dict(venue_cfg)
         exchange_cfg = {venue: venue_cfg}
+        _inject_slippage_defaults(
+            exchange_cfg,
+            venue,
+            slippage_base_spread_bps,
+            slippage_volume_impact,
+            slippage_max_bar_participation,
+        )
         eng = EventDrivenBacktestEngine(
             {symbol: df},
             [(strategy, symbol, venue)],

--- a/src/tradingbot/config/hydra_conf.py
+++ b/src/tradingbot/config/hydra_conf.py
@@ -41,6 +41,7 @@ class SlippageConfig:
     volume_impact: float = 0.1
     spread_mult: float = 1.0
     ofi_impact: float = 0.0
+    max_bar_participation: float | None = None
 
 
 @dataclass

--- a/tests/integration/test_slippage_defaults.py
+++ b/tests/integration/test_slippage_defaults.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import pytest
+from types import SimpleNamespace
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.strategies import STRATEGIES
+
+
+class AlwaysBuyStrategy:
+    name = "alwaysbuy"
+
+    def on_bar(self, context):
+        return SimpleNamespace(side="buy", strength=1.0)
+
+
+@pytest.mark.integration
+def test_inferred_slippage_applies_spread_and_participation(monkeypatch):
+    symbol = "BTCUSDT"
+    idx = pd.date_range("2024-01-01", periods=5, freq="min")
+    df = pd.DataFrame(
+        {
+            "open": [100.0] * 5,
+            "high": [101.0] * 5,
+            "low": [99.0] * 5,
+            "close": [100.0] * 5,
+            "volume": [1000.0] * 5,
+        },
+        index=idx,
+    )
+    monkeypatch.setitem(STRATEGIES, "alwaysbuy", AlwaysBuyStrategy)
+    engine = EventDrivenBacktestEngine(
+        {symbol: df},
+        [("alwaysbuy", symbol)],
+        latency=1,
+        window=1,
+        slippage=None,
+        exchange_configs={"default": {"market_type": "spot"}},
+    )
+    result = engine.run()
+    assert result["orders"]
+    model = engine.slippage
+    assert model.max_bar_participation is not None
+    assert 0.0 < model.max_bar_participation <= 0.2
+    assert model.base_spread > 0.0
+    qty = 5000.0
+    bar = {"volume": 1000.0, "close": 100.0}
+    price = 100.0
+    adj_price, fill_qty, _ = model.fill("buy", qty, price, bar)
+    expected_cap = bar["volume"] * model.max_bar_participation
+    assert fill_qty == pytest.approx(expected_cap)
+    assert adj_price > price


### PR DESCRIPTION
## Summary
- derive slippage base spread, volume impact, and bar participation defaults when no model is provided
- expose CLI overrides for the inferred slippage defaults and extend the Hydra slippage config schema
- add an integration test ensuring the inferred slippage model applies a spread and participation cap

## Testing
- pytest tests/integration/test_slippage_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68db25f7a480832d86f6f4af808ebc9e