### PR TITLE
Rebalance mean reversion hold management

### DIFF
--- a/src/tradingbot/strategies/mean_reversion.py
+++ b/src/tradingbot/strategies/mean_reversion.py
@@ -99,6 +99,13 @@ PARAM_INFO = {
     "trend_rsi_shift": "Desplazamiento base del RSI para filtrar tendencias",
     "trend_rsi_shift_max": "Límite máximo del desplazamiento dinámico del RSI",
     "min_volatility": "Volatilidad mínima reciente en bps",
+    "upper_rsi_floor": "Nivel mínimo de RSI considerado sobrecompra",
+    "lower_rsi_ceiling": "Nivel máximo de RSI considerado sobreventa",
+    "upper_rsi_cap": "Límite máximo para el umbral superior dinámico del RSI",
+    "lower_rsi_cap": "Límite inferior para el umbral inferior dinámico del RSI",
+    "exit_rsi_neutral_high": "Zona neutral superior del RSI para cerrar largos",
+    "exit_rsi_neutral_low": "Zona neutral inferior del RSI para cerrar cortos",
+    "trend_exit": "Habilita el cierre basado en reversión de tendencia/RSI",
 }
 
 
@@ -348,29 +355,151 @@ class MeanReversion(Strategy):
         )
         self.only_buy_dip = kwargs.get("only_buy_dip", tf in {"30m", "1h"})
         self._base_only_buy_dip = self.only_buy_dip
-        default_time_stop_bars = 0.0
-        min_time_stop_bars = 1
-        if tf_minutes >= 30.0:
-            if tf_minutes < 60.0:
-                min_time_stop_bars = 5
+        min_hold_param = kwargs.get("min_hold_bars")
+        if min_hold_param is None:
+            if tf_minutes <= 5.0:
+                min_hold_param = 2.0
+            elif tf_minutes <= 30.0:
+                min_hold_param = 1.0
             else:
-                min_time_stop_bars = 3
-            default_time_stop_bars = float(min_time_stop_bars)
+                min_hold_param = 0.0
+        try:
+            min_hold_param = float(min_hold_param)
+        except (TypeError, ValueError):
+            min_hold_param = 0.0
+        if min_hold_param > 0:
+            base_min_hold = int(math.ceil(min_hold_param))
+        else:
+            base_min_hold = 0
+        self._base_min_hold_bars = base_min_hold
+        self._min_hold_floor = 1 if tf_minutes <= 30.0 else 0
 
-        self._time_stop_target_bars = 0
-        self._min_time_stop_bars = 0
-        time_stop_param = float(kwargs.get("time_stop", default_time_stop_bars))
-        if time_stop_param > 0:
-            target_bars = int(math.ceil(time_stop_param))
-            target_bars = max(min_time_stop_bars, target_bars)
-            self._time_stop_target_bars = target_bars
-            self._min_time_stop_bars = min_time_stop_bars
-
-        self._time_stop_minutes = self._time_stop_target_bars * tf_minutes if self._time_stop_target_bars else 0
+        max_hold_param = kwargs.get("time_stop", kwargs.get("max_hold_bars", 0.0))
+        try:
+            max_hold_param = float(max_hold_param)
+        except (TypeError, ValueError):
+            max_hold_param = 0.0
+        if max_hold_param > 0:
+            base_max_hold = int(math.ceil(max_hold_param))
+            base_max_hold = max(1, base_max_hold)
+        else:
+            base_max_hold = 0
+        self._base_max_hold_bars = base_max_hold
         self.time_stop = 0
         self._open_bars: dict[str, int] = {}
