### PR TITLE
Align scalp pingpong strength clamp with raw size limit

### DIFF
--- a/src/tradingbot/strategies/scalp_pingpong.py
+++ b/src/tradingbot/strategies/scalp_pingpong.py
@@ -100,7 +100,9 @@ class ScalpPingPong(Strategy):
     """Mean-reversion scalping strategy using z-score of returns."""
 
     name = "scalp_pingpong"
-    max_signal_strength = 6.0
+    # Keep the clamp for ``raw_size`` and the normalisation ceiling in sync so that the
+    # strategy can use the entire [0, 1] strength range when volatility sizing saturates.
+    max_signal_strength = 3.0
 
     def __init__(
         self,
@@ -266,7 +268,7 @@ class ScalpPingPong(Strategy):
         if self.max_signal_strength <= 0:
             return self.finalize_signal(bar, price, None)
         normalized = raw_size / self.max_signal_strength
-        effective_min = self.min_strength_fraction * 0.5
+        effective_min = self.min_strength_fraction
         if normalized < effective_min:
             return self.finalize_signal(bar, price, None)
         normalized = min(1.0, normalized)


### PR DESCRIPTION
## Summary
- align `ScalpPingPong.max_signal_strength` with the `raw_size` clamp and document the rationale so saturated signals normalise to 1.0
- honour `min_strength_fraction` directly when filtering signals, enabling intentionally small trades

## Testing
- python - <<'PY' (synthetic ScalpPingPong backtest at 15m/1h to verify signal size coverage)


------
https://chatgpt.com/codex/tasks/task_e_68ded9f55670832d97c1854634ba4c65