### PR TITLE
Limit OHLC fills by bar participation

### DIFF
--- a/src/tradingbot/backtesting/engine.py
+++ b/src/tradingbot/backtesting/engine.py
@@ -195,6 +195,10 @@ class SlippageModel:
     max_bar_participation: float, optional
         Maximum fraction of the bar volume allowed to execute in a single fill.
         ``None`` disables the cap.
+    min_bar_liquidity: float, optional
+        Minimum liquidity threshold (in units) that must be available on a bar
+        when only OHLCV data is present.  Bars offering less than this amount
+        will not execute the order.
     """
 
     def __init__(
@@ -206,6 +210,7 @@ class SlippageModel:
         base_spread: float = 0.0,
         pct: float = 0.0001,
         max_bar_participation: float | None = None,
+        min_bar_liquidity: float | None = None,
         ohlc_spread_factor: float | None = None,
         ohlc_spread_bps: float | None = None,
     ) -> None:
@@ -236,6 +241,10 @@ class SlippageModel:
                 self.max_bar_participation = None
             else:
                 self.max_bar_participation = min(max_bar_participation, 1.0)
+        if min_bar_liquidity is None:
+            self.min_bar_liquidity = 0.0
+        else:
+            self.min_bar_liquidity = max(0.0, float(min_bar_liquidity))
     def _compute_spread(self, bar: Mapping[str, float] | pd.Series) -> float:
         def _safe_float(value: Any) -> float | None:
             if value is None:
@@ -375,18 +384,25 @@ class SlippageModel:
             if not partial and exec_qty < qty:
                 return float(price), 0.0, queue_pos_val
         else:
-            if vol <= liquidity_floor:
-                return float(price), 0.0, queue_pos_val
-            exec_qty = qty
-        max_participation = self.max_bar_participation
-        if max_participation is not None and vol > 0.0:
-            max_exec = max(0.0, vol * max_participation)
-            if max_exec <= liquidity_floor:
-                return float(price), 0.0, queue_pos_val
-            if exec_qty > max_exec:
-                if not partial:
+            max_participation = self.max_bar_participation
+            if max_participation is None:
+                if vol <= liquidity_floor:
                     return float(price), 0.0, queue_pos_val
-                exec_qty = max_exec
+                exec_qty = qty
+                queue_pos_val = 0.0
+            else:
+                participation = max(0.0, float(max_participation))
+                bar_capacity = max(0.0, vol * participation)
+                bar_liquidity = max(bar_capacity - max(queue_pos_val, 0.0), 0.0)
+                min_liquidity = getattr(self, "min_bar_liquidity", 0.0) or 0.0
+                if bar_liquidity < max(liquidity_floor, min_liquidity):
+                    return float(price), 0.0, queue_pos_val
+                exec_qty = min(qty, bar_liquidity)
+                if not partial and exec_qty < qty:
+                    return float(price), 0.0, queue_pos_val
+                if exec_qty <= 0.0:
+                    return float(price), 0.0, queue_pos_val
+                queue_pos_val = min(bar_capacity, queue_pos_val + exec_qty)
         if exec_qty <= 0.0:
             return float(price), 0.0, queue_pos_val
         side_is_buy = side == "buy"

--- a/tests/backtesting/test_slippage_microscopic_volume.py
+++ b/tests/backtesting/test_slippage_microscopic_volume.py
@@ -108,3 +108,25 @@ def test_healthy_volume_fill_matches_original_behaviour(monkeypatch):
     )
     expected_slippage = (fill_price - order_summary["place_price"]) * fill_qty
     assert result["slippage"] == pytest.approx(expected_slippage)
+
+
+def test_max_participation_caps_fill_without_depth():
+    bar = {"volume": 1000.0, "close": 100.0}
+    slippage = SlippageModel(
+        volume_impact=0.0,
+        pct=0.0,
+        max_bar_participation=0.2,
+        min_bar_liquidity=1e-9,
+    )
+
+    price, fill_qty, queue_pos = slippage.fill(
+        "buy", 1000.0, 100.0, bar, queue_pos=0.0, partial=True
+    )
+    assert fill_qty == pytest.approx(200.0)
+    assert queue_pos == pytest.approx(200.0)
+
+    _, fill_qty_2, queue_pos_2 = slippage.fill(
+        "buy", 800.0, 100.0, bar, queue_pos=queue_pos, partial=True
+    )
+    assert fill_qty_2 == pytest.approx(0.0)
+    assert queue_pos_2 == pytest.approx(200.0)


### PR DESCRIPTION
## Summary
- add a `min_bar_liquidity` parameter to the slippage model so OHLC-only datasets can reject bars with insufficient liquidity
- enforce the bar participation cap when no depth is available by tracking consumed volume via the queue position
- cover the new behaviour with a regression test that ensures large orders only trade the configured share of a bar

## Testing
- pytest tests/backtesting/test_slippage_microscopic_volume.py

------
https://chatgpt.com/codex/tasks/task_e_68dbdc908b4c832dbf5989d0b53f9001