+
+        self._trend_exit_enabled = bool(kwargs.get("trend_exit", True))
+        neutral_high = float(kwargs.get("exit_rsi_neutral_high", 55.0))
+        neutral_low = float(kwargs.get("exit_rsi_neutral_low", 45.0))
+        if not math.isfinite(neutral_high):
+            neutral_high = 55.0
+        if not math.isfinite(neutral_low):
+            neutral_low = 45.0
+        if neutral_low > neutral_high:
+            neutral_low, neutral_high = neutral_high, neutral_low
+        self._exit_rsi_neutral_high = min(99.0, max(neutral_high, neutral_low + 1.0))
+        self._exit_rsi_neutral_low = max(1.0, min(neutral_low, self._exit_rsi_neutral_high - 1.0))
+
+        upper_floor = float(kwargs.get("upper_rsi_floor", 70.0))
+        lower_ceiling = float(kwargs.get("lower_rsi_ceiling", 30.0))
+        upper_cap = float(kwargs.get("upper_rsi_cap", 96.0))
+        lower_cap = float(kwargs.get("lower_rsi_cap", 4.0))
+        self._upper_rsi_floor = max(50.0, min(99.0, upper_floor))
+        self._lower_rsi_ceiling = min(50.0, max(1.0, lower_ceiling))
+        self._upper_rsi_cap = max(self._upper_rsi_floor + 1.0, min(99.5, upper_cap))
+        self._lower_rsi_cap = min(self._lower_rsi_ceiling - 1.0, max(0.0, lower_cap))
+        if self._lower_rsi_cap < 0.0:
+            self._lower_rsi_cap = 0.0
+        if self._lower_rsi_cap >= self._lower_rsi_ceiling:
+            self._lower_rsi_cap = max(0.0, self._lower_rsi_ceiling - 1.0)
+
         self.risk_service = kwargs.get("risk_service")
         self._rq = RollingQuantileCache()
+
+    def _scaled_min_hold_bars(self, tf_minutes: float) -> int:
+        base_minutes = self._base_timeframe_minutes or tf_minutes
+        if (
+            self._base_min_hold_bars <= 0
+            or tf_minutes <= 0
+            or base_minutes is None
+            or base_minutes <= 0
+        ):
+            return max(0, self._min_hold_floor)
+        desired_minutes = self._base_min_hold_bars * base_minutes
+        scaled_bars = int(math.ceil(desired_minutes / tf_minutes))
+        min_bars = max(0, self._min_hold_floor)
+        return max(min_bars, scaled_bars)
+
+    def _scaled_max_hold_bars(self, tf_minutes: float) -> int:
+        base_minutes = self._base_timeframe_minutes or tf_minutes
+        if (
+            self._base_max_hold_bars <= 0
+            or tf_minutes <= 0
+            or base_minutes is None
+            or base_minutes <= 0
+        ):
+            return 0
+        desired_minutes = self._base_max_hold_bars * base_minutes
+        scaled_bars = int(math.ceil(desired_minutes / tf_minutes))
+        return max(1, scaled_bars)
+
+    def _maybe_exit_for_trend(
+        self,
+        bar: dict,
+        price: float,
+        trade: dict | None,
+        *,
+        hold_bars: int,
+        min_hold_bars: int,
+        last_rsi: float,
+        trend_dir: int,
+        market_state: str,
+    ) -> Signal | None:
+        if not self._trend_exit_enabled or trade is None:
+            return None
+        if hold_bars < max(1, min_hold_bars):
+            return None
+        if isinstance(trade, dict):
+            side_value = trade.get("side")
+        else:
+            side_value = getattr(trade, "side", None)
+        side = str(side_value or "").lower()
+        if side not in {"buy", "sell"}:
+            return None
+        neutral_high = self._exit_rsi_neutral_high
+        neutral_low = self._exit_rsi_neutral_low
+        market_trending = market_state in {"trend", "breakout"}
+        exit_side = "sell" if side == "buy" else "buy"
+        if side == "buy":
+            if last_rsi >= neutral_high or (market_trending and trend_dir < 0):
+                return self.finalize_signal(bar, price, Signal(exit_side, 1.0))
+        else:
+            if last_rsi <= neutral_low or (market_trending and trend_dir > 0):
+                return self.finalize_signal(bar, price, Signal(exit_side, 1.0))
+        return None
+
+    def _maybe_time_stop_exit(
+        self,
+        bar: dict,
+        price: float,
+        trade: dict | None,
+        *,
+        hold_bars: int,
+        max_hold_bars: int,
+    ) -> Signal | None:
+        if trade is None or max_hold_bars <= 0:
+            return None
+        if hold_bars < max(1, max_hold_bars):
+            return None
+        if isinstance(trade, dict):
+            side_value = trade.get("side")
+        else:
+            side_value = getattr(trade, "side", None)
+        side = str(side_value or "").lower()
+        if side not in {"buy", "sell"}:
+            return None
+        exit_side = "sell" if side == "buy" else "buy"
+        return self.finalize_signal(bar, price, Signal(exit_side, 1.0))
 
     def _vol_floor_windows(self, tf_minutes: float) -> tuple[int, int]:
         base_minutes = self._base_timeframe_minutes or tf_minutes
