### PR TITLE
Improve scalp pingpong trend handling

### DIFF
--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -28,6 +28,7 @@ PARAM_INFO = {
     "trend_ma": "Ventana para la media móvil de tendencia",
     "trend_rsi_n": "Ventana del RSI para medir tendencia",
     "trend_threshold": "Umbral para considerar la tendencia fuerte",
+    "trend_extreme_mult": "Multiplicador del umbral de tendencia para pausar operaciones",
     "trend_penalty_pct": "Penalización porcentual al z-score cuando la tendencia va en contra",
 }
 
@@ -68,6 +69,9 @@ class ScalpPingPongConfig:
     trend_threshold : float, optional
         Threshold (% over MA or RSI points) to treat the trend as strong,
         by default ``10.0``.
+    trend_extreme_mult : float, optional
+        Multiplicador del ``trend_threshold`` a partir del cual las señales
+        contrarias a la tendencia se deshabilitan, por defecto ``3.0``.
     trend_penalty_pct : float, optional
         Incremento porcentual requerido sobre el ``z_threshold`` cuando la
         tendencia va en contra, por defecto ``75.0``.
@@ -85,6 +89,7 @@ class ScalpPingPongConfig:
     trend_ma: int = 50
     trend_rsi_n: int = 50
     trend_threshold: float = 10.0
+    trend_extreme_mult: float = 3.0
     trend_penalty_pct: float = 75.0
 
 
@@ -231,20 +236,32 @@ class ScalpPingPong(Strategy):
         vol_size = max(0.2, min(3.0, vol_size))
 
         trend_dir = 0
-        if len(closes) >= trend_ma:
-            ma = closes.rolling(trend_ma).mean().iloc[-1]
-            if not pd.isna(ma) and ma != 0:
-                diff_pct = (price - ma) / ma * 100
-                if diff_pct > self.cfg.trend_threshold:
-                    trend_dir = 1
-                elif diff_pct < -self.cfg.trend_threshold:
-                    trend_dir = -1
-        elif len(closes) >= trend_rsi_n:
-            trsi = rsi(df, trend_rsi_n).iloc[-1]
-            if trsi > 50 + self.cfg.trend_threshold:
-                trend_dir = 1
-            elif trsi < 50 - self.cfg.trend_threshold:
-                trend_dir = -1
+        extreme_trend_dir = 0
+        trend_threshold = float(getattr(self.cfg, "trend_threshold", 0.0))
+        extreme_mult = max(1.0, float(getattr(self.cfg, "trend_extreme_mult", 3.0)))
+        if trend_threshold > 0:
+            if len(closes) >= trend_ma:
+                ma = closes.rolling(trend_ma).mean().iloc[-1]
+                if not pd.isna(ma) and ma != 0:
+                    diff_pct = (price - ma) / ma * 100
+                    if diff_pct > trend_threshold:
+                        trend_dir = 1
+                    elif diff_pct < -trend_threshold:
+                        trend_dir = -1
+                    if abs(diff_pct) >= trend_threshold * extreme_mult:
+                        extreme_trend_dir = 1 if diff_pct > 0 else -1
+            elif len(closes) >= trend_rsi_n:
+                trsi_series = rsi(df, trend_rsi_n)
+                if not trsi_series.empty:
+                    trsi_val = trsi_series.iloc[-1]
+                    if not pd.isna(trsi_val):
+                        bias = float(trsi_val) - 50.0
+                        if bias > trend_threshold:
+                            trend_dir = 1
+                        elif bias < -trend_threshold:
+                            trend_dir = -1
+                        if abs(bias) >= trend_threshold * extreme_mult:
+                            extreme_trend_dir = 1 if bias > 0 else -1
 
         penalty_mult = 1.0 + max(0.0, float(self.cfg.trend_penalty_pct)) / 100.0
         z_buy = float(self.cfg.z_threshold) * (penalty_mult if trend_dir == -1 else 1.0)
@@ -254,12 +271,21 @@ class ScalpPingPong(Strategy):
 
         if z <= -z_buy:
             side = "buy"
-            strength = max(0.05, min(2.5, abs(z) / z_buy))
+            strength = abs(z) / z_buy
         elif z >= z_sell:
             side = "sell"
-            strength = max(0.05, min(2.5, abs(z) / z_sell))
+            strength = abs(z) / z_sell
         else:
             return None
