### PR TITLE
Enhance scalp pingpong volatility gating and add reference backtest

### DIFF
--- a/docs/backtests/scalp_pingpong_reference.py
+++ b/docs/backtests/scalp_pingpong_reference.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(ROOT / "src"))
+
+from tradingbot.backtesting.engine import EventDrivenBacktestEngine
+from tradingbot.strategies import STRATEGIES
+from tradingbot.strategies.scalp_pingpong import ScalpPingPong, ScalpPingPongConfig
+
+
+@dataclass
+class BacktestMetrics:
+    fills: int = 0
+    trades: int = 0
+    wins: int = 0
+    win_rate: float = 0.0
+    fee_total: float = 0.0
+    pnl: float = 0.0
+
+    def accumulate(self, other: "BacktestMetrics") -> None:
+        self.fills += other.fills
+        self.trades += other.trades
+        self.wins += other.wins
+        self.fee_total += other.fee_total
+        self.pnl += other.pnl
+
+    def recompute(self) -> None:
+        self.win_rate = self.wins / self.trades if self.trades else 0.0
+
+
+def _synthetic_window(tf_minutes: int, periods: int = 290, seed: int = 0) -> pd.DataFrame:
+    """Create a deterministic OHLCV window with trend and low-volatility regimes."""
+
+    rng = np.random.RandomState(10 + tf_minutes + seed * 7)
+    idx = pd.date_range("2021-01-01", periods=periods, freq=f"{tf_minutes}min")
+
+    seg_a = 100
+    seg_b = 40
+    seg_c = 40
+    seg_d = 80
+    seg_e = periods - (seg_a + seg_b + seg_c + seg_d)
+
+    t_a = np.linspace(0, 6 * math.pi, seg_a)
+    returns_a = 0.0022 * np.sin(t_a) + rng.normal(0, 0.00025, seg_a)
+
+    returns_b = np.full(seg_b, 0.0013) + rng.normal(0, 0.00018, seg_b)
+    returns_c = np.full(seg_c, -0.0011) + rng.normal(0, 0.0002, seg_c)
+    returns_d = rng.normal(0, 0.000004, seg_d)
+    t_e = np.linspace(0, 4 * math.pi, seg_e)
+    returns_e = 0.0045 * np.sin(t_e) + rng.normal(0, 0.0002, seg_e)
+
+    returns = np.concatenate([returns_a, returns_b, returns_c, returns_d, returns_e])
+    prices = 18000.0 * np.exp(np.cumsum(returns))
+
+    opens = np.concatenate(([prices[0]], prices[:-1]))
+    highs = np.maximum(opens, prices) * (1 + rng.uniform(0.0002, 0.0010, periods))
+    lows = np.minimum(opens, prices) * (1 - rng.uniform(0.0002, 0.0010, periods))
+    spread = rng.uniform(0.5, 1.5, periods)
+    bids = prices - spread
+    asks = prices + spread
+    volumes = rng.uniform(50, 120, periods) * (1 + tf_minutes / 100.0)
+
+    frame = pd.DataFrame(
+        {
+            "timestamp": idx,
+            "open": opens,
+            "high": highs,
+            "low": lows,
+            "close": prices,
+            "volume": volumes,
+            "bid": bids,
+            "ask": asks,
+        }
+    )
+    return frame
+
+
+def _compute_trade_stats(fills: Iterable[Tuple]) -> Tuple[int, int, float]:
+    position = 0.0
+    realized_acc = 0.0
+    trades: list[float] = []
+    fee_total = 0.0
+    for fill in fills:
+        # Tuple layout documented in EventDrivenBacktestEngine.run
+        _, _, side, _, qty, _, _, _, fee_cost, _, realized_pnl, _, _ = fill
+        qty = float(qty)
+        realized_pnl = float(realized_pnl)
+        fee_total += float(fee_cost)
+        if side == "buy":
+            position += qty
+        else:
+            position -= qty
+        realized_acc += realized_pnl
+        if abs(position) <= 1e-9 and abs(realized_acc) > 0:
+            trades.append(realized_acc)
+            realized_acc = 0.0
+    trade_count = len(trades)
+    wins = sum(1 for pnl in trades if pnl > 0)
+    return trade_count, wins, fee_total
+
+
+def _run_backtest(
+    data: Dict[str, pd.DataFrame],
+    timeframe: str,
+    mode: str,
+) -> BacktestMetrics:
+    original_cls = STRATEGIES[ScalpPingPong.name]
+
+    class BaselineScalpPingPong(ScalpPingPong):
+        def __init__(self, **kwargs):
+            cfg = ScalpPingPongConfig(
+                min_volatility=0.0,
+                min_volatility_quantile=0.0,
+                min_volatility_window_mult=1.0,
+                min_volatility_fallbacks={1.0: 0.0, 5.0: 0.0, 15.0: 0.0, 30.0: 0.0, 60.0: 0.0},
+                trend_penalty_pct=0.0,
+            )
+            super().__init__(cfg=cfg, **kwargs)
+
+    class UpdatedScalpPingPong(ScalpPingPong):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+    STRATEGIES[ScalpPingPong.name] = (
+        BaselineScalpPingPong if mode == "baseline" else UpdatedScalpPingPong
+    )
+    try:
+        engine = EventDrivenBacktestEngine(
+            data,
+            [(ScalpPingPong.name, "BTC/USDT")],
+            latency=0,
+            window=90,
+            verbose_fills=True,
+            exchange_configs={
+                "default": {
+                    "tick_size": 0.1,
+                    "maker_fee": 0.0,
+                    "taker_fee": 0.0006,
+                    "market_type": "perp",
+                }
+            },
+            timeframes={"BTC/USDT": timeframe},
+            risk_pct=1.0,
+        )
+        result = engine.run()
+    finally:
+        STRATEGIES[ScalpPingPong.name] = original_cls
+
+    trade_count, win_count, fee_total = _compute_trade_stats(result["fills"])
+    pnl = float(result.get("pnl", 0.0))
+    return BacktestMetrics(
+        fills=int(result.get("fill_count", 0)),
+        trades=trade_count,
+        wins=win_count,
+        win_rate=(win_count / trade_count if trade_count else 0.0),
+        fee_total=fee_total,
+        pnl=pnl,
+    )
+
+
+def main() -> None:
+    timeframes = ["5m", "15m", "30m"]
+    seeds = [0, 1, 2]
+    aggregated: Dict[str, Dict[str, BacktestMetrics]] = {}
+
+    for tf in timeframes:
+        aggregated[tf] = {"baseline": BacktestMetrics(), "updated": BacktestMetrics()}
+        minutes = int(tf.rstrip("m"))
+        for seed in seeds:
+            window = _synthetic_window(minutes, seed=seed)
+            data = {"BTC/USDT": window}
+            base = _run_backtest({k: v.copy() for k, v in data.items()}, tf, "baseline")
+            upd = _run_backtest({k: v.copy() for k, v in data.items()}, tf, "updated")
+            aggregated[tf]["baseline"].accumulate(base)
+            aggregated[tf]["updated"].accumulate(upd)
+
+    for tf in timeframes:
+        print(f"=== {tf} timeframe ===")
+        for label in ("baseline", "updated"):
+            metrics = aggregated[tf][label]
+            metrics.recompute()
+            print(
+                f"{label}: trades={metrics.trades} fills={metrics.fills} "
+                f"wins={metrics.wins} win_rate={metrics.win_rate:.3f} "
+                f"fees={metrics.fee_total:.4f} pnl={metrics.pnl:.2f}"
+            )
+
+    print("\nSummary (win_rate↑, fees↓ across seeds):")
+    for tf in timeframes:
+        base = aggregated[tf]["baseline"]
+        upd = aggregated[tf]["updated"]
+        delta_win = upd.win_rate - base.win_rate
+        delta_fee = upd.fee_total - base.fee_total
+        print(
+            f"{tf}: win_rate Δ={delta_win:+.3f} fee Δ={delta_fee:+.4f} (base={base.win_rate:.3f}/{base.fee_total:.4f}, "
+            f"updated={upd.win_rate:.3f}/{upd.fee_total:.4f})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pandas as pd
 
@@ -22,9 +22,13 @@ PARAM_INFO = {
     "z_threshold": "Z-score absoluto para abrir operación",
     "volatility_factor": "Factor de tamaño según volatilidad",
     "min_volatility": "Volatilidad mínima reciente en bps",
+    "min_volatility_quantile": "Cuantil usado para estimar el piso de volatilidad",
+    "min_volatility_window_mult": "Multiplicador de ventana para estimar la volatilidad mínima",
+    "min_volatility_fallbacks": "Piso mínimo de volatilidad por timeframe (en bps)",
     "trend_ma": "Ventana para la media móvil de tendencia",
     "trend_rsi_n": "Ventana del RSI para medir tendencia",
     "trend_threshold": "Umbral para considerar la tendencia fuerte",
+    "trend_penalty_pct": "Penalización porcentual al z-score cuando la tendencia va en contra",
 }
 
 
@@ -44,7 +48,18 @@ class ScalpPingPongConfig:
         y un factor de ``0.02`` el aporte de tamaño será ``1.0`` (saturado
         al límite superior).  Valor por defecto ``0.02``.
     min_volatility : float, optional
-        Volatilidad mínima reciente en bps requerida para operar, por defecto ``0``.
+        Volatilidad mínima reciente en bps requerida para operar. Si es ``0`` se
+        estima dinámicamente a partir de cuantiles recientes y un piso por
+        timeframe.
+    min_volatility_quantile : float, optional
+        Cuantil de la volatilidad histórica (desviación estándar de retornos) a
+        utilizar como piso, por defecto ``0.25``.
+    min_volatility_window_mult : float, optional
+        Multiplicador de la ventana base para estimar el cuantil de
+        volatilidad mínima, por defecto ``4.0``.
+    min_volatility_fallbacks : dict, optional
+        Mapa ``{minutos: bps}`` con el piso mínimo de volatilidad por
+        timeframe, por defecto ``{1: 0.1, 5: 0.3, 15: 0.5, 30: 0.7, 60: 0.9}``.
     trend_ma : int, optional
         Window for the moving average used to gauge trend, by default ``50``.
     trend_rsi_n : int, optional
@@ -53,15 +68,24 @@ class ScalpPingPongConfig:
     trend_threshold : float, optional
         Threshold (% over MA or RSI points) to treat the trend as strong,
         by default ``10.0``.
+    trend_penalty_pct : float, optional
+        Incremento porcentual requerido sobre el ``z_threshold`` cuando la
+        tendencia va en contra, por defecto ``75.0``.
     """
 
     lookback: int = 15
     z_threshold: float = 0.2
     volatility_factor: float = 0.02
     min_volatility: float = 0.0
+    min_volatility_quantile: float = 0.25
+    min_volatility_window_mult: float = 4.0
+    min_volatility_fallbacks: dict[float, float] = field(
+        default_factory=lambda: {1.0: 0.1, 5.0: 0.3, 15.0: 0.5, 30.0: 0.7, 60.0: 0.9}
+    )
     trend_ma: int = 50
     trend_rsi_n: int = 50
     trend_threshold: float = 10.0
+    trend_penalty_pct: float = 75.0
 
 
 liquidity = LiquidityFilterManager()
@@ -93,6 +117,7 @@ class ScalpPingPong(Strategy):
         self.cfg = cfg or ScalpPingPongConfig(**params)
         self.risk_service = risk_service
         self.timeframe = tf
+        self._last_vol_floor_bps = 0.0
 
     def _calc_zscore(self, closes: pd.Series, lookback: int) -> float:
         lookback = max(MIN_BARS, int(lookback))
@@ -108,6 +133,54 @@ class ScalpPingPong(Strategy):
         if pd.isna(z) or not math.isfinite(float(z)):
             return 0.0
         return float(z)
+
+    def _fallback_vol_floor(self, tf_minutes: float) -> float:
+        mapping = getattr(self.cfg, "min_volatility_fallbacks", {}) or {}
+        if not mapping:
+            return 0.1
+        try:
+            items = sorted((float(k), float(v)) for k, v in mapping.items())
+        except (TypeError, ValueError):
+            return 0.1
+        floor = items[0][1]
+        for minute_mark, value in items:
+            floor = value
+            if tf_minutes <= minute_mark:
+                return floor
+        return floor
+
+    def _dynamic_vol_floor(
+        self,
+        returns: pd.Series,
+        lookback: int,
+        tf_minutes: float,
+    ) -> float:
+        quantile = float(getattr(self.cfg, "min_volatility_quantile", 0.25))
+        quantile = min(max(quantile, 0.0), 1.0)
+        window_mult = max(float(getattr(self.cfg, "min_volatility_window_mult", 4.0)), 1.0)
+        base_window = max(MIN_BARS, int(lookback))
+        vol_series = returns.rolling(base_window).std().dropna()
+        dynamic = 0.0
+        latest_bps = 0.0
+        if not vol_series.empty:
+            latest_bps = float(vol_series.iloc[-1]) * 10000.0
+        if not vol_series.empty:
+            hist_window = int(max(base_window, int(math.ceil(base_window * window_mult))))
+            hist_window = min(len(vol_series), hist_window)
+            recent = vol_series.iloc[-hist_window:]
+            quant = float(recent.quantile(quantile))
+            if math.isfinite(quant) and quant > 0:
+                dynamic = quant * 10000.0
+        if not math.isfinite(dynamic) or dynamic <= 0:
+            dynamic = 0.0
+        if latest_bps > 0:
+            if dynamic <= 0:
+                dynamic = latest_bps
+            else:
+                dynamic = min(dynamic, latest_bps)
+        if not math.isfinite(dynamic) or dynamic <= 0:
+            return 0.0
+        return dynamic
 
     @record_signal_metrics(liquidity)
     def on_bar(self, bar: dict) -> Signal | None:
@@ -134,12 +207,25 @@ class ScalpPingPong(Strategy):
                 else 0.0
             )
             vol_bps = vol * 10000
-        if vol_bps < self.cfg.min_volatility:
+        tf_floor = float(getattr(self.cfg, "min_volatility", 0.0))
+        fallback_floor = self._fallback_vol_floor(tf_minutes)
+        if tf_floor <= 0:
+            vol_floor = self._dynamic_vol_floor(returns, lookback, tf_minutes)
+        else:
+            vol_floor = tf_floor
+        vol_floor = max(vol_floor, fallback_floor)
+        if vol_bps > 0 and bar.get("atr") is not None:
+            cap_floor = vol_bps
+            if vol_floor > cap_floor:
+                vol_floor = max(fallback_floor, cap_floor)
+        self._last_vol_floor_bps = vol_floor
+        bar["vol_floor_bps"] = vol_floor
+        if vol_bps < vol_floor:
             return None
         abs_price = max(abs(price), 1e-9)
         price_vol = abs_price * (vol_bps / 10000.0)
         bar["volatility"] = price_vol
-        target_bps = max(vol_bps, self.cfg.min_volatility)
+        target_bps = max(vol_bps, vol_floor)
         bar["target_volatility"] = abs_price * (target_bps / 10000.0)
         vol_size = vol_bps * self.cfg.volatility_factor
         vol_size = max(0.2, min(3.0, vol_size))
@@ -160,12 +246,11 @@ class ScalpPingPong(Strategy):
             elif trsi < 50 - self.cfg.trend_threshold:
                 trend_dir = -1
 
-        z_buy = self.cfg.z_threshold + (
-            self.cfg.trend_threshold / 100 if trend_dir == -1 else 0
-        )
-        z_sell = self.cfg.z_threshold + (
-            self.cfg.trend_threshold / 100 if trend_dir == 1 else 0
-        )
+        penalty_mult = 1.0 + max(0.0, float(self.cfg.trend_penalty_pct)) / 100.0
+        z_buy = float(self.cfg.z_threshold) * (penalty_mult if trend_dir == -1 else 1.0)
+        z_sell = float(self.cfg.z_threshold) * (penalty_mult if trend_dir == 1 else 1.0)
+        z_buy = max(z_buy, 1e-9)
+        z_sell = max(z_sell, 1e-9)
 
         if z <= -z_buy:
             side = "buy"


### PR DESCRIPTION
## Summary
- add timeframe-aware volatility floor configuration and trend-aware z-score penalty to `ScalpPingPong`
- expose the last computed volatility floor on each bar and gate trades when realized volatility sits below the adaptive floor
- create `docs/backtests/scalp_pingpong_reference.py` to reproduce baseline vs updated backtests across multiple seeds and timeframes

## Testing
- PYTHONPATH=src pytest tests/test_scalp_pingpong.py
- PYTHONPATH=src python docs/backtests/scalp_pingpong_reference.py

------
https://chatgpt.com/codex/tasks/task_e_68db12fb2374832dae7bd11dadda183f