@@ -454,8 +583,16 @@ class MeanReversion(Strategy):
         dev *= mix
         dev = max(dynamic_floor, min(dynamic_cap, dev))
 
-        upper = 50 + dev
-        lower = 50 - dev
+        upper = max(self._upper_rsi_floor, 50 + dev)
+        lower = min(self._lower_rsi_ceiling, 50 - dev)
+        upper = min(self._upper_rsi_cap, upper)
+        lower = max(self._lower_rsi_cap, lower)
+        if upper <= lower:
+            mid = (self._upper_rsi_floor + self._lower_rsi_ceiling) * 0.5
+            upper = min(self._upper_rsi_cap, max(upper, mid + 5.0))
+            lower = max(self._lower_rsi_cap, min(lower, mid - 5.0))
+            if upper <= lower:
+                upper = min(self._upper_rsi_cap, max(upper, lower + 1.0))
         return upper, lower
 
     def _adaptive_rsi_period(self, tf_minutes: float, window_size: int) -> int:
@@ -786,27 +923,28 @@ class MeanReversion(Strategy):
 
         bar_timeframe = bar.get("timeframe", self.timeframe)
         tf_minutes = timeframe_to_minutes(bar_timeframe)
-        base_minutes = self._base_timeframe_minutes
-        if self._time_stop_target_bars <= 0 or tf_minutes <= 0:
-            time_stop_bars = 0
-        else:
-            desired_minutes = self._time_stop_target_bars * base_minutes
-            scaled_bars = int(math.ceil(desired_minutes / tf_minutes))
-            min_bars = self._min_time_stop_bars or 1
-            time_stop_bars = max(min_bars, scaled_bars)
-        self.time_stop = time_stop_bars
-
-        if time_stop_bars and self.risk_service is not None and bar.get("symbol"):
-            sym = bar["symbol"]
-            trade = self.risk_service.get_trade(sym)
+        min_hold_bars = self._scaled_min_hold_bars(tf_minutes)
+        max_hold_bars = self._scaled_max_hold_bars(tf_minutes)
+        self.time_stop = max_hold_bars
+        trade = None
+        hold_bars = 0
+        if self.risk_service is not None and actual_symbol:
+            trade = self.risk_service.get_trade(actual_symbol)
             if trade:
-                cnt = self._open_bars.get(sym, 0) + 1
-                self._open_bars[sym] = cnt
-                if cnt >= time_stop_bars:
-                    side_exit = "sell" if trade.get("side") == "buy" else "buy"
-                    return self.finalize_signal(bar, price, Signal(side_exit, 1.0))
+                hold_bars = self._open_bars.get(actual_symbol, 0) + 1
+                self._open_bars[actual_symbol] = hold_bars
             else:
