### PR TITLE
Adjust scalp pingpong volatility sizing by timeframe

### DIFF
--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -43,10 +43,13 @@ class ScalpPingPongConfig:
     z_threshold : float, optional
         Absolute z-score value required to open a trade, by default ``0.2``.
     volatility_factor : float, optional
-        Fraction of the recent volatility (expressed in basis points) used
-        to size positions.  For example, con una volatilidad de ``50`` bps
-        y un factor de ``0.02`` el aporte de tamaño será ``1.0`` (saturado
-        al límite superior).  Valor por defecto ``0.02``.
+        Factor base usado para escalar el tamaño en función de la
+        volatilidad reciente (expresada en puntos básicos).  El valor se
+        adapta automáticamente al timeframe mediante la relación
+        ``base * sqrt(tf_minutes / 5)`` limitada a un rango prudente, lo
+        que resulta en factores efectivos ~``0.015`` en 3 m, ``0.02`` en
+        5 m, ``0.05`` en 30 m, ``0.07`` en 1 h y ``0.10`` en 4 h.  Valor
+        base por defecto ``0.02``.
     min_volatility : float, optional
         Volatilidad mínima reciente en bps requerida para operar. Si es ``0`` se
         estima dinámicamente a partir de cuantiles recientes y un piso por
@@ -94,6 +97,36 @@ liquidity = LiquidityFilterManager()
 # that momentum and mean-reversion indicators never collapse to just a handful
 # of observations.
 MIN_BARS = 5
+
+
+def _scaled_volatility_factor(tf_minutes: float, base_factor: float) -> float:
+    """Scale the base volatility factor according to the bar timeframe."""
+
+    minutes = max(float(tf_minutes), 1.0)
+    base = max(float(base_factor), 0.0)
+    scaled = base * math.sqrt(minutes / 5.0)
+    return min(max(scaled, 0.01), 0.10)
+
+
+def _vol_size_bounds(tf_minutes: float) -> tuple[float, float]:
+    """Return timeframe-aware clamps for the volatility sized strength."""
+
+    minutes = max(float(tf_minutes), 1.0)
+    if minutes <= 3.0:
+        return 0.1, 1.2
+    if minutes <= 5.0:
+        return 0.15, 1.5
+    if minutes <= 15.0:
+        return 0.2, 2.0
+    if minutes <= 30.0:
+        return 0.25, 2.5
+    if minutes <= 60.0:
+        return 0.3, 3.2
+    if minutes <= 120.0:
+        return 0.35, 3.6
+    if minutes <= 240.0:
+        return 0.4, 4.0
+    return 0.45, 4.5
 
 
 class ScalpPingPong(Strategy):
@@ -227,8 +260,11 @@ class ScalpPingPong(Strategy):
         bar["volatility"] = price_vol
         target_bps = max(vol_bps, vol_floor)
         bar["target_volatility"] = abs_price * (target_bps / 10000.0)
-        vol_size = vol_bps * self.cfg.volatility_factor
-        vol_size = max(0.2, min(3.0, vol_size))
+        scaled_factor = _scaled_volatility_factor(tf_minutes, self.cfg.volatility_factor)
+        bar["volatility_factor"] = scaled_factor
+        vol_size = vol_bps * scaled_factor
+        clamp_min, clamp_max = _vol_size_bounds(tf_minutes)
+        vol_size = max(clamp_min, min(clamp_max, vol_size))
 
         trend_dir = 0
         if len(closes) >= trend_ma:


### PR DESCRIPTION
## Summary
- scale the scalp_pingpong volatility factor according to the bar timeframe and clamp it to a safe range
- derive timeframe-aware volatility sizing bounds so shorter scalps use tighter sizes while swing frames can scale further
- document the new default effective factors in the strategy configuration docstring

## Testing
- python - <<'PY'
import sys
from pathlib import Path

import numpy as np
import pandas as pd

ROOT = Path.cwd()
sys.path.insert(0, str(ROOT / "src"))

from tradingbot.backtesting.engine import EventDrivenBacktestEngine
from tradingbot.strategies.scalp_pingpong import ScalpPingPong


def synthetic_frame(tf_minutes: int, bars: int) -> pd.DataFrame:
    rng = np.random.default_rng(200 + tf_minutes)
    scale = 0.0009 * (tf_minutes / 3.0) ** 0.5
    trend = 0.00025 * np.sin(np.linspace(0, 6 * np.pi, bars))
    noise = rng.normal(0, scale, bars)
    returns = trend + noise
    prices = 20000 * np.exp(np.cumsum(returns))
    opens = np.concatenate(([prices[0]], prices[:-1]))
    highs = np.maximum(opens, prices) * (1 + rng.uniform(0.0003, 0.0012, bars))
    lows = np.minimum(opens, prices) * (1 - rng.uniform(0.0003, 0.0012, bars))
    spread = rng.uniform(0.25, 0.8, bars) * (tf_minutes / 3.0) ** 0.3
    volume = rng.uniform(90, 220, bars) * (3.0 / tf_minutes) ** 0.4
    frame = pd.DataFrame(
        {
            "timestamp": pd.date_range("2022-01-01", periods=bars, freq=f"{tf_minutes}min"),
            "open": opens,
            "high": highs,
            "low": lows,
            "close": prices,
            "volume": volume,
        }
    )
    frame["bid"] = frame["close"] - spread
    frame["ask"] = frame["close"] + spread
    return frame


def run_tf(tf_minutes: int, bars: int) -> dict:
    frame = synthetic_frame(tf_minutes, bars)
    tf_label = f"{tf_minutes}m" if tf_minutes < 60 else f"{tf_minutes // 60}h"
    engine = EventDrivenBacktestEngine(
        {"BTC/USDT": frame},
        [(ScalpPingPong.name, "BTC/USDT")],
        window=180 if tf_minutes < 60 else 220,
        latency=0,
        exchange_configs={
            "default": {
                "tick_size": 0.1,
                "maker_fee": 0.0002,
                "taker_fee": 0.0006,
                "market_type": "perp",
            }
        },
        timeframes={"BTC/USDT": tf_label},
        risk_pct=1.0,
        initial_equity=1000.0,
        verbose_fills=True,
    )
    result = engine.run()
    fills = result.get("fills", [])
    fees = sum(float(fill[8]) for fill in fills)
    equity_vol = float(pd.Series(result["equity_curve"]).diff().dropna().std())
    return {
        "timeframe": tf_label,
        "bars": len(frame),
        "fills": len(fills),
        "fees": fees,
        "equity_vol": equity_vol,
        "pnl": float(result.get("pnl", 0.0)),
    }

metrics = [
    run_tf(3, 1800),
    run_tf(30, 900),
    run_tf(240, 360),
]

for row in metrics:
    print(row)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ded9fa826c832db49f13d2425fc704