+        if (side == "buy" and extreme_trend_dir == -1) or (
+            side == "sell" and extreme_trend_dir == 1
+        ):
+            return None
+        if (side == "buy" and trend_dir == -1) or (
+            side == "sell" and trend_dir == 1
+        ):
+            strength *= 0.5
+        strength = max(0.05, min(2.5, strength))
         raw_size = max(0.0, min(3.0, strength * vol_size))
         if raw_size <= 0:
             return self.finalize_signal(bar, price, None)

--- a/tests/test_scalp_pingpong.py
+++ b/tests/test_scalp_pingpong.py
@@ -274,3 +274,93 @@ def test_scalp_pingpong_backtest_records_maker_fill():
         assert fill_price <= limit_price + 1e-9
     else:
         assert fill_price >= limit_price - 1e-9
+
+
+def _thirty_minute_trending_window() -> pd.DataFrame:
+    rows: list[dict[str, float]] = []
+    ts_index = pd.date_range("2022-02-01", periods=120, freq="30min")
+    price = 100.0
+    for idx, ts in enumerate(ts_index):
+        if idx < 48:
+            step = (-1) ** idx * 0.6
+        elif idx < 84:
+            step = 5.0 + 0.4 * (idx - 48)
+        else:
+            step = -5.5 - 0.35 * (idx - 84)
+        open_ = price
+        close = price + step
+        high = max(open_, close) + 0.35
+        low = min(open_, close) - 0.35
+        volume = 1_200.0 if idx < 48 else 2_400.0
+        rows.append(
+            {
+                "timestamp": int(ts.timestamp()),
+                "open": open_,
+                "high": high,
+                "low": low,
+                "close": close,
+                "volume": volume,
+            }
+        )
+        price = close
+    return pd.DataFrame(rows)
+
+
+def _run_scalp_pingpong_backtest(
+    data: pd.DataFrame, extreme_mult: float
+) -> dict[str, object]:
+    engine = EventDrivenBacktestEngine(
+        {"SYM": data},
+        [("scalp_pingpong", "SYM")],
+        window=65,
+        latency=1,
+        verbose_fills=True,
+        timeframes={"SYM": "30m"},
+        risk_pct=1.0,
+    )
+    key = ("scalp_pingpong", "SYM")
+    svc = engine.risk[key]
+    cfg = ScalpPingPongConfig(
+        lookback=20,
+        z_threshold=0.15,
+        volatility_factor=0.05,
+        min_volatility=0.0,
+        trend_ma=90,
+        trend_rsi_n=60,
+        trend_threshold=3.0,
+        trend_extreme_mult=extreme_mult,
+        trend_penalty_pct=60.0,
+    )
+    engine.strategies[key] = ScalpPingPong(
+        cfg=cfg,
+        risk_service=svc,
+        timeframe="30m",
+    )
+    return engine.run()
+
+
+def _entry_trades_in_trend(fills: list[tuple], start_ts: int) -> list[tuple]:
+    return [fill for fill in fills if fill[1] == "order" and fill[0] >= start_ts]
+
+
+def _win_rate(fills: list[tuple]) -> float:
+    exits = [f for f in fills if f[1] != "order" and abs(f[4]) > 1e-9]
+    wins = sum(1 for f in exits if f[10] > 1e-9)
+    losses = sum(1 for f in exits if f[10] < -1e-9)
+    total = wins + losses
+    return wins / total if total else 0.0
+
+
+def test_scalp_pingpong_backtest_30m_extreme_trends_reduce_risk():
+    data = _thirty_minute_trending_window()
+    baseline = _run_scalp_pingpong_backtest(data, extreme_mult=50.0)
+    filtered = _run_scalp_pingpong_backtest(data, extreme_mult=2.0)
+
+    trend_start_ts = int(data["timestamp"].iloc[48])
+    baseline_entries = _entry_trades_in_trend(baseline["fills"], trend_start_ts)
+    filtered_entries = _entry_trades_in_trend(filtered["fills"], trend_start_ts)
+
+    assert baseline_entries, "Se esperaban operaciones en la fase tendencial base"
+    assert len(filtered_entries) < len(baseline_entries)
+
+    assert _win_rate(filtered["fills"]) > _win_rate(baseline["fills"])


### PR DESCRIPTION
## Summary
- add an extreme trend multiplier parameter to scalp_pingpong and bail out of counter-trend trades when regimes become too strong
- halve signal strength for mild counter-trend setups to reduce exposure without disabling signals entirely
- add a 30m backtest that asserts fewer trades and a better win rate under strong trend regimes

## Testing
- pytest tests/test_scalp_pingpong.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ded9fce0f4832dae53839a8bf4beb5