-                self._open_bars[sym] = 0
+                self._open_bars[actual_symbol] = 0
+
+        time_exit = self._maybe_time_stop_exit(
+            bar,
+            price,
+            trade,
+            hold_bars=hold_bars,
+            max_hold_bars=max_hold_bars,
+        )
+        if time_exit is not None:
+            return time_exit
 
         returns = price_series.pct_change().dropna()
         vol_series = (
@@ -888,9 +1026,22 @@ class MeanReversion(Strategy):
                     trend_dir = -1
         elif len(df) >= self.trend_rsi_n:
             trsi = rsi(df, self.trend_rsi_n).iloc[-1]
-            if trsi > 50 + trend_offset:
+            neutral_shift = max(0.5, trend_offset * 0.4)
+            upper_neutral = min(
+                self._upper_rsi_floor,
+                max(55.0, 60.0 + neutral_shift),
+            )
+            lower_neutral = max(
+                self._lower_rsi_ceiling,
+                min(45.0, 40.0 - neutral_shift),
+            )
+            if lower_neutral >= upper_neutral:
+                mid = (upper_neutral + lower_neutral) * 0.5
+                upper_neutral = mid + 1.0
+                lower_neutral = mid - 1.0
+            if trsi > upper_neutral:
                 trend_dir = 1
-            elif trsi < 50 - trend_offset:
+            elif trsi < lower_neutral:
                 trend_dir = -1
 
         market_state, regime_metrics = self._detect_market_state(
@@ -901,6 +1052,18 @@ class MeanReversion(Strategy):
             vol_ratio,
             tf_minutes,
         )
+        exit_signal = self._maybe_exit_for_trend(
+            bar,
+            price,
+            trade,
+            hold_bars=hold_bars,
+            min_hold_bars=min_hold_bars,
+            last_rsi=last_rsi,
+            trend_dir=trend_dir,
+            market_state=market_state,
+        )
+        if exit_signal is not None:
+            return exit_signal
         calibration = self._dynamic_calibration(
             tf_minutes=tf_minutes,
             market_state=market_state,

--- a/tests/test_mean_reversion.py
+++ b/tests/test_mean_reversion.py
@@ -3,7 +3,7 @@ import math
 import pandas as pd
 from tradingbot.execution.order_types import Order
 from tradingbot.strategies import mean_reversion as mr
-from tradingbot.strategies.base import Signal, timeframe_to_minutes
+from tradingbot.strategies.base import Signal
 from tradingbot.strategies.mean_reversion import (
     MeanReversion,
     _normalized_strength,
@@ -195,47 +195,76 @@ class DummyRiskService:
     def manage_position(self, trade, sig):
         return "hold"
 
+    def calc_position_size(self, strength, price, **kwargs):  # noqa: ANN001
+        return float(strength or 0.0)
 
-def test_mean_reversion_multi_timeframe_time_stop(monkeypatch):
-    df = pd.DataFrame(
-        {
-            "open": [100 + 0.2 * i for i in range(60)],
-            "high": [100 + 0.2 * i + 0.1 for i in range(60)],
-            "low": [100 + 0.2 * i - 0.1 for i in range(60)],
-            "close": [100 + 0.2 * i for i in range(60)],
-            "volume": [50.0] * 60,
-        }
+    @staticmethod
+    def initial_stop(price, side, atr):  # noqa: ANN001
+        if str(side).lower() == "buy":
+            return float(price) - float(atr or 0.0)
+        return float(price) + float(atr or 0.0)
+
+    @staticmethod
+    def update_signal_strength(symbol, strength):  # noqa: ANN001
+        return None
+
+
+def test_mean_reversion_trend_exit_respects_min_hold():
+    strat = MeanReversion(timeframe="1h", time_stop=9, min_volatility=0)
+    trade = {"side": "buy"}
+    bar = {"symbol": "X"}
+    price = 100.0
+
+    signal = strat._maybe_exit_for_trend(
+        bar,
+        price,
+        trade,
+        hold_bars=2,
+        min_hold_bars=3,
+        last_rsi=82.0,
+        trend_dir=-1,
+        market_state="trend",
     )
-    monkeypatch.setattr(mr, "rsi", _const_rsi(50))
-    monkeypatch.setattr(
-        MeanReversion, "auto_threshold", lambda self, series, **_: (60, 40)
+    assert signal is None
+
+    signal = strat._maybe_exit_for_trend(
+        bar,
+        price,
+        trade,
+        hold_bars=3,
+        min_hold_bars=3,
+        last_rsi=82.0,
+        trend_dir=-1,
+        market_state="trend",
     )
+    assert signal is not None
+    assert signal.side == "sell"
 
-    risk = DummyRiskService("buy")
-    strat = MeanReversion(timeframe="1h", time_stop=6, min_volatility=0, risk_service=risk)
-    bar_minutes = timeframe_to_minutes("4h")
-    expected_bars = max(
-        strat._min_time_stop_bars or 1,
-        math.ceil(
-            strat._time_stop_target_bars
-            * strat._base_timeframe_minutes
-            / bar_minutes
-        ),
+
+def test_mean_reversion_time_stop_exit_triggers():
+    strat = MeanReversion(timeframe="15m", time_stop=6, min_volatility=0)
+    trade = {"side": "sell"}
+    bar = {"symbol": "Y"}
+    price = 150.0
+
+    signal = strat._maybe_time_stop_exit(
+        bar,
+        price,
+        trade,
+        hold_bars=5,
+        max_hold_bars=6,
     )
-    assert expected_bars >= 3
+    assert signal is None
 
-    symbol = "X"
-    for idx in range(1, expected_bars):
-        sig = strat.on_bar({"window": df, "timeframe": "4h", "symbol": symbol, "volume": 50.0})
-        assert sig is None
-        assert strat.time_stop == expected_bars
-        assert strat._open_bars[symbol] == idx
-
-    exit_sig = strat.on_bar({"window": df, "timeframe": "4h", "symbol": symbol, "volume": 50.0})
-    assert exit_sig is not None
-    assert exit_sig.side == "sell"
-    assert strat.time_stop == expected_bars
-    assert strat._open_bars[symbol] == expected_bars
+    signal = strat._maybe_time_stop_exit(
+        bar,
+        price,
+        trade,
+        hold_bars=6,
+        max_hold_bars=6,
+    )
+    assert signal is not None
+    assert signal.side == "buy"
 
 
 def test_low_volatility_windows_block_signals(monkeypatch):

--- a/tests/test_timeframe_adaptation.py
+++ b/tests/test_timeframe_adaptation.py
@@ -76,25 +76,42 @@ def test_momentum_cooldown_scales():
     assert strat_slow.cooldown_bars == 1
 
 
-def test_mean_reversion_time_stop_scales():
-    df = _make_ohlcv(80)
-    strat_fast = MeanReversion(timeframe="1m", time_stop=10, min_volatility=0)
-    strat_slow = MeanReversion(timeframe="1h", time_stop=10, min_volatility=0)
+def test_mean_reversion_hold_windows_scale():
+    strat_fast = MeanReversion(
+        timeframe="1m",
+        min_hold_bars=4,
+        time_stop=10,
+        min_volatility=0,
+    )
+    strat_slow = MeanReversion(
+        timeframe="1h",
+        min_hold_bars=4,
+        time_stop=10,
+        min_volatility=0,
+    )
     strat_default_30m = MeanReversion(timeframe="30m", min_volatility=0)
     strat_default_1h = MeanReversion(timeframe="1h", min_volatility=0)
 
-    strat_fast.on_bar({"window": df, "timeframe": "1m", "symbol": "X"})
-    strat_slow.on_bar({"window": df, "timeframe": "1h", "symbol": "X"})
-    strat_default_30m.on_bar({"window": df, "timeframe": "30m", "symbol": "X"})
-    strat_default_1h.on_bar({"window": df, "timeframe": "1h", "symbol": "X"})
+    assert strat_fast._base_min_hold_bars == 4
+    assert strat_slow._base_min_hold_bars == 4
+    assert strat_fast._base_max_hold_bars == 10
+    assert strat_slow._base_max_hold_bars == 10
 
-    assert strat_fast.time_stop == 10
-    assert strat_slow.time_stop == 10
-    assert strat_default_30m.time_stop == 5
-    assert strat_default_1h.time_stop == 3
+    assert strat_default_30m._base_min_hold_bars == 1
+    assert strat_default_30m._base_max_hold_bars == 9
+    assert strat_default_1h._base_min_hold_bars == 0
+    assert strat_default_1h._base_max_hold_bars == 7
 
-    strat_slow.on_bar({"window": df, "timeframe": "4h", "symbol": "X"})
-    assert strat_slow.time_stop == 3
+    assert strat_fast._scaled_min_hold_bars(1.0) == 4
+    assert strat_slow._scaled_min_hold_bars(60.0) == 4
+    assert strat_slow._scaled_min_hold_bars(240.0) == 1
+    assert strat_fast._scaled_max_hold_bars(1.0) == 10
+    assert strat_slow._scaled_max_hold_bars(60.0) == 10
+    assert strat_slow._scaled_max_hold_bars(240.0) == 3
+    assert strat_default_30m._scaled_min_hold_bars(30.0) == 1
+    assert strat_default_30m._scaled_max_hold_bars(30.0) == 9
+    assert strat_default_1h._scaled_min_hold_bars(60.0) == 0
+    assert strat_default_1h._scaled_max_hold_bars(60.0) == 7
 
 
 def test_scalp_pingpong_lookback_scales():


### PR DESCRIPTION
## Summary
- separate min-hold configuration from time-based stops so we can exit on trend changes without waiting dozens of bars
- add a dedicated time-stop exit helper that enforces the max hold horizon inside on_bar
- refresh the strategy adaptation tests to cover the new min/max hold scaling and add coverage for the time-stop exit helper

## Testing
- pytest tests/test_mean_reversion.py::test_mean_reversion_trend_exit_respects_min_hold -q
- pytest tests/test_mean_reversion.py::test_mean_reversion_time_stop_exit_triggers -q
- pytest tests/test_timeframe_adaptation.py::test_mean_reversion_hold_windows_scale -q

------
https://chatgpt.com/codex/tasks/task_e_68efec1be698832d9157dd1c5138ecfa